### PR TITLE
Removed  suffix from Log types

### DIFF
--- a/analysis/rules/cis/aws_cloudtrail_modified.yml
+++ b/analysis/rules/cis/aws_cloudtrail_modified.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.CloudTrail.CloudTrailModified
 DisplayName: CloudTrail Modified
 Enabled: true
 ResourceTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - CIS
@@ -18,7 +18,7 @@ Reference: reference.link
 Tests:
   -
     Name: CloudTrail Was Modified
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {
@@ -62,7 +62,7 @@ Tests:
       }
   -
     Name: CloudTrail Was Not Modified
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {

--- a/analysis/rules/cis/aws_config_service_modified.yml
+++ b/analysis/rules/cis/aws_config_service_modified.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.CloudTrail.ConfigServiceModified
 DisplayName: AWS Config Service Modified
 Enabled: true
 ResourceTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - CIS
@@ -18,7 +18,7 @@ Reference: https://aws.amazon.com/config/
 Tests:
   -
     Name: Config Recorder Stopped
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {
@@ -61,7 +61,7 @@ Tests:
       }
   -
     Name: Config Recorder Started
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {

--- a/analysis/rules/cis/aws_console_login_failed.yml
+++ b/analysis/rules/cis/aws_console_login_failed.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.CloudTrail.ConsoleLoginFailed
 DisplayName: Failed Console Login
 Enabled: true
 ResourceTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - CIS
@@ -18,7 +18,7 @@ Reference: reference.link
 Tests:
   -
     Name: Failed Login
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {
@@ -51,7 +51,7 @@ Tests:
       }
   -
     Name: Successful Login
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {
@@ -84,7 +84,7 @@ Tests:
       }
   -
     Name: Non Login Event
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {

--- a/analysis/rules/cis/aws_console_login_without_mfa.yml
+++ b/analysis/rules/cis/aws_console_login_without_mfa.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.CloudTrail.ConsoleLoginWithoutMFA
 DisplayName: Logins Without MFA
 Enabled: true
 ResourceTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - CIS
@@ -18,7 +18,7 @@ Reference: reference.link
 Tests:
   -
     Name: No MFA
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {
@@ -51,7 +51,7 @@ Tests:
       }
   -
     Name: Yes MFA 
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {
@@ -84,7 +84,7 @@ Tests:
       }
   -
     Name: No MFA but Login Failed
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {

--- a/analysis/rules/cis/aws_ec2_gateway_modified.yml
+++ b/analysis/rules/cis/aws_ec2_gateway_modified.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.CloudTrail.EC2GatewayModified
 DisplayName: EC2 Network Gateway Modified
 Enabled: true
 ResourceTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - CIS
@@ -18,7 +18,7 @@ Reference: reference.link
 Tests:
   -
     Name: Network Gateway Modified
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {
@@ -64,7 +64,7 @@ Tests:
       }
   -
     Name: Network Gateway Not Modified
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {

--- a/analysis/rules/cis/aws_ec2_network_acl_modified.yml
+++ b/analysis/rules/cis/aws_ec2_network_acl_modified.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.CloudTrail.EC2NetworkACLModified
 DisplayName: EC2 Network ACL Modified
 Enabled: true
 ResourceTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - CIS
@@ -18,7 +18,7 @@ Reference: reference.link
 Tests:
   -
     Name: Network ACL Modified
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {
@@ -70,7 +70,7 @@ Tests:
       }
   -
     Name: Network ACL Not Modified
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {

--- a/analysis/rules/cis/aws_ec2_route_table_modified.yml
+++ b/analysis/rules/cis/aws_ec2_route_table_modified.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.CloudTrail.EC2RouteTableModified
 DisplayName: EC2 Route Table Modified
 Enabled: true
 ResourceTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - CIS
@@ -18,7 +18,7 @@ Reference: reference.link
 Tests:
   -
     Name: Route Table Modified
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {
@@ -65,7 +65,7 @@ Tests:
       }
   -
     Name: Route Table Not Modified
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {

--- a/analysis/rules/cis/aws_ec2_security_group_modified.yml
+++ b/analysis/rules/cis/aws_ec2_security_group_modified.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.CloudTrail.EC2SecurityGroupModified
 DisplayName: EC2 Security Group Modified
 Enabled: true
 ResourceTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - CIS
@@ -18,7 +18,7 @@ Reference: reference.link
 Tests:
   -
     Name: Security Group Modified
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {
@@ -84,7 +84,7 @@ Tests:
       }
   -
     Name: Security Group Not Modified
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {

--- a/analysis/rules/cis/aws_ec2_vpc_modified.yml
+++ b/analysis/rules/cis/aws_ec2_vpc_modified.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.CloudTrail.EC2VPCModified
 DisplayName: EC2 VPC Modified
 Enabled: true
 ResourceTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - CIS
@@ -18,7 +18,7 @@ Reference: reference.link
 Tests:
   -
     Name: VPC Modified
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {
@@ -87,7 +87,7 @@ Tests:
       }
   -
     Name: VPC Not Modified
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {

--- a/analysis/rules/cis/aws_iam_policy_modified.yml
+++ b/analysis/rules/cis/aws_iam_policy_modified.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.CloudTrail.IAMPolicyModified
 DisplayName: IAM Policy Modified
 Enabled: true
 ResourceTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - CIS
@@ -18,7 +18,7 @@ Reference: reference.link
 Tests:
   -
     Name: IAM Policy Change
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {
@@ -61,7 +61,7 @@ Tests:
       }
   -
     Name: Not IAM Policy Change
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {

--- a/analysis/rules/cis/aws_kms_cmk_loss.yml
+++ b/analysis/rules/cis/aws_kms_cmk_loss.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.CloudTrail.KMSCustomerManagedKeyLoss
 DisplayName: Potential KMS CMK Loss
 Enabled: true
 ResourceTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - CIS
@@ -18,7 +18,7 @@ Reference: reference.link
 Tests:
   -
     Name: KMS Key Disabled
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {
@@ -68,7 +68,7 @@ Tests:
       }
   -
     Name: KMS Key Scheduled For Deletion
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {
@@ -123,7 +123,7 @@ Tests:
       }
   -
     Name: KMS Key Non Deletion Event
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {

--- a/analysis/rules/cis/aws_root_activity.yml
+++ b/analysis/rules/cis/aws_root_activity.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.CloudTrail.RootActivity
 DisplayName: Root Account Activity
 Enabled: true
 ResourceTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - CIS
@@ -18,7 +18,7 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html
 Tests:
   -
     Name: Root Activity
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {
@@ -69,7 +69,7 @@ Tests:
       }
   -
     Name: IAMUser Activity
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {

--- a/analysis/rules/cis/aws_s3_bucket_policy_modified.yml
+++ b/analysis/rules/cis/aws_s3_bucket_policy_modified.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.CloudTrail.S3BucketPolicyModified
 DisplayName: AWS S3 Bucket Policy Modified
 Enabled: true
 ResourceTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - CIS
@@ -18,7 +18,7 @@ Reference: reference.link
 Tests:
   -
     Name: S3 Bucket Policy Modified
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {
@@ -74,7 +74,7 @@ Tests:
       }
   -
     Name: S3 Bucket Policy Not Modified
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {

--- a/analysis/rules/cis/aws_unauthorized_api_call.yml
+++ b/analysis/rules/cis/aws_unauthorized_api_call.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.CloudTrail.UnauthorizedAPICall
 DisplayName: Monitor Unauthorized API Calls
 Enabled: true
 ResourceTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - CIS
@@ -18,7 +18,7 @@ Reference: reference.link
 Tests:
   -
     Name: Unauthorized API Call
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {
@@ -55,7 +55,7 @@ Tests:
       }
   -
     Name: Authorized API Call
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {

--- a/analysis/rules/s3_access_logs/aws_s3_access_error.yml
+++ b/analysis/rules/s3_access_logs/aws_s3_access_error.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.S3ServerAccess.AccessError
 DisplayName: AWS S3 Access Error
 Enabled: true
 ResourceTypes:
-  - AWS.S3ServerAccess.Log
+  - AWS.S3ServerAccess
 Tags:
   - AWS
 Severity: Low
@@ -17,7 +17,7 @@ Reference:
 Tests:
   -
     Name: Access No Error
-    ResourceType: AWS.S3ServerAccess.Log
+    ResourceType: AWS.S3ServerAccess
     ExpectedResult: false
     Resource: 
       {
@@ -25,7 +25,7 @@ Tests:
       }
   -
     Name: Access Error
-    ResourceType: AWS.S3ServerAccess.Log
+    ResourceType: AWS.S3ServerAccess
     ExpectedResult: true
     Resource: 
       {

--- a/analysis/rules/s3_access_logs/aws_s3_access_ip_whitelist.yml
+++ b/analysis/rules/s3_access_logs/aws_s3_access_ip_whitelist.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.S3ServerAccess.IPWhitelist
 DisplayName: AWS S3 Access IP Whitelist
 Enabled: true
 ResourceTypes:
-  - AWS.S3ServerAccess.Log
+  - AWS.S3ServerAccess
 Tags:
   - AWS
 Severity: Medium
@@ -17,7 +17,7 @@ Reference:
 Tests:
   -
     Name: Access From Approved IP
-    ResourceType: AWS.S3ServerAccess.Log
+    ResourceType: AWS.S3ServerAccess
     ExpectedResult: false
     Resource: 
       {
@@ -25,7 +25,7 @@ Tests:
       }
   -
     Name: Access From Unapproved IP
-    ResourceType: AWS.S3ServerAccess.Log
+    ResourceType: AWS.S3ServerAccess
     ExpectedResult: true
     Resource: 
       {

--- a/analysis/rules/s3_access_logs/aws_s3_insecure_access.yml
+++ b/analysis/rules/s3_access_logs/aws_s3_insecure_access.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.S3ServerAccess.InsecureAccess
 DisplayName: AWS S3 Insecure Access
 Enabled: true
 ResourceTypes:
-  - AWS.S3ServerAccess.Log
+  - AWS.S3ServerAccess
 Tags:
   - AWS
 Severity: Medium
@@ -17,7 +17,7 @@ Reference:
 Tests:
   -
     Name: Secure Access
-    ResourceType: AWS.S3ServerAccess.Log
+    ResourceType: AWS.S3ServerAccess
     ExpectedResult: false
     Resource: 
       {
@@ -27,7 +27,7 @@ Tests:
       }
   -
     Name: Insecure Access
-    ResourceType: AWS.S3ServerAccess.Log
+    ResourceType: AWS.S3ServerAccess
     ExpectedResult: true
     Resource: 
       {

--- a/analysis/rules/s3_access_logs/aws_s3_unauthenticated_access.yml
+++ b/analysis/rules/s3_access_logs/aws_s3_unauthenticated_access.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.S3ServerAccess.UnauthenticatedAccess
 DisplayName: AWS S3 Unauthenticated Access
 Enabled: true
 ResourceTypes:
-  - AWS.S3ServerAccess.Log
+  - AWS.S3ServerAccess
 Tags:
   - AWS
 Severity: Low
@@ -15,7 +15,7 @@ Runbook: >
 Tests:
   -
     Name: Authenticated Access
-    ResourceType: AWS.S3ServerAccess.Log
+    ResourceType: AWS.S3ServerAccess
     ExpectedResult: false
     Resource: 
       {
@@ -24,7 +24,7 @@ Tests:
       }
   -
     Name: Unauthenticated Access
-    ResourceType: AWS.S3ServerAccess.Log
+    ResourceType: AWS.S3ServerAccess
     ExpectedResult: true
     Resource: 
       {

--- a/analysis/rules/vpc_flow_logs/aws_vpc_healthy_log_status.yml
+++ b/analysis/rules/vpc_flow_logs/aws_vpc_healthy_log_status.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.VPCFlowLog.HealthyLogStatus
 DisplayName: AWS VPC Healthy Log Status
 Enabled: true
 ResourceTypes:
-  - AWS.VPCFlow.Log
+  - AWS.VPCFlow
 Tags:
   - AWS
 Severity: Low
@@ -17,11 +17,11 @@ Runbook: >
 Tests:
   -
     Name: Healthy Log Status
-    ResourceType: AWS.VPCFlow.Log
+    ResourceType: AWS.VPCFlow
     ExpectedResult: false
     Resource: {"log-status": "OK"}
   -
     Name: Unhealthy Log Status
-    ResourceType: AWS.VPCFlow.Log
+    ResourceType: AWS.VPCFlow
     ExpectedResult: true
     Resource: {"log-status": "SKIPDATA"}

--- a/analysis/rules/vpc_flow_logs/aws_vpc_inbound_traffic_port_blacklist.yml
+++ b/analysis/rules/vpc_flow_logs/aws_vpc_inbound_traffic_port_blacklist.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.VPCFlowLog.InboundPortBlacklist
 DisplayName: VPC Flow Logs Inbound Port Blacklist
 Enabled: true
 ResourceTypes:
-  - AWS.VPCFlow.Log
+  - AWS.VPCFlow
 Tags:
   - AWS
 Severity: High
@@ -15,7 +15,7 @@ Runbook: >
 Tests:
   -
     Name: Public to Private IP on Restricted Port
-    ResourceType: AWS.VPCFlow.Log
+    ResourceType: AWS.VPCFlow
     ExpectedResult: true
     Resource: 
       {
@@ -25,7 +25,7 @@ Tests:
       }
   -
     Name: Public to Private IP on Allowed Port
-    ResourceType: AWS.VPCFlow.Log
+    ResourceType: AWS.VPCFlow
     ExpectedResult: false
     Resource: 
       {
@@ -35,7 +35,7 @@ Tests:
       }
   -
     Name: Private to Private IP on Restricted Port
-    ResourceType: AWS.VPCFlow.Log
+    ResourceType: AWS.VPCFlow
     ExpectedResult: false
     Resource: 
       {

--- a/analysis/rules/vpc_flow_logs/aws_vpc_inbound_traffic_port_whitelist.yml
+++ b/analysis/rules/vpc_flow_logs/aws_vpc_inbound_traffic_port_whitelist.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.VPCFlowLog.InboundPortWhitelist
 DisplayName: VPC Flow Logs Inbound Port Whitelist
 Enabled: true
 ResourceTypes:
-  - AWS.VPCFlow.Log
+  - AWS.VPCFlow
 Tags:
   - AWS
 Severity: High
@@ -15,7 +15,7 @@ Runbook: >
 Tests:
   -
     Name: Public to Private IP on Restricted Port
-    ResourceType: AWS.VPCFlow.Log
+    ResourceType: AWS.VPCFlow
     ExpectedResult: true
     Resource: 
       {
@@ -25,7 +25,7 @@ Tests:
       }
   -
     Name: Public to Private IP on Allowed Port
-    ResourceType: AWS.VPCFlow.Log
+    ResourceType: AWS.VPCFlow
     ExpectedResult: false
     Resource: 
       {
@@ -35,7 +35,7 @@ Tests:
       }
   -
     Name: Private to Private IP on Restricted Port
-    ResourceType: AWS.VPCFlow.Log
+    ResourceType: AWS.VPCFlow
     ExpectedResult: false
     Resource: 
       {

--- a/analysis/rules/vpc_flow_logs/aws_vpc_unapproved_outbound_dns.yml
+++ b/analysis/rules/vpc_flow_logs/aws_vpc_unapproved_outbound_dns.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.VPCFlowLog.UnapprovedOutboundDNS
 DisplayName: VPC Flow Logs Unapproved Outbound DNS Traffic
 Enabled: true
 ResourceTypes:
-  - AWS.VPCFlow.Log
+  - AWS.VPCFlow
 Tags:
   - AWS
 Severity: Medium
@@ -15,7 +15,7 @@ Runbook: >
 Tests:
   -
     Name: Approved Outbound DNS Traffic
-    ResourceType: AWS.VPCFlow.Log
+    ResourceType: AWS.VPCFlow
     ExpectedResult: false
     Resource:
       {
@@ -25,7 +25,7 @@ Tests:
       }
   -
     Name: Unapproved Outbound DNS Traffic
-    ResourceType: AWS.VPCFlow.Log
+    ResourceType: AWS.VPCFlow
     ExpectedResult: true
     Resource:
       {
@@ -35,7 +35,7 @@ Tests:
       }
   -
     Name: Outbound Non-DNS Traffic
-    ResourceType: AWS.VPCFlow.Log
+    ResourceType: AWS.VPCFlow
     ExpectedResult: false
     Resource:
       {

--- a/tests/fixtures/valid_policies/example_rule.yml
+++ b/tests/fixtures/valid_policies/example_rule.yml
@@ -6,7 +6,7 @@ Severity: High
 PolicyID: AWS.CloudTrail.MFAEnabled
 Enabled: true
 ResourceTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS Managed Rules - Security, Identity & Compliance
   - AWS
@@ -18,7 +18,7 @@ Reference: https://www.link-to-info.io
 Tests:
   -
     Name: Root MFA not enabled fails compliance
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       Arn: arn:aws:iam::123456789012:user/root
@@ -29,7 +29,7 @@ Tests:
       UserName: root
   -
     Name: User MFA not enabled fails compliance
-    ResourceType: AWS.CloudTrail.Log
+    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {


### PR DESCRIPTION
### Background

The `.Log` suffix has been removed from log types (it was redundant)
Updating the default rules so that they don't include the `.Log` suffix

### Changes
Find & Remove `.Log`occurences

@nhakmiller  Not sure how to create a new release of the rules. I'll need your help for it once this is merged. 