### PR TITLE
Rules perform safe lookups

### DIFF
--- a/analysis/aws_rules_cis/aws_cloudtrail_modified.py
+++ b/analysis/aws_rules_cis/aws_cloudtrail_modified.py
@@ -9,4 +9,4 @@ CLOUDTRAIL_CHANGE_EVENTS = {
 
 
 def rule(event):
-    return event['eventName'] in CLOUDTRAIL_CHANGE_EVENTS
+    return event.get('eventName') in CLOUDTRAIL_CHANGE_EVENTS

--- a/analysis/aws_rules_cis/aws_config_service_modified.py
+++ b/analysis/aws_rules_cis/aws_config_service_modified.py
@@ -8,4 +8,4 @@ CONFIG_SERVICE_MODIFIED_EVENTS = {
 
 
 def rule(event):
-    return event['eventName'] in CONFIG_SERVICE_MODIFIED_EVENTS
+    return event.get('eventName') in CONFIG_SERVICE_MODIFIED_EVENTS

--- a/analysis/aws_rules_cis/aws_console_login_failed.py
+++ b/analysis/aws_rules_cis/aws_console_login_failed.py
@@ -1,7 +1,7 @@
 def rule(event):
     # This rule only applies to ConsoleLogin actions
-    if event['eventName'] != 'ConsoleLogin':
+    if event.get('eventName') != 'ConsoleLogin':
         return False
 
     # Alert on failed logins
-    return event['responseElements']['ConsoleLogin'] != 'Success'
+    return event.get('responseElements', {}).get('ConsoleLogin') != 'Success'

--- a/analysis/aws_rules_cis/aws_console_login_without_mfa.py
+++ b/analysis/aws_rules_cis/aws_console_login_without_mfa.py
@@ -1,11 +1,11 @@
 def rule(event):
     # This rule only applies to ConsoleLogin actions
-    if event['eventName'] != 'ConsoleLogin':
+    if event.get('eventName') != 'ConsoleLogin':
         return False
 
     # This rule only applies to successful logins
-    if event['responseElements']['ConsoleLogin'] != 'Success':
+    if event.get('responseElements', {}).get('ConsoleLogin') != 'Success':
         return False
 
     # Alert if MFA was not used
-    return event['additionalEventData']['MFAUsed'] == 'No'
+    return event.get('additionalEventData', {}).get('MFAUsed') == 'No'

--- a/analysis/aws_rules_cis/aws_ec2_gateway_modified.py
+++ b/analysis/aws_rules_cis/aws_ec2_gateway_modified.py
@@ -10,4 +10,4 @@ EC2_GATEWAY_MODIFIED_EVENTS = {
 
 
 def rule(event):
-    return event['eventName'] in EC2_GATEWAY_MODIFIED_EVENTS
+    return event.get('eventName') in EC2_GATEWAY_MODIFIED_EVENTS

--- a/analysis/aws_rules_cis/aws_ec2_network_acl_modified.py
+++ b/analysis/aws_rules_cis/aws_ec2_network_acl_modified.py
@@ -10,4 +10,4 @@ EC2_NACL_MODIFIED_EVENTS = {
 
 
 def rule(event):
-    return event['eventName'] in EC2_NACL_MODIFIED_EVENTS
+    return event.get('eventName') in EC2_NACL_MODIFIED_EVENTS

--- a/analysis/aws_rules_cis/aws_ec2_route_table_modified.py
+++ b/analysis/aws_rules_cis/aws_ec2_route_table_modified.py
@@ -11,4 +11,4 @@ EC2_RT_MODIFIED_EVENTS = {
 
 
 def rule(event):
-    return event['eventName'] in EC2_RT_MODIFIED_EVENTS
+    return event.get('eventName') in EC2_RT_MODIFIED_EVENTS

--- a/analysis/aws_rules_cis/aws_ec2_security_group_modified.py
+++ b/analysis/aws_rules_cis/aws_ec2_security_group_modified.py
@@ -10,4 +10,4 @@ EC2_SG_MODIFIED_EVENTS = {
 
 
 def rule(event):
-    return event['eventName'] in EC2_SG_MODIFIED_EVENTS
+    return event.get('eventName') in EC2_SG_MODIFIED_EVENTS

--- a/analysis/aws_rules_cis/aws_ec2_vpc_modified.py
+++ b/analysis/aws_rules_cis/aws_ec2_vpc_modified.py
@@ -15,4 +15,4 @@ EC2_VPC_MODIFIED_EVENTS = {
 
 
 def rule(event):
-    return event['eventName'] in EC2_VPC_MODIFIED_EVENTS
+    return event.get('eventName') in EC2_VPC_MODIFIED_EVENTS

--- a/analysis/aws_rules_cis/aws_iam_policy_modified.py
+++ b/analysis/aws_rules_cis/aws_iam_policy_modified.py
@@ -24,4 +24,4 @@ POLICY_CHANGE_EVENTS = {
 
 
 def rule(event):
-    return event['eventName'] in POLICY_CHANGE_EVENTS
+    return event.get('eventName') in POLICY_CHANGE_EVENTS

--- a/analysis/aws_rules_cis/aws_kms_cmk_loss.py
+++ b/analysis/aws_rules_cis/aws_kms_cmk_loss.py
@@ -6,4 +6,4 @@ KMS_LOSS_EVENTS = {
 
 
 def rule(event):
-    return event['eventName'] in KMS_LOSS_EVENTS
+    return event.get('eventName') in KMS_LOSS_EVENTS

--- a/analysis/aws_rules_cis/aws_root_activity.py
+++ b/analysis/aws_rules_cis/aws_root_activity.py
@@ -1,4 +1,4 @@
 def rule(event):
-    return (event['userIdentity']['type'] == 'Root' and
-            event['userIdentity'].get('invokedBy') is None and
-            event['eventType'] != 'AwsServiceEvent')
+    return (event.get('userIdentity', {}).get('type') == 'Root' and
+            event.get('userIdentity', {}).get('invokedBy') is None and
+            event.get('eventType') != 'AwsServiceEvent')

--- a/analysis/aws_rules_cis/aws_s3_bucket_policy_modified.py
+++ b/analysis/aws_rules_cis/aws_s3_bucket_policy_modified.py
@@ -13,4 +13,4 @@ S3_POLICY_CHANGE_EVENTS = {
 
 
 def rule(event):
-    return event['eventName'] in S3_POLICY_CHANGE_EVENTS
+    return event.get('eventName') in S3_POLICY_CHANGE_EVENTS

--- a/analysis/aws_rules_s3_access_logs/aws_s3_access_error.py
+++ b/analysis/aws_rules_s3_access_logs/aws_s3_access_error.py
@@ -1,2 +1,2 @@
 def rule(event):
-    return event['errorCode'] != '-'
+    return 'errorCode' in event

--- a/analysis/aws_rules_s3_access_logs/aws_s3_access_error.yml
+++ b/analysis/aws_rules_s3_access_logs/aws_s3_access_error.yml
@@ -21,7 +21,7 @@ Tests:
     ExpectedResult: false
     Resource: 
       {
-        "errorCode": "-"
+        "otherFields": "values"
       }
   -
     Name: Access Error

--- a/analysis/aws_rules_s3_access_logs/aws_s3_access_ip_whitelist.py
+++ b/analysis/aws_rules_s3_access_logs/aws_s3_access_ip_whitelist.py
@@ -6,6 +6,10 @@ IP_WHITELIST = {
 
 
 def rule(event):
+    # Only evaluate if the remoteIP field is present
+    if 'remoteIP' not in event:
+        return False
+
     cidr_ip = ip_network(event['remoteIP'])
     return not any(
         cidr_ip.subnet_of(approved_ip_range)

--- a/analysis/aws_rules_s3_access_logs/aws_s3_insecure_access.py
+++ b/analysis/aws_rules_s3_access_logs/aws_s3_insecure_access.py
@@ -1,2 +1,2 @@
 def rule(event):
-    return event['cipherSuite'] == '-' or event['tlsVersion'] == '-'
+    return 'cipherSuite' not in event or 'tlsVersion' not in event

--- a/analysis/aws_rules_s3_access_logs/aws_s3_insecure_access.yml
+++ b/analysis/aws_rules_s3_access_logs/aws_s3_insecure_access.yml
@@ -32,6 +32,5 @@ Tests:
     Resource: 
       {
         "bucket" : "example-bucket",
-        "cipherSuite": "-",
-        "tlsVersion": "-"
+        "tlsVersion": "TLSv1.2"
       }

--- a/analysis/aws_rules_s3_access_logs/aws_s3_unauthenticated_access.py
+++ b/analysis/aws_rules_s3_access_logs/aws_s3_unauthenticated_access.py
@@ -5,7 +5,7 @@ NO_AUTH_BUCKETS = {
 
 
 def rule(event):
-    if event['bucket'] in NO_AUTH_BUCKETS:
+    if event.get('bucket') in NO_AUTH_BUCKETS:
         return False
 
-    return event['requester'] == '-'
+    return 'requester' not in event

--- a/analysis/aws_rules_s3_access_logs/aws_s3_unauthenticated_access.yml
+++ b/analysis/aws_rules_s3_access_logs/aws_s3_unauthenticated_access.yml
@@ -29,5 +29,4 @@ Tests:
     Resource: 
       {
         "bucket" : "example-bucket",
-        "requester": "-"
       }

--- a/analysis/aws_rules_vpc_flow_logs/aws_vpc_healthy_log_status.py
+++ b/analysis/aws_rules_vpc_flow_logs/aws_vpc_healthy_log_status.py
@@ -1,2 +1,2 @@
 def rule(event):
-    return event['log-status'] == 'SKIPDATA'
+    return event.get('log-status') == 'SKIPDATA'

--- a/analysis/aws_rules_vpc_flow_logs/aws_vpc_inbound_traffic_port_blacklist.py
+++ b/analysis/aws_rules_vpc_flow_logs/aws_vpc_inbound_traffic_port_blacklist.py
@@ -21,4 +21,4 @@ def rule(event):
     # Alert if the traffic is destined for internal IP addresses
     #
     # Defaults to False(no alert) if 'dstaddr' key is not present
-    return ip_network(event.get('dstaddr', '1.0.0.0/32')).is_private:
+    return ip_network(event.get('dstaddr', '1.0.0.0/32')).is_private

--- a/analysis/aws_rules_vpc_flow_logs/aws_vpc_inbound_traffic_port_blacklist.py
+++ b/analysis/aws_rules_vpc_flow_logs/aws_vpc_inbound_traffic_port_blacklist.py
@@ -6,6 +6,10 @@ CONTROLLED_PORTS = [
 
 
 def rule(event):
+    # This rule can only be evaluated if users have enabled these fields in their VPC Flow Logs
+    if 'dstport' not in event or 'srcaddr' not in event or 'dstaddr' not in event:
+        return False
+
     # Only monitor for blacklisted ports
     if event['dstport'] not in CONTROLLED_PORTS:
         return False

--- a/analysis/aws_rules_vpc_flow_logs/aws_vpc_inbound_traffic_port_blacklist.py
+++ b/analysis/aws_rules_vpc_flow_logs/aws_vpc_inbound_traffic_port_blacklist.py
@@ -1,25 +1,24 @@
 from ipaddress import ip_network
-CONTROLLED_PORTS = [
+CONTROLLED_PORTS = {
     22,
     3389,
-]
+}
 
 
 def rule(event):
-    # This rule can only be evaluated if users have enabled these fields in their VPC Flow Logs
-    if 'dstport' not in event or 'srcaddr' not in event or 'dstaddr' not in event:
-        return False
-
     # Only monitor for blacklisted ports
-    if event['dstport'] not in CONTROLLED_PORTS:
+    #
+    # Defaults to True (no alert) if 'dstport' is not present
+    if event.get('dstport') not in CONTROLLED_PORTS:
         return False
 
     # Only monitor for traffic coming from non-private IP space
-    if ip_network(event['srcaddr']).is_private:
+    #
+    # Defaults to True (no alert) if 'srcaddr' key is not present
+    if ip_network(event.get('srcaddr', '0.0.0.0/32')).is_private:
         return False
 
     # Alert if the traffic is destined for internal IP addresses
-    if ip_network(event['dstaddr']).is_private:
-        return True
-
-    return False
+    #
+    # Defaults to False(no alert) if 'dstaddr' key is not present
+    return ip_network(event.get('dstaddr', '1.0.0.0/32')).is_private:

--- a/analysis/aws_rules_vpc_flow_logs/aws_vpc_inbound_traffic_port_whitelist.py
+++ b/analysis/aws_rules_vpc_flow_logs/aws_vpc_inbound_traffic_port_whitelist.py
@@ -6,6 +6,10 @@ APPROVED_PORTS = [
 
 
 def rule(event):
+    # This rule can only be evaluated if users have enabled these fields in their VPC Flow Logs
+    if 'dstport' not in event or 'srcaddr' not in event or 'dstaddr' not in event:
+        return False
+
     # Only monitor for non whitelisted ports
     if event['dstport'] in APPROVED_PORTS:
         return False

--- a/analysis/aws_rules_vpc_flow_logs/aws_vpc_inbound_traffic_port_whitelist.py
+++ b/analysis/aws_rules_vpc_flow_logs/aws_vpc_inbound_traffic_port_whitelist.py
@@ -23,4 +23,4 @@ def rule(event):
     # Alert if the traffic is destined for internal IP addresses
     #
     # Defaults to False (no alert) if 'dstaddr' key is not present
-    return ip_network(event.get('dstaddr', '1.0.0.0/32')).is_private:
+    return ip_network(event.get('dstaddr', '1.0.0.0/32')).is_private

--- a/analysis/aws_rules_vpc_flow_logs/aws_vpc_inbound_traffic_port_whitelist.py
+++ b/analysis/aws_rules_vpc_flow_logs/aws_vpc_inbound_traffic_port_whitelist.py
@@ -1,13 +1,13 @@
 from ipaddress import ip_network
-APPROVED_PORTS = [
+APPROVED_PORTS = {
     80,
     443,
-]
+}
 
 
 def rule(event):
-    # This rule can only be evaluated if users have enabled these fields in their VPC Flow Logs
-    if 'dstport' not in event or 'srcaddr' not in event or 'dstaddr' not in event:
+    # Can't perform this check without a destination port
+    if 'dstport' not in event:
         return False
 
     # Only monitor for non whitelisted ports
@@ -15,11 +15,12 @@ def rule(event):
         return False
 
     # Only monitor for traffic coming from non-private IP space
-    if ip_network(event['srcaddr']).is_private:
+    #
+    # Defaults to True (no alert) if 'srcaddr' key is not present
+    if ip_network(event.get('srcaddr', '0.0.0.0/32')).is_private:
         return False
 
     # Alert if the traffic is destined for internal IP addresses
-    if ip_network(event['dstaddr']).is_private:
-        return True
-
-    return False
+    #
+    # Defaults to False (no alert) if 'dstaddr' key is not present
+    return ip_network(event.get('dstaddr', '1.0.0.0/32')).is_private:

--- a/analysis/aws_rules_vpc_flow_logs/aws_vpc_unapproved_outbound_dns.py
+++ b/analysis/aws_rules_vpc_flow_logs/aws_vpc_unapproved_outbound_dns.py
@@ -7,16 +7,17 @@ APPROVED_DNS_SERVERS = {
 
 
 def rule(event):
-    # This rule can only be evaluated if users have enabled these fields in their VPC Flow Logs
-    if 'dstport' not in event or 'srcaddr' not in event or 'dstaddr' not in event:
-        return False
-
     # Common DNS ports, for better security use an application layer aware network monitor
-    if event['dstport'] != 53 and event['dstport'] != 5353:
+    #
+    # Defaults to True (no alert) if 'dstport' key is not present
+    if event.get('dstport') != 53 and event.get('dstport') != 5353:
         return False
 
     # Only monitor traffic that is originating internally
-    if not ip_network(event['srcaddr']).is_private:
+    #
+    # Defaults to True (no alert) if 'srcaddr' key is not present
+    if not ip_network(event.get('srcaddr', '0.0.0.0/32')).is_private:
         return False
 
-    return event['dstaddr'] not in APPROVED_DNS_SERVERS
+    # No clean way to check set memmbership and default to False (no alert), so explicitly check for key
+    return 'dstaddr' in event && event['dstaddr'] not in APPROVED_DNS_SERVERS

--- a/analysis/aws_rules_vpc_flow_logs/aws_vpc_unapproved_outbound_dns.py
+++ b/analysis/aws_rules_vpc_flow_logs/aws_vpc_unapproved_outbound_dns.py
@@ -7,6 +7,10 @@ APPROVED_DNS_SERVERS = {
 
 
 def rule(event):
+    # This rule can only be evaluated if users have enabled these fields in their VPC Flow Logs
+    if 'dstport' not in event or 'srcaddr' not in event or 'dstaddr' not in event:
+        return False
+
     # Common DNS ports, for better security use an application layer aware network monitor
     if event['dstport'] != 53 and event['dstport'] != 5353:
         return False

--- a/analysis/aws_rules_vpc_flow_logs/aws_vpc_unapproved_outbound_dns.py
+++ b/analysis/aws_rules_vpc_flow_logs/aws_vpc_unapproved_outbound_dns.py
@@ -19,5 +19,5 @@ def rule(event):
     if not ip_network(event.get('srcaddr', '0.0.0.0/32')).is_private:
         return False
 
-    # No clean way to check set memmbership and default to False (no alert), so explicitly check for key
-    return 'dstaddr' in event && event['dstaddr'] not in APPROVED_DNS_SERVERS
+    # No clean way to default to False (no alert), so explicitly check for key
+    return 'dstaddr' in event and event['dstaddr'] not in APPROVED_DNS_SERVERS


### PR DESCRIPTION
### Background

The way that the Panther backend handles log processing has changed, and as a result not all top level keys are always present in a given log now. This means that even for top level keys we must perform lookups that do not assume the key is present, otherwise we risk keys errors. Additionally, we no longer maintain the S3 access log standard of the string `-` meaning a null value, and instead replace it with an actual null value (and so omit the key entirely). This change updates all the default rules to reflect this change.

Closes #17.

### Changes

* Updated all rules to perform safe lookups when accessing top level keys

### Testing

* testing with `make ci`
