### PR TITLE
[guardduty] init rules for high/med/low sev findings

### DIFF
--- a/analysis/aws_rules_guardduty/aws_guardduty_high_sev_findings.py
+++ b/analysis/aws_rules_guardduty/aws_guardduty_high_sev_findings.py
@@ -1,0 +1,2 @@
+def rule(event):
+    return 7.0 <= float(event.get('severity', 0)) <= 8.9

--- a/analysis/aws_rules_guardduty/aws_guardduty_high_sev_findings.yml
+++ b/analysis/aws_rules_guardduty/aws_guardduty_high_sev_findings.yml
@@ -1,0 +1,60 @@
+AnalysisType: rule
+Filename: aws_guardduty_high_sev_findings.py
+PolicyID: AWS.GuardDuty.HighSeverityFinding
+DisplayName: AWS GuardDuty High Severity Finding
+Enabled: true
+ResourceTypes:
+  - AWS.GuardDuty
+Tags:
+  - AWS
+Severity: High
+Description: >
+  A high-severity GuardDuty finding has been identified, which could indicate a host-compromise.
+Runbook: >
+  Search related logs to understand the root cause of the activity.
+Reference:
+  https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings.html#guardduty_findings-severity
+Tests:
+  -
+    Name: High Sev Finding
+    ResourceType: AWS.GuardDuty
+    ExpectedResult: true
+    Resource:
+      {
+        "schemaVersion": "2.0",
+        "accountId": "123456789012",
+        "region": "us-east-1",
+        "partition": "aws",
+        "arn": "arn:aws:guardduty:us-west-2:123456789012:detector/111111bbbbbbbbbb5555555551111111/finding/90b82273685661b9318f078d0851fe9a",
+        "type": "PrivilegeEscalation:IAMUser/AdministrativePermissions",
+        "service": {
+          "serviceName": "guardduty",
+          "detectorId": "111111bbbbbbbbbb5555555551111111",
+          "action": {
+            "actionType": "AWS_API_CALL",
+            "awsApiCallAction": {
+              "api": "PutRolePolicy",
+              "serviceName": "iam.amazonaws.com",
+              "callerType": "Domain",
+              "domainDetails": {
+                "domain": "cloudformation.amazonaws.com"
+              },
+              "affectedResources": {
+                "AWS::IAM::Role": "arn:aws:iam::123456789012:role/IAMRole"
+              }
+            }
+          },
+          "resourceRole": "TARGET",
+          "additionalInfo": {},
+          "evidence": null,
+          "eventFirstSeen": "2020-02-14T17:59:17Z",
+          "eventLastSeen": "2020-02-14T17:59:17Z",
+          "archived": false,
+          "count": 1
+        },
+        "severity": 8,
+        "createdAt": "2020-02-14T18:12:22.316Z",
+        "updatedAt": "2020-02-14T18:12:22.316Z",
+        "title": "Principal AssumedRole:IAMRole attempted to add a policy to themselves that is highly permissive.",
+        "description": "Principal AssumedRole:IAMRole attempted to add a highly permissive policy to themselves."
+      }

--- a/analysis/aws_rules_guardduty/aws_guardduty_low_sev_findings.py
+++ b/analysis/aws_rules_guardduty/aws_guardduty_low_sev_findings.py
@@ -1,0 +1,2 @@
+def rule(event):
+    return 0.1 <= float(event.get('severity', 0)) <= 3.9

--- a/analysis/aws_rules_guardduty/aws_guardduty_low_sev_findings.yml
+++ b/analysis/aws_rules_guardduty/aws_guardduty_low_sev_findings.yml
@@ -1,0 +1,60 @@
+AnalysisType: rule
+Filename: aws_guardduty_low_sev_findings.py
+PolicyID: AWS.GuardDuty.LowSeverityFinding
+DisplayName: AWS GuardDuty Low Severity Finding
+Enabled: true
+ResourceTypes:
+  - AWS.GuardDuty
+Tags:
+  - AWS
+Severity: Low
+Description: >
+  A low-severity GuardDuty finding has been identified, which could indicate a host-compromise.
+Runbook: >
+  Search related logs to understand the root cause of the activity.
+Reference:
+  https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings.html#guardduty_findings-severity
+Tests:
+  -
+    Name: Low Sev Finding
+    ResourceType: AWS.GuardDuty
+    ExpectedResult: true
+    Resource:
+      {
+        "schemaVersion": "2.0",
+        "accountId": "123456789012",
+        "region": "us-east-1",
+        "partition": "aws",
+        "arn": "arn:aws:guardduty:us-west-2:123456789012:detector/111111bbbbbbbbbb5555555551111111/finding/90b82273685661b9318f078d0851fe9a",
+        "type": "PrivilegeEscalation:IAMUser/AdministrativePermissions",
+        "service": {
+          "serviceName": "guardduty",
+          "detectorId": "111111bbbbbbbbbb5555555551111111",
+          "action": {
+            "actionType": "AWS_API_CALL",
+            "awsApiCallAction": {
+              "api": "PutRolePolicy",
+              "serviceName": "iam.amazonaws.com",
+              "callerType": "Domain",
+              "domainDetails": {
+                "domain": "cloudformation.amazonaws.com"
+              },
+              "affectedResources": {
+                "AWS::IAM::Role": "arn:aws:iam::123456789012:role/IAMRole"
+              }
+            }
+          },
+          "resourceRole": "TARGET",
+          "additionalInfo": {},
+          "evidence": null,
+          "eventFirstSeen": "2020-02-14T17:59:17Z",
+          "eventLastSeen": "2020-02-14T17:59:17Z",
+          "archived": false,
+          "count": 1
+        },
+        "severity": 1,
+        "createdAt": "2020-02-14T18:12:22.316Z",
+        "updatedAt": "2020-02-14T18:12:22.316Z",
+        "title": "Principal AssumedRole:IAMRole attempted to add a policy to themselves that is highly permissive.",
+        "description": "Principal AssumedRole:IAMRole attempted to add a highly permissive policy to themselves."
+      }

--- a/analysis/aws_rules_guardduty/aws_guardduty_med_sev_findings.py
+++ b/analysis/aws_rules_guardduty/aws_guardduty_med_sev_findings.py
@@ -1,0 +1,2 @@
+def rule(event):
+    return 4.0 <= float(event.get('severity', 0)) <= 6.9

--- a/analysis/aws_rules_guardduty/aws_guardduty_med_sev_findings.yml
+++ b/analysis/aws_rules_guardduty/aws_guardduty_med_sev_findings.yml
@@ -1,0 +1,60 @@
+AnalysisType: rule
+Filename: aws_guardduty_med_sev_findings.py
+PolicyID: AWS.GuardDuty.MediumSeverityFinding
+DisplayName: AWS GuardDuty Medium Severity Finding
+Enabled: true
+ResourceTypes:
+  - AWS.GuardDuty
+Tags:
+  - AWS
+Severity: Medium
+Description: >
+  A medium-severity GuardDuty finding has been identified, which could indicate a host-compromise.
+Runbook: >
+  Search related logs to understand the root cause of the activity.
+Reference:
+  https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings.html#guardduty_findings-severity
+Tests:
+  -
+    Name: Medium Sev Finding
+    ResourceType: AWS.GuardDuty
+    ExpectedResult: true
+    Resource:
+      {
+        "schemaVersion": "2.0",
+        "accountId": "123456789012",
+        "region": "us-east-1",
+        "partition": "aws",
+        "arn": "arn:aws:guardduty:us-west-2:123456789012:detector/111111bbbbbbbbbb5555555551111111/finding/90b82273685661b9318f078d0851fe9a",
+        "type": "PrivilegeEscalation:IAMUser/AdministrativePermissions",
+        "service": {
+          "serviceName": "guardduty",
+          "detectorId": "111111bbbbbbbbbb5555555551111111",
+          "action": {
+            "actionType": "AWS_API_CALL",
+            "awsApiCallAction": {
+              "api": "PutRolePolicy",
+              "serviceName": "iam.amazonaws.com",
+              "callerType": "Domain",
+              "domainDetails": {
+                "domain": "cloudformation.amazonaws.com"
+              },
+              "affectedResources": {
+                "AWS::IAM::Role": "arn:aws:iam::123456789012:role/IAMRole"
+              }
+            }
+          },
+          "resourceRole": "TARGET",
+          "additionalInfo": {},
+          "evidence": null,
+          "eventFirstSeen": "2020-02-14T17:59:17Z",
+          "eventLastSeen": "2020-02-14T17:59:17Z",
+          "archived": false,
+          "count": 1
+        },
+        "severity": 5,
+        "createdAt": "2020-02-14T18:12:22.316Z",
+        "updatedAt": "2020-02-14T18:12:22.316Z",
+        "title": "Principal AssumedRole:IAMRole attempted to add a policy to themselves that is highly permissive.",
+        "description": "Principal AssumedRole:IAMRole attempted to add a highly permissive policy to themselves."
+      }


### PR DESCRIPTION
### Background

Basic GuardDuty rules for flagging high/medium/low severity findings

### Changes

* ^ 

### Testing

```
$ panther-cli test --policies analysis/aws_rules_guardduty/
[INFO]: Testing Policies in analysis/aws_rules_guardduty/

AWS.GuardDuty.HighSeverityFinding
	[PASS] High Sev Finding

AWS.GuardDuty.LowSeverityFinding
	[PASS] Low Sev Finding

AWS.GuardDuty.MediumSeverityFinding
	[PASS] Medium Sev Finding
```
