### PR TITLE
Rule for Updated Credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 <h1 align="center">Panther Analysis</h1>
 
 <p align="center">
+  <i>Built-in Panther Detections</i>
+</p>
+
+<p align="center">
   <a href="https://docs.runpanther.io">Documentation</a> |
   <a href="https://docs.runpanther.io/quick-start">Quick Start</a>
 </p>
@@ -62,7 +66,7 @@ The following setup will assume that you are using GitHub to host your git repos
   - Set the `Privacy` radio button to `Private` (unless you want your configurations to be public)
   - You will be redirected to a loading page while the repository is being imported. After a short while, you the repository will be available and you can clone it and begin development normally.
 
-#### Setup - git command line 
+#### Setup - git command line
 
 The following setup will use the git command line directly.
 

--- a/analysis/aws_rules_cloudtrail/aws_s3_bucket_deleted.py
+++ b/analysis/aws_rules_cloudtrail/aws_s3_bucket_deleted.py
@@ -2,5 +2,6 @@ def rule(event):
     # Capture DeleteBucket, DeleteBucketPolicy, DeleteBucketWebsite
     return event.get('eventName').startswith('DeleteBucket')
 
+
 def dedup(event):
     return event.get('userIdentity', {}).get('arn')

--- a/analysis/aws_rules_cloudtrail/aws_s3_bucket_deleted.py
+++ b/analysis/aws_rules_cloudtrail/aws_s3_bucket_deleted.py
@@ -1,3 +1,6 @@
 def rule(event):
     # Capture DeleteBucket, DeleteBucketPolicy, DeleteBucketWebsite
     return event.get('eventName').startswith('DeleteBucket')
+
+def dedup(event):
+    return event.get('userIdentity', {}).get('arn')

--- a/analysis/aws_rules_cloudtrail/aws_update_credentials.py
+++ b/analysis/aws_rules_cloudtrail/aws_update_credentials.py
@@ -1,0 +1,9 @@
+UPDATE_EVENTS = {
+    'ChangePassword', 'CreateAccessKey', 'CreateLoginProfile', 'CreateUser'
+}
+
+def rule(event):
+    return event.get('eventName') in UPDATE_EVENTS
+
+def dedup(event):
+    return event.get('userIdentity', {}).get('userName')

--- a/analysis/aws_rules_cloudtrail/aws_update_credentials.py
+++ b/analysis/aws_rules_cloudtrail/aws_update_credentials.py
@@ -2,8 +2,10 @@ UPDATE_EVENTS = {
     'ChangePassword', 'CreateAccessKey', 'CreateLoginProfile', 'CreateUser'
 }
 
+
 def rule(event):
     return event.get('eventName') in UPDATE_EVENTS
+
 
 def dedup(event):
     return event.get('userIdentity', {}).get('userName')

--- a/analysis/aws_rules_cloudtrail/aws_update_credentials.yml
+++ b/analysis/aws_rules_cloudtrail/aws_update_credentials.yml
@@ -7,7 +7,7 @@ ResourceTypes:
   - AWS.CloudTrail
 Tags:
   - AWS
-  - 'S3'
+  - IAM
 Severity: Info
 Description: A new password, access key, or user has been created
 Runbook: This rule is purely informational, there is no action needed.

--- a/analysis/aws_rules_cloudtrail/aws_update_credentials.yml
+++ b/analysis/aws_rules_cloudtrail/aws_update_credentials.yml
@@ -1,0 +1,87 @@
+AnalysisType: rule
+Filename: aws_update_credentials.py
+PolicyID: AWS.IAM.CredentialsUpdated
+DisplayName: New IAM Credentials Issued
+Enabled: true
+ResourceTypes:
+  - AWS.CloudTrail
+Tags:
+  - AWS
+  - 'S3'
+Severity: Info
+Description: A new password, access key, or user has been created
+Runbook: This rule is purely informational, there is no action needed.
+Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/list_identityandaccessmanagement.html
+Tests:
+  -
+    Name: User Password Was Changed
+    ResourceType: AWS.CloudTrail
+    ExpectedResult: true
+    Resource:
+      {
+        "eventVersion": "1.05",
+        "userIdentity": {
+            "type": "IAMUser",
+            "principalId": "AAAAIIIIIIU74NPJW5K76",
+            "arn": "arn:aws:iam::123456789012:user/test_user",
+            "accountId": "123456789012",
+            "accessKeyId": "AAAAIIIIIIU74NPJW5K76",
+            "userName": "test_user",
+            "sessionContext": {
+                "attributes": {
+                    "mfaAuthenticated": "true",
+                    "creationDate": "2019-12-31T01:50:17Z"
+                }
+            },
+            "invokedBy": "signin.amazonaws.com"
+        },
+        "eventTime": "2019-12-31T01:50:46Z",
+        "eventSource": "iam.amazonaws.com",
+        "eventName": "ChangePassword",
+        "awsRegion": "us-east-1",
+        "sourceIPAddress": "64.25.27.224",
+        "userAgent": "signin.amazonaws.com",
+        "requestParameters": null,
+        "responseElements": null,
+        "requestID": "a431f05e-67e1-11ea-bc55-0242ac130003",
+        "eventID": "a431f05e-67e1-11ea-bc55-0242ac130003",
+        "readOnly": false,
+        "eventType": "AwsApiCall",
+        "recipientAccountId": "123456789012"
+      }
+  -
+    Name: MFA Device Was Created
+    ResourceType: AWS.CloudTrail
+    ExpectedResult: false
+    Resource:
+      {
+        "eventVersion": "1.05",
+        "userIdentity": {
+            "type": "IAMUser",
+            "principalId": "AAAAIIIIIIU74NPJW5K76",
+            "arn": "arn:aws:iam::123456789012:user/test_user",
+            "accountId": "123456789012",
+            "accessKeyId": "AAAAIIIIIIU74NPJW5K76",
+            "userName": "test_user",
+            "sessionContext": {
+                "attributes": {
+                    "mfaAuthenticated": "true",
+                    "creationDate": "2019-12-31T01:50:17Z"
+                }
+            },
+            "invokedBy": "signin.amazonaws.com"
+        },
+        "eventTime": "2019-12-31T01:50:46Z",
+        "eventSource": "iam.amazonaws.com",
+        "eventName": "CreateVirtualMFADevice",
+        "awsRegion": "us-east-1",
+        "sourceIPAddress": "64.25.27.224",
+        "userAgent": "signin.amazonaws.com",
+        "requestParameters": null,
+        "responseElements": null,
+        "requestID": "a431f05e-67e1-11ea-bc55-0242ac130003",
+        "eventID": "a431f05e-67e1-11ea-bc55-0242ac130003",
+        "readOnly": false,
+        "eventType": "AwsApiCall",
+        "recipientAccountId": "123456789012"
+      }


### PR DESCRIPTION
### Background

Add a new rule for monitoring IAM credential changes

### Changes

* New rule for `aws_update_credentials.yml`
* Update the dedup key on the `aws_s3_bucket_deleted.py` to group by the ARN deleting the bucket

### Testing

```
$ panther-cli test --policies analysis/aws_rules_cloudtrail/
[INFO]: Testing Policies in analysis/aws_rules_cloudtrail/

AWS.S3.BucketDeleted
	[PASS] An S3 Bucket was deleted
	[PASS] An S3 Object Deleted

AWS.IAM.CredentialsUpdated
	[PASS] User Password Was Changed
	[PASS] MFA Device Was Created
```
