### PR TITLE
Update test procedures and README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,17 @@ install:
 	pipenv install
 
 test:
-	tmp=$$(mktemp -d); \
+	@tmp=$$(mktemp -d); \
 	for d in $(analysis_directories); \
 	do \
 		cp -r $$d "$$tmp"; \
 	done; \
+	panther_analysis_tool test --path "$$tmp"; \
+	rm -r "$$tmp";
+
+test-single:
+	@tmp=$$(mktemp -d); \
+	cp -r globals "$$tmp"; \
+	cp -r $(pack) "$$tmp"; \
 	panther_analysis_tool test --path "$$tmp"; \
 	rm -r "$$tmp";

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,10 @@ install:
 	pipenv install
 
 test:
+	tmp=$$(mktemp -d); \
 	for d in $(analysis_directories); \
 	do \
-		panther_analysis_tool test --path $$d; \
-	done
+		cp -r $$d "$$tmp"; \
+	done; \
+	panther_analysis_tool test --path "$$tmp"; \
+	rm -r "$$tmp";

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ The specification file MUST:
 ## Testing
 Both policies and tests can define unit tests, which can be used to ensure they are performing as expected on test data before pushing them live to a production environment. This can help guarantee correctness of code, as well as protect against exceptions and unexpected behavior. To run these tests, consider using the `panther_analysis_tool` directly or making use of the `Makefile` provided here. For using the `panther_analysis_tool` directly, please refer to the [documentation](https://github.com/panther-labs/panther_analysis_tool).
 
-The benefit of using this Makefile is that (if run from this directory), it will automatically include the `aws_globals` helper functtions.
+The benefit of using this Makefile is that (if run from this directory), it will automatically include the `aws_globals` helper functions.
 
 The `make test` target will test all policies and rules in the packs already in this repo, and this functionality can be expanded by modifying the `Makefile`. The `make test-single` target takes a single parameter, `pack`, and will test just the contents of that directory. Example usage:
 

--- a/README.md
+++ b/README.md
@@ -140,8 +140,6 @@ Tests:
       Based: On the Schema
 ```
 
-Note that unit testing currently does not support function mocks. We recommend not writing unit tests for functions that make network calls, as the behavior may be unexpected.
-
 The requirements for the Policy body and specification files are listed below.
 
 The Python body MUST:
@@ -206,7 +204,6 @@ Tests:
       For: Our Log
       Based: On the Schema
 ```
-Note that unit testing currently does not support function mocks. We recommend not writing unit tests for functions that make network calls, as the behavior may be unexpected.
 
 The requirements for the Rule body and specification files are listed below.
 
@@ -232,6 +229,28 @@ The specification file MUST:
     - PolicyID
     - ResourceTypes
     - Severity
+
+## Testing
+Both policies and tests can define unit tests, which can be used to ensure they are performing as expected on test data before pushing them live to a production environment. This can help guarantee correctness of code, as well as protect against exceptions and unexpected behavior. To run these tests, consider using the `panther_analysis_tool` directly or making use of the `Makefile` provided here. For using the `panther_analysis_tool` directly, please refer to the [documentation](https://github.com/panther-labs/panther_analysis_tool).
+
+The benefit of using this Makefile is that (if run from this directory), it will automatically include the `aws_globals` helper functtions.
+
+The `make test` target will test all policies and rules in the packs already in this repo, and this functionality can be expanded by modifying the `Makefile`. The `make test-single` target takes a single parameter, `pack`, and will test just the contents of that directory. Example usage:
+
+```bash
+make test-single pack=osquery_rules
+[INFO]: Testing analysis packs in /var/folders/p3/l1lxj0057dj01rw34rfr0r8h0000gn/T/tmp.Bq2hgZNI
+
+OSquery.Mac.ALFDisabled
+	[PASS] ALF Disabled
+	[PASS] ALF Enabled
+
+OSquery.Mac.OSXAttacks
+	[PASS] App running on Desktop that is watching keyboard events
+	[PASS] App is running from approved path
+```
+
+Note that unit testing currently does not support function call mocking. We recommend not writing unit tests for functions that make network calls, as the behavior may be unexpected.
 
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following setup will assume that you are using GitHub to host your git repos
 
   - Navigate to github.com while logged in to a user in your organization
   - Select the `+` button drop down in the top right corner, and select `Import repository`
-  - In the `Your old repository's clone URL` section add our public repo: `git@github.com:panther-labs/panther-analysis.git`
+  - In the `Your old repository's clone URL` section add our public repo: `https://github.com/panther-labs/panther-analysis.git`
   - Make sure the `Owner` drop down is set to your organization, and then add a `Name` (such as `panther-analysis-internal`)
   - Set the `Privacy` radio button to `Private` (unless you want your configurations to be public)
   - You will be redirected to a loading page while the repository is being imported. After a short while, you the repository will be available and you can clone it and begin development normally.

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ The specification file MUST:
     - Severity
 
 ## Testing
-Both policies and tests can define unit tests, which can be used to ensure they are performing as expected on test data before pushing them live to a production environment. This can help guarantee correctness of code, as well as protect against exceptions and unexpected behavior. To run these tests, consider using the `panther_analysis_tool` directly or making use of the `Makefile` provided here. For using the `panther_analysis_tool` directly, please refer to the [documentation](https://github.com/panther-labs/panther_analysis_tool).
+Both policies and rules can define unit tests, which can be used to ensure they are performing as expected on test data before pushing them live to a production environment. This can help guarantee correctness of code, as well as protect against exceptions and unexpected behavior. To run these tests, consider using the `panther_analysis_tool` directly or making use of the `Makefile` provided here. For using the `panther_analysis_tool` directly, please refer to the [documentation](https://github.com/panther-labs/panther_analysis_tool).
 
 The benefit of using this Makefile is that (if run from this directory), it will automatically include the `aws_globals` helper functions.
 


### PR DESCRIPTION
### Background

Previously the `make test` command did not work if any policies or rules actually made use of the `aws_globals` file. This is because of the way the `panther_analysis_tool` was being used, it expects to find all files under one root directory and we were not testing it in that way. I've update the Makefile to work first copy all policies/rules into a temporary directory, then run the `panther_analysis_tool` against that directory.

### Changes

* Updated `make test` target
* Updated incorrect line in README (was pointing to a git link when it needed to be an https link)

### Testing

* `make test`
