### PR TITLE
[aws_rules] deduping, helper func, titles

### DIFF
--- a/aws_rules_cis/aws_kms_cmk_loss.py
+++ b/aws_rules_cis/aws_kms_cmk_loss.py
@@ -1,9 +1,14 @@
 # API calls that are indicative of KMS CMK Deletion
-KMS_LOSS_EVENTS = {
-    'DisableKey',
-    'ScheduleKeyDeletion',
-}
+KMS_LOSS_EVENTS = {'DisableKey', 'ScheduleKeyDeletion'}
+KMS_KEY_TYPE = 'AWS::KMS::Key'
 
 
 def rule(event):
     return event.get('eventName') in KMS_LOSS_EVENTS
+
+
+def dedup(event):
+    for resource in event['resources']:
+        if resource['type'] == KMS_KEY_TYPE:
+            return resource['ARN']
+    return None

--- a/aws_rules_cis/aws_s3_bucket_policy_modified.py
+++ b/aws_rules_cis/aws_s3_bucket_policy_modified.py
@@ -13,7 +13,8 @@ S3_POLICY_CHANGE_EVENTS = {
 
 
 def rule(event):
-    return event.get('eventName') in S3_POLICY_CHANGE_EVENTS
+    return event.get(
+        'eventName') in S3_POLICY_CHANGE_EVENTS and not event.get('errorCode')
 
 
 def dedup(event):

--- a/aws_rules_cis/aws_s3_bucket_policy_modified.yml
+++ b/aws_rules_cis/aws_s3_bucket_policy_modified.yml
@@ -74,6 +74,63 @@ Tests:
           "recipientAccountId": "123456789012"
       }
   -
+    Name: S3 Bucket Policy Modified Error Response
+    LogType: AWS.CloudTrail
+    ExpectedResult: false
+    Log:
+      {
+          "eventVersion": "1.05",
+          "userIdentity": {
+              "type": "AssumedRole",
+              "principalId": "1111:tester",
+              "arn": "arn:aws:sts::123456789012:assumed-role/tester",
+              "accountId": "123456789012",
+              "accessKeyId": "1",
+              "sessionContext": {
+                  "attributes": {
+                      "mfaAuthenticated": "true",
+                      "creationDate": "2019-01-01T00:00:00Z"
+                  },
+                  "sessionIssuer": {
+                      "type": "Role",
+                      "principalId": "1111",
+                      "arn": "arn:aws:iam::123456789012:role/tester",
+                      "accountId": "123456789012",
+                      "userName": "tester"
+                  }
+              }
+          },
+          "eventTime": "2019-01-01T00:00:00Z",
+          "eventSource": "s3.amazonaws.com",
+          "errorCode": "AccessDenied",
+          "eventName": "PutBucketAcl",
+          "awsRegion": "us-west-2",
+          "sourceIPAddress": "111.111.111.111",
+          "userAgent": "Mozilla",
+          "requestParameters": {
+              "host": [
+                  "bucket.s3.us-west-2.amazonaws.com"
+              ],
+              "bucketName": "bucket",
+              "acl": [
+                  ""
+              ],
+              "x-amz-acl": [
+                  "private"
+              ]
+          },
+          "responseElements": null,
+          "additionalEventData": {
+              "SignatureVersion": "SigV4",
+              "CipherSuite": "ECDHE-RSA-AES128-GCM-SHA256",
+              "AuthenticationMethod": "AuthHeader"
+          },
+          "requestID": "1",
+          "eventID": "1",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789012"
+      }
+  -
     Name: S3 Bucket Policy Not Modified
     LogType: AWS.CloudTrail
     ExpectedResult: false

--- a/aws_rules_cis/aws_unauthorized_api_call.py
+++ b/aws_rules_cis/aws_unauthorized_api_call.py
@@ -1,12 +1,31 @@
+from ipaddress import ip_address
+
+
 def rule(event):
+    # Validate the request came from outside of AWS
+    try:
+        ip_address(event.get('sourceIpAddress'))
+    except ValueError:
+        return False
     return event.get('errorCode') == 'AccessDenied'
 
 
+def helper_strip_role_session_id(user_identity_arn):
+    # The Arn structure is arn:aws:sts::123456789012:assumed-role/RoleName/<sessionId>
+    arn_parts = user_identity_arn.split('/')
+    if arn_parts:
+        return '/'.join(arn_parts[:2])
+    return user_identity_arn
+
+
 def dedup(event):
-    return event.get('userIdentity', {}).get('arn')
+    user_identity = event.get('userIdentity', {})
+    if user_identity.get('type') == 'AssumedRole':
+        return helper_strip_role_session_id(user_identity.get('arn', ''))
+    return user_identity.get('arn')
 
 
 def title(event):
     user_identity = event.get('userIdentity')
     return 'Access denied to {} {}'.format(user_identity.get('type'),
-                                           user_identity.get('arn'))
+                                           dedup(event))

--- a/aws_rules_cis/aws_unauthorized_api_call.yml
+++ b/aws_rules_cis/aws_unauthorized_api_call.yml
@@ -11,7 +11,7 @@ Reports:
   CIS:
     - 3.1
 Severity: Low
-Description: An unauthorized AWS API call was made.
+Description: An unauthorized AWS API call was made
 Runbook: https://docs.runpanther.io/log-analysis/rules/aws/aws-unauthorized-api-call
 Reference: https://amzn.to/3aOukaA
 Tests:
@@ -41,10 +41,47 @@ Tests:
           "eventSource": "iam.amazonaws.com",
           "eventName": "CreateServiceLinkedRole",
           "awsRegion": "us-east-1",
-          "sourceIPAddress": "111.111.111.111",
+          "sourceIpAddress": "3.10.107.144",
           "userAgent": "signin.amazonaws.com",
           "errorCode": "AccessDenied",
           "errorMessage": "User: arn:aws:iam::123456789012:user/tester is not authorized to perform: iam:Action on resource: arn:aws:iam::123456789012:resource",
+          "requestParameters": null,
+          "responseElements": null,
+          "requestID": "1",
+          "eventID": "1",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789012"
+      }
+  -
+    Name: Unauthorized API Call from Within AWS
+    LogType: AWS.CloudTrail
+    ExpectedResult: false
+    Log:
+      {
+          "eventVersion": "1.05",
+          "userIdentity": {
+              "type": "IAMUser",
+              "principalId": "1111",
+              "arn": "arn:aws:iam::123456789012:user/tester",
+              "accountId": "123456789012",
+              "accessKeyId": "1",
+              "userName": "tester",
+              "sessionContext": {
+                  "attributes": {
+                      "mfaAuthenticated": "true",
+                      "creationDate": "2019-01-01T00:00:00Z"
+                  }
+              },
+              "invokedBy": "signin.amazonaws.com"
+          },
+          "eventTime": "2019-01-01T00:00:00Z",
+          "eventSource": "iam.amazonaws.com",
+          "eventName": "CreateServiceLinkedRole",
+          "awsRegion": "us-east-1",
+          "sourceIpAddress": "sqs.amazonaws.com",
+          "errorCode": "AccessDenied",
+          "errorMessage": "User: arn:aws:iam::123456789012:user/tester is not authorized to perform: iam:Action on resource: arn:aws:iam::123456789012:resource",
+          "userAgent": "sqs.amazonaws.com",
           "requestParameters": null,
           "responseElements": null,
           "requestID": "1",
@@ -78,7 +115,7 @@ Tests:
           "eventSource": "iam.amazonaws.com",
           "eventName": "CreateServiceLinkedRole",
           "awsRegion": "us-east-1",
-          "sourceIPAddress": "111.111.111.111",
+          "sourceIpAddress": "111.111.111.111",
           "userAgent": "signin.amazonaws.com",
           "requestParameters": null,
           "responseElements": null,

--- a/aws_rules_cloudtrail/aws_s3_bucket_deleted.py
+++ b/aws_rules_cloudtrail/aws_s3_bucket_deleted.py
@@ -4,13 +4,18 @@ def rule(event):
         'DeleteBucket') and not event.get('errorCode')
 
 
+def helper_strip_role_session_id(user_identity_arn):
+    # The Arn structure is arn:aws:sts::123456789012:assumed-role/RoleName/<sessionId>
+    arn_parts = user_identity_arn.split('/')
+    if arn_parts:
+        return '/'.join(arn_parts[:2])
+    return user_identity_arn
+
+
 def dedup(event):
     user_identity = event.get('userIdentity', {})
     if user_identity.get('type') == 'AssumedRole':
-        # arn:aws:sts::123456789012:assumed-role/RoleName/<sessionId>
-        arn_parts = user_identity.get('arn', '').split('/')
-        if arn_parts:
-            return '/'.join(arn_parts[:2])
+        return helper_strip_role_session_id(user_identity.get('arn', ''))
     return user_identity.get('arn')
 
 


### PR DESCRIPTION
### Background

There are a couple of emerging themes starting to show:

1. Let's only alert on successful API calls
2. A way to strip the session out of an AssumedRole ARN
3. Formal rule helper support it needed

### Changes

* Tune more AWS rules (see changes for context)

### Testing

* Locally with `panther_analysis_tool`
