### PR TITLE
[aws_policies_s3] fix accidental tag in resource type

### DIFF
--- a/aws_policies_s3/aws_s3_bucket_policy_allow_with_not_principal.yml
+++ b/aws_policies_s3/aws_s3_bucket_policy_allow_with_not_principal.yml
@@ -5,9 +5,9 @@ DisplayName: AWS S3 Bucket Policy Allow With Not Principal
 Enabled: true
 ResourceTypes:
   - AWS.S3.Bucket
-  - Identity & Access Management
 Tags:
   - AWS
+  - Identity & Access Management
 Severity: High
 Description: >
   Prevents the use of a 'Not' principal in conjunction with an allow effect in an S3 bucket policy, which would allow global access for the resource besides the principals specified.

--- a/aws_policies_s3/aws_s3_bucket_principal_restrictions.yml
+++ b/aws_policies_s3/aws_s3_bucket_principal_restrictions.yml
@@ -5,9 +5,9 @@ DisplayName: AWS S3 Bucket Principal Restrictions
 Enabled: true
 ResourceTypes:
   - AWS.S3.Bucket
-  - Identity & Access Management
 Tags:
   - AWS
+  - Identity & Access Management
 Reports:
   PCI:
     - 10.5.1

--- a/aws_policies_s3/aws_s3_bucket_public_access_block.yml
+++ b/aws_policies_s3/aws_s3_bucket_public_access_block.yml
@@ -5,9 +5,9 @@ DisplayName: AWS S3 Bucket Public Access Block
 Enabled: true
 ResourceTypes:
   - AWS.S3.Bucket
-  - Data Protection
 Tags:
   - AWS
+  - Data Protection
 Reports:
   PCI:
     - 2.2.3

--- a/aws_policies_s3/aws_s3_bucket_public_read.yml
+++ b/aws_policies_s3/aws_s3_bucket_public_read.yml
@@ -5,10 +5,9 @@ DisplayName: AWS S3 Bucket Public Read
 Enabled: true
 ResourceTypes:
   - AWS.S3.Bucket
-  - Identity & Access Management
-  - Data Protection
 Tags:
   - AWS
+  - Identity & Access Management
   - Data Protection
 Reports:
   PCI:


### PR DESCRIPTION
### Background

I found an issue where tags were accidentally listed as ResourceTypes. @nhakmiller can you see if any other policies/rules have this issue?

### Changes

* Fix typo in ResourceTypes

### Testing

* CI
