### PR TITLE
[osquery] whitelist photoshop

### DIFF
--- a/osquery_rules/mac/osquery_mac_osx_attacks_keyboard_events.py
+++ b/osquery_rules/mac/osquery_mac_osx_attacks_keyboard_events.py
@@ -12,14 +12,11 @@ APPROVED_PROCESS_PATHS = {
     '/var/*',
 }
 
-QUERIES = {
-    'pack_osx-attacks_Keyboard_Event_Taps',
-    'pack/osx-attacks/Keyboard_Event_Taps'
-}
+APPROVED_APPLICATION_NAMES = {'Adobe Photoshop CC 2019'}
 
 
 def rule(event):
-    if event['name'] not in QUERIES:
+    if 'Keyboard_Event_Taps' not in event['name']:
         return False
 
     if event['action'] != 'added':
@@ -27,6 +24,9 @@ def rule(event):
 
     process_path = event['columns'].get('path')
     if not process_path:
+        return False
+
+    if event['columns'].get('name') in APPROVED_APPLICATION_NAMES:
         return False
 
     # Alert if the process is running outside any of the approved paths
@@ -39,5 +39,4 @@ def dedup(event):
 
 
 def title(event):
-    return 'Keylogger malware detected on {}'.format(
-        event.get('hostIdentifier'))
+    return 'Keylogger detected on {}'.format(event.get('hostIdentifier'))


### PR DESCRIPTION
### Background

Tune the osquery keyboard taps rule

### Changes

* Whitelist photoshop

### Testing

```
Osquery.Mac.ApplicationFirewallSettings
	[PASS] ALF Disabled
	[PASS] ALF Enabled

Osquery.Mac.AutoUpdateEnabled
	[PASS] Auto Updates Disabled
	[PASS] Auto Updates Enabled
	[PASS] Wrong Key

Osquery.Mac.OSXAttacks
	[PASS] Valid malware discovered
	[PASS] Keyboard event taps query is ignored

Osquery.Mac.OSXAttacksKeyboardEvents
	[PASS] App running on Desktop that is watching keyboard events
	[PASS] App is running from approved path
	[PASS] Unrelated query does not alert

Osquery.Mac.UnwantedChromeExtensions
	[PASS] Unwanted Extension Detected
	[PASS] No Unwanted Chrome Extension Detected
```