### PR TITLE
May Update: S3 Rules

### DIFF
--- a/aws_s3_policies/aws_s3_bucket_mfa_delete.yml
+++ b/aws_s3_policies/aws_s3_bucket_mfa_delete.yml
@@ -2,7 +2,7 @@ AnalysisType: policy
 Filename: aws_s3_bucket_mfa_delete.py
 PolicyID: AWS.S3.Bucket.MFADelete
 DisplayName: AWS S3 Bucket MFA Delete
-Enabled: true
+Enabled: false
 ResourceTypes:
   - AWS.S3.Bucket
 Tags:

--- a/aws_s3_rules/aws_s3_access_error.py
+++ b/aws_s3_rules/aws_s3_access_error.py
@@ -1,3 +1,5 @@
+from fnmatch import fnmatch
+
 # https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
 HTTP_STATUS_CODES_TO_MONITOR = {
     400,  # Bad Request
@@ -7,7 +9,8 @@ HTTP_STATUS_CODES_TO_MONITOR = {
 
 
 def rule(event):
-    return event['httpstatus'] in HTTP_STATUS_CODES_TO_MONITOR
+    return (fnmatch(event['operation'], 'REST.*.OBJECT') and
+            event['httpstatus'] in HTTP_STATUS_CODES_TO_MONITOR)
 
 
 def dedup(event):
@@ -15,5 +18,4 @@ def dedup(event):
 
 
 def title(event):
-    return 'Errors found on requests to S3 Bucket {}'.format(
-        event.get('bucket'))
+    return 'Request errors found to S3 Bucket {}'.format(event.get('bucket'))

--- a/aws_s3_rules/aws_s3_access_error.py
+++ b/aws_s3_rules/aws_s3_access_error.py
@@ -1,5 +1,12 @@
+# https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+HTTP_STATUS_CODES_TO_MONITOR = {
+    400, # Bad Request
+    403, # Forbidden
+    405, # Method Not Allowed
+}
+
 def rule(event):
-    return 'errorCode' in event
+    return event['httpstatus'] in HTTP_STATUS_CODES_TO_MONITOR
 
 
 def dedup(event):
@@ -7,4 +14,4 @@ def dedup(event):
 
 
 def title(event):
-    return 'Error When Accessing S3 Bucket {}'.format(event.get('bucket'))
+    return 'Errors found on requests to S3 Bucket {}'.format(event.get('bucket'))

--- a/aws_s3_rules/aws_s3_access_error.py
+++ b/aws_s3_rules/aws_s3_access_error.py
@@ -1,9 +1,10 @@
 # https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
 HTTP_STATUS_CODES_TO_MONITOR = {
-    400, # Bad Request
-    403, # Forbidden
-    405, # Method Not Allowed
+    400,  # Bad Request
+    403,  # Forbidden
+    405,  # Method Not Allowed
 }
+
 
 def rule(event):
     return event['httpstatus'] in HTTP_STATUS_CODES_TO_MONITOR
@@ -14,4 +15,5 @@ def dedup(event):
 
 
 def title(event):
-    return 'Errors found on requests to S3 Bucket {}'.format(event.get('bucket'))
+    return 'Errors found on requests to S3 Bucket {}'.format(
+        event.get('bucket'))

--- a/aws_s3_rules/aws_s3_access_error.yml
+++ b/aws_s3_rules/aws_s3_access_error.yml
@@ -11,7 +11,8 @@ Tags:
   - Security Control
 Severity: Low
 Description: >
-  Checks for errors during S3 access. This could be due to insufficient access permissions, non-existant buckets, or other reasons.
+  Checks for errors during S3 Object access.
+  This could be due to insufficient access permissions, non-existant buckets, or other reasons.
 Runbook: >
   Investigate the specific error and determine if it is an ongoing issue that needs to be addressed or a one off or transient error that can be ignored.
 Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/ErrorCode.html
@@ -27,9 +28,25 @@ Tests:
         "remoteip": "10.106.38.245",
         "requester": "arn:aws:iam::162777425019:user/awslogsdelivery",
         "requestid": "5CDAB4038253B0E4",
-        "operation": "REST.HEAD.BUCKET",
+        "operation": "REST.GET.OBJECT",
         "httpstatus": 403,
         "errorcode": "AccessDenied",
+        "tlsversion": "TLSv1.2"
+      }
+  -
+    Name: 403 on HEAD.BUCKET
+    LogType: AWS.S3ServerAccess
+    ExpectedResult: false
+    Log:
+      {
+        "bucket": "panther-auditlogs",
+        "time": "2020-04-22 07:48:45.000",
+        "remoteip": "10.106.38.245",
+        "requester": "arn:aws:iam::162777425019:user/awslogsdelivery",
+        "requestid": "5CDAB4038253B0E4",
+        "operation": "REST.HEAD.BUCKET",
+        "httpstatus": 403,
+        "errorcode": "InternalServerError",
         "tlsversion": "TLSv1.2"
       }
   -

--- a/aws_s3_rules/aws_s3_access_error.yml
+++ b/aws_s3_rules/aws_s3_access_error.yml
@@ -2,6 +2,7 @@ AnalysisType: rule
 Filename: aws_s3_access_error.py
 RuleID: AWS.S3.ServerAccess.Error
 DisplayName: AWS S3 Access Error
+DedupPeriodMinutes: 720 # 12 hours
 Enabled: true
 LogTypes:
   - AWS.S3ServerAccess
@@ -10,25 +11,40 @@ Tags:
   - Security Control
 Severity: Low
 Description: >
-  Checks for errors during S3 access. This could be due to insufficient access permissions, non-existant buckets, or other many other reasons.
+  Checks for errors during S3 access. This could be due to insufficient access permissions, non-existant buckets, or other reasons.
 Runbook: >
   Investigate the specific error and determine if it is an ongoing issue that needs to be addressed or a one off or transient error that can be ignored.
-Reference:
-  https://docs.aws.amazon.com/AmazonS3/latest/dev/ErrorCode.html
+Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/ErrorCode.html
 Tests:
-  -
-    Name: Access No Error
-    LogType: AWS.S3ServerAccess
-    ExpectedResult: false
-    Log:
-      {
-        "otherFields": "values"
-      }
   -
     Name: Access Error
     LogType: AWS.S3ServerAccess
     ExpectedResult: true
     Log:
       {
-        "errorCode": "NoSuchKey"
+        "bucket": "panther-auditlogs",
+        "time": "2020-04-22 07:48:45.000",
+        "remoteip": "10.106.38.245",
+        "requester": "arn:aws:iam::162777425019:user/awslogsdelivery",
+        "requestid": "5CDAB4038253B0E4",
+        "operation": "REST.HEAD.BUCKET",
+        "httpstatus": 403,
+        "errorcode": "AccessDenied",
+        "tlsversion": "TLSv1.2"
+      }
+  -
+    Name: Internal Server Error
+    LogType: AWS.S3ServerAccess
+    ExpectedResult: false
+    Log:
+      {
+        "bucket": "panther-auditlogs",
+        "time": "2020-04-22 07:48:45.000",
+        "remoteip": "10.106.38.245",
+        "requester": "arn:aws:iam::162777425019:user/awslogsdelivery",
+        "requestid": "5CDAB4038253B0E4",
+        "operation": "REST.HEAD.BUCKET",
+        "httpstatus": 500,
+        "errorcode": "InternalServerError",
+        "tlsversion": "TLSv1.2"
       }

--- a/aws_s3_rules/aws_s3_access_ip_whitelist.py
+++ b/aws_s3_rules/aws_s3_access_ip_whitelist.py
@@ -1,6 +1,6 @@
 from ipaddress import ip_network
-BUCKET_NAMES = {
-    # Example bucket names go here
+BUCKETS_TO_MONITOR = {
+    # Example bucket names to watch go here
 }
 WHITELIST_NETWORKS = {
     # IP addresses (in CIDR notation) indicating approved IP ranges for accessing S3 buckets}
@@ -9,8 +9,8 @@ WHITELIST_NETWORKS = {
 
 
 def rule(event):
-    if BUCKET_NAMES:
-        if event['bucket'] not in BUCKET_NAMES:
+    if BUCKETS_TO_MONITOR:
+        if event['bucket'] not in BUCKETS_TO_MONITOR:
             return False
 
     if 'remoteIP' not in event:

--- a/aws_s3_rules/aws_s3_access_ip_whitelist.py
+++ b/aws_s3_rules/aws_s3_access_ip_whitelist.py
@@ -1,19 +1,25 @@
 from ipaddress import ip_network
-# IP addresses (in CIDR notation) indicating approved IP ranges for accessing S3 buckets
-IP_WHITELIST = {
+BUCKET_NAMES = {
+    # Example bucket names go here
+}
+WHITELIST_NETWORKS = {
+    # IP addresses (in CIDR notation) indicating approved IP ranges for accessing S3 buckets}
     ip_network('10.0.0.0/8'),
 }
 
 
 def rule(event):
-    # Only evaluate if the remoteIP field is present
+    if BUCKET_NAMES:
+        if event['bucket'] not in BUCKET_NAMES:
+            return False
+
     if 'remoteIP' not in event:
         return False
 
     cidr_ip = ip_network(event['remoteIP'])
     return not any(
         cidr_ip.subnet_of(approved_ip_range)
-        for approved_ip_range in IP_WHITELIST)
+        for approved_ip_range in WHITELIST_NETWORKS)
 
 
 def dedup(event):
@@ -21,4 +27,4 @@ def dedup(event):
 
 
 def title(event):
-    return 'Non-Approved Access to S3 Bucket {}'.format(event.get('bucket'))
+    return 'Non-Approved IP access to S3 bucket {}'.format(event.get('bucket'))

--- a/aws_s3_rules/aws_s3_access_ip_whitelist.yml
+++ b/aws_s3_rules/aws_s3_access_ip_whitelist.yml
@@ -2,6 +2,7 @@ AnalysisType: rule
 Filename: aws_s3_access_ip_whitelist.py
 RuleID: AWS.S3.ServerAccess.IPWhitelist
 DisplayName: AWS S3 Access IP Whitelist
+DedupPeriodMinutes: 60 # 1 hour
 Enabled: false
 LogTypes:
   - AWS.S3ServerAccess

--- a/aws_s3_rules/aws_s3_insecure_access.py
+++ b/aws_s3_rules/aws_s3_insecure_access.py
@@ -4,8 +4,8 @@ SECURE_BUCKETS = {
 
 
 def rule(event):
-    return (event['bucket'] in SECURE_BUCKETS and 'ciphersuite' not in event or
-            'tlsVersion' not in event)
+    return (event['bucket'] in SECURE_BUCKETS and
+            'ciphersuite' not in event or 'tlsVersion' not in event)
 
 
 def dedup(event):
@@ -13,4 +13,4 @@ def dedup(event):
 
 
 def title(event):
-    return 'Insecure AWS S3 Access on {}'.format(event.get('bucket'))
+    return 'Insecure AWS S3 access to {}'.format(event.get('bucket'))

--- a/aws_s3_rules/aws_s3_insecure_access.py
+++ b/aws_s3_rules/aws_s3_insecure_access.py
@@ -1,11 +1,5 @@
-SECURE_BUCKETS = {
-    # example-bucket-name,
-}
-
-
 def rule(event):
-    return (event['bucket'] in SECURE_BUCKETS and
-            'ciphersuite' not in event or 'tlsVersion' not in event)
+    return 'ciphersuite' not in event or 'tlsVersion' not in event
 
 
 def dedup(event):

--- a/aws_s3_rules/aws_s3_insecure_access.yml
+++ b/aws_s3_rules/aws_s3_insecure_access.yml
@@ -10,7 +10,7 @@ Tags:
   - AWS
   - Configuration Required
   - Security Control
-Severity: Medium
+Severity: Low
 Description: >
   Checks if HTTP (unencrypted) was used to access objects in an S3 bucket, as opposed to HTTPS (encrypted).
 Runbook: >

--- a/aws_s3_rules/aws_s3_unauthenticated_access.py
+++ b/aws_s3_rules/aws_s3_unauthenticated_access.py
@@ -1,12 +1,9 @@
-# A list of buckets where unauthenticated access is not expected
+# A list of buckets where authenticated access is expected
 AUTH_BUCKETS = {'example-bucket'}
 
 
 def rule(event):
-    if event.get('bucket') not in AUTH_BUCKETS:
-        return False
-
-    return 'requester' not in event
+    return event.get('bucket') in AUTH_BUCKETS and 'requester' not in event
 
 
 def dedup(event):

--- a/aws_s3_rules/aws_s3_unauthenticated_access.py
+++ b/aws_s3_rules/aws_s3_unauthenticated_access.py
@@ -14,4 +14,4 @@ def dedup(event):
 
 
 def title(event):
-    return 'Unauthenticated Access to S3 Bucket  {}'.format(event.get('bucket'))
+    return 'Unauthenticated access to S3 bucket  {}'.format(event.get('bucket'))

--- a/aws_s3_rules/aws_s3_unknown_requester_get_object.py
+++ b/aws_s3_rules/aws_s3_unknown_requester_get_object.py
@@ -1,0 +1,29 @@
+from fnmatch import fnmatch
+
+BUCKET_ROLE_MAPPING = {
+    'panther-bootstrap-processeddata-*': [
+        'arn:aws:sts::*:assumed-role/panther-log-analysis-AthenaApiFunctionRole-*/panther-athena-api',
+        'arn:aws:sts::*:assumed-role/panther-cloud-security-EventProcessorFunctionRole-*/panther-aws-event-processor',
+        'arn:aws:sts::*:assumed-role/panther-log-analysis-RulesEngineFunctionRole-*/panther-rules-engine'
+    ]
+}
+
+def _unknown_requester_access(event):
+    for bucket_pattern, role_patterns in event.items():
+        if not fnmatch(bucket_pattern, event['bucket']):
+            continue
+        if not any([fnmatch(role, event['requester']) for role in role_patterns]):
+            return True
+    return False
+
+def rule(event):
+    return (event['operation'] == 'REST.GET.OBJECT' and
+            _unknown_requester_access(event))
+
+
+def dedup(event):
+    return event.get('bucket')
+
+
+def title(event):
+    return 'Unknown requester pulling data from S3 bucket {}'.format(event.get('bucket'))

--- a/aws_s3_rules/aws_s3_unknown_requester_get_object.py
+++ b/aws_s3_rules/aws_s3_unknown_requester_get_object.py
@@ -8,13 +8,18 @@ BUCKET_ROLE_MAPPING = {
     ]
 }
 
+
 def _unknown_requester_access(event):
-    for bucket_pattern, role_patterns in event.items():
-        if not fnmatch(bucket_pattern, event['bucket']):
+    for bucket_pattern, role_patterns in BUCKET_ROLE_MAPPING.items():
+        if not fnmatch(event['bucket'], bucket_pattern):
             continue
-        if not any([fnmatch(role, event['requester']) for role in role_patterns]):
+        if not any([
+                fnmatch(event['requester'], role_pattern)
+                for role_pattern in role_patterns
+        ]):
             return True
     return False
+
 
 def rule(event):
     return (event['operation'] == 'REST.GET.OBJECT' and
@@ -26,4 +31,5 @@ def dedup(event):
 
 
 def title(event):
-    return 'Unknown requester pulling data from S3 bucket {}'.format(event.get('bucket'))
+    return 'Unknown requester pulling data from S3 bucket {}'.format(
+        event.get('bucket'))

--- a/aws_s3_rules/aws_s3_unknown_requester_get_object.yml
+++ b/aws_s3_rules/aws_s3_unknown_requester_get_object.yml
@@ -1,8 +1,8 @@
 AnalysisType: rule
-Filename: aws_s3_insecure_access.py
-RuleID: AWS.S3.ServerAccess.Insecure
-DisplayName: AWS S3 Insecure Access
-DedupPeriodMinutes: 720 # 12 hours
+Filename: aws_s3_unknown_requester_get_object.py
+RuleID: AWS.S3.ServerAccess.UnknownRequester
+DisplayName: AWS S3 Unknown Requester
+DedupPeriodMinutes: 60 # 1 hour
 Enabled: true
 LogTypes:
   - AWS.S3ServerAccess
@@ -10,27 +10,28 @@ Tags:
   - AWS
   - Configuration Required
   - Security Control
-Severity: Medium
+Reports:
+  Panther:
+    - Data Access
+Severity: Low
 Description: >
-  Checks if HTTP (unencrypted) was used to access objects in an S3 bucket, as opposed to HTTPS (encrypted).
+  Checks for S3 access attempts where the requester is not an authenticated AWS user.
 Runbook: >
-  Add a condition on the S3 bucket policy that denies access via http.
-Reference:
-  https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-policy-for-config-rule/
+  If unathenticated S3 access is not expected for this bucket, update it's access policies.
 Tests:
   -
-    Name: Secure Access to S3 Bucket
+    Name: Expected Access
     LogType: AWS.S3ServerAccess
     ExpectedResult: false
     Log:
       {
         "bucketowner": "f16a9e81a6589df1c902c86f7982fd14a88787db",
-        "bucket": "cloudtrail",
+        "bucket": "panther-bootstrap-processeddata-AF1341JAK",
         "time": "2020-02-14 00:53:48.000000000",
         "remoteip": "127.0.0.1",
-        "requester": "arn:aws:sts::123456789012:assumed-role/eagle/regionalDeliverySession",
+        "requester": "arn:aws:sts::123456789012:assumed-role/panther-log-analysis-AthenaApiFunctionRole-1KK31J1/panther-athena-api",
         "requestid": "101B7403B9828743",
-        "operation": "REST.PUT.OBJECT",
+        "operation": "REST.GET.OBJECT",
         "key": "AWSLogs/o-wwwwwwgggg/234567890123/CloudTrail-Digest/ca-central-1/2020/02/14/234567890123_CloudTrail-Digest_ca-central-1_POrgTrail_us-east-1_20200214T001007Z.json.gz",
         "requesturi": "PUT /AWSLogs/o-wwwwwwgggg/234567890123/CloudTrail-Digest/ca-central-1/2020/02/14/234567890123_CloudTrail-Digest_ca-central-1_POrgTrail_us-east-1_20200214T001007Z.json.gz HTTP/1.1",
         "httpstatus": 200,
@@ -43,30 +44,21 @@ Tests:
         "ciphersuite": "ECDHE-RSA-AES128-SHA",
         "authenticationtype": "AuthHeader",
         "hostheader": "cloudtrail.s3.us-east-1.amazonaws.com",
-        "tlsVersion": "TLSv1.2",
-        "p_log_type": "AWS.S3ServerAccess",
-        "p_row_id": "8855aa99ff77abc8dcb0e36e0a",
-        "p_event_time": "2020-02-14 00:53:48.000000000",
-        "p_any_ip_addresses": [
-          "55.99.86.234"
-        ],
-        "p_any_aws_arns": [
-          "arn:aws:sts::123456789012:assumed-role/eagle/regionalDeliverySession"
-        ]
+        "tlsVersion": "TLSv1.2"
       }
   -
-    Name: Insecure Access to S3 Bucket
+    Name: Unexpected Access
     LogType: AWS.S3ServerAccess
     ExpectedResult: true
     Log:
       {
         "bucketowner": "f16a9e81a6589df1c902c86f7982fd14a88787db",
-        "bucket": "cloudtrail",
+        "bucket": "panther-bootstrap-processeddata-AF1341JAK",
         "time": "2020-02-14 00:53:48.000000000",
         "remoteip": "127.0.0.1",
-        "requester": "arn:aws:sts::123456789012:assumed-role/eagle/regionalDeliverySession",
+        "requester": "arn:aws:iam::123456789012:user/jim-bob",
         "requestid": "101B7403B9828743",
-        "operation": "REST.PUT.OBJECT",
+        "operation": "REST.GET.OBJECT",
         "key": "AWSLogs/o-wwwwwwgggg/234567890123/CloudTrail-Digest/ca-central-1/2020/02/14/234567890123_CloudTrail-Digest_ca-central-1_POrgTrail_us-east-1_20200214T001007Z.json.gz",
         "requesturi": "PUT /AWSLogs/o-wwwwwwgggg/234567890123/CloudTrail-Digest/ca-central-1/2020/02/14/234567890123_CloudTrail-Digest_ca-central-1_POrgTrail_us-east-1_20200214T001007Z.json.gz HTTP/1.1",
         "httpstatus": 200,
@@ -76,15 +68,8 @@ Tests:
         "useragent": "aws-internal/3 aws-sdk-java/1.11.714 Linux/4.9.184-0.1.ac.235.83.329.metal1.x86_64 OpenJDK_64-Bit_Server_VM/25.242-b08 java/1.8.0_242 vendor/Oracle_Corporation",
         "hostid": "neRpT/AXRsS3LMBqq/wND59opwPRWWKn7F6evEhdbS99me5fyIXpVI/MMIn6ECgU1YZAqwuF8Bw=",
         "signatureversion": "SigV4",
+        "ciphersuite": "ECDHE-RSA-AES128-SHA",
         "authenticationtype": "AuthHeader",
         "hostheader": "cloudtrail.s3.us-east-1.amazonaws.com",
-        "p_log_type": "AWS.S3ServerAccess",
-        "p_row_id": "8855aa99ff77abc8dcb0e36e0a",
-        "p_event_time": "2020-02-14 00:53:48.000000000",
-        "p_any_ip_addresses": [
-          "55.99.86.234"
-        ],
-        "p_any_aws_arns": [
-          "arn:aws:sts::123456789012:assumed-role/eagle/regionalDeliverySession"
-        ]
+        "tlsVersion": "TLSv1.2"
       }

--- a/aws_s3_rules/aws_s3_unknown_requester_get_object.yml
+++ b/aws_s3_rules/aws_s3_unknown_requester_get_object.yml
@@ -14,10 +14,8 @@ Reports:
   Panther:
     - Data Access
 Severity: Low
-Description: >
-  Checks for S3 access attempts where the requester is not an authenticated AWS user.
-Runbook: >
-  If unathenticated S3 access is not expected for this bucket, update it's access policies.
+Description: Validates that proper IAM entities are accessing sensitive data buckets.
+Runbook: If the S3 access is not expected for this bucket, investigate the requester's other traffic.
 Tests:
   -
     Name: Expected Access


### PR DESCRIPTION
### Background

A general audit and refresh of our S3 access log rules

### Changes

* Disable MFA delete policy by default
* Tune S3 access log rules, disable some by default, update severities and test cases

### Testing

Locally:

```
[INFO]: Testing analysis packs in aws_s3_rules/

AWS.S3.ServerAccess.Error
	[PASS] Access Error
	[PASS] Internal Server Error

AWS.S3.ServerAccess.IPWhitelist
	[PASS] Access From Approved IP
	[PASS] Access From Unapproved IP

AWS.S3.ServerAccess.Insecure
	[PASS] Secure Access to S3 Bucket
	[PASS] Insecure Access to S3 Bucket

AWS.S3.ServerAccess.Unauthenticated
	[PASS] Authenticated Access
	[PASS] Unauthenticated Access

AWS.S3.ServerAccess.UnknownRequester
	[PASS] Expected Access
	[PASS] Unexpected Access
```
