### PR TITLE
Add default global

### DIFF
--- a/global_helpers/panther_default.py
+++ b/global_helpers/panther_default.py
@@ -1,0 +1,9 @@
+# Define common code here that all of your policies and rules can share.
+#
+# Example usage:
+#
+# import panther
+# def policy(resource):
+#     return panther.example_helper()
+def example_helper():
+    return True

--- a/global_helpers/panther_default.yml
+++ b/global_helpers/panther_default.yml
@@ -1,0 +1,4 @@
+AnalysisType: global
+GlobalID: panther
+Filename: panther_default.py
+Description: The default global accessible via the Panther web UI.


### PR DESCRIPTION
### Background

By default, the only global accessible via the web UI is the one with the ID `panther`. This change adds this global to the default analysis pack so that users who want a CLI first workflow can still manage this out of the box global.

### Changes

* Added the default global

### Testing

* `make ci`
