### PR TITLE
fix: typo in the one of the rules

### DIFF
--- a/aws_account_policies/aws_password_policy_complexity_guidelines.yml
+++ b/aws_account_policies/aws_password_policy_complexity_guidelines.yml
@@ -44,7 +44,7 @@ Tests:
         "RequireUppercaseCharacters": true
       }
   -
-    Name: Password Policyu Does Not Require Numbers
+    Name: Password Policy Does Not Require Numbers
     ResourceType: AWS.PasswordPolicy
     ExpectedResult: false
     Resource:


### PR DESCRIPTION
### Background

Spelling mistake `Policyu` -> `Policy`

### Changes

* Fixed spelling

### Testing

* n/a
