### PR TITLE
tune s3 error rule

### DIFF
--- a/aws_cloudtrail_rules/aws_unauthorized_api_call.yml
+++ b/aws_cloudtrail_rules/aws_unauthorized_api_call.yml
@@ -11,7 +11,7 @@ Tags:
 Reports:
   CIS:
     - 3.1
-Severity: Low
+Severity: Info
 Description: An unauthorized AWS API call was made
 Runbook: https://docs.runpanther.io/log-analysis/rules/built-in-rule-runbooks/aws-unauthorized-api-call
 Reference: https://amzn.to/3aOukaA

--- a/aws_s3_rules/aws_s3_access_error.py
+++ b/aws_s3_rules/aws_s3_access_error.py
@@ -8,6 +8,9 @@ HTTP_STATUS_CODES_TO_MONITOR = {
 
 
 def rule(event):
+    if event.get('useragent', '').startswith('aws-internal'):
+        return False
+
     return (pattern_match(event.get('operation'), 'REST.*.OBJECT') and
             event.get('httpstatus') in HTTP_STATUS_CODES_TO_MONITOR)
 

--- a/aws_s3_rules/aws_s3_access_error.yml
+++ b/aws_s3_rules/aws_s3_access_error.yml
@@ -18,6 +18,32 @@ Runbook: >
 Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/ErrorCode.html
 Tests:
   -
+    Name: Amazon Access Error
+    LogType: AWS.S3ServerAccess
+    ExpectedResult: false
+    Log:
+      {
+        "authenticationtype": "AuthHeader",
+        "bucket": "cloudtrail",
+        "bucketowner": "2c8e3610de4102c8e3610de4102c8e3610de410",
+        "bytessent": 9438,
+        "ciphersuite": "ECDHE-RSA-AES128-SHA",
+        "errorcode": "SignatureDoesNotMatch",
+        "hostheader": "cloudtrail.s3.us-west-2.amazonaws.com",
+        "hostid": "2c8e3610de4102c8e3610de4102c8e3610de410",
+        "httpstatus": 403,
+        "key": "AWSLogs/o-3h3h3h3h3h/123456789012/CloudTrail/us-east-1/2020/06/21/123456789012_CloudTrail_us-east-1_20200621T2035Z_ZqQWc4WNXOQUiIic.json.gz",
+        "operation": "REST.PUT.OBJECT",
+        "remoteip": "54.159.198.108",
+        "requestid": "8EFD962F22F2A510",
+        "requesturi": "PUT /AWSLogs/o-wyibehgf3h/123456789012/CloudTrail/us-east-1/2020/06/21/123456789012_CloudTrail_us-east-1_20200621T2035Z_ZqQWc4WNXOQUiIic.json.gz HTTP/1.1",
+        "signatureversion": "SigV4",
+        "time": "2020-06-21 20:41:25.000000000",
+        "tlsVersion": "TLSv1.2",
+        "totaltime": 9,
+        "useragent": "aws-internal/3"
+      }
+  -
     Name: Access Error
     LogType: AWS.S3ServerAccess
     ExpectedResult: true


### PR DESCRIPTION
### Background

Ignore errors when sending from Amazon

### Changes

* Move the AccessDenied rule to INFO (it's required for CIS still)
* Adjust the s3 error rule to ignore Amazon incomplete body errors

### Testing

* CLI
