### PR TITLE
ignore service linked role creation

### DIFF
--- a/aws_cloudtrail_rules/aws_root_activity.py
+++ b/aws_cloudtrail_rules/aws_root_activity.py
@@ -1,11 +1,13 @@
 from panther import lookup_aws_account_name  # pylint: disable=import-error
 
+EVENT_ALLOW_LIST = {'CreateServiceLinkedRole', 'ConsoleLogin'}
+
 
 def rule(event):
     return (event['userIdentity'].get('type') == 'Root' and
             event['userIdentity'].get('invokedBy') is None and
             event['eventType'] != 'AwsServiceEvent' and
-            event['eventName'] != 'ConsoleLogin')
+            event['eventName'] not in EVENT_ALLOW_LIST)
 
 
 def dedup(event):

--- a/aws_cloudtrail_rules/aws_root_activity.yml
+++ b/aws_cloudtrail_rules/aws_root_activity.yml
@@ -19,6 +19,57 @@ Runbook: >
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html
 Tests:
   -
+    Name: Root Activity - CreateServiceLinkedRole
+    LogType: AWS.CloudTrail
+    ExpectedResult: false
+    Log:
+      {
+          "eventVersion": "1.05",
+          "userIdentity": {
+              "type": "Root",
+              "principalId": "123456789012",
+              "arn": "arn:aws:iam::123456789012:root",
+              "accountId": "123456789012",
+              "accessKeyId": "1",
+              "sessionContext": {
+                  "attributes": {
+                      "mfaAuthenticated": "false",
+                      "creationDate": "2019-01-01T00:00:00Z"
+                  }
+              }
+          },
+          "eventTime": "2019-01-01T00:00:00Z",
+          "eventSource": "s3.amazonaws.com",
+          "eventName": "CreateServiceLinkedRole",
+          "awsRegion": "us-west-2",
+          "sourceIPAddress": "111.111.111.111",
+          "userAgent": "Mozilla",
+          "requestParameters": {
+              "bucketName": "bucket",
+              "versioning": [
+                  ""
+              ],
+              "host": [
+                  "bucket.s3.us-west-2.amazonaws.com"
+              ],
+              "VersioningConfiguration": {
+                  "Status": "Enabled",
+                  "xmlns": "http://s3.amazonaws.com/doc/2006-03-01/",
+                  "MfaDelete": "Enabled"
+              }
+          },
+          "responseElements": null,
+          "additionalEventData": {
+              "SignatureVersion": "SigV4",
+              "CipherSuite": "ECDHE-RSA-AES128-GCM-SHA256",
+              "AuthenticationMethod": "AuthHeader"
+          },
+          "requestID": "1",
+          "eventID": "1",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789012"
+      }
+  -
     Name: Root Activity
     LogType: AWS.CloudTrail
     ExpectedResult: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,5 @@
-# Functional Dependencies
-panther-analysis-tool==0.3.0
-policyuniverse==1.3.2.2
-
-# CI Dependencies
-bandit==1.6.2
-mypy==0.770
-pylint==2.5.2
-yapf==0.30.0
-## The following requirements were added by pip freeze:
 astroid==2.4.1
+bandit==1.6.2
 boto3==1.12.22
 botocore==1.15.24
 contextlib2==0.5.5
@@ -21,10 +12,14 @@ isort==4.3.21
 jmespath==0.9.5
 lazy-object-proxy==1.4.1
 mccabe==0.6.1
+mypy==0.782
 mypy-extensions==0.4.3
 nose==1.3.7
+panther-analysis-tool==0.3.2
 pbr==5.4.1
+policyuniverse==1.3.2.2
 pyfakefs==4.0.2
+pylint==2.5.3
 python-dateutil==2.8.1
 PyYAML==5.1.1
 s3transfer==0.3.3
@@ -38,3 +33,4 @@ typed-ast==1.4.0
 typing-extensions==3.7.4
 urllib3==1.25.8
 wrapt==1.11.2
+yapf==0.30.0


### PR DESCRIPTION
### Background

It appears that the action of creating a ServiceLinkedRole is coming from Amazon upon account creation - adding it to the allow list for now.

### Changes

* Update CloudTrail Root rule
* Upgrade dev requirements
* Add test case

Tested locally with the PAT