### PR TITLE
Escape quotes when using shlex.split()

### DIFF
--- a/osquery_rules/osquery_linux_aws_commands.py
+++ b/osquery_rules/osquery_linux_aws_commands.py
@@ -12,7 +12,8 @@ def rule(event):
     command = event['columns'].get('command')
     if not command:
         return False
-    command_args = shlex.split(command.replace("'", "\\'")) # escape single quotes
+    command_args = shlex.split(command.replace("'",
+                                               "\\'")) # escape single quotes
 
     if command_args[0] == 'aws':
         return True

--- a/osquery_rules/osquery_linux_aws_commands.py
+++ b/osquery_rules/osquery_linux_aws_commands.py
@@ -12,7 +12,7 @@ def rule(event):
     command = event['columns'].get('command')
     if not command:
         return False
-    command_args = shlex.split(command)
+    command_args = shlex.split(command.replace("'", "\\'")) # escape single quotes
 
     if command_args[0] == 'aws':
         return True

--- a/osquery_rules/osquery_linux_aws_commands.py
+++ b/osquery_rules/osquery_linux_aws_commands.py
@@ -13,7 +13,7 @@ def rule(event):
     if not command:
         return False
     command_args = shlex.split(command.replace("'",
-                                               "\\'")) # escape single quotes
+                                               "\\'"))  # escape single quotes
 
     if command_args[0] == 'aws':
         return True

--- a/osquery_rules/osquery_linux_aws_commands.yml
+++ b/osquery_rules/osquery_linux_aws_commands.yml
@@ -46,3 +46,18 @@ Tests:
           "username": "ubuntu"
         }
       }
+  -
+    Name:  Command with quote executed
+    LogType: Osquery.Differential
+    ExpectedResult: false
+    Log:
+      {
+        "name": "pack_incident-response_shell_history",
+        "action": "added",
+        "columns": {
+          "command": "git commit -m 'all done'",
+          "uid": "1000",
+          "directory": "/home/ubuntu",
+          "username": "ubuntu"
+        }
+      }

--- a/osquery_rules/osquery_suspicious_cron.py
+++ b/osquery_rules/osquery_suspicious_cron.py
@@ -25,7 +25,7 @@ def suspicious_cmd_pairs(command):
 
 def suspicious_cmd_args(command):
     command_args = shlex.split(command.replace("'",
-                                               "\\'")) # escape single quotes
+                                               "\\'"))  # escape single quotes
     for cmd in command_args:
         if any([fnmatch(cmd, c) for c in SUSPICIOUS_CRON_CMD_ARGS]):
             return True

--- a/osquery_rules/osquery_suspicious_cron.py
+++ b/osquery_rules/osquery_suspicious_cron.py
@@ -24,7 +24,7 @@ def suspicious_cmd_pairs(command):
 
 
 def suspicious_cmd_args(command):
-    command_args = shlex.split(command)
+    command_args = shlex.split(command.replace("'", "\\'")) # escape single quotes
     for cmd in command_args:
         if any([fnmatch(cmd, c) for c in SUSPICIOUS_CRON_CMD_ARGS]):
             return True

--- a/osquery_rules/osquery_suspicious_cron.py
+++ b/osquery_rules/osquery_suspicious_cron.py
@@ -24,7 +24,8 @@ def suspicious_cmd_pairs(command):
 
 
 def suspicious_cmd_args(command):
-    command_args = shlex.split(command.replace("'", "\\'")) # escape single quotes
+    command_args = shlex.split(command.replace("'",
+                                               "\\'")) # escape single quotes
     for cmd in command_args:
         if any([fnmatch(cmd, c) for c in SUSPICIOUS_CRON_CMD_ARGS]):
             return True

--- a/osquery_rules/osquery_suspicious_cron.yml
+++ b/osquery_rules/osquery_suspicious_cron.yml
@@ -111,3 +111,22 @@ Tests:
           "path": "/etc/crontab"
         }
       }
+  -
+    Name: Command with quotes
+    LogType: Osquery.Differential
+    ExpectedResult: false
+    Log:
+      {
+        "name": "pack_incident-response_crontab",
+        "action": "added",
+        "columns": {
+          "event": "",
+          "minute": "17",
+          "hour": "*",
+          "day_of_month": "*",
+          "month": "*",
+          "day_of_week": "7",
+          "command": "runit 'go fast'",
+          "path": "/etc/crontab"
+        }
+      }


### PR DESCRIPTION
### Background
Got a pager alert on a failed rule. Issue was not handing quoted strings in shlex.split()

### Changes

* escape input to shlex.split()

### Testing

* make test
