### PR TITLE
fix: renamed the tests to have different names, cleaned up object

### DIFF
--- a/aws_cloudtrail_rules/aws_iam_user_recon_denied.yml
+++ b/aws_cloudtrail_rules/aws_iam_user_recon_denied.yml
@@ -16,7 +16,44 @@ Runbook: Analyze the IP they came from, and other actions taken before/after.
 Reference: https://runpanther.io
 Tests:
   -
-    Name: Unauthorized API Call from Within AWS
+    Name: Unauthorized API Call from Within AWS (IP)
+    LogType: AWS.CloudTrail
+    ExpectedResult: false
+    Log:
+      {
+          "eventVersion": "1.05",
+          "userIdentity": {
+              "type": "IAMUser",
+              "principalId": "1111",
+              "arn": "arn:aws:iam::123456789012:user/tester",
+              "accountId": "123456789012",
+              "accessKeyId": "1",
+              "userName": "tester",
+              "sessionContext": {
+                  "attributes": {
+                      "mfaAuthenticated": "true",
+                      "creationDate": "2019-01-01T00:00:00Z"
+                  }
+              },
+              "invokedBy": "signin.amazonaws.com"
+          },
+          "eventTime": "2019-01-01T00:00:00Z",
+          "eventSource": "iam.amazonaws.com",
+          "eventName": "CreateServiceLinkedRole",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "3.10.107.144",
+          "errorCode": "AccessDenied",
+          "errorMessage": "User: arn:aws:iam::123456789012:user/tester is not authorized to perform: iam:Action on resource: arn:aws:iam::123456789012:resource",
+          "userAgent": "sqs.amazonaws.com",
+          "requestParameters": null,
+          "responseElements": null,
+          "requestID": "1",
+          "eventID": "1",
+          "eventType": "AwsApiCall",
+          "recipientAccountId": "123456789012"
+      }
+  -
+    Name: Unauthorized API Call from Within AWS (FQDN)
     LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:

--- a/aws_cloudtrail_rules/aws_iam_user_recon_denied.yml
+++ b/aws_cloudtrail_rules/aws_iam_user_recon_denied.yml
@@ -16,43 +16,6 @@ Runbook: Analyze the IP they came from, and other actions taken before/after.
 Reference: https://runpanther.io
 Tests:
   -
-    Name: Unauthorized API Call from Within AWS (IP)
-    LogType: AWS.CloudTrail
-    ExpectedResult: false
-    Log:
-      {
-          "eventVersion": "1.05",
-          "userIdentity": {
-              "type": "IAMUser",
-              "principalId": "1111",
-              "arn": "arn:aws:iam::123456789012:user/tester",
-              "accountId": "123456789012",
-              "accessKeyId": "1",
-              "userName": "tester",
-              "sessionContext": {
-                  "attributes": {
-                      "mfaAuthenticated": "true",
-                      "creationDate": "2019-01-01T00:00:00Z"
-                  }
-              },
-              "invokedBy": "signin.amazonaws.com"
-          },
-          "eventTime": "2019-01-01T00:00:00Z",
-          "eventSource": "iam.amazonaws.com",
-          "eventName": "CreateServiceLinkedRole",
-          "awsRegion": "us-east-1",
-          "sourceIPAddress": "3.10.107.144",
-          "errorCode": "AccessDenied",
-          "errorMessage": "User: arn:aws:iam::123456789012:user/tester is not authorized to perform: iam:Action on resource: arn:aws:iam::123456789012:resource",
-          "userAgent": "sqs.amazonaws.com",
-          "requestParameters": null,
-          "responseElements": null,
-          "requestID": "1",
-          "eventID": "1",
-          "eventType": "AwsApiCall",
-          "recipientAccountId": "123456789012"
-      }
-  -
     Name: Unauthorized API Call from Within AWS (FQDN)
     LogType: AWS.CloudTrail
     ExpectedResult: false

--- a/aws_cloudtrail_rules/aws_unauthorized_api_call.yml
+++ b/aws_cloudtrail_rules/aws_unauthorized_api_call.yml
@@ -17,7 +17,7 @@ Runbook: https://docs.runpanther.io/log-analysis/rules/built-in-rule-runbooks/aw
 Reference: https://amzn.to/3aOukaA
 Tests:
   -
-    Name: Unauthorized API Call
+    Name: Unauthorized API Call from Within AWS (IP)
     LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
@@ -43,9 +43,9 @@ Tests:
           "eventName": "CreateServiceLinkedRole",
           "awsRegion": "us-east-1",
           "sourceIPAddress": "3.10.107.144",
-          "userAgent": "signin.amazonaws.com",
           "errorCode": "AccessDenied",
           "errorMessage": "User: arn:aws:iam::123456789012:user/tester is not authorized to perform: iam:Action on resource: arn:aws:iam::123456789012:resource",
+          "userAgent": "sqs.amazonaws.com",
           "requestParameters": null,
           "responseElements": null,
           "requestID": "1",
@@ -54,7 +54,7 @@ Tests:
           "recipientAccountId": "123456789012"
       }
   -
-    Name: Unauthorized API Call from Within AWS
+    Name: Unauthorized API Call from Within AWS (FQDN)
     LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:


### PR DESCRIPTION
### Background

There was a bug in a rule causing the frontend to prevent the user from updating a rule because it has two tests with the same name.

### Changes

* Renamed the tests to have the suffix `(IP)` and `(FQDN)` respectively
* Cleaned up duplicate object attributes, added an extra test to match internal.

### Testing

* Locally and in the frontend.
