### PR TITLE
Fix recon rule

### DIFF
--- a/aws_cloudtrail_policies/aws_cloudtrail_s3_bucket_public.yml
+++ b/aws_cloudtrail_policies/aws_cloudtrail_s3_bucket_public.yml
@@ -10,6 +10,7 @@ Tags:
   - Data Protection
 Reports:
   CIS:
+    - 2.3
 Severity: High
 Description: >
   This policy validates that CloudTrail S3 buckets are not publicly accessible.

--- a/aws_cloudtrail_rules/aws_iam_user_recon_denied.py
+++ b/aws_cloudtrail_rules/aws_iam_user_recon_denied.py
@@ -32,18 +32,18 @@ def rule(event):
         if event['eventSource'].startswith(event_source) and any(
                 fnmatch(event['eventName'], event_pattern)
                 for event_pattern in event_patterns):
-            return True
+            return evaluate_threshold(
+                '{}-AccessDeniedCounter'.format(
+                    event['userIdentity'].get('arn')),
+                THRESH,
+                THRESH_TTL,
+            )
 
-    # Return an alert if the threshold was exceeded
-    return evaluate_threshold(
-        '{}-AccessDeniedCounter'.format(event['userIdentity'].get('arn')),
-        THRESH,
-        THRESH_TTL,
-    )
+    return False
 
 
 def dedup(event):
-    return event['userIdentity']['arn']
+    return event['userIdentity'].get('arn')
 
 
 def title(event):

--- a/aws_config_policies/aws_config_global_resources.yml
+++ b/aws_config_policies/aws_config_global_resources.yml
@@ -8,8 +8,6 @@ ResourceTypes:
 Tags:
   - AWS
   - Security Control
-Reports:
-  CIS:
 Severity: Low
 Description: >
   You can have AWS Config record supported types of global resources, such as

--- a/aws_iam_policies/aws_password_unused.yml
+++ b/aws_iam_policies/aws_password_unused.yml
@@ -10,6 +10,7 @@ Tags:
   - Identity & Access Management
 Reports:
   CIS:
+    - 1.3
   PCI:
     - 8.1.4
 Severity: Low

--- a/aws_iam_policies/aws_root_account_access_keys.yml
+++ b/aws_iam_policies/aws_root_account_access_keys.yml
@@ -10,6 +10,7 @@ Tags:
   - Identity & Access Management
 Reports:
   CIS:
+    - 1.12
   PCI:
     - 7.1.2
     - 8.5

--- a/aws_iam_policies/aws_root_account_hardware_mfa.yml
+++ b/aws_iam_policies/aws_root_account_hardware_mfa.yml
@@ -10,6 +10,8 @@ Tags:
   - Identity & Access Management
 Reports:
   CIS:
+    - 1.13
+    - 1.14
   PCI:
     - 7.1.2
 Severity: High

--- a/aws_vpc_policies/aws_security_group_administrative_ingress.yml
+++ b/aws_vpc_policies/aws_security_group_administrative_ingress.yml
@@ -10,6 +10,8 @@ Tags:
   - Security Control
 Reports:
   CIS:
+    - 4.1
+    - 4.2
 Severity: High
 Description: >
   This policy validates that AWS Security Groups don't allow unrestricted inbound traffic on

--- a/aws_vpc_policies/aws_vpc_flow_logs.yml
+++ b/aws_vpc_policies/aws_vpc_flow_logs.yml
@@ -10,6 +10,7 @@ Tags:
   - Security Control
 Reports:
   CIS:
+    - 2.9
 Severity: Medium
 Description: >
   This policy validates that AWS VPCs (Virtual Private Clouds) have network flow logging enabled.


### PR DESCRIPTION
### Background

While developing the latest GSuite rules, I think I noticed a bug in the IAM User recon rule. Let me know if you think this change is correct.

Additionally, `make test` found a handful of misformatted config files. I'm assuming the recent(ish) `panther_analysis_tool`  updates caught a previously missed formatting issue.

### Changes

* Changed IAM recon rule logic
* Fixed `Reports` field on several policies and rules

### Testing

* Unit testing
