### PR TITLE
Osquery: Ignore ValueErrors when parsing command

### DIFF
--- a/osquery_rules/osquery_linux_aws_commands.py
+++ b/osquery_rules/osquery_linux_aws_commands.py
@@ -12,8 +12,11 @@ def rule(event):
     command = event['columns'].get('command')
     if not command:
         return False
-    command_args = shlex.split(command.replace("'",
-                                               "\\'"))  # escape single quotes
+    try:
+        command_args = shlex.split(command)
+    except ValueError:
+        # "No escaped character" or "No closing quotation" - probably an invalid command
+        return False
 
     if command_args[0] == 'aws':
         return True

--- a/osquery_rules/osquery_linux_aws_commands.yml
+++ b/osquery_rules/osquery_linux_aws_commands.yml
@@ -47,7 +47,7 @@ Tests:
         }
       }
   -
-    Name:  Command with quote executed
+    Name: Command with quote executed
     LogType: Osquery.Differential
     ExpectedResult: false
     Log:
@@ -56,6 +56,21 @@ Tests:
         "action": "added",
         "columns": {
           "command": "git commit -m 'all done'",
+          "uid": "1000",
+          "directory": "/home/ubuntu",
+          "username": "ubuntu"
+        }
+      }
+  -
+    Name: Invalid command ignored
+    LogType: Osquery.Differential
+    ExpectedResult: false
+    Log:
+      {
+        "name": "pack_incident-response_shell_history",
+        "action": "added",
+        "columns": {
+          "command": "unopened '",
           "uid": "1000",
           "directory": "/home/ubuntu",
           "username": "ubuntu"


### PR DESCRIPTION
### Background

We were paged over the weekend for 2 different errors:

* failed to run rule Osquery.Linux.AWSCommandExecuted RuleResult ValueError('No closing quotation')
* failed to run rule Osquery.Linux.AWSCommandExecuted RuleResult ValueError('No escaped character')

These are caused by `shlex.split(command)` if the input command is invalid. Since osquery is just reading the shell history, I assume it's possible for invalid commands to be entered by developers - these should be safely ignored and not trigger errors.

This also reverts #72 - `shlex` is designed to handle single quotes, I'm not sure why we had to escape them:

```python
import shlex
shlex.split("git commit -m 'multi word msg'")
# ['git', 'commit', '-m', 'multi word msg']
```

All of the tests pass without the escaping; I assume it was an (incorrect) attempt to fix the same issue I encountered.

This rule in general seems fragile - for example, in our environment we would always be invoking `aws-vault exec my-profile --- aws`, so I don't know if `shlex.split(command)[0]` would be `aws` in our case. What if you had environment variables beforehand, like `AWS_REGION=us-east-2 aws ...`?

Here I'm just fixing the error, but if we decided to do a simpler check (like `' aws ' in command`) that would also avoid the error in the first place as well as address more use cases, but in exchange for more false positives

### Changes

* Ignore `ValueError` raised by `shlex`
* Revert #72 

### Testing

* `make test-single pack=osquery_rules`
