### PR TITLE
Remove broken runbook links, ignore Panther stacks in stack drift policy

### DIFF
--- a/aws_acm_policies/aws_acm_certificate_valid.yml
+++ b/aws_acm_policies/aws_acm_certificate_valid.yml
@@ -14,7 +14,7 @@ Description: >
   This policy checks if an ACM certificate renewal is pending or has failed and is in use
   by any other resources within the account.
 Runbook: >
-  https://docs.runpanther.io/amazon-web-services/policies/aws-acm-certificates-are-valid
+  From the ACM panel in the AWS console, check and resolve the certificate status.
 Reference: https://docs.aws.amazon.com/acm/latest/userguide/check-certificate-renewal-status.html
 Tests:
   -

--- a/aws_cloudformation_policies/aws_cloudformation_stack_drifted.py
+++ b/aws_cloudformation_policies/aws_cloudformation_stack_drifted.py
@@ -1,8 +1,6 @@
 # CloudFormation stacks tagged with "STACK=(name)" will be marked as passing.
 IGNORE_STACK_TAGS = {
-    'panther-bootstrap-gateway',
-    'panther-cloud-security',
-    'panther-core',
+    'panther-bootstrap-gateway', 'panther-cloud-security', 'panther-core',
     'panther-log-analysis'
 }
 
@@ -14,7 +12,8 @@ def policy(resource):
     # Some of Panther's own stacks contain Lambda functions which will always show as "drifted."
     # Panther stacks have a fixed "Stack" tag, even though the real stack name is dynamic.
     tags = resource['Tags']
-    if tags.get('Application') == 'Panther' and tags.get('Stack') in IGNORE_STACK_TAGS:
+    if tags.get('Application') == 'Panther' and tags.get(
+            'Stack') in IGNORE_STACK_TAGS:
         return True
 
     return False

--- a/aws_cloudformation_policies/aws_cloudformation_stack_drifted.py
+++ b/aws_cloudformation_policies/aws_cloudformation_stack_drifted.py
@@ -1,2 +1,20 @@
+# CloudFormation stacks tagged with "STACK=(name)" will be marked as passing.
+IGNORE_STACK_TAGS = {
+    'panther-bootstrap-gateway',
+    'panther-cloud-security',
+    'panther-core',
+    'panther-log-analysis'
+}
+
+
 def policy(resource):
-    return resource['DriftInformation']['StackDriftStatus'] != "DRIFTED"
+    if resource['DriftInformation']['StackDriftStatus'] != "DRIFTED":
+        return True
+
+    # Some of Panther's own stacks contain Lambda functions which will always show as "drifted."
+    # Panther stacks have a fixed "Stack" tag, even though the real stack name is dynamic.
+    tags = resource['Tags']
+    if tags.get('Application') == 'Panther' and tags.get('Stack') in IGNORE_STACK_TAGS:
+        return True
+
+    return False

--- a/aws_cloudformation_policies/aws_cloudformation_stack_drifted.yml
+++ b/aws_cloudformation_policies/aws_cloudformation_stack_drifted.yml
@@ -9,13 +9,14 @@ Tags:
   - AWS
   - Operations
   - Panther
-Severity: Medium
+Severity: Low
 Description: >
   A stack has drifted from its defined configuration.
 Runbook: >
-  Analyze CloudTrail logs to understand which user changed the drifted resource(s), and
-  ensure it was legitimate.
-  https://docs.runpanther.io/amazon-web-services/policies/aws-cloudformation-stack-has-not-drifted
+  From the CloudFormation web console, look at the drifted resources for the failing stack.
+  If the drift is expected, update the policy ignore list to exclude this stack.
+  Otherwise, analyze CloudTrail logs to understand who changed the drifted resource(s) and ensure
+  it was legitimate access.
 Reference: https://amzn.to/2z8dDFW
 Tests:
   -
@@ -35,6 +36,68 @@ Tests:
         "TimeCreated": "2019-04-02T17:16:30.000Z",
         "Capabilities": [
           "CAPABILITY_NAMED_IAM"
+        ],
+        "ChangeSetId": null,
+        "DeletionTime": null,
+        "Description": "IAM Admin role",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "LastCheckTimestamp": "2019-04-02T17:16:30Z",
+          "StackDriftStatus": "DRIFTED"
+        },
+        "EnableTerminationProtection": null,
+        "LastUpdatedTime": "2019-04-02T17:16:30Z",
+        "NotificationARNs": [],
+        "Outputs": null,
+        "Parameters": [
+          {
+            "ParameterKey": "MaxSessionDurationSec",
+            "ParameterValue": "28800",
+            "ResolvedValue": null,
+            "UsePreviousValue": null
+          },
+          {
+            "ParameterKey": "Prefix",
+            "ParameterValue": "Dev",
+            "ResolvedValue": null,
+            "UsePreviousValue": null
+          }
+        ],
+        "ParentId": null,
+        "RoleARN": "arn:aws:iam::123456789012:role/CFNServiceRole",
+        "RollbackConfiguration": {
+          "MonitoringTimeInMinutes": null,
+          "RollbackTriggers": []
+        },
+        "RootId": null,
+        "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/iam-roles/12345678901258f4c3a3-c67c-4f81-afe1-509a2065de91",
+        "StackStatus": "UPDATE_COMPLETE",
+        "StackStatusReason": null,
+        "TimeoutInMinutes": null,
+        "Drifts": []
+      }
+  -
+    Name: Stack Drifted but Ignored
+    ResourceType: AWS.CloudFormation.Stack
+    ExpectedResult: false
+    Resource:
+      {
+        "AccountID": "123456789012",
+        "Region": "us-west-2",
+        "ARN": "arn:aws:cloudformation:us-west-2:123456789012:stack/iam-roles/12345678901258f4c3a3-c67c-4f81-afe1-509a2065de91",
+        "ID": "arn:aws:cloudformation:us-west-2:123456789012:stack/iam-roles/12345678901258f4c3a3-c67c-4f81-afe1-509a2065de91",
+        "Name": "panther-master-Panther-XXXXXXXXXXXXX-BootstrapGateway-XXXXXXXXXXXXX",
+        "Tags": {
+          "Application": "Panther",
+          "PantherEdition": "Community",
+          "PantherVersion": "v1.7.1",
+          "Stack": "panther-bootstrap-gateway"
+        },
+        "ResourceID": "arn:aws:cloudformation:us-west-2:123456789012:stack/iam-roles/12345678901258f4c3a3-c67c-4f81-afe1-509a2065de91",
+        "ResourceType": "AWS.CloudFormation.Stack",
+        "TimeCreated": "2019-04-02T17:16:30.000Z",
+        "Capabilities": [
+            "CAPABILITY_NAMED_IAM"
         ],
         "ChangeSetId": null,
         "DeletionTime": null,

--- a/aws_cloudformation_policies/aws_cloudformation_stack_uses_iam_role.yml
+++ b/aws_cloudformation_policies/aws_cloudformation_stack_uses_iam_role.yml
@@ -16,7 +16,6 @@ Description: >
 Runbook: >
   Create a new IAM role to be assumable by the cloudformation service, and then update the
   current stack with the --role-arn argument.
-  https://docs.runpanther.io/amazon-web-services/policies/aws-cloudformation-stack-uses-iam-service-role
 Reference: https://amzn.to/2HAdfny
 Tests:
   -

--- a/aws_cloudformation_policies/aws_cloudformation_termination_protection.yml
+++ b/aws_cloudformation_policies/aws_cloudformation_termination_protection.yml
@@ -17,7 +17,6 @@ Description: >
 Runbook: >
   This setting can only be enabled on stack creation. To add it to an existing stack, it must
   be re-created with the --enable-termination-protection flag.
-  https://docs.runpanther.io/amazon-web-services/policies/aws-cloudformation-stack-has-termination-protection
 Reference: https://amzn.to/2HAdfny
 Tests:
   -

--- a/aws_cloudwatch_policies/aws_cloudwatch_loggroup_data_retention.yml
+++ b/aws_cloudwatch_policies/aws_cloudwatch_loggroup_data_retention.yml
@@ -13,7 +13,8 @@ Description: >
   By default, logs are kept indefinitely and never expire. You can adjust the retention policy
   for each log group, keeping the indefinite retention, or choosing a specific retention period.
 Runbook: >
-  https://docs.runpanther.io/amazon-web-services/policies/aws-cloudtrail-logs-has-data-retention-of-one-year
+  Change the CloudWatch log group retention from the CloudWatch Logs web console,
+  SDK, CloudFormation, or any other supported method.
 Reference: https://docs.aws.amazon.com/cli/latest/reference/logs/put-retention-policy.html
 Tests:
   -

--- a/aws_cloudwatch_policies/aws_cloudwatch_loggroup_encrypted.yml
+++ b/aws_cloudwatch_policies/aws_cloudwatch_loggroup_encrypted.yml
@@ -8,11 +8,12 @@ ResourceTypes:
 Tags:
   - AWS
   - Panther
-Severity: Medium
+Severity: Low
 Description: >
-  Logs can be encrypted with a CMK to protect sensitive data in logs.
+  AWS automatically performs server-side encryption of logs, but you can encrypt with your own CMK
+  to protect extra sensitive log data.
 Runbook: >
-  https://docs.runpanther.io/amazon-web-services/policies/aws-cloudwatch-logs-are-encrypted
+  Encrypt the CloudWatch log group with a KMS key, or add this log group to the ignore list.
 Reference: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html
 Tests:
   -

--- a/aws_config_policies/aws_config_all_resource_types.yml
+++ b/aws_config_policies/aws_config_all_resource_types.yml
@@ -13,7 +13,7 @@ Description: >
   This policy ensurers that you have a comprehensive configuration audit in place for
   all resource types in AWS.
 Runbook: >
-  https://docs.runpanther.io/amazon-web-services/policies/aws-config-records-all-resource-types
+  Update AWS Config to record changes to all supported resource types.
 Reference: https://aws.amazon.com/blogs/mt/aws-config-best-practices/
 Tests:
   -

--- a/aws_config_policies/aws_config_recording_enabled.yml
+++ b/aws_config_policies/aws_config_recording_enabled.yml
@@ -12,8 +12,7 @@ Severity: High
 Description: >
   This policy ensures that the config recorder is operational and capturing changes to
   your account.
-Runbook: >
-  https://docs.runpanther.io/amazon-web-services/policies/aws-config-is-recording
+Runbook: Enable AWS Config recording
 Reference: https://docs.aws.amazon.com/config/latest/developerguide/stop-start-recorder.html
 Tests:
   -

--- a/aws_config_policies/aws_config_recording_no_error.yml
+++ b/aws_config_policies/aws_config_recording_no_error.yml
@@ -13,7 +13,7 @@ Description: >
   This policy ensures that the config recorder is operational and capturing changes to
   your account without error.
 Runbook: >
-  https://docs.runpanther.io/amazon-web-services/policies/aws-config-recording-with-no-errors
+  Check the AWS Config console to understand and resolve the cause of the errors.
 Reference: https://docs.aws.amazon.com/config/latest/developerguide/notification-delivery-failed.html
 Tests:
   -

--- a/aws_ec2_policies/aws_ami_private.yml
+++ b/aws_ec2_policies/aws_ami_private.yml
@@ -13,7 +13,7 @@ Severity: High
 Description: >
   This policy ensures that AMIs you have created are not configured to allow public access, which could result in accidental data loss. AMI's that you use but do not own are not evaluated by this policy.
 Runbook: >
-  https://docs.runpanther.io/amazon-web-services/policies/aws-customer-owned-ami-is-private
+  Immediately remove public access from the AMI until you can determine whether that setting is intentional
 Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sharing-amis.html
 Tests:
   -

--- a/aws_ec2_policies/aws_ec2_volume_encryption.yml
+++ b/aws_ec2_policies/aws_ec2_volume_encryption.yml
@@ -12,7 +12,6 @@ Severity: High
 Description: >
   You can encrypt both the boot and data volumes of an EC2 instance.
 Runbook: >
-  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#encryption-by-default-api
   https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-ec2-instance-volumes-are-encrypted
 Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
 Tests:

--- a/aws_ec2_policies/aws_ec2_volume_snapshot_encrypted.yml
+++ b/aws_ec2_policies/aws_ec2_volume_snapshot_encrypted.yml
@@ -12,8 +12,7 @@ Severity: High
 Description: >
   You can encrypt the snapshot of an EC2 volume to protect against accidental data loss
 Runbook: >
-  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#encryption-by-default-api
-  https://docs.runpanther.io/amazon-web-services/policies/aws-ec2-volume-snapshot-is-encrypted
+  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-ec2-volume-is-encrypted
 Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
 Tests:
   -

--- a/aws_iam_policies/aws_cloudtrail_least_privilege.yml
+++ b/aws_iam_policies/aws_cloudtrail_least_privilege.yml
@@ -14,7 +14,7 @@ Severity: Medium
 Description: >
   Users with permissions to disable or reconfigure CloudTrail should be limited.
 Runbook: >
-  https://docs.runpanther.io/amazon-web-services/policies/aws-cloudtrail-least-privilege-access-configured
+  Remove the AWSCloudTrailFullAccess managed IAM policy from all but one user in the account.
 Reference: https://amzn.to/2ZEUrKm
 Tests:
   -

--- a/aws_rds_policies/aws_rds_instance_auto_minor_version_upgrade_enabled.yml
+++ b/aws_rds_policies/aws_rds_instance_auto_minor_version_upgrade_enabled.yml
@@ -20,7 +20,6 @@ Runbook: >
   For major version upgrades, you must manually modify the DB engine version through the
   AWS Management Console, AWS CLI, or RDS API. For minor version upgrades,
   you can manually modify the engine version, or you can choose to enable auto minor version upgrades.
-  https://docs.runpanther.io/amazon-web-services/policies/aws-rds-instance-has-auto-minor-version-upgrade-enabled
 Reference: https://amzn.to/2L8POnD
 Tests:
   -

--- a/aws_s3_rules/aws_s3_unauthenticated_access.yml
+++ b/aws_s3_rules/aws_s3_unauthenticated_access.yml
@@ -13,7 +13,7 @@ Severity: Low
 Description: >
   Checks for S3 access attempts where the requester is not an authenticated AWS user.
 Runbook: >
-  If unathenticated S3 access is not expected for this bucket, update it's access policies.
+  If unathenticated S3 access is not expected for this bucket, update its access policies.
 Tests:
   -
     Name: Authenticated Access

--- a/aws_vpc_policies/aws_network_acl_restricted_ssh.yml
+++ b/aws_vpc_policies/aws_network_acl_restricted_ssh.yml
@@ -12,7 +12,7 @@ Severity: High
 Description: >
   SSH access should only be granted from protected network CIDR ranges.
 Runbook: >
-  https://docs.runpanther.io/amazon-web-services/policies/aws-network-acl-restricts-ssh
+  Remove the NACL rule granting unprotected SSH access.
 Reference: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-recommended-nacl-rules.html
 Tests:
   -


### PR DESCRIPTION
### Background

Both customers and developers have reported broken policy runbook links. Specifically:

* AWS CloudFormation Stack Drift: https://docs.runpanther.io/amazon-web-services/policies/aws-cloudformation-stack-has-not-drifted
* AWS CloudWatch Log Encryption: https://docs.runpanther.io/amazon-web-services/policies/aws-cloudwatch-logs-are-encrypted

I audited all runbook links - we had 14 broken links. With only one exception, these pages actually don't exist and never have, as far as I can tell. I looked at our documentation history to make sure I didn't accidentally remove them when moving the docs around, but it doesn't look like they were ever there.

#### Future Runbooks

Our runbooks are scattered and in the future will need some kind of standardization. Only half have doc pages, and a substantial part of the remainder are pretty trivial. Several literally say "Search related logs to understand the root cause of the activity." Encryption not enabled? Then the runbook is "enable encryption." Volumes public? Runbook is "make volumes not public," etc. Often, the runbook and the reference or description are essentially the same.

One idea would be to auto-generate the runbook using information from the event in each alert. E.g. "runbook: 'aws s3 put-bucket-policy --bucket-name your-bucket ...'" Or we could auto-generate the policy documentation from the metadata in this repo. Or should we just remove the runbook completely and rely on description / reference?

For now, what we have is fine, just flagging this as a problem to address someday

### Changes

* Remove broken runbook links
* Downgrade "CloudFormation Stack Drift" to low severity and ignore some of Panther's own stacks

### Testing

* Manually checked every runbook link
* Searched for any reference to "docs.runpanther.io/amazon-web-services"
* Added unit test for modified stack drift rule
