### PR TITLE
removing AWS.IAM.ROLE from ResourceTypes from inline policy check

### DIFF
--- a/aws_iam_policies/aws_iam_resource_does_not_have_inline_policy.yml
+++ b/aws_iam_policies/aws_iam_resource_does_not_have_inline_policy.yml
@@ -5,7 +5,6 @@ Enabled: true
 ResourceTypes:
   - AWS.IAM.User
   - AWS.IAM.Group
-  - AWS.IAM.Role
 Tags:
   - AWS
   - PCI


### PR DESCRIPTION
### Background

Remove AWS.IAM.ROLE from ResourceTypes in inline policy check because IAM Roles commonly have inline policies.  This is not a bad pattern for IAMS roles, whereas for users/groups it is discouraged.   

### Changes

* removed AWS.IAM.ROLE from ResourceTypes
### Testing

* `make test` and ran panther_analysis_tool against changed directory.  
