### PR TITLE
addressing new dedup|title checks

### DIFF
--- a/gcp_audit_rules/gcp_gcs_public.py
+++ b/gcp_audit_rules/gcp_gcs_public.py
@@ -33,5 +33,5 @@ def dedup(event):
 
 
 def title(event):
-    'GCS bucket [{}] made public'.format(event['resource'].get(
+    return 'GCS bucket [{}] made public'.format(event['resource'].get(
         'labels', {}).get('bucket_name', '<BUCKET_NOT_FOUND>'))

--- a/gsuite_reports_rules/gsuite_drive_overly_visible.yml
+++ b/gsuite_reports_rules/gsuite_drive_overly_visible.yml
@@ -20,6 +20,7 @@ Tests:
     ExpectedResult: false
     Log:
       {
+        'p_row_id': '111222',
         'actor': {'email': 'bobert@example.com'},
         'id': {'applicationName': 'drive'},
         'events': [
@@ -35,6 +36,7 @@ Tests:
     ExpectedResult: false
     Log:
       {
+        'p_row_id': '111222',
         'actor': {'email': 'bobert@example.com'},
         'id': {'applicationName': 'drive'},
         'events': [
@@ -51,6 +53,7 @@ Tests:
     ExpectedResult: true
     Log:
       {
+        'p_row_id': '111222',
         'actor': {'email': 'bobert@example.com'},
         'id': {'applicationName': 'drive'},
         'events': [

--- a/gsuite_reports_rules/gsuite_drive_visibility_change.yml
+++ b/gsuite_reports_rules/gsuite_drive_visibility_change.yml
@@ -20,6 +20,7 @@ Tests:
     ExpectedResult: false
     Log:
       {
+        'p_row_id': '111222',
         'actor': {'email': 'bobert@example.com'},
         'id': {'applicationName': 'drive'},
         'events': [
@@ -35,6 +36,7 @@ Tests:
     ExpectedResult: false
     Log:
       {
+        'p_row_id': '111222',
         'actor': {'email': 'bobert@example.com'},
         'id': {'applicationName': 'drive'},
         'events': [
@@ -50,6 +52,7 @@ Tests:
     ExpectedResult: true
     Log:
       {
+        'p_row_id': '111222',
         'actor': {'email': 'bobert@example.com'},
         'id': {'applicationName': 'drive'},
         'events': [
@@ -65,6 +68,7 @@ Tests:
     ExpectedResult: false
     Log:
       {
+        'p_row_id': '111222',
         'actor': {'email': 'bobert@example.com'},
         'id': {'applicationName': 'drive'},
         'events': [

--- a/osquery_rules/osquery_mac_osx_attacks.yml
+++ b/osquery_rules/osquery_mac_osx_attacks.yml
@@ -22,6 +22,7 @@ Tests:
       {
         "name": "pack_osx-attacks_Leverage-A_1",
         "action": "added",
+        "hostIdentifier": "test-host",
         "columns": {
           "path": "/Users/johnny/Desktop/Siri.app/Contents/MacOS/Siri",
           "pid": 100,
@@ -36,6 +37,7 @@ Tests:
       {
         "name": "pack_osx-attacks_Keyboard_Event_Taps",
         "action": "added",
+        "hostIdentifier": "test-host",
         "columns": {
           "path": "/System/Library/CoreServices/Siri.app/Contents/MacOS/Siri",
           "pid": 100,

--- a/osquery_rules/osquery_mac_osx_attacks_keyboard_events.yml
+++ b/osquery_rules/osquery_mac_osx_attacks_keyboard_events.yml
@@ -22,6 +22,7 @@ Tests:
       {
         "name": "pack_osx-attacks_Keyboard_Event_Taps",
         "action": "added",
+        "hostIdentifier": "test-host",
         "columns": {
           "path": "/Users/johnny/Desktop/Siri.app/Contents/MacOS/Siri",
           "pid": 100,
@@ -36,6 +37,7 @@ Tests:
       {
         "name": "pack_osx-attacks_Keyboard_Event_Taps",
         "action": "added",
+        "hostIdentifier": "test-host",
         "columns": {
           "path": "/System/Library/CoreServices/Siri.app/Contents/MacOS/Siri",
           "pid": 100,
@@ -49,6 +51,7 @@ Tests:
     Log:
       {
         "action": "added",
+        "hostIdentifier": "test-host",
         "calendarTime": "2020-04-10 23:26:11.000000000",
         "columns": {
           "blocks_size": "4096",

--- a/osquery_rules/osquery_outdated.py
+++ b/osquery_rules/osquery_outdated.py
@@ -12,4 +12,5 @@ def dedup(event):
 
 
 def title(event):
-    'Osquery Version {} is Outdated'.format(event['columns'].get('version'))
+    return 'Osquery Version {} is Outdated'.format(
+        event['columns'].get('version'))

--- a/osquery_rules/osquery_outdated.yml
+++ b/osquery_rules/osquery_outdated.yml
@@ -19,6 +19,7 @@ Tests:
     Log:
       {
           "action": "added",
+          "hostIdentifier": "test-host",
           "calendarTime": "Tue Sep 11 16:14:21 2018 UTC",
           "columns": {
               "build_distro": "10.12",
@@ -56,6 +57,7 @@ Tests:
     Log:
       {
           "action": "added",
+          "hostIdentifier": "test-host",
           "calendarTime": "Tue Sep 11 16:14:21 2018 UTC",
           "columns": {
               "build_distro": "10.12",

--- a/osquery_rules/osquery_suspicious_cron.yml
+++ b/osquery_rules/osquery_suspicious_cron.yml
@@ -23,6 +23,7 @@ Tests:
     Log:
       {
         "name": "pack_incident-response_crontab",
+        "hostIdentifier": "test-host",
         "action": "added",
         "columns": {
           "event": "",
@@ -43,6 +44,7 @@ Tests:
       {
         "name": "pack_incident-response_crontab",
         "action": "added",
+        "hostIdentifier": "test-host",
         "columns": {
           "event": "",
           "minute": "17",
@@ -62,6 +64,7 @@ Tests:
       {
         "name": "pack_incident-response_crontab",
         "action": "added",
+        "hostIdentifier": "test-host",
         "columns": {
           "event": "",
           "minute": "17",
@@ -81,6 +84,7 @@ Tests:
       {
         "name": "pack_incident-response_crontab",
         "action": "added",
+        "hostIdentifier": "test-host",
         "columns": {
           "event": "",
           "minute": "17",
@@ -100,6 +104,7 @@ Tests:
       {
         "name": "pack_incident-response_crontab",
         "action": "added",
+        "hostIdentifier": "test-host",
         "columns": {
           "event": "",
           "minute": "17",
@@ -119,6 +124,7 @@ Tests:
       {
         "name": "pack_incident-response_crontab",
         "action": "added",
+        "hostIdentifier": "test-host",
         "columns": {
           "event": "",
           "minute": "17",


### PR DESCRIPTION
### Background

After updating the panther_analysis_tool to check for non-None returns from the dedup and title methods [panther_analysis_tool issue](https://github.com/panther-labs/panther_analysis_tool/issues/18) I found a few new failing cases.  This addresses those cases.

### Changes

* Added missing fields needed for dedup
* Added missing return statement

### Testing

* `make test` and running new version of panther_analysis_tool with title/dedup checks against this repo.  
