### PR TITLE
Added case for session authentication

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @kostaspap @nhakmiller @austinbyers
+*       @kostaspap @nhakmiller @austinbyers @lindsey-w

--- a/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
+++ b/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
@@ -151,3 +151,49 @@ Tests:
           "eventType": "AwsConsoleSignIn",
           "recipientAccountId": "123456789012"
       }
+  -
+    Name: No MFA but was authenticated from session with MFA
+    LogType: AWS.CloudTrail
+    ExpectedResult: false
+    Log:
+      {
+          "eventVersion": "1.05",
+          "userIdentity": {
+              "type": "AssumedRole",
+              "principalId": "1111",
+              "arn": "arn:aws:iam::123456789012:role/MFAOnlyRole",
+              "accountId": "123456789012",
+              "userName": "tester",
+              "sessionContext": {
+                "attributes": {
+                  "creationDate": "2020-01-01T00:00:00Z",
+                  "mfaAuthenticated": "true"
+                },
+                "sessionIssuer": {
+                  "accountId": "123456789012",
+                  "arn": "arn:aws:iam::123456789012:role/MFAOnlyRole",
+                  "principalId": "ABC123",
+                  "type": "Role",
+                  "userName": "MFAOnlyRole"
+                },
+                "webIdFederationData": {}
+              }
+          },
+          "eventTime": "2019-01-01T00:00:00Z",
+          "eventSource": "signin.amazonaws.com",
+          "eventName": "ConsoleLogin",
+          "awsRegion": "us-east-1",
+          "sourceIPAddress": "111.111.111.111",
+          "userAgent": "Mozilla",
+          "requestParameters": null,
+          "responseElements": {
+              "ConsoleLogin": "Success"
+          },
+          "additionalEventData": {
+              "MobileVersion": "No",
+              "MFAUsed": "No"
+          },
+          "eventID": "1",
+          "eventType": "AwsConsoleSignIn",
+          "recipientAccountId": "123456789012"
+      }


### PR DESCRIPTION
### Background

The AWS console login without MFA rule did not account for cases where a session that was authenticated with MFA created a pre-authenticated sign in url that allowed someone to login directly without MFA. This case should generally be allowed, as it still requires the user to be MFA authenticated initially.

Additionally, taking this opportunity to add @lindsey-w as a codeowner on this repo.

### Changes

* Added a case for sessions that were created by another session that was MFA authenticated
* Added @lindsey-w to `CODEOWNERS`

### Testing

* Created new unit test
