### PR TITLE
udpate to type cast to int for int comparison

### DIFF
--- a/gsuite_reports_rules/gsuite_mobile_device_screen_unlock_fail.py
+++ b/gsuite_reports_rules/gsuite_mobile_device_screen_unlock_fail.py
@@ -9,9 +9,10 @@ def rule(event):
 
     for details in event.get('events', [{}]):
         if (details.get('type') == 'suspicious_activity' and
-                details.get('name') == 'FAILED_PASSWORD_ATTEMPTS_EVENT' and
-                param_lookup(details.get('parameters', {}),
-                             'FAILED_PASSWD_ATTEMPTS') > MAX_UNLOCK_ATTEMPTS):
+                details.get('name') == 'FAILED_PASSWORD_ATTEMPTS_EVENT' and int(
+                    param_lookup(details.get('parameters', {}),
+                                 'FAILED_PASSWD_ATTEMPTS')) >
+                MAX_UNLOCK_ATTEMPTS):
             return True
 
     return False

--- a/gsuite_reports_rules/gsuite_mobile_device_screen_unlock_fail.yml
+++ b/gsuite_reports_rules/gsuite_mobile_device_screen_unlock_fail.yml
@@ -41,7 +41,7 @@ Tests:
         ]
       }
   -
-    Name: Multiple Failed Login Attempts
+    Name: Multiple Failed Login Attempts with int Type
     LogType: GSuites.Reports
     ExpectedResult: true
     Log:
@@ -56,3 +56,20 @@ Tests:
           }
         ]
       }
+  -
+    Name: Multiple Failed Login Attempts with String Type
+    LogType: GSuites.Reports
+    ExpectedResult: true
+    Log:
+      {
+        'actor': {'email': 'bobert@example.com'},
+        'id': {'applicationName': 'mobile'},
+        'events': [
+          {
+            'type': 'suspicious_activity',
+            'name': 'FAILED_PASSWORD_ATTEMPTS_EVENT',
+            'parameters': [{'name': 'FAILED_PASSWD_ATTEMPTS', 'intValue': '100'}]
+          }
+        ]
+      }
+


### PR DESCRIPTION
### Background

This addresses the type error identified in the gsuite rule.  It can now handle both int and String type for the `FAILED_PASSWD_ATTEMPTS` param lookup.  All other instances of param_lookup were already String comparisons/no other int type casting requirements found. Closes #103 

### Changes

* casting string to int in an compare statement.
* added new test case for String type `FAILED_PASSWD_ATTEMPTS` 

### Testing

* `make test` and running `panther_analysis_tool` against the updated dir
