### PR TITLE
Remove Deprecated/Optional Fields

### DIFF
--- a/aws_account_policies/aws_password_policy_complexity_guidelines.yml
+++ b/aws_account_policies/aws_password_policy_complexity_guidelines.yml
@@ -27,7 +27,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 Tests:
   -
     Name: Password Policy Does Not Require Lowercase Characters
-    ResourceType: AWS.PasswordPolicy
     ExpectedResult: false
     Resource:
       {
@@ -45,7 +44,6 @@ Tests:
       }
   -
     Name: Password Policy Does Not Require Numbers
-    ResourceType: AWS.PasswordPolicy
     ExpectedResult: false
     Resource:
       {
@@ -63,7 +61,6 @@ Tests:
       }
   -
     Name: Password Policy Does Not Require Symbols
-    ResourceType: AWS.PasswordPolicy
     ExpectedResult: false
     Resource:
       {
@@ -81,7 +78,6 @@ Tests:
       }
   -
     Name: Password Policy Does Not Require Uppercase Characters
-    ResourceType: AWS.PasswordPolicy
     ExpectedResult: false
     Resource:
       {
@@ -99,7 +95,6 @@ Tests:
       }
   -
     Name: Password Policy Enforces Insufficient Password Length
-    ResourceType: AWS.PasswordPolicy
     ExpectedResult: false
     Resource:
       {
@@ -117,7 +112,6 @@ Tests:
       }
   -
     Name: Password Policy Meets All Complexity Requirements
-    ResourceType: AWS.PasswordPolicy
     ExpectedResult: true
     Resource:
       {

--- a/aws_account_policies/aws_password_policy_password_age_limit.yml
+++ b/aws_account_policies/aws_password_policy_password_age_limit.yml
@@ -23,7 +23,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 Tests:
   -
     Name: Adequate Max Password Age Set
-    ResourceType: AWS.PasswordPolicy
     ExpectedResult: true
     Resource:
       {
@@ -41,7 +40,6 @@ Tests:
       }
   -
     Name: Inadequate Max Password Age Set
-    ResourceType: AWS.PasswordPolicy
     ExpectedResult: false
     Resource:
       {
@@ -59,7 +57,6 @@ Tests:
       }
   -
     Name: Max Password Age Not Set
-    ResourceType: AWS.PasswordPolicy
     ExpectedResult: false
     Resource:
       {

--- a/aws_account_policies/aws_password_policy_password_reuse.yml
+++ b/aws_account_policies/aws_password_policy_password_reuse.yml
@@ -24,7 +24,6 @@ Reference: >
 Tests:
   -
     Name: Insufficient Password Reuse Prevention Enabled
-    ResourceType: AWS.PasswordPolicy
     ExpectedResult: false
     Resource:
       {
@@ -42,7 +41,6 @@ Tests:
       }
   -
     Name: No Password Reuse Prevention Enabled
-    ResourceType: AWS.PasswordPolicy
     ExpectedResult: false
     Resource:
       {
@@ -60,7 +58,6 @@ Tests:
       }
   -
     Name: Sufficient Password Reuse Prevention Enabled
-    ResourceType: AWS.PasswordPolicy
     ExpectedResult: true
     Resource:
       {

--- a/aws_account_policies/aws_resource_minimum_tags.yml
+++ b/aws_account_policies/aws_resource_minimum_tags.yml
@@ -21,7 +21,6 @@ Reference: https://aws.amazon.com/answers/account-management/aws-tagging-strateg
 Tests:
   -
     Name: EC2 Instance Has Less Then The Minimum Number Of Tags Set
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: false
     Resource:
       {
@@ -184,7 +183,6 @@ Tests:
       }
   -
     Name: EC2 Instance Has Minimum Number Of Tags
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: true
     Resource:
       {
@@ -352,7 +350,6 @@ Tests:
       }
   -
     Name: EC2 Instance Has No Tags Set
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: false
     Resource:
       {
@@ -515,7 +512,6 @@ Tests:
       }
   -
     Name: IAM User Has Less Than The Minimum Number Of Tags Set
-    ResourceType: AWS.IAM.User
     ExpectedResult: false
     Resource:
       {
@@ -568,7 +564,6 @@ Tests:
       }
   -
     Name: IAM User Has Minimum Number Of Tags Set
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {
@@ -626,7 +621,6 @@ Tests:
       }
   -
     Name: IAM User Has No Tags Set
-    ResourceType: AWS.IAM.User
     ExpectedResult: false
     Resource:
       {

--- a/aws_account_policies/aws_resource_required_tags.yml
+++ b/aws_account_policies/aws_resource_required_tags.yml
@@ -21,7 +21,6 @@ Reference: https://aws.amazon.com/answers/account-management/aws-tagging-strateg
 Tests:
    -
      Name: EC2 Instance Has No Required Tags
-     ResourceType: AWS.EC2.Instance
      ExpectedResult: false
      Resource:
        {
@@ -189,7 +188,6 @@ Tests:
        }
    -
      Name: EC2 Instance Has No Tags
-     ResourceType: AWS.EC2.Instance
      ExpectedResult: true
      Resource:
        {
@@ -347,7 +345,6 @@ Tests:
        }
    -
      Name: IAM User Has No Required Tags
-     ResourceType: AWS.IAM.User
      ExpectedResult: false
      Resource:
        {
@@ -406,7 +403,6 @@ Tests:
        }
    -
      Name: IAM User Has No Tags
-     ResourceType: AWS.IAM.User
      ExpectedResult: true
      Resource:
        {

--- a/aws_acm_policies/aws_acm_certificate_expiration.yml
+++ b/aws_acm_policies/aws_acm_certificate_expiration.yml
@@ -17,7 +17,6 @@ Reference: https://docs.aws.amazon.com/acm/latest/userguide/troubleshooting-rene
 Tests:
   -
     Name: Future Expiration
-    ResourceType: AWS.ACM.Certificate
     ExpectedResult: true
     Resource:
       {
@@ -85,7 +84,6 @@ Tests:
       }
   -
     Name: Past Expiration
-    ResourceType: AWS.ACM.Certificate
     ExpectedResult: false
     Resource:
       {

--- a/aws_acm_policies/aws_acm_certificate_has_secure_algorithms.yml
+++ b/aws_acm_policies/aws_acm_certificate_has_secure_algorithms.yml
@@ -21,7 +21,6 @@ Reference: https://docs.aws.amazon.com/acm/latest/userguide/acm-certificate.html
 Tests:
   -
     Name: Certificate Has Secure Algorithms
-    ResourceType: AWS.ACM.Certificate
     ExpectedResult: true
     Resource:
       {
@@ -85,7 +84,6 @@ Tests:
       }
   -
     Name: Certificate Has One Insecure Agorithm
-    ResourceType: AWS.ACM.Certificate
     ExpectedResult: false
     Resource:
       {
@@ -149,7 +147,6 @@ Tests:
       }
   -
     Name: Certificate Has Two Insecure Agorithms
-    ResourceType: AWS.ACM.Certificate
     ExpectedResult: false
     Resource:
       {

--- a/aws_acm_policies/aws_acm_certificate_valid.yml
+++ b/aws_acm_policies/aws_acm_certificate_valid.yml
@@ -19,7 +19,6 @@ Reference: https://docs.aws.amazon.com/acm/latest/userguide/check-certificate-re
 Tests:
   -
     Name: Certificate renewal pending validation
-    ResourceType: AWS.ACM.Certificate
     ExpectedResult: false
     Resource:
       {
@@ -89,7 +88,6 @@ Tests:
       }
   -
     Name: Certificate renewal failed
-    ResourceType: AWS.ACM.Certificate
     ExpectedResult: false
     Resource:
       {
@@ -159,7 +157,6 @@ Tests:
       }
   -
     Name: Certificate has been issued
-    ResourceType: AWS.ACM.Certificate
     ExpectedResult: true
     Resource:
       {
@@ -229,7 +226,6 @@ Tests:
       }
   -
     Name: Certificate is INELIGIBLE but not in use
-    ResourceType: AWS.ACM.Certificate
     ExpectedResult: true
     Resource:
       {

--- a/aws_cloudformation_policies/aws_cloudformation_stack_drifted.yml
+++ b/aws_cloudformation_policies/aws_cloudformation_stack_drifted.yml
@@ -21,7 +21,6 @@ Reference: https://amzn.to/2z8dDFW
 Tests:
   -
     Name: Stack Drifted
-    ResourceType: AWS.CloudFormation.Stack
     ExpectedResult: false
     Resource:
       {
@@ -78,7 +77,6 @@ Tests:
       }
   -
     Name: Stack Drifted but Ignored
-    ResourceType: AWS.CloudFormation.Stack
     ExpectedResult: true
     Resource:
       {
@@ -140,7 +138,6 @@ Tests:
       }
   -
     Name: Stack In Sync
-    ResourceType: AWS.CloudFormation.Stack
     ExpectedResult: true
     Resource:
       {

--- a/aws_cloudformation_policies/aws_cloudformation_stack_uses_iam_role.yml
+++ b/aws_cloudformation_policies/aws_cloudformation_stack_uses_iam_role.yml
@@ -20,7 +20,6 @@ Reference: https://amzn.to/2HAdfny
 Tests:
   -
     Name: IAM Service Role Attached
-    ResourceType: AWS.CloudFormation.Stack
     ExpectedResult: true
     Resource:
       {
@@ -77,7 +76,6 @@ Tests:
       }
   -
     Name: No Service Role Provided
-    ResourceType: AWS.CloudFormation.Stack
     ExpectedResult: false
     Resource:
       {
@@ -134,7 +132,6 @@ Tests:
       }
   -
     Name: No Service Role Provided But Stack Is StackSet
-    ResourceType: AWS.CloudFormation.Stack
     ExpectedResult: true
     Resource:
       {

--- a/aws_cloudformation_policies/aws_cloudformation_termination_protection.yml
+++ b/aws_cloudformation_policies/aws_cloudformation_termination_protection.yml
@@ -21,7 +21,6 @@ Reference: https://amzn.to/2HAdfny
 Tests:
   -
     Name: Termination Protection Enabled
-    ResourceType: AWS.CloudFormation.Stack
     ExpectedResult: true
     Resource:
       {
@@ -78,7 +77,6 @@ Tests:
       }
   -
     Name: Termination Protection Not Specified
-    ResourceType: AWS.CloudFormation.Stack
     ExpectedResult: false
     Resource:
       {
@@ -135,7 +133,6 @@ Tests:
       }
   -
     Name: Termination Protection Not Specified On Nested Stack
-    ResourceType: AWS.CloudFormation.Stack
     ExpectedResult: true
     Resource:
       {

--- a/aws_cloudtrail_policies/aws_cloudtrail_cloudwatch_logs.yml
+++ b/aws_cloudtrail_policies/aws_cloudtrail_cloudwatch_logs.yml
@@ -22,7 +22,6 @@ Reference: >
 Tests:
   -
     Name: CloudWatch Logs Not Setup
-    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {
@@ -75,7 +74,6 @@ Tests:
       }
   -
     Name: CloudTrail Set But No Logs Delivered
-    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {
@@ -128,7 +126,6 @@ Tests:
       }
   -
     Name: CloudTrail Set But Logs Delivered Too Long Ago
-    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {
@@ -181,7 +178,6 @@ Tests:
       }
   -
     Name: CloudTrail Set And Logs Delivered Recently
-    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {

--- a/aws_cloudtrail_policies/aws_cloudtrail_enabled.yml
+++ b/aws_cloudtrail_policies/aws_cloudtrail_enabled.yml
@@ -24,7 +24,6 @@ Reference: >
 Tests:
   -
     Name: Global CloudTrail Is Enabled
-    ResourceType: AWS.CloudTrail.Meta
     ExpectedResult: true
     Resource:
       {
@@ -51,7 +50,6 @@ Tests:
       }
   -
     Name: CloudTrail Enabled with ReadOnly Management Events
-    ResourceType: AWS.CloudTrail.Meta
     ExpectedResult: false
     Resource:
       {
@@ -66,7 +64,6 @@ Tests:
       }
   -
     Name: No Global CloudTrail Enabled
-    ResourceType: AWS.CloudTrail.Meta
     ExpectedResult: false
     Resource:
       {

--- a/aws_cloudtrail_policies/aws_cloudtrail_log_encryption.yml
+++ b/aws_cloudtrail_policies/aws_cloudtrail_log_encryption.yml
@@ -21,7 +21,6 @@ Reference: >
 Tests:
   -
     Name: KMS CMK Does Not Exist
-    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {
@@ -74,7 +73,6 @@ Tests:
       }
   -
     Name: KMS CMK Exists
-    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {

--- a/aws_cloudtrail_policies/aws_cloudtrail_log_validation.yml
+++ b/aws_cloudtrail_policies/aws_cloudtrail_log_validation.yml
@@ -23,7 +23,6 @@ Reference: >
 Tests:
   -
     Name: Log File Validation Disabled
-    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {
@@ -76,7 +75,6 @@ Tests:
       }
   -
     Name: Log File Validation Enabled
-    ResourceType: AWS.CloudTrail
     ExpectedResult: true
     Resource:
       {
@@ -129,7 +127,6 @@ Tests:
       }
   -
     Name: Log File Validation Not Set
-    ResourceType: AWS.CloudTrail
     ExpectedResult: false
     Resource:
       {

--- a/aws_cloudtrail_rules/aws_ami_modified_for_public_access.yml
+++ b/aws_cloudtrail_rules/aws_ami_modified_for_public_access.yml
@@ -4,7 +4,7 @@ RuleID: AWS.CloudTrail.AMIModifiedForPublicAccess
 DisplayName: Amazon Machine Image (AMI) Modified to Allow Public Access
 Enabled: true
 LogTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
 Severity: Medium

--- a/aws_cloudtrail_rules/aws_ami_modified_for_public_access.yml
+++ b/aws_cloudtrail_rules/aws_ami_modified_for_public_access.yml
@@ -22,7 +22,6 @@ Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sharingamis-intro
 Tests:
   -
     Name: AMI Made Public
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: true
     Log:
       {
@@ -77,7 +76,6 @@ Tests:
       }
   -
     Name: AMI Not Made Public
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {
@@ -132,7 +130,6 @@ Tests:
       }
   -
     Name: AMI Launch Permissions Not Modified
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_cloudtrail_created.yml
+++ b/aws_cloudtrail_rules/aws_cloudtrail_created.yml
@@ -19,7 +19,6 @@ Reference: https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_Ope
 Tests:
   -
     Name: CloudTrail Was Created
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -63,7 +62,6 @@ Tests:
       }
   -
     Name: KMS Decrypt Event
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_cloudtrail_stopped.yml
+++ b/aws_cloudtrail_rules/aws_cloudtrail_stopped.yml
@@ -19,7 +19,6 @@ Reference: https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_Ope
 Tests:
   -
     Name: CloudTrail Was Stopped
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -63,7 +62,6 @@ Tests:
       }
   -
     Name: CloudTrail Was Started
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_config_service_created.yml
+++ b/aws_cloudtrail_rules/aws_config_service_created.yml
@@ -20,7 +20,6 @@ Reference: https://aws.amazon.com/config/
 Tests:
   -
     Name: Config Recorder Delivery Channel Created
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -63,7 +62,6 @@ Tests:
       }
   -
     Name: Config Recorder Deleted
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_config_service_disabled_deleted.yml
+++ b/aws_cloudtrail_rules/aws_config_service_disabled_deleted.yml
@@ -20,7 +20,6 @@ Reference: https://aws.amazon.com/config/
 Tests:
   -
     Name: Config Recorder Delivery Channel Created
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {
@@ -63,7 +62,6 @@ Tests:
       }
   -
     Name: Config Recorder Deleted
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {

--- a/aws_cloudtrail_rules/aws_console_login_failed.yml
+++ b/aws_cloudtrail_rules/aws_console_login_failed.yml
@@ -21,7 +21,6 @@ Reference: https://amzn.to/3aMSmTd
 Tests:
   -
     Name: Failed Login
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -54,7 +53,6 @@ Tests:
       }
   -
     Name: Successful Login
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {
@@ -87,7 +85,6 @@ Tests:
       }
   -
     Name: Non Login Event
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
+++ b/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.h
 Tests:
   -
     Name: No MFA Login
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -53,7 +52,6 @@ Tests:
       }
   -
     Name: MFA Login but with SAML
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {
@@ -87,7 +85,6 @@ Tests:
       }
   -
     Name: Yes MFA Login
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {
@@ -120,7 +117,6 @@ Tests:
       }
   -
     Name: No MFA but Login Failed
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {
@@ -153,7 +149,6 @@ Tests:
       }
   -
     Name: No MFA but was authenticated from session with MFA
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_console_login_without_saml.yml
+++ b/aws_cloudtrail_rules/aws_console_login_without_saml.yml
@@ -18,7 +18,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_e
 Tests:
   -
     Name: Login with SAML
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {
@@ -52,7 +51,6 @@ Tests:
       }
   -
     Name: Normal Login
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {

--- a/aws_cloudtrail_rules/aws_console_root_login.yml
+++ b/aws_cloudtrail_rules/aws_console_root_login.yml
@@ -21,7 +21,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html
 Tests:
   -
     Name: Successful Root Login
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -54,7 +53,6 @@ Tests:
       }
   -
     Name: Non-Login Event
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_console_root_login_failed.yml
+++ b/aws_cloudtrail_rules/aws_console_root_login_failed.yml
@@ -20,7 +20,6 @@ Reference: https://amzn.to/3aMSmTd
 Tests:
   -
     Name: Failed Root Login
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -53,7 +52,6 @@ Tests:
       }
   -
     Name: Successful Login
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {
@@ -86,7 +84,6 @@ Tests:
       }
   -
     Name: Non-Login Event
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_ec2_gateway_modified.yml
+++ b/aws_cloudtrail_rules/aws_ec2_gateway_modified.yml
@@ -18,7 +18,6 @@ Reference: reference.link
 Tests:
   -
     Name: Network Gateway Modified
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -64,7 +63,6 @@ Tests:
       }
   -
     Name: Network Gateway Not Modified
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_ec2_network_acl_modified.yml
+++ b/aws_cloudtrail_rules/aws_ec2_network_acl_modified.yml
@@ -18,7 +18,6 @@ Reference: reference.link
 Tests:
   -
     Name: Network ACL Modified
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -70,7 +69,6 @@ Tests:
       }
   -
     Name: Network ACL Not Modified
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_ec2_route_table_modified.yml
+++ b/aws_cloudtrail_rules/aws_ec2_route_table_modified.yml
@@ -17,7 +17,6 @@ Reference: reference.link
 Tests:
   -
     Name: Route Table Modified
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -64,7 +63,6 @@ Tests:
       }
   -
     Name: Route Table Not Modified
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_ec2_security_group_modified.yml
+++ b/aws_cloudtrail_rules/aws_ec2_security_group_modified.yml
@@ -19,7 +19,6 @@ Reference: reference.link
 Tests:
   -
     Name: Security Group Modified
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -85,7 +84,6 @@ Tests:
       }
   -
     Name: Security Group Not Modified
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_ec2_vpc_modified.yml
+++ b/aws_cloudtrail_rules/aws_ec2_vpc_modified.yml
@@ -18,7 +18,6 @@ Reference: reference.link
 Tests:
   -
     Name: VPC Modified
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -87,7 +86,6 @@ Tests:
       }
   -
     Name: VPC Not Modified
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_iam_anything_changed.yml
+++ b/aws_cloudtrail_rules/aws_iam_anything_changed.yml
@@ -4,7 +4,7 @@ RuleID: AWS.CloudTrail.IAMAnythingChanged
 DisplayName: IAM Change
 Enabled: true
 LogTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - Identity and Access Management

--- a/aws_cloudtrail_rules/aws_iam_anything_changed.yml
+++ b/aws_cloudtrail_rules/aws_iam_anything_changed.yml
@@ -17,7 +17,6 @@ Reference: reference.link
 Tests:
   -
     Name: IAM Change
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: true
     Log:
       {
@@ -62,7 +61,6 @@ Tests:
       }
   -
     Name: IAM Read Only Activity
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_iam_assume_role_blacklist_ignored.yml
+++ b/aws_cloudtrail_rules/aws_iam_assume_role_blacklist_ignored.yml
@@ -4,7 +4,7 @@ RuleID: AWS.CloudTrail.IAMAssumeRoleBlacklistIgnored
 DisplayName: IAM Assume Role Blacklist Ignored
 Enabled: false
 LogTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - Configuration Required

--- a/aws_cloudtrail_rules/aws_iam_assume_role_blacklist_ignored.yml
+++ b/aws_cloudtrail_rules/aws_iam_assume_role_blacklist_ignored.yml
@@ -18,7 +18,6 @@ Reference: reference.link
 Tests:
   -
     Name: IAM Blacklisted Role Assumed
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: true
     Log:
       {
@@ -75,7 +74,6 @@ Tests:
       }
   -
     Name: IAM Non Blacklisted Role Assumed
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_iam_entity_created_without_cloudformation.yml
+++ b/aws_cloudtrail_rules/aws_iam_entity_created_without_cloudformation.yml
@@ -4,7 +4,7 @@ RuleID: AWS.CloudTrail.IAMEntityCreatedWithoutCloudFormation
 DisplayName: IAM Entity Created Without CloudFormation
 Enabled: false
 LogTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - Configuration Required

--- a/aws_cloudtrail_rules/aws_iam_entity_created_without_cloudformation.yml
+++ b/aws_cloudtrail_rules/aws_iam_entity_created_without_cloudformation.yml
@@ -18,7 +18,6 @@ Reference: reference.link
 Tests:
   -
     Name: IAM Entity Created Automatically
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {
@@ -62,7 +61,6 @@ Tests:
       }
   -
     Name: IAM Entity Created Manually With Approved Role
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: true
     Log:
       {
@@ -105,7 +103,6 @@ Tests:
       }
   -
     Name: IAM Entity Created Manually
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: true
     Log:
       {
@@ -148,7 +145,6 @@ Tests:
       }
   -
     Name: Non IAM Entity Creation Event
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_iam_policy_modified.yml
+++ b/aws_cloudtrail_rules/aws_iam_policy_modified.yml
@@ -19,7 +19,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html
 Tests:
   -
     Name: IAM Policy Change
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -62,7 +61,6 @@ Tests:
       }
   -
     Name: Not IAM Policy Change
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_iam_user_recon_denied.yml
+++ b/aws_cloudtrail_rules/aws_iam_user_recon_denied.yml
@@ -17,7 +17,6 @@ Reference: https://runpanther.io
 Tests:
   -
     Name: Unauthorized API Call from Within AWS (FQDN)
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {
@@ -54,7 +53,6 @@ Tests:
       }
   -
     Name: Authorized API Call
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_key_compromised.yml
+++ b/aws_cloudtrail_rules/aws_key_compromised.yml
@@ -14,7 +14,6 @@ Reference: N/A
 Tests:
   -
     Name: An AWS Access Key was Uploaded to Github
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {

--- a/aws_cloudtrail_rules/aws_kms_cmk_loss.yml
+++ b/aws_cloudtrail_rules/aws_kms_cmk_loss.yml
@@ -19,7 +19,6 @@ Reference: https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.h
 Tests:
   -
     Name: KMS Key Disabled
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -69,7 +68,6 @@ Tests:
       }
   -
     Name: KMS Key Scheduled For Deletion
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -124,7 +122,6 @@ Tests:
       }
   -
     Name: KMS Key Non Deletion Event
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_network_acl_permissive_entry.yml
+++ b/aws_cloudtrail_rules/aws_network_acl_permissive_entry.yml
@@ -4,7 +4,7 @@ RuleID: AWS.CloudTrail.NetworkACLPermissiveEntry
 DisplayName: AWS Network ACL Overly Permissive Entry Created
 Enabled: true
 LogTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
 Severity: Medium

--- a/aws_cloudtrail_rules/aws_network_acl_permissive_entry.yml
+++ b/aws_cloudtrail_rules/aws_network_acl_permissive_entry.yml
@@ -19,7 +19,6 @@ Reference: reference.link
 Tests:
   -
     Name: Overly Permissive Entry Added
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: true
     Log:
       {
@@ -75,7 +74,6 @@ Tests:
       }
   -
     Name: Not Overly Permissive Entry Added
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_resource_made_public.yml
+++ b/aws_cloudtrail_rules/aws_resource_made_public.yml
@@ -4,7 +4,7 @@ RuleID: AWS.CloudTrail.ResourceMadePublic
 DisplayName: AWS Resource Made Public
 Enabled: true
 LogTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
 Severity: Medium

--- a/aws_cloudtrail_rules/aws_resource_made_public.yml
+++ b/aws_cloudtrail_rules/aws_resource_made_public.yml
@@ -19,7 +19,6 @@ Reference: reference.link
 Tests:
   -
     Name: S3 Made Publicly Accessible
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: true
     Log:
       {
@@ -88,7 +87,6 @@ Tests:
       }
   -
     Name: S3 Not Made Publicly Accessible
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_root_access_key_created.yml
+++ b/aws_cloudtrail_rules/aws_root_access_key_created.yml
@@ -21,7 +21,6 @@ Reference: https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-key
 Tests:
   -
     Name: Root Access Key Created
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: true
     Log:
       {
@@ -61,7 +60,6 @@ Tests:
       }
   -
     Name: Root Created Access Key For User
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_root_access_key_created.yml
+++ b/aws_cloudtrail_rules/aws_root_access_key_created.yml
@@ -4,7 +4,7 @@ RuleID: AWS.CloudTrail.RootAccessKeyCreated
 DisplayName: Root Account Access Key Created
 Enabled: true
 LogTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - Identity and Access Management

--- a/aws_cloudtrail_rules/aws_root_activity.yml
+++ b/aws_cloudtrail_rules/aws_root_activity.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html
 Tests:
   -
     Name: Root Activity - CreateServiceLinkedRole
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {
@@ -71,7 +70,6 @@ Tests:
       }
   -
     Name: Root Activity
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -122,7 +120,6 @@ Tests:
       }
   -
     Name: IAMUser Activity
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_root_console_login.yml
+++ b/aws_cloudtrail_rules/aws_root_console_login.yml
@@ -19,7 +19,6 @@ Reference: reference.link
 Tests:
   -
     Name: Root Console Login
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: true
     Log:
       {
@@ -52,7 +51,6 @@ Tests:
       }
   -
     Name: Root Non Console Login
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {
@@ -85,7 +83,6 @@ Tests:
       }
   -
     Name: Non Root Console Login
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {
@@ -118,7 +115,6 @@ Tests:
       }
   -
     Name: Root Failed Console Login
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_root_console_login.yml
+++ b/aws_cloudtrail_rules/aws_root_console_login.yml
@@ -4,7 +4,7 @@ RuleID: AWS.CloudTrail.RootConsoleLogin
 DisplayName: Root Account Console Login
 Enabled: true
 LogTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - Identity and Access Management

--- a/aws_cloudtrail_rules/aws_root_failed_console_login.yml
+++ b/aws_cloudtrail_rules/aws_root_failed_console_login.yml
@@ -4,7 +4,7 @@ RuleID: AWS.CloudTrail.RootFailedConsoleLogin
 DisplayName: Root Account Failed Console Login
 Enabled: true
 LogTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - Identity and Access Management

--- a/aws_cloudtrail_rules/aws_root_failed_console_login.yml
+++ b/aws_cloudtrail_rules/aws_root_failed_console_login.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html
 Tests:
   -
     Name: Root Console Login
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {
@@ -53,7 +52,6 @@ Tests:
       }
   -
     Name: Root Non Console Login
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {
@@ -86,7 +84,6 @@ Tests:
       }
   -
     Name: Non Root Console Login
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {
@@ -119,7 +116,6 @@ Tests:
       }
   -
     Name: Root Failed Console Login
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: true
     Log:
       {

--- a/aws_cloudtrail_rules/aws_root_password_changed.yml
+++ b/aws_cloudtrail_rules/aws_root_password_changed.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passw
 Tests:
   -
     Name: Root Password Changed
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: true
     Log:
       {
@@ -50,7 +49,6 @@ Tests:
       }
   -
     Name: Root Password Change Failed
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_root_password_changed.yml
+++ b/aws_cloudtrail_rules/aws_root_password_changed.yml
@@ -4,7 +4,7 @@ RuleID: AWS.CloudTrail.RootPasswordChanged
 DisplayName: Root Password Changed
 Enabled: true
 LogTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
   - Identity and Access Management

--- a/aws_cloudtrail_rules/aws_s3_bucket_deleted.yml
+++ b/aws_cloudtrail_rules/aws_s3_bucket_deleted.yml
@@ -14,7 +14,6 @@ Reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html
 Tests:
   -
     Name: An S3 Bucket was deleted
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -67,7 +66,6 @@ Tests:
       }
   -
     Name: S3 Bucket Deletion Failed
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {
@@ -87,7 +85,6 @@ Tests:
       }
   -
     Name: An S3 Object Deleted
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_s3_bucket_policy_modified.yml
+++ b/aws_cloudtrail_rules/aws_s3_bucket_policy_modified.yml
@@ -19,7 +19,6 @@ Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.ht
 Tests:
   -
     Name: S3 Bucket Policy Modified
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -75,7 +74,6 @@ Tests:
       }
   -
     Name: S3 Bucket Policy Modified Error Response
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {
@@ -132,7 +130,6 @@ Tests:
       }
   -
     Name: S3 Bucket Policy Not Modified
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_security_configuration_change.yml
+++ b/aws_cloudtrail_rules/aws_security_configuration_change.yml
@@ -4,7 +4,7 @@ RuleID: AWS.CloudTrail.SecurityConfigurationChange
 DisplayName: Account Security Configuration Changed
 Enabled: true
 LogTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
 Severity: Medium

--- a/aws_cloudtrail_rules/aws_security_configuration_change.yml
+++ b/aws_cloudtrail_rules/aws_security_configuration_change.yml
@@ -18,7 +18,6 @@ Reference: reference.link
 Tests:
   -
     Name: Security Configuration Changed
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: true
     Log:
       {
@@ -63,7 +62,6 @@ Tests:
       }
   -
     Name: Security Configuration Not Changed
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {
@@ -108,7 +106,6 @@ Tests:
       }
   -
     Name: Non Security Configuration Change
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_snapshot_made_public.yml
+++ b/aws_cloudtrail_rules/aws_snapshot_made_public.yml
@@ -17,7 +17,6 @@ Reference: reference.link
 Tests:
   -
     Name: Snapshot Made Publicly Accessible
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: true
     Log:
       {
@@ -73,7 +72,6 @@ Tests:
       }
   -
     Name: Snapshot Not Made Publicly Accessible
-    LogType: AWS.CloudTrail.Log
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_snapshot_made_public.yml
+++ b/aws_cloudtrail_rules/aws_snapshot_made_public.yml
@@ -4,7 +4,7 @@ RuleID: AWS.CloudTrail.SnapshotMadePublic
 DisplayName: AWS Snapshot Made Public
 Enabled: true
 LogTypes:
-  - AWS.CloudTrail.Log
+  - AWS.CloudTrail
 Tags:
   - AWS
 Reports:

--- a/aws_cloudtrail_rules/aws_unauthorized_api_call.yml
+++ b/aws_cloudtrail_rules/aws_unauthorized_api_call.yml
@@ -18,7 +18,6 @@ Reference: https://amzn.to/3aOukaA
 Tests:
   -
     Name: Unauthorized API Call from Within AWS (IP)
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -55,7 +54,6 @@ Tests:
       }
   -
     Name: Unauthorized API Call from Within AWS (FQDN)
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {
@@ -92,7 +90,6 @@ Tests:
       }
   -
     Name: Authorized API Call
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudtrail_rules/aws_update_credentials.yml
+++ b/aws_cloudtrail_rules/aws_update_credentials.yml
@@ -15,7 +15,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/list_identityandacce
 Tests:
   -
     Name: User Password Was Changed
-    LogType: AWS.CloudTrail
     ExpectedResult: true
     Log:
       {
@@ -51,7 +50,6 @@ Tests:
       }
   -
     Name: MFA Device Was Created
-    LogType: AWS.CloudTrail
     ExpectedResult: false
     Log:
       {

--- a/aws_cloudwatch_policies/aws_cloudwatch_loggroup_data_retention.yml
+++ b/aws_cloudwatch_policies/aws_cloudwatch_loggroup_data_retention.yml
@@ -19,7 +19,6 @@ Reference: https://docs.aws.amazon.com/cli/latest/reference/logs/put-retention-p
 Tests:
   -
     Name: Unlimited Log Retention
-    ResourceType: AWS.CloudWatch.LogGroup
     ExpectedResult: true
     Resource:
       {
@@ -43,7 +42,6 @@ Tests:
       }
   -
     Name: Logs Retained 1 Year
-    ResourceType: AWS.CloudWatch.LogGroup
     ExpectedResult: true
     Resource:
       {
@@ -67,7 +65,6 @@ Tests:
       }
   -
     Name: Logs Retained 2 Years
-    ResourceType: AWS.CloudWatch.LogGroup
     ExpectedResult: true
     Resource:
       {
@@ -91,7 +88,6 @@ Tests:
       }
   -
     Name: Logs Retained 1 Week
-    ResourceType: AWS.CloudWatch.LogGroup
     ExpectedResult: false
     Resource:
       {

--- a/aws_cloudwatch_policies/aws_cloudwatch_loggroup_encrypted.yml
+++ b/aws_cloudwatch_policies/aws_cloudwatch_loggroup_encrypted.yml
@@ -18,7 +18,6 @@ Reference: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-
 Tests:
   -
     Name: Logs Are Encrypted
-    ResourceType: AWS.CloudWatch.LogGroup
     ExpectedResult: true
     Resource:
       {
@@ -42,7 +41,6 @@ Tests:
       }
   -
     Name: Logs Are Not Encrypted
-    ResourceType: AWS.CloudWatch.LogGroup
     ExpectedResult: false
     Resource:
       {

--- a/aws_config_policies/aws_config_all_resource_types.yml
+++ b/aws_config_policies/aws_config_all_resource_types.yml
@@ -18,7 +18,6 @@ Reference: https://aws.amazon.com/blogs/mt/aws-config-best-practices/
 Tests:
   -
     Name: All Resources Supported
-    ResourceType: AWS.Config.Recorder
     ExpectedResult: true
     Resource:
       {
@@ -44,7 +43,6 @@ Tests:
       }
   -
     Name: All Resources Not Supported
-    ResourceType: AWS.Config.Recorder
     ExpectedResult: false
     Resource:
       {

--- a/aws_config_policies/aws_config_global_resources.yml
+++ b/aws_config_policies/aws_config_global_resources.yml
@@ -18,7 +18,6 @@ Reference: https://amzn.to/2MO8xXM
 Tests:
   -
     Name: Global Resources Are Enabled
-    ResourceType: AWS.Config.Meta
     ExpectedResult: true
     Resource:
       {
@@ -27,7 +26,6 @@ Tests:
       }
   -
     Name: Global Resources Are Not Enabled
-    ResourceType: AWS.Config.Meta
     ExpectedResult: false
     Resource:
       {

--- a/aws_config_policies/aws_config_recording_enabled.yml
+++ b/aws_config_policies/aws_config_recording_enabled.yml
@@ -17,7 +17,6 @@ Reference: https://docs.aws.amazon.com/config/latest/developerguide/stop-start-r
 Tests:
   -
     Name: Recording Enabled
-    ResourceType: AWS.Config.Recorder
     ExpectedResult: true
     Resource:
       {
@@ -45,7 +44,6 @@ Tests:
       }
   -
     Name: Recording Disabled
-    ResourceType: AWS.Config.Recorder
     ExpectedResult: false
     Resource:
       {

--- a/aws_config_policies/aws_config_recording_no_error.yml
+++ b/aws_config_policies/aws_config_recording_no_error.yml
@@ -18,7 +18,6 @@ Reference: https://docs.aws.amazon.com/config/latest/developerguide/notification
 Tests:
   -
     Name: Recording Enabled with No Errors
-    ResourceType: AWS.Config.Recorder
     ExpectedResult: true
     Resource:
       {
@@ -46,7 +45,6 @@ Tests:
       }
   -
     Name: Recording Errored
-    ResourceType: AWS.Config.Recorder
     ExpectedResult: false
     Resource:
       {

--- a/aws_dynamodb_policies/aws_dynamodb_autoscaling.yml
+++ b/aws_dynamodb_policies/aws_dynamodb_autoscaling.yml
@@ -19,7 +19,6 @@ Reference: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Auto
 Tests:
   -
     Name: AutoScaling Enabled
-    ResourceType: AWS.DynamoDB.Table
     ExpectedResult: true
     Resource:
       {
@@ -139,7 +138,6 @@ Tests:
       }
   -
     Name: AutoScaling Never Configured
-    ResourceType: AWS.DynamoDB.Table
     ExpectedResult: false
     Resource:
       {
@@ -219,7 +217,6 @@ Tests:
       }
   -
     Name: AutoScaling Not Enabled For Table
-    ResourceType: AWS.DynamoDB.Table
     ExpectedResult: false
     Resource:
       {
@@ -321,7 +318,6 @@ Tests:
       }
   -
     Name: Billing Mode Pay Per Request
-    ResourceType: AWS.DynamoDB.Table
     ExpectedResult: true
     Resource:
       {

--- a/aws_dynamodb_policies/aws_dynamodb_autoscaling_configuration.yml
+++ b/aws_dynamodb_policies/aws_dynamodb_autoscaling_configuration.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Auto
 Tests:
   -
     Name: AutoScaling Correctly Provisioned
-    ResourceType: AWS.DynamoDB.Table
     ExpectedResult: true
     Resource:
       {
@@ -140,7 +139,6 @@ Tests:
       }
   -
     Name: AutoScaling Never Configured
-    ResourceType: AWS.DynamoDB.Table
     ExpectedResult: false
     Resource:
       {
@@ -194,7 +192,6 @@ Tests:
       }
   -
     Name: AutoScaling Not Applicable
-    ResourceType: AWS.DynamoDB.Table
     ExpectedResult: true
     Resource:
       {
@@ -251,7 +248,6 @@ Tests:
       }
   -
     Name: AutoScaling Not Configured
-    ResourceType: AWS.DynamoDB.Table
     ExpectedResult: false
     Resource:
       {
@@ -334,7 +330,6 @@ Tests:
       }
   -
     Name: Secondary Index Max Write Capacity Over Provisioned
-    ResourceType: AWS.DynamoDB.Table
     ExpectedResult: false
     Resource:
       {
@@ -454,7 +449,6 @@ Tests:
       }
   -
     Name: Table Min Read Capacity Under Provisioned
-    ResourceType: AWS.DynamoDB.Table
     ExpectedResult: false
     Resource:
       {
@@ -574,7 +568,6 @@ Tests:
       }
   -
     Name: Table Min Write Capacity Under Provisioned
-    ResourceType: AWS.DynamoDB.Table
     ExpectedResult: false
     Resource:
       {

--- a/aws_dynamodb_policies/aws_dynamodb_table_encryption.yml
+++ b/aws_dynamodb_policies/aws_dynamodb_table_encryption.yml
@@ -21,7 +21,6 @@ Reference: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Encr
 Tests:
   -
     Name: Encryption Disabled
-    ResourceType: AWS.DynamoDB.Table
     ExpectedResult: false
     Resource:
       {
@@ -78,7 +77,6 @@ Tests:
       }
   -
     Name: Encryption Enabled
-    ResourceType: AWS.DynamoDB.Table
     ExpectedResult: true
     Resource:
       {
@@ -135,7 +133,6 @@ Tests:
       }
   -
     Name: Encryption Not Set
-    ResourceType: AWS.DynamoDB.Table
     ExpectedResult: false
     Resource:
       {

--- a/aws_dynamodb_policies/aws_dynamodb_table_ttl_enabled.yml
+++ b/aws_dynamodb_policies/aws_dynamodb_table_ttl_enabled.yml
@@ -21,7 +21,6 @@ Reference: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.
 Tests:
   -
     Name: TTL Enabled
-    ResourceType: AWS.DynamoDB.Table
     ExpectedResult: true
     Resource:
       {
@@ -92,7 +91,6 @@ Tests:
       }
   -
     Name: TTL Disabled
-    ResourceType: AWS.DynamoDB.Table
     ExpectedResult: false
     Resource:
       {

--- a/aws_ec2_policies/aws_ami_private.yml
+++ b/aws_ec2_policies/aws_ami_private.yml
@@ -18,7 +18,6 @@ Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sharing-amis.html
 Tests:
   -
     Name: Private AMI
-    ResourceType: AWS.EC2.AMI
     ExpectedResult: true
     Resource:
       {
@@ -55,7 +54,6 @@ Tests:
       }
   -
     Name: Public AMI
-    ResourceType: AWS.EC2.AMI
     ExpectedResult: false
     Resource:
       {

--- a/aws_ec2_policies/aws_ec2_ami_approved_host.yml
+++ b/aws_ec2_policies/aws_ec2_ami_approved_host.yml
@@ -17,7 +17,6 @@ Reference: https://aws.amazon.com/ec2/dedicated-hosts/
 Tests:
   -
     Name: Instance AMI Does Not Have Required Host
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: true
     Resource:
       {
@@ -185,7 +184,6 @@ Tests:
       }
   -
     Name: Instance Launched On Incorrect Host
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: false
     Resource:
       {
@@ -353,7 +351,6 @@ Tests:
       }
   -
     Name: Instance Launched On Required Host
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: true
     Resource:
       {
@@ -521,7 +518,6 @@ Tests:
       }
   -
     Name: Instance Not Launched On Dedicated Host But Has Host Requirement
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: false
     Resource:
       {

--- a/aws_ec2_policies/aws_ec2_ami_approved_instance_type.yml
+++ b/aws_ec2_policies/aws_ec2_ami_approved_instance_type.yml
@@ -17,7 +17,6 @@ Reference: https://aws.amazon.com/ec2/instance-types/
 Tests:
   -
     Name: Instance Does Not Have Type Restriction
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: true
     Resource:
       {
@@ -185,7 +184,6 @@ Tests:
       }
   -
     Name: Instance Has Incorrect Instance Type
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: false
     Resource:
       {
@@ -353,7 +351,6 @@ Tests:
       }
   -
     Name: Instance Has Required Instance Type
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: true
     Resource:
       {

--- a/aws_ec2_policies/aws_ec2_ami_approved_tenancy.yml
+++ b/aws_ec2_policies/aws_ec2_ami_approved_tenancy.yml
@@ -17,7 +17,6 @@ Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instanc
 Tests:
   -
     Name: Instance Does Not Have Tenancy Requirements
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: true
     Resource:
       {
@@ -185,7 +184,6 @@ Tests:
       }
   -
     Name: Instance Does Not Meet Tenancy Requirements
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: false
     Resource:
       {
@@ -353,7 +351,6 @@ Tests:
       }
   -
     Name: Instance Meets Tenancy Requirements
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: true
     Resource:
       {

--- a/aws_ec2_policies/aws_ec2_cde_volume_encrypted.yml
+++ b/aws_ec2_policies/aws_ec2_cde_volume_encrypted.yml
@@ -22,7 +22,6 @@ Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.htm
 Tests:
   -
     Name: Volume Encrypted
-    ResourceType: AWS.EC2.Volume
     ExpectedResult: true
     Resource:
       {
@@ -78,7 +77,6 @@ Tests:
       }
   -
     Name: Volume Not Encrypted
-    ResourceType: AWS.EC2.Volume
     ExpectedResult: false
     Resource:
       {
@@ -133,7 +131,6 @@ Tests:
       }
   -
     Name: Volume Not Encrypted But Not In Scope
-    ResourceType: AWS.EC2.Volume
     ExpectedResult: true
     Resource:
       {

--- a/aws_ec2_policies/aws_ec2_instance_approved_ami.yml
+++ b/aws_ec2_policies/aws_ec2_instance_approved_ami.yml
@@ -17,7 +17,6 @@ Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html
 Tests:
   -
     Name: Instance Not Running Approved AMI
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: false
     Resource:
       {
@@ -185,7 +184,6 @@ Tests:
       }
   -
     Name: Instance Running Approved AMI
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: true
     Resource:
       {

--- a/aws_ec2_policies/aws_ec2_instance_approved_host.yml
+++ b/aws_ec2_policies/aws_ec2_instance_approved_host.yml
@@ -17,7 +17,6 @@ Reference: https://aws.amazon.com/ec2/dedicated-hosts/
 Tests:
   -
     Name: Instance Not Running On A Dedicated Host
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: false
     Resource:
       {
@@ -185,7 +184,6 @@ Tests:
       }
   -
     Name: Instance Not Running On Approved Host
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: false
     Resource:
       {
@@ -353,7 +351,6 @@ Tests:
       }
   -
     Name: Instance Running On Approved Host
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: true
     Resource:
       {

--- a/aws_ec2_policies/aws_ec2_instance_approved_instance_type.yml
+++ b/aws_ec2_policies/aws_ec2_instance_approved_instance_type.yml
@@ -17,7 +17,6 @@ Reference: https://aws.amazon.com/ec2/instance-types/
 Tests:
   -
     Name: Instance Not Running Approved Instance Type
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: false
     Resource:
       {
@@ -185,7 +184,6 @@ Tests:
       }
   -
     Name: Instance Running Approved Instance Type
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: true
     Resource:
       {

--- a/aws_ec2_policies/aws_ec2_instance_approved_tenancy.yml
+++ b/aws_ec2_policies/aws_ec2_instance_approved_tenancy.yml
@@ -17,7 +17,6 @@ Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instanc
 Tests:
   -
     Name: Instance Not Running With Required Tenancy
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: false
     Resource:
       {
@@ -185,7 +184,6 @@ Tests:
       }
   -
     Name: Instance Running With Required Tenancy
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: true
     Resource:
       {

--- a/aws_ec2_policies/aws_ec2_instance_approved_vpc.yml
+++ b/aws_ec2_policies/aws_ec2_instance_approved_vpc.yml
@@ -17,7 +17,6 @@ Reference: https://aws.amazon.com/vpc/
 Tests:
   -
     Name: Instance Not Running In Approved VPC
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: false
     Resource:
       {
@@ -185,7 +184,6 @@ Tests:
       }
   -
     Name: Instance Not Running In Approved VPC But Exempted From Rule
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: true
     Resource:
       {
@@ -353,7 +351,6 @@ Tests:
       }
   -
     Name: Instance Running In Approved VPC
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: true
     Resource:
       {

--- a/aws_ec2_policies/aws_ec2_instance_detailed_monitoring.yml
+++ b/aws_ec2_policies/aws_ec2_instance_detailed_monitoring.yml
@@ -17,7 +17,6 @@ Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-
 Tests:
   -
     Name: Detailed Monitoring Disabled
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: false
     Resource:
       {
@@ -185,7 +184,6 @@ Tests:
       }
   -
     Name: Detailed Monitoring Enabled
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: true
     Resource:
       {

--- a/aws_ec2_policies/aws_ec2_instance_ebs_optimization.yml
+++ b/aws_ec2_policies/aws_ec2_instance_ebs_optimization.yml
@@ -17,7 +17,6 @@ Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-optimized.htm
 Tests:
   -
     Name: Instance Does Not Have EBS Optimization Enabled
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: false
     Resource:
       {
@@ -185,7 +184,6 @@ Tests:
       }
   -
     Name: Instance Has EBS Optimization Enabled
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: true
     Resource:
       {
@@ -353,7 +351,6 @@ Tests:
       }
   -
     Name: Instance Type Cannot Be Optimized
-    ResourceType: AWS.EC2.Instance
     ExpectedResult: true
     Resource:
       {

--- a/aws_ec2_policies/aws_ec2_volume_encryption.yml
+++ b/aws_ec2_policies/aws_ec2_volume_encryption.yml
@@ -17,7 +17,6 @@ Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.htm
 Tests:
   -
     Name: Volume Encrypted
-    ResourceType: AWS.EC2.Volume
     ExpectedResult: true
     Resource:
       {
@@ -75,7 +74,6 @@ Tests:
       }
   -
     Name: Volume Not Encrypted
-    ResourceType: AWS.EC2.Volume
     ExpectedResult: false
     Resource:
       {

--- a/aws_ec2_policies/aws_ec2_volume_snapshot_encrypted.yml
+++ b/aws_ec2_policies/aws_ec2_volume_snapshot_encrypted.yml
@@ -17,7 +17,6 @@ Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.htm
 Tests:
   -
     Name: Volume Snapshot Encrypted
-    ResourceType: AWS.EC2.Volume
     ExpectedResult: true
     Resource:
       {
@@ -97,7 +96,6 @@ Tests:
       }
   -
     Name: Volume Snapshot Not Encrypted
-    ResourceType: AWS.EC2.Volume
     ExpectedResult: false
     Resource:
       {
@@ -177,7 +175,6 @@ Tests:
       }
   -
     Name: No Snapshots
-    ResourceType: AWS.EC2.Volume
     ExpectedResult: true
     Resource:
       {

--- a/aws_elb_policies/aws_application_load_balancer_web_acl.yml
+++ b/aws_elb_policies/aws_application_load_balancer_web_acl.yml
@@ -18,7 +18,6 @@ Reference: https://aws.amazon.com/blogs/aws/aws-web-application-firewall-waf-for
 Tests:
   -
     Name: Load Balancer Does Not Have Required WAF Web ACL
-    ResourceType: AWS.ELBV2.ApplicationLoadBalancer
     ExpectedResult: false
     Resource:
       {
@@ -54,7 +53,6 @@ Tests:
       }
   -
     Name: Load Balancer Does Not Require WAF Web ACL
-    ResourceType: AWS.ELBV2.ApplicationLoadBalancer
     ExpectedResult: true
     Resource:
       {
@@ -90,7 +88,6 @@ Tests:
       }
   -
     Name: Load Balancer Has Correct WAF Web ACL
-    ResourceType: AWS.ELBV2.ApplicationLoadBalancer
     ExpectedResult: true
     Resource:
       {

--- a/aws_guardduty_policies/aws_guardduty_enabled.yml
+++ b/aws_guardduty_policies/aws_guardduty_enabled.yml
@@ -17,7 +17,6 @@ Reference: https://aws.amazon.com/guardduty/
 Tests:
   -
     Name: Detectors Do Not Exist
-    ResourceType: AWS.GuardDuty.Detector.Meta
     ExpectedResult: false
     Resource:
       {
@@ -31,7 +30,6 @@ Tests:
       }
   -
     Name: Detectors Exist
-    ResourceType: AWS.GuardDuty.Detector.Meta
     ExpectedResult: true
     Resource:
       {
@@ -49,7 +47,6 @@ Tests:
       }
   -
     Name: Detectors Exist But Not in Required Regions
-    ResourceType: AWS.GuardDuty.Detector.Meta
     ExpectedResult: false
     Resource:
       {

--- a/aws_guardduty_policies/aws_guardduty_master_account.yml
+++ b/aws_guardduty_policies/aws_guardduty_master_account.yml
@@ -19,7 +19,6 @@ Tests:
   -
     # This can't be tested right now as we cannot set the MASTER_ACCOUNT_ID variable for testing
     Name: Detector Not Logging to Master
-    ResourceType: AWS.GuardDuty.Detector
     # Should be false if we could set MASTER_ACCOUNT_ID for testing
     ExpectedResult: true
     Resource:
@@ -41,7 +40,6 @@ Tests:
       }
   -
     Name: Detector Logging to Master
-    ResourceType: AWS.GuardDuty.Detector
     ExpectedResult: true
     Resource:
       {

--- a/aws_guardduty_rules/aws_guardduty_high_sev_findings.yml
+++ b/aws_guardduty_rules/aws_guardduty_high_sev_findings.yml
@@ -18,7 +18,6 @@ Reference:
 Tests:
   -
     Name: High Sev Finding
-    LogType: AWS.GuardDuty
     ExpectedResult: true
     Log:
       {

--- a/aws_guardduty_rules/aws_guardduty_low_sev_findings.yml
+++ b/aws_guardduty_rules/aws_guardduty_low_sev_findings.yml
@@ -18,7 +18,6 @@ Reference:
 Tests:
   -
     Name: Low Sev Finding
-    LogType: AWS.GuardDuty
     ExpectedResult: true
     Log:
       {

--- a/aws_guardduty_rules/aws_guardduty_med_sev_findings.yml
+++ b/aws_guardduty_rules/aws_guardduty_med_sev_findings.yml
@@ -18,7 +18,6 @@ Reference:
 Tests:
   -
     Name: Medium Sev Finding
-    LogType: AWS.GuardDuty
     ExpectedResult: true
     Log:
       {

--- a/aws_iam_policies/aws_access_key_rotation.yml
+++ b/aws_iam_policies/aws_access_key_rotation.yml
@@ -24,7 +24,6 @@ Reference: >
 Tests:
   -
     Name: Root User Access Key 1 Rotated Over 90 Days Ago
-    ResourceType: AWS.IAM.RootUser
     ExpectedResult: false
     Resource:
       {
@@ -60,7 +59,6 @@ Tests:
       }
   -
     Name: Root User Access Key 2 Rotated Less Than 90 Days Ago
-    ResourceType: AWS.IAM.RootUser
     ExpectedResult: true
     Resource:
       {
@@ -96,7 +94,6 @@ Tests:
       }
   -
     Name: User Access Key 1 Rotated Less Than 90 Days Ago
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {
@@ -149,7 +146,6 @@ Tests:
       }
   -
     Name: User Access Key 1 Rotated Over 90 Days Ago
-    ResourceType: AWS.IAM.User
     ExpectedResult: false
     Resource:
       {
@@ -202,7 +198,6 @@ Tests:
       }
   -
     Name: User Access Key 2 Rotated Less Than 90 Days Ago
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {
@@ -255,7 +250,6 @@ Tests:
       }
   -
     Name: User Access Key 2 Rotated Over 90 Days Ago
-    ResourceType: AWS.IAM.User
     ExpectedResult: false
     Resource:
       {

--- a/aws_iam_policies/aws_access_key_unused.yml
+++ b/aws_iam_policies/aws_access_key_unused.yml
@@ -23,7 +23,6 @@ Reference: >
 Tests:
   -
     Name: Root User Access Key 1 Used And Rotated Over 90 Days Ago
-    ResourceType: AWS.IAM.RootUser
     ExpectedResult: false
     Resource:
       {
@@ -59,7 +58,6 @@ Tests:
       }
   -
     Name: Root User Access Key 2 Never Used But Rotated Less Than 90 Days Ago
-    ResourceType: AWS.IAM.RootUser
     ExpectedResult: true
     Resource:
       {
@@ -95,7 +93,6 @@ Tests:
       }
   -
     Name: User Access Key 1 Never Used But Rotated Less Than 90 Days Ago
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {
@@ -148,7 +145,6 @@ Tests:
       }
   -
     Name: User Access Key 1 Used And Rotated Over 90 Days Ago
-    ResourceType: AWS.IAM.User
     ExpectedResult: false
     Resource:
       {
@@ -201,7 +197,6 @@ Tests:
       }
   -
     Name: User Access Key 1 Used Less Than 90 Days Ago
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {
@@ -254,7 +249,6 @@ Tests:
       }
   -
     Name: User Access Key 2 Used And Rotated Over 90 Days Ago
-    ResourceType: AWS.IAM.User
     ExpectedResult: false
     Resource:
       {
@@ -307,7 +301,6 @@ Tests:
       }
   -
     Name: User Access Key 2 Used Less Than 90 Days Ago
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {
@@ -360,7 +353,6 @@ Tests:
       }
   -
     Name: User No Active Access Keys
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {

--- a/aws_iam_policies/aws_access_keys_at_account_creation.yml
+++ b/aws_iam_policies/aws_access_keys_at_account_creation.yml
@@ -24,7 +24,6 @@ Reference: >
 Tests:
   -
     Name: Root User Access Key Created At Account Creation
-    ResourceType: AWS.IAM.RootUser
     ExpectedResult: false
     Resource:
       {
@@ -60,7 +59,6 @@ Tests:
       }
   -
     Name: Root User Access Key Not Created At Acccount Creation
-    ResourceType: AWS.IAM.RootUser
     ExpectedResult: true
     Resource:
       {
@@ -96,7 +94,6 @@ Tests:
       }
   -
     Name: Root User Access Key Rotated Since Account Creation
-    ResourceType: AWS.IAM.RootUser
     ExpectedResult: true
     Resource:
       {
@@ -132,7 +129,6 @@ Tests:
       }
   -
     Name: User Access Key Created At Account Creation
-    ResourceType: AWS.IAM.User
     ExpectedResult: false
     Resource:
       {
@@ -185,7 +181,6 @@ Tests:
       }
   -
     Name: User Access Key Not Created At Account Creation
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {
@@ -238,7 +233,6 @@ Tests:
       }
   -
     Name: User Access Key Rotated Since Account Creation
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {

--- a/aws_iam_policies/aws_cloudtrail_least_privilege.yml
+++ b/aws_iam_policies/aws_cloudtrail_least_privilege.yml
@@ -19,7 +19,6 @@ Reference: https://amzn.to/2ZEUrKm
 Tests:
   -
     Name: Limited Membership to IAM Group with CloudTrail FullAccess Policy
-    ResourceType: AWS.IAM.Group
     ExpectedResult: true
     Resource:
       {
@@ -48,7 +47,6 @@ Tests:
       }
   -
     Name: More Than 2 Users in IAM Group with CloudTrail FullAccess Policy
-    ResourceType: AWS.IAM.Group
     ExpectedResult: false
     Resource:
       {

--- a/aws_iam_policies/aws_iam_group_users.yml
+++ b/aws_iam_policies/aws_iam_group_users.yml
@@ -18,7 +18,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 Tests:
   -
     Name: Group Has No Users
-    ResourceType: AWS.IAM.Group
     ExpectedResult: false
     Resource:
       {
@@ -31,7 +30,6 @@ Tests:
       }
   -
     Name: Group Has Users
-    ResourceType: AWS.IAM.Group
     ExpectedResult: true
     Resource:
       {

--- a/aws_iam_policies/aws_iam_inline_policy_does_not_grant_network_admin_access.yml
+++ b/aws_iam_policies/aws_iam_inline_policy_does_not_grant_network_admin_access.yml
@@ -24,7 +24,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_mana
 Tests:
   -
     Name: IAM Entity Has No Inline Policy
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {

--- a/aws_iam_policies/aws_iam_policy_administrative_privileges.yml
+++ b/aws_iam_policies/aws_iam_policy_administrative_privileges.yml
@@ -22,7 +22,6 @@ Reference: >
 Tests:
   -
     Name: Policy Does Not Grant Full Administrative Privileges
-    ResourceType: AWS.IAM.Policy
     ExpectedResult: true
     Resource:
       {
@@ -56,7 +55,6 @@ Tests:
       }
   -
     Name: Policy Grant Full Administrative Access With Multiple Resources
-    ResourceType: AWS.IAM.Policy
     ExpectedResult: false
     Resource:
       {
@@ -90,7 +88,6 @@ Tests:
       }
   -
     Name: Policy Grants Full Administrative Privileges
-    ResourceType: AWS.IAM.Policy
     ExpectedResult: false
     Resource:
       {

--- a/aws_iam_policies/aws_iam_policy_assigned_to_user.yml
+++ b/aws_iam_policies/aws_iam_policy_assigned_to_user.yml
@@ -24,7 +24,6 @@ Reference: https://amzn.to/2Pss7Ln
 Tests:
   -
     Name: Managed Policy Directly Assigned
-    ResourceType: AWS.IAM.User
     ExpectedResult: false
     Resource:
       {
@@ -81,7 +80,6 @@ Tests:
       }
   -
     Name: Inline Policy Directly Assigned
-    ResourceType: AWS.IAM.User
     ExpectedResult: false
     Resource:
       {
@@ -136,7 +134,6 @@ Tests:
       }
   -
     Name: No Policies Directly Assigned
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {

--- a/aws_iam_policies/aws_iam_policy_blacklist.yml
+++ b/aws_iam_policies/aws_iam_policy_blacklist.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html
 Tests:
   -
     Name: IAM User Does Not Have Blacklisted Policy
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {
@@ -73,7 +72,6 @@ Tests:
       }
   -
     Name: IAM User Has Blacklisted Policy
-    ResourceType: AWS.IAM.User
     ExpectedResult: false
     Resource:
       {

--- a/aws_iam_policies/aws_iam_policy_does_not_grant_admin_access.yml
+++ b/aws_iam_policies/aws_iam_policy_does_not_grant_admin_access.yml
@@ -21,7 +21,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html
 Tests:
   -
     Name: Policy Does Not Grant Administrative Privileges
-    ResourceType: AWS.IAM.Policy
     ExpectedResult: true
     Resource:
       {
@@ -55,7 +54,6 @@ Tests:
       }
   -
     Name: Policy Does Grant Administrative Privileges
-    ResourceType: AWS.IAM.Policy
     ExpectedResult: false
     Resource:
       {

--- a/aws_iam_policies/aws_iam_policy_does_not_grant_network_admin_access.yml
+++ b/aws_iam_policies/aws_iam_policy_does_not_grant_network_admin_access.yml
@@ -19,7 +19,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html
 Tests:
   -
     Name: IAM Policy Does Not Grant VPC Permissions
-    ResourceType: AWS.IAM.Policy
     ExpectedResult: true
     Resource:
       {
@@ -53,7 +52,6 @@ Tests:
       }
   -
     Name: IAM Policy Does Grant VPC Write Permissions
-    ResourceType: AWS.IAM.Policy
     ExpectedResult: false
     Resource:
       {
@@ -87,7 +85,6 @@ Tests:
       }
   -
     Name: IAM Policy Grants Only VPC Read Permissions
-    ResourceType: AWS.IAM.Policy
     ExpectedResult: true
     Resource:
       {

--- a/aws_iam_policies/aws_iam_policy_role_mapping.yml
+++ b/aws_iam_policies/aws_iam_policy_role_mapping.yml
@@ -18,7 +18,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
 Tests:
   -
     Name: Policy Applied To Required Roles
-    ResourceType: AWS.IAM.Policy
     ExpectedResult: true
     Resource:
       {
@@ -56,7 +55,6 @@ Tests:
       }
   -
     Name: Policy Does Not Have Role Mappings
-    ResourceType: AWS.IAM.Policy
     ExpectedResult: true
     Resource:
       {
@@ -90,7 +88,6 @@ Tests:
       }
   -
     Name: Policy Not Applied To Required Roles
-    ResourceType: AWS.IAM.Policy
     ExpectedResult: false
     Resource:
       {

--- a/aws_iam_policies/aws_iam_resource_does_not_have_inline_policy.yml
+++ b/aws_iam_policies/aws_iam_resource_does_not_have_inline_policy.yml
@@ -21,7 +21,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_mana
 Tests:
   -
     Name: IAM User Has Inline Policy
-    ResourceType: AWS.IAM.User
     ExpectedResult: false
     Resource:
       {
@@ -74,7 +73,6 @@ Tests:
       }
   -
     Name: IAM User Has No Inline Policy
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {

--- a/aws_iam_policies/aws_iam_role_restricts_usage.yml
+++ b/aws_iam_policies/aws_iam_role_restricts_usage.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_permiss
 Tests:
   -
     Name: Role Restricts Usage
-    ResourceType: AWS.IAM.Role
     ExpectedResult: true
     Resource:
       {
@@ -46,7 +45,6 @@ Tests:
       }
   -
     Name: Role Does Not Restrict Usage
-    ResourceType: AWS.IAM.Role
     ExpectedResult: false
     Resource:
       {
@@ -72,7 +70,6 @@ Tests:
       }
   -
     Name: Role Restrict Usage With Deny Statement
-    ResourceType: AWS.IAM.Role
     ExpectedResult: true
     Resource:
       {
@@ -98,7 +95,6 @@ Tests:
       }
   -
     Name: Role Restrict Usage With Deny Statement
-    ResourceType: AWS.IAM.Role
     ExpectedResult: true
     Resource:
       {

--- a/aws_iam_policies/aws_iam_user_mfa.yml
+++ b/aws_iam_policies/aws_iam_user_mfa.yml
@@ -23,7 +23,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_e
 Tests:
   -
     Name: Password Disabled, MFA Disabled
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {
@@ -76,7 +75,6 @@ Tests:
       }
   -
     Name: Password Disabled, MFA Enabled
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {
@@ -129,7 +127,6 @@ Tests:
       }
   -
     Name: Password Enabled, MFA Disabled
-    ResourceType: AWS.IAM.User
     ExpectedResult: false
     Resource:
       {
@@ -182,7 +179,6 @@ Tests:
       }
   -
     Name: Password Enabled, MFA Enabled
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {

--- a/aws_iam_policies/aws_iam_user_not_in_conflicting_groups.yml
+++ b/aws_iam_policies/aws_iam_user_not_in_conflicting_groups.yml
@@ -21,7 +21,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups.html
 Tests:
   -
     Name: User In Conflicting Groups
-    ResourceType: AWS.IAM.User
     ExpectedResult: false
     Resource:
       {
@@ -81,7 +80,6 @@ Tests:
       }
   -
     Name: User Not In Conflicting Groups
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {

--- a/aws_iam_policies/aws_password_unused.yml
+++ b/aws_iam_policies/aws_password_unused.yml
@@ -22,7 +22,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 Tests:
   -
     Name: Password Last Used Less Than 90 Days Ago
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {
@@ -75,7 +74,6 @@ Tests:
       }
   -
     Name: Password Last Used Over 90 Days Ago
-    ResourceType: AWS.IAM.User
     ExpectedResult: false
     Resource:
       {
@@ -128,7 +126,6 @@ Tests:
       }
   -
     Name: Password Never Used, Password Last Changed Less Than 90 Days Ago
-    ResourceType: AWS.IAM.User
     ExpectedResult: true
     Resource:
       {
@@ -181,7 +178,6 @@ Tests:
       }
   -
     Name: Password Never Used, Password Last Changed Over 90 Days Ago
-    ResourceType: AWS.IAM.User
     ExpectedResult: false
     Resource:
       {

--- a/aws_iam_policies/aws_root_account_access_keys.yml
+++ b/aws_iam_policies/aws_root_account_access_keys.yml
@@ -23,7 +23,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 Tests:
   -
     Name: Access Key 1 Active
-    ResourceType: AWS.IAM.RootUser
     ExpectedResult: false
     Resource:
       {
@@ -59,7 +58,6 @@ Tests:
       }
   -
     Name: Access Key 2 Active
-    ResourceType: AWS.IAM.RootUser
     ExpectedResult: false
     Resource:
       {
@@ -95,7 +93,6 @@ Tests:
       }
   -
     Name: Access Keys 1 and 2 Active
-    ResourceType: AWS.IAM.RootUser
     ExpectedResult: false
     Resource:
       {
@@ -131,7 +128,6 @@ Tests:
       }
   -
     Name: No Access Keys Enabled
-    ResourceType: AWS.IAM.RootUser
     ExpectedResult: true
     Resource:
       {

--- a/aws_iam_policies/aws_root_account_hardware_mfa.yml
+++ b/aws_iam_policies/aws_root_account_hardware_mfa.yml
@@ -23,7 +23,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 Tests:
   -
     Name: MFA Active With No Virtual MFA Device
-    ResourceType: AWS.IAM.RootUser
     ExpectedResult: true
     Resource:
       {
@@ -59,7 +58,6 @@ Tests:
       }
   -
     Name: MFA Active With Virtual MFA Device
-    ResourceType: AWS.IAM.RootUser
     ExpectedResult: false
     Resource:
       {
@@ -98,7 +96,6 @@ Tests:
       }
   -
     Name: MFA Not Active
-    ResourceType: AWS.IAM.RootUser
     ExpectedResult: true
     Resource:
       {

--- a/aws_iam_policies/aws_root_account_mfa.yml
+++ b/aws_iam_policies/aws_root_account_mfa.yml
@@ -23,7 +23,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 Tests:
   -
     Name: MFA Enabled
-    ResourceType: AWS.IAM.RootUser
     ExpectedResult: true
     Resource:
       {
@@ -59,7 +58,6 @@ Tests:
       }
   -
     Name: MFA Not Enabled
-    ResourceType: AWS.IAM.RootUser
     ExpectedResult: false
     Resource:
       {

--- a/aws_kms_policies/aws_cmk_key_rotation.yml
+++ b/aws_kms_policies/aws_cmk_key_rotation.yml
@@ -23,7 +23,6 @@ Reference: >
 Tests:
   -
     Name: Key Managed By AWS
-    ResourceType: AWS.KMS.Key
     ExpectedResult: true
     Resource:
       {
@@ -47,7 +46,6 @@ Tests:
       }
   -
     Name: Key Rotation Enabled
-    ResourceType: AWS.KMS.Key
     ExpectedResult: true
     Resource:
       {
@@ -71,7 +69,6 @@ Tests:
       }
   -
     Name: Key Rotation Never Set
-    ResourceType: AWS.KMS.Key
     ExpectedResult: false
     Resource:
       {
@@ -95,7 +92,6 @@ Tests:
       }
   -
     Name: Key Rotation Not Enabled
-    ResourceType: AWS.KMS.Key
     ExpectedResult: false
     Resource:
       {

--- a/aws_kms_policies/aws_kms_key_policy_restricts_usage.yml
+++ b/aws_kms_policies/aws_kms_key_policy_restricts_usage.yml
@@ -19,7 +19,6 @@ Reference: https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.ht
 Tests:
   -
     Name: Key Usage Not Restricted
-    ResourceType: AWS.KMS.Key
     ExpectedResult: false
     Resource:
       {
@@ -43,7 +42,6 @@ Tests:
       }
   -
     Name: Key Restricts Usage With Condition
-    ResourceType: AWS.KMS.Key
     ExpectedResult: true
     Resource:
       {

--- a/aws_load_balancer_policies/aws_alb_ssl_policy.yml
+++ b/aws_load_balancer_policies/aws_alb_ssl_policy.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/creat
 Tests:
   -
     Name: Strong Ciphers Internet Facing
-    ResourceType: AWS.ELBV2.ApplicationLoadBalancer
     ExpectedResult: true
     Resource:
       {
@@ -183,7 +182,6 @@ Tests:
       }
   -
     Name: Default Ciphers
-    ResourceType: AWS.ELBV2.ApplicationLoadBalancer
     ExpectedResult: false
     Resource:
       {
@@ -348,7 +346,6 @@ Tests:
       }
   -
     Name: Default Ciphers Internal Load Balancer
-    ResourceType: AWS.ELBV2.ApplicationLoadBalancer
     ExpectedResult: true
     Resource:
       {

--- a/aws_load_balancer_policies/aws_elbv2_load_balancer_has_ssl_policy.yml
+++ b/aws_load_balancer_policies/aws_elbv2_load_balancer_has_ssl_policy.yml
@@ -19,7 +19,6 @@ Reference: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/l
 Tests:
   -
     Name: LB Using SSL Policy
-    ResourceType: AWS.ELBV2.ApplicationLoadBalancer
     ExpectedResult: true
     Resource:
       {
@@ -112,7 +111,6 @@ Tests:
       }
   -
     Name: LB Not Using SSL Policy
-    ResourceType: AWS.ELBV2.ApplicationLoadBalancer
     ExpectedResult: False
     Resource:
       {

--- a/aws_rds_policies/aws_rds_instance_auto_minor_version_upgrade_enabled.yml
+++ b/aws_rds_policies/aws_rds_instance_auto_minor_version_upgrade_enabled.yml
@@ -24,7 +24,6 @@ Reference: https://amzn.to/2L8POnD
 Tests:
   -
     Name: Instance Auto Minor Version Upgrade Enabled
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: true
     Resource:
       {
@@ -166,7 +165,6 @@ Tests:
       }
   -
     Name: Instance Auto Minor Version Upgrade Not Enabled
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: false
     Resource:
       {

--- a/aws_rds_policies/aws_rds_instance_backup.yml
+++ b/aws_rds_policies/aws_rds_instance_backup.yml
@@ -18,7 +18,6 @@ Reference: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWi
 Tests:
   -
     Name: RDS Instance Backup Disabled
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: false
     Resource:
       {
@@ -160,7 +159,6 @@ Tests:
       }
   -
     Name: RDS Instance Backup Enabled
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: true
     Resource:
       {

--- a/aws_rds_policies/aws_rds_instance_backup_retention_acceptable.yml
+++ b/aws_rds_policies/aws_rds_instance_backup_retention_acceptable.yml
@@ -21,7 +21,6 @@ Reference: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWi
 Tests:
   -
     Name: RDS Instance Backup Disabled
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: false
     Resource:
       {
@@ -166,7 +165,6 @@ Tests:
       }
   -
     Name: RDS Instance Backup Enabled
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: true
     Resource:
       {

--- a/aws_rds_policies/aws_rds_instance_encryption.yml
+++ b/aws_rds_policies/aws_rds_instance_encryption.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encry
 Tests:
   -
     Name: KMS Key Does Not Exist
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: false
     Resource:
       {
@@ -162,7 +161,6 @@ Tests:
       }
   -
     Name: KMS Key Exists
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: true
     Resource:
       {

--- a/aws_rds_policies/aws_rds_instance_high_availability.yml
+++ b/aws_rds_policies/aws_rds_instance_high_availability.yml
@@ -18,7 +18,6 @@ Reference: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.Multi
 Tests:
   -
     Name: Multi AZ Is False
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: false
     Resource:
       {
@@ -160,7 +159,6 @@ Tests:
       }
   -
     Name: Multi AZ Is False with Aurora
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: true
     Resource:
       {
@@ -302,7 +300,6 @@ Tests:
       }
   -
     Name: Multi AZ Is True
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: true
     Resource:
       {

--- a/aws_rds_policies/aws_rds_instance_public_access.yml
+++ b/aws_rds_policies/aws_rds_instance_public_access.yml
@@ -17,7 +17,6 @@ Reference: https://docs.aws.amazon.com/en_pv/AmazonRDS/latest/UserGuide/USER_VPC
 Tests:
   -
     Name: Instance Not Publicly Accessible
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: true
     Resource:
       {
@@ -159,7 +158,6 @@ Tests:
       }
   -
     Name: Instance Publicly Accessible
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: false
     Resource:
       {

--- a/aws_rds_policies/aws_rds_instance_snapshot_public_access.yml
+++ b/aws_rds_policies/aws_rds_instance_snapshot_public_access.yml
@@ -17,7 +17,6 @@ Reference: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWi
 Tests:
   -
     Name: Instance Has No Snapshots
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: true
     Resource:
       {
@@ -140,7 +139,6 @@ Tests:
       }
   -
     Name: Instance Snapshot Can Be Returned By All
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: false
     Resource:
       {
@@ -282,7 +280,6 @@ Tests:
       }
   -
     Name: Instance Snapshot Can Be Returned By All In List
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: false
     Resource:
       {
@@ -427,7 +424,6 @@ Tests:
       }
   -
     Name: Instance Snapshot Can Be Returned By Some
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: true
     Resource:
       {
@@ -569,7 +565,6 @@ Tests:
       }
   -
     Name: Instance Snapshot Cannot Be Restored By All
-    ResourceType: AWS.RDS.Instance
     ExpectedResult: true
     Resource:
       {

--- a/aws_redshift_policies/aws_redshift_cluster_encryption.yml
+++ b/aws_redshift_policies/aws_redshift_cluster_encryption.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-db-encr
 Tests:
   -
     Name: Encryption Enabled
-    ResourceType: AWS.Redshift.Cluster
     ExpectedResult: true
     Resource:
       {
@@ -105,7 +104,6 @@ Tests:
       }
   -
     Name: Encryption Not Enabled
-    ResourceType: AWS.Redshift.Cluster
     ExpectedResult: false
     Resource:
       {

--- a/aws_redshift_policies/aws_redshift_cluster_logging.yml
+++ b/aws_redshift_policies/aws_redshift_cluster_logging.yml
@@ -17,7 +17,6 @@ Reference: https://aws.amazon.com/premiumsupport/knowledge-center/logs-redshift-
 Tests:
   -
     Name: Logging Disabled
-    ResourceType: AWS.Redshift.Cluster
     ExpectedResult: false
     Resource:
       {
@@ -102,7 +101,6 @@ Tests:
       }
   -
     Name: Logging Enabled
-    ResourceType: AWS.Redshift.Cluster
     ExpectedResult: true
     Resource:
       {

--- a/aws_redshift_policies/aws_redshift_cluster_maintenance_window.yml
+++ b/aws_redshift_policies/aws_redshift_cluster_maintenance_window.yml
@@ -17,7 +17,6 @@ Reference: https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-cluster
 Tests:
   -
     Name: Correct Preferred Maintenance Window
-    ResourceType: AWS.Redshift.Cluster
     ExpectedResult: true
     Resource:
       {
@@ -102,7 +101,6 @@ Tests:
       }
   -
     Name: Incorrect Preferred Maintenance Window
-    ResourceType: AWS.Redshift.Cluster
     ExpectedResult: false
     Resource:
       {

--- a/aws_redshift_policies/aws_redshift_cluster_snapshot_retention.yml
+++ b/aws_redshift_policies/aws_redshift_cluster_snapshot_retention.yml
@@ -17,7 +17,6 @@ Reference: https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-snapsho
 Tests:
   -
     Name: Insufficient Backup Retention Period
-    ResourceType: AWS.Redshift.Cluster
     ExpectedResult: false
     Resource:
       {
@@ -102,7 +101,6 @@ Tests:
       }
   -
     Name: Sufficient Backup Retention Period
-    ResourceType: AWS.Redshift.Cluster
     ExpectedResult: true
     Resource:
       {

--- a/aws_redshift_policies/aws_redshift_cluster_snapshot_retention_acceptable.yml
+++ b/aws_redshift_policies/aws_redshift_cluster_snapshot_retention_acceptable.yml
@@ -21,7 +21,6 @@ Reference: https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-snapsho
 Tests:
   -
     Name: Insufficient Backup Retention Period
-    ResourceType: AWS.Redshift.Cluster
     ExpectedResult: false
     Resource:
       {
@@ -108,7 +107,6 @@ Tests:
       }
   -
     Name: Sufficient Backup Retention Period
-    ResourceType: AWS.Redshift.Cluster
     ExpectedResult: true
     Resource:
       {

--- a/aws_redshift_policies/aws_redshift_cluster_version_upgrade.yml
+++ b/aws_redshift_policies/aws_redshift_cluster_version_upgrade.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-cluster
 Tests:
   -
     Name: Allow Version Upgrade Not Set
-    ResourceType: AWS.Redshift.Cluster
     ExpectedResult: false
     Resource:
       {
@@ -105,7 +104,6 @@ Tests:
       }
   -
     Name: Allow Version Upgrade
-    ResourceType: AWS.Redshift.Cluster
     ExpectedResult: true
     Resource:
       {
@@ -190,7 +188,6 @@ Tests:
       }
   -
     Name: Does Not Allow Version Upgrade
-    ResourceType: AWS.Redshift.Cluster
     ExpectedResult: false
     Resource:
       {

--- a/aws_s3_policies/aws_s3_bucket_action_restrictions.yml
+++ b/aws_s3_policies/aws_s3_bucket_action_restrictions.yml
@@ -21,7 +21,6 @@ Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-polici
 Tests:
   -
     Name: Bucket Restricts Action
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: true
     Resource:
       {
@@ -55,7 +54,6 @@ Tests:
       }
   -
     Name: Bucket Does Not Restrict S3 Actions
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {
@@ -89,7 +87,6 @@ Tests:
       }
   -
     Name: Bucket Does Not Restrict Any Actions Expanded
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {
@@ -124,7 +121,6 @@ Tests:
       }
   -
     Name: Bucket Restricts Action With Deny Statement
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: true
     Resource:
       {

--- a/aws_s3_policies/aws_s3_bucket_encryption.yml
+++ b/aws_s3_policies/aws_s3_bucket_encryption.yml
@@ -21,7 +21,6 @@ Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.htm
 Tests:
   -
     Name: Bucket Has No Encryption Rules
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {
@@ -69,7 +68,6 @@ Tests:
       }
   -
     Name: Encryption Is Set
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: true
     Resource:
       {
@@ -124,7 +122,6 @@ Tests:
       }
   -
     Name: SSE Algorithm Is Not Set
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {

--- a/aws_s3_policies/aws_s3_bucket_lifecycle_configuration.yml
+++ b/aws_s3_policies/aws_s3_bucket_lifecycle_configuration.yml
@@ -22,7 +22,6 @@ Reference: https://amzn.to/2visoXr
 Tests:
   -
     Name: Bucket Has a Compliant 1-Year Lifecycle Configuration
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: true
     Resource:
       {
@@ -78,7 +77,6 @@ Tests:
       }
   -
     Name: Bucket Does Not Have Lifecycle Configuration
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {
@@ -112,7 +110,6 @@ Tests:
       }
   -
     Name: Bucket Has Insufficient Lifecycle Configuration
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {

--- a/aws_s3_policies/aws_s3_bucket_logging.yml
+++ b/aws_s3_policies/aws_s3_bucket_logging.yml
@@ -18,7 +18,6 @@ Reference: https://blog.runpanther.io/s3-bucket-access-logging/
 Tests:
   -
     Name: Bucket Logging Policy Is Disabled
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {
@@ -73,7 +72,6 @@ Tests:
       }
   -
     Name: Bucket Logging Policy Is Enabled
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: true
     Resource:
       {

--- a/aws_s3_policies/aws_s3_bucket_mfa_delete.yml
+++ b/aws_s3_policies/aws_s3_bucket_mfa_delete.yml
@@ -17,7 +17,6 @@ Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMFADelete.html
 Tests:
   -
     Name: Bucket MFA Delete Never Set
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {
@@ -51,7 +50,6 @@ Tests:
       }
   -
     Name: Bucket Has MFA Delete Enabled
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: true
     Resource:
       {
@@ -85,7 +83,6 @@ Tests:
       }
   -
     Name: Bucket Does Not MFA Delete Enabled
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {

--- a/aws_s3_policies/aws_s3_bucket_name_dns_compliance.yml
+++ b/aws_s3_policies/aws_s3_bucket_name_dns_compliance.yml
@@ -16,7 +16,6 @@ Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.ht
 Tests:
   -
     Name: Bucket Name Has No Periods
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: true
     Resource:
       {
@@ -71,7 +70,6 @@ Tests:
       }
   -
     Name: Bucket Name Has Periods
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {

--- a/aws_s3_policies/aws_s3_bucket_object_lock_configured.yml
+++ b/aws_s3_policies/aws_s3_bucket_object_lock_configured.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html
 Tests:
   -
     Name: Obect Lock Configured With Governance
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {
@@ -82,7 +81,6 @@ Tests:
       }
   -
     Name: Obect Lock Configured With Compliance
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: true
     Resource:
       {
@@ -144,7 +142,6 @@ Tests:
       }
   -
     Name: Obect Lock Not Configured
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {

--- a/aws_s3_policies/aws_s3_bucket_policy_allow_with_not_principal.yml
+++ b/aws_s3_policies/aws_s3_bucket_policy_allow_with_not_principal.yml
@@ -17,7 +17,6 @@ Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_e
 Tests:
   -
     Name: Bucket Uses Allow With Principal
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: true
     Resource:
       {
@@ -51,7 +50,6 @@ Tests:
       }
   -
     Name: Bucket Uses Allow With Not Principal
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {

--- a/aws_s3_policies/aws_s3_bucket_principal_restrictions.yml
+++ b/aws_s3_policies/aws_s3_bucket_principal_restrictions.yml
@@ -21,7 +21,6 @@ Reference: https://aws.amazon.com/premiumsupport/knowledge-center/secure-s3-reso
 Tests:
   -
     Name: Bucket Does Not Restrict Principal
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {
@@ -55,7 +54,6 @@ Tests:
       }
   -
     Name: Bucket Does Restrict Principal
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: true
     Resource:
       {
@@ -89,7 +87,6 @@ Tests:
       }
   -
     Name: Bucket Does Not Restrict Principal But Has Condition
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: true
     Resource:
       {

--- a/aws_s3_policies/aws_s3_bucket_public_access_block.yml
+++ b/aws_s3_policies/aws_s3_bucket_public_access_block.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-
 Tests:
   -
     Name: Public Access Block Configuration Is Not Set
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {
@@ -70,7 +69,6 @@ Tests:
       }
   -
     Name: Public Access Block Configuration Is Set
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: true
     Resource:
       {

--- a/aws_s3_policies/aws_s3_bucket_public_read.yml
+++ b/aws_s3_policies/aws_s3_bucket_public_read.yml
@@ -21,7 +21,6 @@ Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-
 Tests:
   -
     Name: Bucket Allows READ Access For All Users
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {
@@ -76,7 +75,6 @@ Tests:
       }
   -
     Name: Bucket Allows READ For All Authenticated Users
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {
@@ -131,7 +129,6 @@ Tests:
       }
   -
     Name: Bucket Allows WRITE To All Users
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: true
     Resource:
       {

--- a/aws_s3_policies/aws_s3_bucket_public_write.yml
+++ b/aws_s3_policies/aws_s3_bucket_public_write.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.ht
 Tests:
   -
     Name: Bucket Grants READ To All Authenticated Users
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: true
     Resource:
       {
@@ -75,7 +74,6 @@ Tests:
       }
   -
     Name: Bucket Grants WRITE To All Authenticated Users
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {
@@ -130,7 +128,6 @@ Tests:
       }
   -
     Name: Bucket Grants WRITE To All Users
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {

--- a/aws_s3_policies/aws_s3_bucket_secure_access.yml
+++ b/aws_s3_policies/aws_s3_bucket_secure_access.yml
@@ -21,7 +21,6 @@ Reference: https://aws.amazon.com/premiumsupport/knowledge-center/secure-s3-reso
 Tests:
   -
     Name: Bucket Uses Allow With Condition
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: true
     Resource:
       {
@@ -55,7 +54,6 @@ Tests:
       }
   -
     Name: Bucket Uses Allow With Wrong Condition
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {
@@ -89,7 +87,6 @@ Tests:
       }
   -
     Name: Bucket Uses Allow Without Condition
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {
@@ -123,7 +120,6 @@ Tests:
       }
   -
     Name: Bucket Has No Access Policy 
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {

--- a/aws_s3_policies/aws_s3_bucket_versioning.yml
+++ b/aws_s3_policies/aws_s3_bucket_versioning.yml
@@ -21,7 +21,6 @@ Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html
 Tests:
   -
     Name: Bucket Versioning Disabled
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: false
     Resource:
       {
@@ -76,7 +75,6 @@ Tests:
       }
   -
     Name: Bucket Versioning Enabled
-    ResourceType: AWS.S3.Bucket
     ExpectedResult: true
     Resource:
       {

--- a/aws_s3_rules/aws_s3_access_error.yml
+++ b/aws_s3_rules/aws_s3_access_error.yml
@@ -19,7 +19,6 @@ Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/ErrorCode.html
 Tests:
   -
     Name: Amazon Access Error
-    LogType: AWS.S3ServerAccess
     ExpectedResult: false
     Log:
       {
@@ -45,7 +44,6 @@ Tests:
       }
   -
     Name: Access Error
-    LogType: AWS.S3ServerAccess
     ExpectedResult: true
     Log:
       {
@@ -61,7 +59,6 @@ Tests:
       }
   -
     Name: 403 on HEAD.BUCKET
-    LogType: AWS.S3ServerAccess
     ExpectedResult: false
     Log:
       {
@@ -77,7 +74,6 @@ Tests:
       }
   -
     Name: Internal Server Error
-    LogType: AWS.S3ServerAccess
     ExpectedResult: false
     Log:
       {

--- a/aws_s3_rules/aws_s3_access_ip_whitelist.yml
+++ b/aws_s3_rules/aws_s3_access_ip_whitelist.yml
@@ -20,7 +20,6 @@ Reference:
 Tests:
   -
     Name: Access From Approved IP
-    LogType: AWS.S3ServerAccess
     ExpectedResult: false
     Log:
       {
@@ -29,7 +28,6 @@ Tests:
       }
   -
     Name: Access From Unapproved IP
-    LogType: AWS.S3ServerAccess
     ExpectedResult: true
     Log:
       {

--- a/aws_s3_rules/aws_s3_insecure_access.yml
+++ b/aws_s3_rules/aws_s3_insecure_access.yml
@@ -20,7 +20,6 @@ Reference:
 Tests:
   -
     Name: Secure Access to S3 Bucket
-    LogType: AWS.S3ServerAccess
     ExpectedResult: false
     Log:
       {
@@ -56,7 +55,6 @@ Tests:
       }
   -
     Name: Delete Marker Call
-    LogType: AWS.S3ServerAccess
     ExpectedResult: False
     Log:
       {
@@ -76,7 +74,6 @@ Tests:
       }
   -
     Name: Insecure Access to S3 Bucket
-    LogType: AWS.S3ServerAccess
     ExpectedResult: true
     Log:
       {

--- a/aws_s3_rules/aws_s3_unauthenticated_access.yml
+++ b/aws_s3_rules/aws_s3_unauthenticated_access.yml
@@ -17,7 +17,6 @@ Runbook: >
 Tests:
   -
     Name: Authenticated Access
-    LogType: AWS.S3ServerAccess
     ExpectedResult: false
     Log:
       {
@@ -26,7 +25,6 @@ Tests:
       }
   -
     Name: Unauthenticated Access
-    LogType: AWS.S3ServerAccess
     ExpectedResult: true
     Log:
       {

--- a/aws_s3_rules/aws_s3_unknown_requester_get_object.yml
+++ b/aws_s3_rules/aws_s3_unknown_requester_get_object.yml
@@ -19,7 +19,6 @@ Runbook: If the S3 access is not expected for this bucket, investigate the reque
 Tests:
   -
     Name: Expected Access
-    LogType: AWS.S3ServerAccess
     ExpectedResult: false
     Log:
       {
@@ -46,7 +45,6 @@ Tests:
       }
   -
     Name: Unexpected Access
-    LogType: AWS.S3ServerAccess
     ExpectedResult: true
     Log:
       {
@@ -73,7 +71,6 @@ Tests:
       }
   -
     Name: Failed Request
-    LogType: AWS.S3ServerAccess
     ExpectedResult: false
     Log:
       {

--- a/aws_vpc_policies/aws_network_acl_restricted_ssh.yml
+++ b/aws_vpc_policies/aws_network_acl_restricted_ssh.yml
@@ -17,7 +17,6 @@ Reference: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-recommended-nacl
 Tests:
   -
     Name: Secure VPC SSH Access
-    ResourceType: AWS.EC2.NetworkACL
     ExpectedResult: true
     Resource:
       {
@@ -71,7 +70,6 @@ Tests:
       }
   -
     Name: Global VPC SSH Access
-    ResourceType: AWS.EC2.NetworkACL
     ExpectedResult: false
     Resource:
       {
@@ -112,7 +110,6 @@ Tests:
       }
   -
     Name: Global VPC SSH Access From Range
-    ResourceType: AWS.EC2.NetworkACL
     ExpectedResult: false
     Resource:
       {
@@ -153,7 +150,6 @@ Tests:
       }
   -
     Name: Global VPC SSH Access From Unrestricted Port Range
-    ResourceType: AWS.EC2.NetworkACL
     ExpectedResult: false
     Resource:
       {

--- a/aws_vpc_policies/aws_network_acl_restricts_inbound_traffic.yml
+++ b/aws_vpc_policies/aws_network_acl_restricts_inbound_traffic.yml
@@ -21,7 +21,6 @@ Reference: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-recommended-nacl
 Tests:
   -
     Name: Network ACL Restricts Inbound Traffic
-    ResourceType: AWS.EC2.NetworkACL
     ExpectedResult: true
     Resource:
       {
@@ -80,7 +79,6 @@ Tests:
       }
   -
     Name: Network ACL Does Not Restrict Inbound Traffic
-    ResourceType: AWS.EC2.NetworkACL
     ExpectedResult: false
     Resource:
       {

--- a/aws_vpc_policies/aws_network_acl_restricts_insecure_protocols.yml
+++ b/aws_vpc_policies/aws_network_acl_restricts_insecure_protocols.yml
@@ -19,7 +19,6 @@ Reference: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-recommended-nacl
 Tests:
   -
     Name: Network ACL Restricts Insecure Protocols
-    ResourceType: AWS.EC2.NetworkACL
     ExpectedResult: true
     Resource:
       {
@@ -75,7 +74,6 @@ Tests:
       }
   -
     Name: Insecure Ports Not Restricted
-    ResourceType: AWS.EC2.NetworkACL
     ExpectedResult: false
     Resource:
       {
@@ -118,7 +116,6 @@ Tests:
       }
   -
     Name: All Ports Allowed
-    ResourceType: AWS.EC2.NetworkACL
     ExpectedResult: false
     Resource:
       {

--- a/aws_vpc_policies/aws_network_acl_restricts_outbound_traffic.yml
+++ b/aws_vpc_policies/aws_network_acl_restricts_outbound_traffic.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-recommended-nacl
 Tests:
   -
     Name: Network ACL Restricts Outbound Traffic
-    ResourceType: AWS.EC2.NetworkACL
     ExpectedResult: true
     Resource:
       {
@@ -79,7 +78,6 @@ Tests:
       }
   -
     Name: Network ACL Does Not Restrict Outbound Traffic
-    ResourceType: AWS.EC2.NetworkACL
     ExpectedResult: false
     Resource:
       {

--- a/aws_vpc_policies/aws_only_dmz_security_groups_publicly_accessible.yml
+++ b/aws_vpc_policies/aws_only_dmz_security_groups_publicly_accessible.yml
@@ -20,7 +20,6 @@ Reference: https://en.wikipedia.org/wiki/DMZ_(computing)
 Tests:
   -
     Name: DMZ Security Group Does Allows Public Access
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: true
     Resource:
       {
@@ -84,7 +83,6 @@ Tests:
       }
   -
     Name: Non DMZ Security Group Allows Public Access
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: false
     Resource:
       {
@@ -148,7 +146,6 @@ Tests:
       }
   -
     Name: Non DMZ Security Group Does Not Allow Public Access
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: true
     Resource:
       {

--- a/aws_vpc_policies/aws_security_group_administrative_ingress.yml
+++ b/aws_vpc_policies/aws_security_group_administrative_ingress.yml
@@ -22,7 +22,6 @@ Reference: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.h
 Tests:
   -
     Name: Inbound IP Permission On All IPs On Acceptable Ports
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: true
     Resource:
       {
@@ -197,7 +196,6 @@ Tests:
       }
   -
     Name: Inbound IP Permissions On All IPs On Restricted Ports
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: false
     Resource:
       {
@@ -372,7 +370,6 @@ Tests:
       }
   -
     Name: Inbound IP Permission On All IPv6 On Restricted Ports
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: false
     Resource:
       {
@@ -547,7 +544,6 @@ Tests:
       }
   -
     Name: Inbound IP Permission On Specific IP On Restricted Port
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: true
     Resource:
       {
@@ -722,7 +718,6 @@ Tests:
       }
   -
     Name: No Inbound IP Permissions
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: true
     Resource:
       {

--- a/aws_vpc_policies/aws_security_group_restricts_access_to_cde.yml
+++ b/aws_vpc_policies/aws_security_group_restricts_access_to_cde.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/cli/latest/userguide/cli-services-ec2-sg.
 Tests:
   -
     Name: In Scope Security Group Restricts Access
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: true
     Resource:
       {
@@ -84,7 +83,6 @@ Tests:
       }
   -
     Name: In Scope Security Group Does Not Restrict Access
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: false
     Resource:
       {
@@ -148,7 +146,6 @@ Tests:
       }
   -
     Name: Out Of Scope Security Group Does Not Restrict Access
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: true
     Resource:
       {

--- a/aws_vpc_policies/aws_security_group_restricts_inbound_traffic.yml
+++ b/aws_vpc_policies/aws_security_group_restricts_inbound_traffic.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/cli/latest/userguide/cli-services-ec2-sg.
 Tests:
   -
     Name: Security Group Restricts Inbound Traffic
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: true
     Resource:
       {
@@ -72,7 +71,6 @@ Tests:
       }
   -
     Name: Security Group Does Not Restrict Inbound Traffic (None)
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: false
     Resource:
       {
@@ -124,7 +122,6 @@ Tests:
       }
   -
     Name: Security Group Does Not Restrict Inbound Traffic
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: false
     Resource:
       {

--- a/aws_vpc_policies/aws_security_group_restricts_inter_security_group_traffic.yml
+++ b/aws_vpc_policies/aws_security_group_restricts_inter_security_group_traffic.yml
@@ -19,7 +19,6 @@ Reference: https://docs.aws.amazon.com/cli/latest/userguide/cli-services-ec2-sg.
 Tests:
   -
     Name: Security Group Restricts Inter Security Group Traffic
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: true
     Resource:
       {
@@ -71,7 +70,6 @@ Tests:
       }
   -
     Name: Security Group Does Not Restrict Inter Security Group Traffic
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: false
     Resource:
       {
@@ -123,7 +121,6 @@ Tests:
       }
   -
     Name: Security Group Does Not Restrict Internet Traffic
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: true
     Resource:
       {

--- a/aws_vpc_policies/aws_security_group_restricts_outbound_traffic.yml
+++ b/aws_vpc_policies/aws_security_group_restricts_outbound_traffic.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/cli/latest/userguide/cli-services-ec2-sg.
 Tests:
   -
     Name: Security Group Restricts Outbound Traffic
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: true
     Resource:
       {
@@ -72,7 +71,6 @@ Tests:
       }
   -
     Name: Security Group Does Not Restrict Outbound Traffic
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: false
     Resource:
       {
@@ -124,7 +122,6 @@ Tests:
       }
   -
     Name: Security Group Does Not Restrict Outbound Traffic (None)
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: false
     Resource:
       {

--- a/aws_vpc_policies/aws_security_group_restricts_traffic_leaving_cde.yml
+++ b/aws_vpc_policies/aws_security_group_restricts_traffic_leaving_cde.yml
@@ -16,7 +16,6 @@ Reference: https://docs.aws.amazon.com/cli/latest/userguide/cli-services-ec2-sg.
 Tests:
   -
     Name: Security Group Restricts Traffic Leaving CDE
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: true
     Resource:
       {
@@ -66,7 +65,6 @@ Tests:
       }
   -
     Name: Security Group Does Not Restrict Traffic Leaving CDE
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: false
     Resource:
       {
@@ -116,7 +114,6 @@ Tests:
       }
   -
     Name: Not In Scope Security Group Does Not Restrict Traffic Leaving CDE
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: true
     Resource:
       {

--- a/aws_vpc_policies/aws_security_group_tightly_restricts_inbound_traffic.yml
+++ b/aws_vpc_policies/aws_security_group_tightly_restricts_inbound_traffic.yml
@@ -21,7 +21,6 @@ Reference: https://docs.aws.amazon.com/cli/latest/userguide/cli-services-ec2-sg.
 Tests:
   -
     Name: Security Group Tightly Restricts Inbound Traffic
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: true
     Resource:
       {
@@ -73,7 +72,6 @@ Tests:
       }
   -
     Name: Security Group Does Not Restrict Inbound Traffic
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: false
     Resource:
       {
@@ -125,7 +123,6 @@ Tests:
       }
   -
     Name: Security Group Does Not Tightly Restrict Inbound Traffic
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: false
     Resource:
       {

--- a/aws_vpc_policies/aws_security_group_tightly_restricts_outbound_traffic.yml
+++ b/aws_vpc_policies/aws_security_group_tightly_restricts_outbound_traffic.yml
@@ -19,7 +19,6 @@ Reference: https://docs.aws.amazon.com/cli/latest/userguide/cli-services-ec2-sg.
 Tests:
   -
     Name: Security Group Tightly Restricts Outbound Traffic
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: true
     Resource:
       {
@@ -71,7 +70,6 @@ Tests:
       }
   -
     Name: Security Group Does Not Restrict Outbound Traffic
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: false
     Resource:
       {
@@ -123,7 +121,6 @@ Tests:
       }
   -
     Name: Security Group Does Not Tightly Restrict Outbound Traffic
-    ResourceType: AWS.EC2.SecurityGroup
     ExpectedResult: false
     Resource:
       {

--- a/aws_vpc_policies/aws_vpc_default_network_acl_restricts_all_traffic.yml
+++ b/aws_vpc_policies/aws_vpc_default_network_acl_restricts_all_traffic.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.htm
 Tests:
   -
     Name: Default Network ACL Has IP Permissions
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: false
     Resource:
       {
@@ -198,7 +197,6 @@ Tests:
       }
   -
     Name: Default Network ACL Has Inbound IP Permissions
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: false
     Resource:
       {
@@ -361,7 +359,6 @@ Tests:
       }
   -
     Name: Default Network ACL Has No IP Permissions
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: true
     Resource:
       {

--- a/aws_vpc_policies/aws_vpc_default_security_restrictions.yml
+++ b/aws_vpc_policies/aws_vpc_default_security_restrictions.yml
@@ -22,7 +22,6 @@ Reference: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.h
 Tests:
   -
     Name: Default Security Group Has IP Permissions
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: false
     Resource:
       {
@@ -192,7 +191,6 @@ Tests:
       }
   -
     Name: Default Security Group Has Inbound IP Permissions
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: false
     Resource:
       {
@@ -347,7 +345,6 @@ Tests:
       }
   -
     Name: Default Security Group Has No IP Permissions
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: true
     Resource:
       {
@@ -482,7 +479,6 @@ Tests:
       }
   -
     Name: Default Security Group Has Outbound IP Permissions
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: false
     Resource:
       {

--- a/aws_vpc_policies/aws_vpc_flow_logs.yml
+++ b/aws_vpc_policies/aws_vpc_flow_logs.yml
@@ -20,7 +20,6 @@ Reference: https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html
 Tests:
   -
     Name: Flow Logging Not Enabled
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: false
     Resource:
       {
@@ -161,7 +160,6 @@ Tests:
       }
   -
     Name: Flow Logs Enabled For Type ACCEPT
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: false
     Resource:
       {
@@ -316,7 +314,6 @@ Tests:
       }
   -
     Name: Flow Logs Enabled For Type ALL
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: true
     Resource:
       {
@@ -471,7 +468,6 @@ Tests:
       }
   -
     Name: Flow Logs Enabled For Type REJECT
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: true
     Resource:
       {
@@ -626,7 +622,6 @@ Tests:
       }
   -
     Name: Flow Logs Enabled For Types ACCEPT, ALL
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: true
     Resource:
       {
@@ -794,7 +789,6 @@ Tests:
       }
   -
     Name: Flow Logs Inactive For Type ALL
-    ResourceType: AWS.EC2.VPC
     ExpectedResult: false
     Resource:
       {

--- a/aws_vpc_rules/aws_vpc_healthy_log_status.yml
+++ b/aws_vpc_rules/aws_vpc_healthy_log_status.yml
@@ -18,11 +18,9 @@ Runbook: >
 Tests:
   -
     Name: Healthy Log Status
-    LogType: AWS.VPCFlow
     ExpectedResult: false
     Log: {"log-status": "OK"}
   -
     Name: Unhealthy Log Status
-    LogType: AWS.VPCFlow
     ExpectedResult: true
     Log: {"log-status": "SKIPDATA"}

--- a/aws_vpc_rules/aws_vpc_inbound_traffic_port_blacklist.yml
+++ b/aws_vpc_rules/aws_vpc_inbound_traffic_port_blacklist.yml
@@ -17,7 +17,6 @@ Runbook: >
 Tests:
   -
     Name: Public to Private IP on Restricted Port
-    LogType: AWS.VPCFlow
     ExpectedResult: true
     Log:
       {
@@ -27,7 +26,6 @@ Tests:
       }
   -
     Name: Public to Private IP on Allowed Port
-    LogType: AWS.VPCFlow
     ExpectedResult: false
     Log:
       {
@@ -37,7 +35,6 @@ Tests:
       }
   -
     Name: Private to Private IP on Restricted Port
-    LogType: AWS.VPCFlow
     ExpectedResult: false
     Log:
       {

--- a/aws_vpc_rules/aws_vpc_inbound_traffic_port_whitelist.yml
+++ b/aws_vpc_rules/aws_vpc_inbound_traffic_port_whitelist.yml
@@ -17,7 +17,6 @@ Runbook: >
 Tests:
   -
     Name: Public to Private IP on Restricted Port
-    LogType: AWS.VPCFlow
     ExpectedResult: true
     Log:
       {
@@ -27,7 +26,6 @@ Tests:
       }
   -
     Name: Public to Private IP on Allowed Port
-    LogType: AWS.VPCFlow
     ExpectedResult: false
     Log:
       {
@@ -37,7 +35,6 @@ Tests:
       }
   -
     Name: Private to Private IP on Restricted Port
-    LogType: AWS.VPCFlow
     ExpectedResult: false
     Log:
       {

--- a/aws_vpc_rules/aws_vpc_unapproved_outbound_dns.yml
+++ b/aws_vpc_rules/aws_vpc_unapproved_outbound_dns.yml
@@ -17,7 +17,6 @@ Runbook: >
 Tests:
   -
     Name: Approved Outbound DNS Traffic
-    LogType: AWS.VPCFlow
     ExpectedResult: false
     Log:
       {
@@ -27,7 +26,6 @@ Tests:
       }
   -
     Name: Unapproved Outbound DNS Traffic
-    LogType: AWS.VPCFlow
     ExpectedResult: true
     Log:
       {
@@ -37,7 +35,6 @@ Tests:
       }
   -
     Name: Outbound Non-DNS Traffic
-    LogType: AWS.VPCFlow
     ExpectedResult: false
     Log:
       {

--- a/aws_waf_policies/aws_waf_has_xss_predicate.yml
+++ b/aws_waf_policies/aws_waf_has_xss_predicate.yml
@@ -21,7 +21,6 @@ Reference: https://docs.aws.amazon.com/waf/latest/developerguide/web-acl-xss-con
 Tests:
   -
     Name: Web ACL Has XSS Predicate
-    ResourceType: AWS.WAF.Regional.WebACL
     ExpectedResult: true
     Resource:
       {
@@ -64,7 +63,6 @@ Tests:
       }
   -
     Name: Web ACL Does Not Have XSS Predicate
-    ResourceType: AWS.WAF.Regional.WebACL
     ExpectedResult: false
     Resource:
       {

--- a/aws_waf_policies/aws_waf_rule_ordering.yml
+++ b/aws_waf_policies/aws_waf_rule_ordering.yml
@@ -19,7 +19,6 @@ Reference: https://docs.aws.amazon.com/waf/latest/developerguide/web-acl-rules.h
 Tests:
   -
     Name: Web ACL Configured Properly
-    ResourceType: AWS.WAF.Regional.WebACL
     ExpectedResult: true
     Resource:
       {
@@ -55,7 +54,6 @@ Tests:
       }
   -
     Name: Web ACL Has Incorrect Rules
-    ResourceType: AWS.WAF.Regional.WebACL
     ExpectedResult: false
     Resource:
       {
@@ -91,7 +89,6 @@ Tests:
       }
   -
     Name: Web ACL Has Rules In Incorrect Order
-    ResourceType: AWS.WAF.Regional.WebACL
     ExpectedResult: false
     Resource:
       {
@@ -127,7 +124,6 @@ Tests:
       }
   -
     Name: Web ACL Has No Ordering Configured
-    ResourceType: AWS.WAF.Regional.WebACL
     ExpectedResult: true
     Resource:
       {

--- a/cisco_umbrella_dns_rules/domain_blocked.yml
+++ b/cisco_umbrella_dns_rules/domain_blocked.yml
@@ -14,7 +14,6 @@ Runbook: Inspect the blocked domain and lookup for malware
 Tests:
   -
     Name: Domain Blocked
-    LogType: CiscoUmbrella.DNS
     ExpectedResult: true
     Log:
       {
@@ -27,7 +26,6 @@ Tests:
       }
   -
     Name: Action Allowed
-    LogType: CiscoUmbrella.DNS
     ExpectedResult: false
     Log:
       {

--- a/cisco_umbrella_dns_rules/fuzzy_matching_domains.yml
+++ b/cisco_umbrella_dns_rules/fuzzy_matching_domains.yml
@@ -17,7 +17,6 @@ Runbook: >
 # Tests:
 #   -
 #     Name: Phishing Domain
-#     LogType: CiscoUmbrella.DNS
 #     ExpectedResult: true
 #     Log:
 #       {}

--- a/cisco_umbrella_dns_rules/suspicious_domains.yml
+++ b/cisco_umbrella_dns_rules/suspicious_domains.yml
@@ -14,7 +14,6 @@ Runbook: Inspect the domain and check the host for other indicators of compromis
 Tests:
   -
     Name: Suspicious Domain
-    LogType: CiscoUmbrella.DNS
     ExpectedResult: true
     Log:
       {
@@ -27,7 +26,6 @@ Tests:
       }
   -
     Name: Safe Domain
-    LogType: CiscoUmbrella.DNS
     ExpectedResult: false
     Log:
       {

--- a/gcp_audit_rules/gcp_gcs_iam_changes.yml
+++ b/gcp_audit_rules/gcp_gcs_iam_changes.yml
@@ -19,7 +19,6 @@ Runbook: Validate the GCS bucket change was safe.
 Tests:
   -
     Name: GCS IAM Change
-    LogType: GCP.AuditLog
     ExpectedResult: true
     Log:
       {

--- a/gcp_audit_rules/gcp_gcs_public.yml
+++ b/gcp_audit_rules/gcp_gcs_public.yml
@@ -18,7 +18,6 @@ Runbook: Validate the GCS bucket change was safe.
 Tests:
   -
     Name: GCS AllUsers Read Permission
-    LogType: GCP.AuditLog
     ExpectedResult: true
     Log:
       {

--- a/gcp_audit_rules/gcp_iam_admin_role_assigned.yml
+++ b/gcp_audit_rules/gcp_iam_admin_role_assigned.yml
@@ -17,7 +17,6 @@ Runbook: Verify with the user who attached the role or add to a whitelist
 Tests:
   -
     Name: Service Admin Role Assigned
-    LogType: GCP.AuditLog
     ExpectedResult: true
     Log:
       {
@@ -174,7 +173,6 @@ Tests:
       }
   -
     Name: Admin Role Assigned
-    LogType: GCP.AuditLog
     ExpectedResult: true
     Log:
       {
@@ -321,7 +319,6 @@ Tests:
       }
   -
     Name: Browser Role Assigned
-    LogType: GCP.AuditLog
     ExpectedResult: false
     Log:
       {

--- a/gcp_audit_rules/gcp_iam_corp_email.yml
+++ b/gcp_audit_rules/gcp_iam_corp_email.yml
@@ -20,7 +20,6 @@ Runbook: Remove the user
 Tests:
   -
     Name: Gmail account added
-    LogType: GCP.AuditLog
     ExpectedResult: true
     Log:
       {
@@ -205,7 +204,6 @@ Tests:
       }
   -
     Name: Runpanther account added
-    LogType: GCP.AuditLog
     ExpectedResult: false
     Log:
       {

--- a/gcp_audit_rules/gcp_iam_custom_role_changes.yml
+++ b/gcp_audit_rules/gcp_iam_custom_role_changes.yml
@@ -18,7 +18,6 @@ Runbook: No action needed, informational
 Tests:
   -
     Name: Custom Role Created
-    LogType: GCP.AuditLog
     ExpectedResult: true
     Log:
       {

--- a/gcp_audit_rules/gcp_sql_config_changes.yml
+++ b/gcp_audit_rules/gcp_sql_config_changes.yml
@@ -19,7 +19,6 @@ Runbook: Validate the Sql Instance configuration change was safe
 Tests:
   -
     Name: Sql Instance Change
-    LogType: GCP.AuditLog
     ExpectedResult: true
     Log:
       {

--- a/gcp_audit_rules/gcp_unused_regions.yml
+++ b/gcp_audit_rules/gcp_unused_regions.yml
@@ -20,7 +20,6 @@ Runbook: Validate the user making the request and the resource created.
 Tests:
   -
     Name: GCE Instance Terminated
-    LogType: GCP.AuditLog
     ExpectedResult: false
     Log:
       {
@@ -61,7 +60,6 @@ Tests:
       }
   -
     Name: GCE Create Instance in SouthAmerica
-    LogType: GCP.AuditLog
     ExpectedResult: true
     Log:
       {
@@ -102,7 +100,6 @@ Tests:
       }
   -
     Name: Create GCS in Asia
-    LogType: GCP.AuditLog
     ExpectedResult: true
     Log:
       {

--- a/gsuite_reports_rules/gsuite_advanced_protection.yml
+++ b/gsuite_reports_rules/gsuite_advanced_protection.yml
@@ -16,7 +16,6 @@ Runbook: >
 Tests:
   -
     Name: Advanced Protection Enabled
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -31,7 +30,6 @@ Tests:
       }
   -
     Name: Advanced Protection Disabled
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {

--- a/gsuite_reports_rules/gsuite_brute_force_login.yml
+++ b/gsuite_reports_rules/gsuite_brute_force_login.yml
@@ -14,7 +14,6 @@ Runbook: Analyze the IP they came from, and other actions taken before/after.
 Tests:
   -
     Name: Normal Login Event
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -28,7 +27,6 @@ Tests:
       }
   -
     Name: Non Login Event
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {

--- a/gsuite_reports_rules/gsuite_doc_ownership_transfer.yml
+++ b/gsuite_reports_rules/gsuite_doc_ownership_transfer.yml
@@ -17,7 +17,6 @@ Runbook: >
 Tests:
   -
     Name: Ownership Transferred Within Organization
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -33,7 +32,6 @@ Tests:
       }
   -
     Name: Document Transferred to External User
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {

--- a/gsuite_reports_rules/gsuite_drive_overly_visible.yml
+++ b/gsuite_reports_rules/gsuite_drive_overly_visible.yml
@@ -16,7 +16,6 @@ Runbook: >
 Tests:
   -
     Name: Access Event
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -32,7 +31,6 @@ Tests:
       }
   -
     Name: Modify Event Without Over Visibility
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -49,7 +47,6 @@ Tests:
       }
   -
     Name: Overly Visible Doc Modified
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {

--- a/gsuite_reports_rules/gsuite_drive_visibility_change.yml
+++ b/gsuite_reports_rules/gsuite_drive_visibility_change.yml
@@ -16,7 +16,6 @@ Runbook: >
 Tests:
   -
     Name: Access Event
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -32,7 +31,6 @@ Tests:
       }
   -
     Name: ACL Change without Visiblity Change
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -48,7 +46,6 @@ Tests:
       }
   -
     Name: Doc Became Public
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {
@@ -64,7 +61,6 @@ Tests:
       }
   -
     Name: Doc Became Private
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {

--- a/gsuite_reports_rules/gsuite_google_access.yml
+++ b/gsuite_reports_rules/gsuite_google_access.yml
@@ -16,7 +16,6 @@ Runbook: >
 Tests:
   -
     Name: Normal Login Event
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -26,7 +25,6 @@ Tests:
       }
   -
     Name: Resource Accessed by Google
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {

--- a/gsuite_reports_rules/gsuite_gov_attack.yml
+++ b/gsuite_reports_rules/gsuite_gov_attack.yml
@@ -16,7 +16,6 @@ Runbook: >
 Tests:
   -
     Name: Normal Login Event
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -26,7 +25,6 @@ Tests:
       }
   -
     Name: Government Backed Attack Warning
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {

--- a/gsuite_reports_rules/gsuite_group_banned_user.yml
+++ b/gsuite_reports_rules/gsuite_group_banned_user.yml
@@ -16,7 +16,6 @@ Runbook: >
 Tests:
   -
     Name: User Added
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -31,7 +30,6 @@ Tests:
       }
   -
     Name: User Banned from Group
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {

--- a/gsuite_reports_rules/gsuite_high_severity_rule.yml
+++ b/gsuite_reports_rules/gsuite_high_severity_rule.yml
@@ -16,7 +16,6 @@ Runbook: >
 Tests:
   -
     Name: Non Triggered Rule
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -30,7 +29,6 @@ Tests:
       }
   -
     Name: High Severity Rule
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {
@@ -46,7 +44,6 @@ Tests:
       }
   -
     Name: Medium Severity Rule
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {

--- a/gsuite_reports_rules/gsuite_leaked_password.yml
+++ b/gsuite_reports_rules/gsuite_leaked_password.yml
@@ -16,7 +16,6 @@ Runbook: >
 Tests:
   -
     Name: Normal Login Event
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -26,7 +25,6 @@ Tests:
       }
   -
     Name: Account Warning Not For Password Leaked
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -41,7 +39,6 @@ Tests:
       }
   -
     Name: Account Warning For Password Leaked
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {

--- a/gsuite_reports_rules/gsuite_login_type.yml
+++ b/gsuite_reports_rules/gsuite_login_type.yml
@@ -17,7 +17,6 @@ Runbook: >
 Tests:
   -
     Name: Login With Approved Type
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -32,7 +31,6 @@ Tests:
       }
   -
     Name: Unapproved Login Type
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {

--- a/gsuite_reports_rules/gsuite_low_severity_rule.yml
+++ b/gsuite_reports_rules/gsuite_low_severity_rule.yml
@@ -16,7 +16,6 @@ Runbook: >
 Tests:
   -
     Name: Non Triggered Rule
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -30,7 +29,6 @@ Tests:
       }
   -
     Name: Low Severity Rule
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {
@@ -46,7 +44,6 @@ Tests:
       }
   -
     Name: Medium Severity Rule
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {

--- a/gsuite_reports_rules/gsuite_medium_severity_rule.yml
+++ b/gsuite_reports_rules/gsuite_medium_severity_rule.yml
@@ -16,7 +16,6 @@ Runbook: >
 Tests:
   -
     Name: Non Triggered Rule
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -30,7 +29,6 @@ Tests:
       }
   -
     Name: High Severity Rule
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -46,7 +44,6 @@ Tests:
       }
   -
     Name: Medium Severity Rule
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {

--- a/gsuite_reports_rules/gsuite_mobile_device_compromise.yml
+++ b/gsuite_reports_rules/gsuite_mobile_device_compromise.yml
@@ -16,7 +16,6 @@ Runbook: >
 Tests:
   -
     Name: Normal Mobile Event
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -26,7 +25,6 @@ Tests:
       }
   -
     Name: Suspicious Activity Shows not Compromised
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -42,7 +40,6 @@ Tests:
       }
   -
     Name: Suspicious Activity Shows Compromised
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {

--- a/gsuite_reports_rules/gsuite_mobile_device_screen_unlock_fail.yml
+++ b/gsuite_reports_rules/gsuite_mobile_device_screen_unlock_fail.yml
@@ -16,7 +16,6 @@ Runbook: >
 Tests:
   -
     Name: Normal Mobile Event
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -26,7 +25,6 @@ Tests:
       }
   -
     Name: Small Number of Failed Logins
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -42,7 +40,6 @@ Tests:
       }
   -
     Name: Multiple Failed Login Attempts with int Type
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {
@@ -58,7 +55,6 @@ Tests:
       }
   -
     Name: Multiple Failed Login Attempts with String Type
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {

--- a/gsuite_reports_rules/gsuite_mobile_device_suspicious_activity.yml
+++ b/gsuite_reports_rules/gsuite_mobile_device_suspicious_activity.yml
@@ -16,7 +16,6 @@ Runbook: >
 Tests:
   -
     Name: Normal Mobile Event
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -26,7 +25,6 @@ Tests:
       }
   -
     Name: Suspicious Activity
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {

--- a/gsuite_reports_rules/gsuite_permissions_delegated.yml
+++ b/gsuite_reports_rules/gsuite_permissions_delegated.yml
@@ -16,7 +16,6 @@ Runbook: >
 Tests:
   -
     Name: Other Admin Action
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -31,7 +30,6 @@ Tests:
       }
   -
     Name: Privileges Assigned
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {

--- a/gsuite_reports_rules/gsuite_suspicious_logins.yml
+++ b/gsuite_reports_rules/gsuite_suspicious_logins.yml
@@ -16,7 +16,6 @@ Runbook: >
 Tests:
   -
     Name: Normal Login Event
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -26,7 +25,6 @@ Tests:
       }
   -
     Name: Account Warning Not For Suspicious Login
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -41,7 +39,6 @@ Tests:
       }
   -
     Name: Account Warning For Suspicious Login
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {

--- a/gsuite_reports_rules/gsuite_two_step_verification.yml
+++ b/gsuite_reports_rules/gsuite_two_step_verification.yml
@@ -16,7 +16,6 @@ Runbook: >
 Tests:
   -
     Name: Two Step Verification Enabled
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -31,7 +30,6 @@ Tests:
       }
   -
     Name: Two Step Verification Disabled
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {

--- a/gsuite_reports_rules/gsuite_user_suspended.yml
+++ b/gsuite_reports_rules/gsuite_user_suspended.yml
@@ -16,7 +16,6 @@ Runbook: >
 Tests:
   -
     Name: Normal Login Event
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -26,7 +25,6 @@ Tests:
       }
   -
     Name: Account Warning Not For User Suspended
-    LogType: GSuites.Reports
     ExpectedResult: false
     Log:
       {
@@ -41,7 +39,6 @@ Tests:
       }
   -
     Name: Account Warning For Suspended User
-    LogType: GSuites.Reports
     ExpectedResult: true
     Log:
       {

--- a/okta_rules/okta_geo_improbable_access.yml
+++ b/okta_rules/okta_geo_improbable_access.yml
@@ -11,7 +11,6 @@ Severity: Medium
 Tests:
   -
     Name: Non Login
-    LogType: Okta.SystemLog
     ExpectedResult: false
     Log:
       {
@@ -22,7 +21,6 @@ Tests:
 # To use these tests, uncomment them and run panther_analysis_tool test with hAWS credentials configured.
 #  -
 #    Name: First Login - Baseline
-#    LogType: Okta.SystemLog
 #    ExpectedResult: false
 #    Log:
 #      {
@@ -117,7 +115,6 @@ Tests:
 #      }
 #  -
 #    Name: Second Login - Safe
-#    LogType: Okta.SystemLog
 #    ExpectedResult: false
 #    Log:
 #      {
@@ -212,7 +209,6 @@ Tests:
 #      }
 #  -
 #    Name: Third Login - Too Fast
-#    LogType: Okta.SystemLog
 #    ExpectedResult: true
 #    Log:
 #      {

--- a/osquery_rules/osquery_linux_aws_commands.yml
+++ b/osquery_rules/osquery_linux_aws_commands.yml
@@ -18,7 +18,6 @@ Reference: https://attack.mitre.org/techniques/T1078/
 Tests:
   -
     Name: AWS command executed
-    LogType: Osquery.Differential
     ExpectedResult: true
     Log:
       {
@@ -33,7 +32,6 @@ Tests:
       }
   -
     Name: Tail command executed
-    LogType: Osquery.Differential
     ExpectedResult: false
     Log:
       {
@@ -48,7 +46,6 @@ Tests:
       }
   -
     Name: Command with quote executed
-    LogType: Osquery.Differential
     ExpectedResult: false
     Log:
       {
@@ -63,7 +60,6 @@ Tests:
       }
   -
     Name: Invalid command ignored
-    LogType: Osquery.Differential
     ExpectedResult: false
     Log:
       {

--- a/osquery_rules/osquery_linux_logins_non_office.yml
+++ b/osquery_rules/osquery_linux_logins_non_office.yml
@@ -19,7 +19,6 @@ Reference: https://attack.mitre.org/techniques/T1078/
 Tests:
   -
     Name: Non-office network login (logged_in_users)
-    LogType: Osquery.Differential
     ExpectedResult: true
     Log:
       {
@@ -33,7 +32,6 @@ Tests:
       }
   -
     Name: Non-office network login (last)
-    LogType: Osquery.Differential
     ExpectedResult: true
     Log:
       {
@@ -50,7 +48,6 @@ Tests:
       }
   -
     Name: Office network login
-    LogType: Osquery.Differential
     ExpectedResult: false
     Log:
       {

--- a/osquery_rules/osquery_mac_application_firewall.yml
+++ b/osquery_rules/osquery_mac_application_firewall.yml
@@ -22,7 +22,6 @@ Reference: https://support.apple.com/en-us/HT201642
 Tests:
   -
     Name: ALF Disabled
-    LogType: Osquery.Differential
     ExpectedResult: true
     Log:
       {
@@ -41,7 +40,6 @@ Tests:
       }
   -
     Name: ALF Enabled
-    LogType: Osquery.Differential
     ExpectedResult: false
     Log:
       {

--- a/osquery_rules/osquery_mac_enable_auto_update.yml
+++ b/osquery_rules/osquery_mac_enable_auto_update.yml
@@ -21,7 +21,6 @@ Runbook: >
 Tests:
   -
     Name: Auto Updates Disabled
-    LogType: Osquery.Differential
     ExpectedResult: true
     Log:
       {
@@ -35,7 +34,6 @@ Tests:
       }
   -
     Name: Auto Updates Enabled
-    LogType: Osquery.Differential
     ExpectedResult: false
     Log:
       {
@@ -49,7 +47,6 @@ Tests:
       }
   -
     Name: Wrong Key
-    LogType: Osquery.Differential
     ExpectedResult: false
     Log:
       {

--- a/osquery_rules/osquery_mac_osx_attacks.yml
+++ b/osquery_rules/osquery_mac_osx_attacks.yml
@@ -16,7 +16,6 @@ Reference: https://github.com/osquery/osquery/blob/master/packs/osx-attacks.conf
 Tests:
   -
     Name: Valid malware discovered
-    LogType: Osquery.Differential
     ExpectedResult: true
     Log:
       {
@@ -31,7 +30,6 @@ Tests:
       }
   -
     Name: Keyboard event taps query is ignored
-    LogType: Osquery.Differential
     ExpectedResult: false
     Log:
       {

--- a/osquery_rules/osquery_mac_osx_attacks_keyboard_events.yml
+++ b/osquery_rules/osquery_mac_osx_attacks_keyboard_events.yml
@@ -16,7 +16,6 @@ Reference: https://support.apple.com/en-us/HT204899
 Tests:
   -
     Name: App running on Desktop that is watching keyboard events
-    LogType: Osquery.Differential
     ExpectedResult: true
     Log:
       {
@@ -31,7 +30,6 @@ Tests:
       }
   -
     Name: App is running from approved path
-    LogType: Osquery.Differential
     ExpectedResult: false
     Log:
       {
@@ -46,7 +44,6 @@ Tests:
       }
   -
     Name: Unrelated query does not alert
-    LogType: Osquery.Differential
     ExpectedResult: false
     Log:
       {

--- a/osquery_rules/osquery_mac_unwanted_chrome_extensions.yml
+++ b/osquery_rules/osquery_mac_unwanted_chrome_extensions.yml
@@ -19,7 +19,6 @@ Runbook: Uninstall the unwanted extension
 Tests:
   -
     Name: Unwanted Extension Detected
-    LogType: Osquery.Differential
     ExpectedResult: true
     Log:
       {
@@ -57,7 +56,6 @@ Tests:
       }
   -
     Name: No Unwanted Chrome Extension Detected
-    LogType: Osquery.Differential
     ExpectedResult: false
     Log:
       {

--- a/osquery_rules/osquery_ossec.yml
+++ b/osquery_rules/osquery_ossec.yml
@@ -19,7 +19,6 @@ Runbook: >
 Tests:
   -
     Name: Rootkit Detected
-    LogType: Osquery.Differential
     ExpectedResult: true
     Log:
       {
@@ -56,7 +55,6 @@ Tests:
       }
   -
     Name: Rootkit Not Detected
-    LogType: Osquery.Differential
     ExpectedResult: false
     Log:
       {

--- a/osquery_rules/osquery_outdated.yml
+++ b/osquery_rules/osquery_outdated.yml
@@ -14,7 +14,6 @@ Runbook: Update the osquery agent.
 Tests:
   -
     Name: osquery out of date
-    LogType: Osquery.Differential
     ExpectedResult: true
     Log:
       {
@@ -52,7 +51,6 @@ Tests:
       }
   -
     Name: osquery up to date
-    LogType: Osquery.Differential
     ExpectedResult: false
     Log:
       {

--- a/osquery_rules/osquery_outdated_macos.yml
+++ b/osquery_rules/osquery_outdated_macos.yml
@@ -15,7 +15,6 @@ Runbook: Update the MacOs version
 Tests:
   -
     Name: MacOS out of date
-    LogType: Osquery.Differential
     ExpectedResult: true
     Log:
       {
@@ -53,7 +52,6 @@ Tests:
       }
   -
     Name: MacOS up to date
-    LogType: Osquery.Differential
     ExpectedResult: false
     Log:
       {

--- a/osquery_rules/osquery_ssh_listener.yml
+++ b/osquery_rules/osquery_ssh_listener.yml
@@ -15,7 +15,6 @@ Runbook: >
 Tests:
   -
     Name: SSH Listener Detected
-    LogType: Osquery.Differential
     ExpectedResult: true
     Log:
       {
@@ -53,7 +52,6 @@ Tests:
       }
   -
     Name: SSH Listener Not Detected
-    LogType: Osquery.Differential
     ExpectedResult: false
     Log:
       {

--- a/osquery_rules/osquery_suspicious_cron.yml
+++ b/osquery_rules/osquery_suspicious_cron.yml
@@ -18,7 +18,6 @@ Reference: https://en.wikipedia.org/wiki/Cron
 Tests:
   -
     Name: Netcat Listener
-    LogType: Osquery.Differential
     ExpectedResult: true
     Log:
       {
@@ -38,7 +37,6 @@ Tests:
       }
   -
     Name: Wget Pipe Bash
-    LogType: Osquery.Differential
     ExpectedResult: true
     Log:
       {
@@ -58,7 +56,6 @@ Tests:
       }
   -
     Name: Wget Execute
-    LogType: Osquery.Differential
     ExpectedResult: true
     Log:
       {
@@ -78,7 +75,6 @@ Tests:
       }
   -
     Name: Dig
-    LogType: Osquery.Differential
     ExpectedResult: true
     Log:
       {
@@ -98,7 +94,6 @@ Tests:
       }
   -
     Name: Built-in Cron
-    LogType: Osquery.Differential
     ExpectedResult: false
     Log:
       {
@@ -118,7 +113,6 @@ Tests:
       }
   -
     Name: Command with quotes
-    LogType: Osquery.Differential
     ExpectedResult: false
     Log:
       {

--- a/templates/example_policy.yml
+++ b/templates/example_policy.yml
@@ -16,7 +16,6 @@ Reference: An optional reference.link
 Tests:
   -
     Name: Name 
-    ResourceType: AWS.Resource
     ExpectedResult: false
     Resource:
       {


### PR DESCRIPTION
### Background

`ResourceType` and `EventType`  are no longer required fields in the unit tests.  We can safely remove these from existing rules/policies to prevent carrying forward tests with unnecessary fields.  Closes #87 

### Changes

* Removed `ResourceType` and `EventType` from all unit tests

### Testing

* `make test` and uploading zipped version into dev account
