### PR TITLE
fix: rule checks for allowed inbound only

### DIFF
--- a/aws_vpc_policies/aws_network_acl_restricted_ssh.py
+++ b/aws_vpc_policies/aws_network_acl_restricted_ssh.py
@@ -3,7 +3,8 @@ def policy(resource):
         # Look for ingress rules from any IP.
         # This could be modified in the future to inspect the size
         # of the source network with the ipaddress.ip_network.num_addresses call.
-        if not entry['Egress'] and entry['CidrBlock'] == '0.0.0.0/0' and entry['RuleAction'] == 'allow':
+        if not entry['Egress'] and entry['CidrBlock'] == '0.0.0.0/0' and entry[
+                'RuleAction'] == 'allow':
             # Check within a range of ports, normally the From/To would be set to 22,
             # but this covers the case where it could be 0-1024.
             if ('PortRange' not in entry or not entry['PortRange'] or

--- a/aws_vpc_policies/aws_network_acl_restricted_ssh.py
+++ b/aws_vpc_policies/aws_network_acl_restricted_ssh.py
@@ -3,7 +3,7 @@ def policy(resource):
         # Look for ingress rules from any IP.
         # This could be modified in the future to inspect the size
         # of the source network with the ipaddress.ip_network.num_addresses call.
-        if not entry['Egress'] and entry['CidrBlock'] == '0.0.0.0/0':
+        if not entry['Egress'] and entry['CidrBlock'] == '0.0.0.0/0' and entry['RuleAction'] == 'allow':
             # Check within a range of ports, normally the From/To would be set to 22,
             # but this covers the case where it could be 0-1024.
             if ('PortRange' not in entry or not entry['PortRange'] or


### PR DESCRIPTION
### Background

The rule for restricting SSH checks for inbound ACL rules, but was also triggering if you set a 'deny' policy. The rule should only look for 'allow' policies.

### Changes

* Modify the rule to check if the inbound ACL rule is an 'allow' policy

### Testing

* mage test:ci
* test inside panther by modifying the rule and setting a previously failing payload
