### PR TITLE
Handle null `NotAfter` values

### DIFF
--- a/aws_acm_policies/aws_acm_certificate_expiration.py
+++ b/aws_acm_policies/aws_acm_certificate_expiration.py
@@ -5,7 +5,7 @@ EXPIRATION_BUFFER = datetime.timedelta(days=60)
 
 
 def policy(resource):
-    if not resource['NotAfter']:
+    if not resource.get('NotAfter'):
         return False
     time_to_expiration = datetime.datetime.strptime(
         resource['NotAfter'], AWS_TIMESTAMP_FORMAT) - datetime.datetime.now()

--- a/aws_acm_policies/aws_acm_certificate_expiration.py
+++ b/aws_acm_policies/aws_acm_certificate_expiration.py
@@ -5,6 +5,8 @@ EXPIRATION_BUFFER = datetime.timedelta(days=60)
 
 
 def policy(resource):
+    if not resource['NotAfter']:
+        return False
     time_to_expiration = datetime.datetime.strptime(
         resource['NotAfter'], AWS_TIMESTAMP_FORMAT) - datetime.datetime.now()
 

--- a/aws_acm_policies/aws_acm_certificate_expiration.yml
+++ b/aws_acm_policies/aws_acm_certificate_expiration.yml
@@ -149,3 +149,70 @@ Tests:
         "Type": "AMAZON_ISSUED",
         "Domain": "test.domain.io"
       }
+  -
+    Name: Null Expiration
+    ExpectedResult: false
+    Resource:
+      {
+        "Arn": "arn:aws:acm:us-east-1:123456789012:certificate/33333333-5555-4444-aaaa-04206915b869",
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/33333333-5555-4444-aaaa-04206915b869",
+        "CertificateAuthorityArn": null,
+        "CreatedAt": "2019-05-23T19:20:52Z",
+        "DomainName": "test.domain.io",
+        "DomainValidationOptions": [
+          {
+            "DomainName": "test.domain.io",
+            "ResourceRecord": {
+              "Name": "_cc1fccccc11111111c286666111ee999.test.domain.io.",
+              "Type": "CNAME",
+              "Value": "_cc1fccccc11111111c286666111ee999.ltfvzjuylp.acm-validations.aws."
+            },
+            "ValidationDomain": "test.domain.io",
+            "ValidationEmails": null,
+            "ValidationMethod": "DNS",
+            "ValidationStatus": "SUCCESS"
+          }
+        ],
+        "ExtendedKeyUsages": [
+          {
+            "Name": "TLS_WEB_CLIENT_AUTHENTICATION",
+            "OID": "1.3.6.1.5.5.7.3.2"
+          },
+          {
+            "Name": "TLS_WEB_SERVER_AUTHENTICATION",
+            "OID": "1.3.6.1.5.5.7.3.1"
+          }
+        ],
+        "FailureReason": null,
+        "ImportedAt": null,
+        "InUseBy": null,
+        "IssuedAt": "2019-05-23T19:21:48Z",
+        "Issuer": "Amazon",
+        "KeyAlgorithm": "RSA-2048",
+        "KeyUsages": [
+          {
+            "Name": "DIGITAL_SIGNATURE"
+          },
+          {
+            "Name": "KEY_ENCIPHERMENT"
+          }
+        ],
+        "NotAfter": null,
+        "NotBefore": "2019-05-23T00:00:00Z",
+        "Options": {
+          "CertificateTransparencyLoggingPreference": "ENABLED"
+        },
+        "RenewalEligibility": "INELIGIBLE",
+        "RenewalSummary": null,
+        "RevocationReason": null,
+        "RevokedAt": null,
+        "Serial": "00:bb:cc:aa:66:11:22:00:dd:88:f8:48:3e:92:6e:0d",
+        "SignatureAlgorithm": "SHA256WITHRSA",
+        "Status": "ISSUED",
+        "Subject": "CN=test.domain.io",
+        "SubjectAlternativeNames": [
+          "test.domain.io"
+        ],
+        "Type": "AMAZON_ISSUED",
+        "Domain": "test.domain.io"
+      }


### PR DESCRIPTION
### Background

Encountering an error when we come across a null value for the acm certificate's `NotAfter` field. This address this problem by returning `False` when the field is None. Closes #29 

### Changes

* Added check for null `NotAfter` field
* Added new test with null `NotAfter` field

### Testing

* `make test` 
