### PR TITLE
remove unnecessary dedup functions

### DIFF
--- a/aws_cloudtrail_rules/aws_cloudtrail_created.py
+++ b/aws_cloudtrail_rules/aws_cloudtrail_created.py
@@ -10,10 +10,6 @@ def rule(event):
     return event['eventName'] in CLOUDTRAIL_CREATE_UPDATE
 
 
-def dedup(event):
-    # Merge events by CloudTrail ARN
-    return event['requestParameters'].get('name')
-
-
 def title(event):
-    return 'CloudTrail [{}] was created/updated'.format(dedup(event))
+    return 'CloudTrail [{}] was created/updated'.format(
+        event['requestParameters'].get('name'))

--- a/aws_cloudtrail_rules/aws_console_login_failed.py
+++ b/aws_cloudtrail_rules/aws_console_login_failed.py
@@ -7,10 +7,6 @@ def rule(event):
             event.get('responseElements', {}).get('ConsoleLogin') == 'Failure')
 
 
-def dedup(event):
-    return event.get('recipientAccountId')
-
-
 def title(event):
     return 'AWS logins failed in account [{}]'.format(
         lookup_aws_account_name(event.get('recipientAccountId')))

--- a/aws_cloudtrail_rules/aws_console_login_without_mfa.py
+++ b/aws_cloudtrail_rules/aws_console_login_without_mfa.py
@@ -21,10 +21,6 @@ def rule(event):
         session_context.get('attributes', {}).get('mfaAuthenticated') != 'true')
 
 
-def dedup(event):
-    return event.get('recipientAccountId')
-
-
 def title(event):
     return 'AWS logins detected without MFA in account [{}]'.format(
         lookup_aws_account_name(event.get('recipientAccountId')))

--- a/aws_cloudtrail_rules/aws_console_login_without_saml.py
+++ b/aws_cloudtrail_rules/aws_console_login_without_saml.py
@@ -8,10 +8,6 @@ def rule(event):
             not additional_event_data.get('SamlProviderArn'))
 
 
-def dedup(event):
-    return event.get('recipientAccountId')
-
-
 def title(event):
     return 'AWS logins without SAML in account [{}]'.format(
         lookup_aws_account_name(event.get('recipientAccountId')))

--- a/aws_cloudtrail_rules/aws_console_root_login.py
+++ b/aws_cloudtrail_rules/aws_console_root_login.py
@@ -7,11 +7,6 @@ def rule(event):
             event.get('responseElements', {}).get('ConsoleLogin') == 'Success')
 
 
-def dedup(event):
-    return '{ip}-{account}'.format(ip=event['sourceIPAddress'],
-                                   account=event.get('recipientAccountId'))
-
-
 def title(event):
     return 'AWS root login detected from [{ip}] in account [{account}]'.format(
         ip=event['sourceIPAddress'],

--- a/aws_cloudtrail_rules/aws_console_root_login_failed.py
+++ b/aws_cloudtrail_rules/aws_console_root_login_failed.py
@@ -7,11 +7,6 @@ def rule(event):
             event.get('responseElements', {}).get('ConsoleLogin') == 'Failure')
 
 
-def dedup(event):
-    return '{ip}-{account}'.format(ip=event['sourceIPAddress'],
-                                   account=event.get('recipientAccountId'))
-
-
 def title(event):
     return 'AWS root login failed from [{ip}] in account [{account}]'.format(
         ip=event['sourceIPAddress'],

--- a/aws_cloudtrail_rules/aws_root_activity.py
+++ b/aws_cloudtrail_rules/aws_root_activity.py
@@ -10,11 +10,6 @@ def rule(event):
             event['eventName'] not in EVENT_ALLOW_LIST)
 
 
-def dedup(event):
-    return '{ip}-{account}'.format(ip=event['sourceIPAddress'],
-                                   account=event.get('recipientAccountId'))
-
-
 def title(event):
     return 'AWS root activity detected from [{ip}] in account [{account}]'.format(
         ip=event['sourceIPAddress'],

--- a/aws_cloudtrail_rules/aws_s3_bucket_policy_modified.py
+++ b/aws_cloudtrail_rules/aws_s3_bucket_policy_modified.py
@@ -17,9 +17,5 @@ def rule(event):
         'eventName') in S3_POLICY_CHANGE_EVENTS and not event.get('errorCode')
 
 
-def dedup(event):
-    return event['userIdentity'].get('arn')
-
-
 def title(event):
     return 'S3 bucket modified by [{}]'.format(event['userIdentity'].get('arn'))

--- a/aws_s3_rules/aws_s3_access_error.py
+++ b/aws_s3_rules/aws_s3_access_error.py
@@ -15,11 +15,6 @@ def rule(event):
             event.get('httpstatus') in HTTP_STATUS_CODES_TO_MONITOR)
 
 
-def dedup(event):
-    return '{status}-{bucket}'.format(status=event.get('httpstatus'),
-                                      bucket=event.get('bucket'))
-
-
 def title(event):
     return '{status} errors found to S3 Bucket [{bucket}]'.format(
         status=event.get('httpstatus'), bucket=event.get('bucket'))

--- a/aws_s3_rules/aws_s3_access_ip_whitelist.py
+++ b/aws_s3_rules/aws_s3_access_ip_whitelist.py
@@ -22,10 +22,6 @@ def rule(event):
         for approved_ip_range in WHITELIST_NETWORKS)
 
 
-def dedup(event):
-    return event.get('bucket')
-
-
 def title(event):
     return 'Non-Approved IP access to S3 Bucket [{}]'.format(
         event.get('bucket'))

--- a/aws_s3_rules/aws_s3_insecure_access.py
+++ b/aws_s3_rules/aws_s3_insecure_access.py
@@ -6,9 +6,5 @@ def rule(event):
             ('ciphersuite' not in event or 'tlsVersion' not in event))
 
 
-def dedup(event):
-    return event.get('bucket')
-
-
 def title(event):
     return 'Insecure access to S3 Bucket [{}]'.format(event.get('bucket'))

--- a/aws_s3_rules/aws_s3_unauthenticated_access.py
+++ b/aws_s3_rules/aws_s3_unauthenticated_access.py
@@ -6,10 +6,6 @@ def rule(event):
     return event.get('bucket') in AUTH_BUCKETS and 'requester' not in event
 
 
-def dedup(event):
-    return event.get('bucket')
-
-
 def title(event):
     return 'Unauthenticated access to S3 Bucket [{}]'.format(
         event.get('bucket'))

--- a/aws_s3_rules/aws_s3_unknown_requester_get_object.py
+++ b/aws_s3_rules/aws_s3_unknown_requester_get_object.py
@@ -32,10 +32,6 @@ def rule(event):
             _unknown_requester_access(event))
 
 
-def dedup(event):
-    return event.get('bucket')
-
-
 def title(event):
     return 'Unknown requester accessing data from S3 Bucket [{}]'.format(
         event.get('bucket'))

--- a/cisco_umbrella_dns_rules/domain_blocked.py
+++ b/cisco_umbrella_dns_rules/domain_blocked.py
@@ -2,9 +2,5 @@ def rule(event):
     return event['action'] == 'Blocked'
 
 
-def dedup(event):
-    return event['domain']
-
-
 def title(event):
     return 'Access denied to domain ' + event['domain']

--- a/cisco_umbrella_dns_rules/fuzzy_matching_domains.py
+++ b/cisco_umbrella_dns_rules/fuzzy_matching_domains.py
@@ -17,7 +17,3 @@ def rule(event):
 
 def title(event):
     return 'Suspicious DNS resolution to {}'.format(event['domain'])
-
-
-def dedup(event):
-    return event['domain']

--- a/cisco_umbrella_dns_rules/suspicious_domains.py
+++ b/cisco_umbrella_dns_rules/suspicious_domains.py
@@ -7,9 +7,5 @@ def rule(event):
     return any(domain in event['domain'] for domain in DOMAINS_TO_MONITOR)
 
 
-def dedup(event):
-    return event['domain']
-
-
 def title(event):
     return 'Suspicious lookup to domain ' + event['domain']

--- a/gcp_audit_rules/gcp_gcs_public.py
+++ b/gcp_audit_rules/gcp_gcs_public.py
@@ -27,11 +27,6 @@ def rule(event):
     return False
 
 
-def dedup(event):
-    return event['resource'].get('labels', {}).get('bucket_name',
-                                                   '<BUCKET_NOT_FOUND>')
-
-
 def title(event):
     return 'GCS bucket [{}] made public'.format(event['resource'].get(
         'labels', {}).get('bucket_name', '<BUCKET_NOT_FOUND>'))

--- a/gcp_audit_rules/gcp_iam_admin_role_assigned.py
+++ b/gcp_audit_rules/gcp_iam_admin_role_assigned.py
@@ -21,11 +21,7 @@ def rule(event):
     return False
 
 
-def dedup(event):
-    return event['resource'].get('labels', {}).get('project_id',
-                                                   '<PROJECT_NOT_FOUND>')
-
-
 def title(event):
     return 'An admin role has been configured in GCP project {}'.format(
-        dedup(event))
+        event['resource'].get('labels', {}).get('project_id',
+                                                '<PROJECT_NOT_FOUND>'))

--- a/gcp_audit_rules/gcp_iam_corp_email.py
+++ b/gcp_audit_rules/gcp_iam_corp_email.py
@@ -19,11 +19,7 @@ def rule(event):
     return False
 
 
-def dedup(event):
-    return event['resource'].get('labels', {}).get('project_id',
-                                                   '<PROJECT_NOT_FOUND>')
-
-
 def title(event):
     return 'A GCP IAM account has been created with a Gmail email in {}'.format(
-        dedup(event))
+        event['resource'].get('labels', {}).get('project_id',
+                                                '<PROJECT_NOT_FOUND>'))

--- a/gcp_audit_rules/gcp_unused_regions.py
+++ b/gcp_audit_rules/gcp_unused_regions.py
@@ -38,11 +38,7 @@ def rule(event):
     return _resource_in_active_region(_get_location_or_zone(event))
 
 
-def dedup(event):
-    return event['resource'].get('labels', {}).get('project_id',
-                                                   '<PROJECT_NOT_FOUND>')
-
-
 def title(event):
     return 'GCP resource(s) created in unused region/zone in project {}'.format(
-        dedup(event))
+        event['resource'].get('labels', {}).get('project_id',
+                                                '<PROJECT_NOT_FOUND>'))

--- a/gravitational_teleport_rules/teleport_auth_errors.py
+++ b/gravitational_teleport_rules/teleport_auth_errors.py
@@ -2,10 +2,6 @@ def rule(event):
     return bool(event.get('error')) and event['event'] == 'auth'
 
 
-def dedup(event):
-    return event.get('user')
-
-
 def title(event):
     return 'A high volume of SSH errors was detected from user [{}]'.format(
         event.get('user', 'USER_NOT_FOUND'))

--- a/gravitational_teleport_rules/teleport_create_user_accounts.py
+++ b/gravitational_teleport_rules/teleport_create_user_accounts.py
@@ -15,11 +15,6 @@ def rule(event):
     return pattern_match_list(event.get('program', ''), USER_CREATE_PATTERNS)
 
 
-def dedup(event):
-    # Group all events by user
-    return event.get('user', 'USER_NOT_FOUND')
-
-
 def title(event):
     return 'User [{}] has manually modified system users'.format(
         event.get('user', 'USER_NOT_FOUND'))

--- a/gravitational_teleport_rules/teleport_network_scanning.py
+++ b/gravitational_teleport_rules/teleport_network_scanning.py
@@ -9,12 +9,6 @@ def rule(event):
     return event.get('program') in SCAN_COMMANDS
 
 
-def dedup(event):
-    # Group by user and program
-    return '{}-{}'.format(event.get('user', 'USER_NOT_FOUND'),
-                          event.get('program', 'PROGRAM_NOT_FOUND'))
-
-
 def title(event):
     return 'User [{}] has issued a network scan with [{}]'.format(
         event.get('user', 'USER_NOT_FOUND'),

--- a/gravitational_teleport_rules/teleport_scheduled_jobs.py
+++ b/gravitational_teleport_rules/teleport_scheduled_jobs.py
@@ -8,10 +8,6 @@ def rule(event):
     return event.get('program') == 'crontab'
 
 
-def dedup(event):
-    return event.get('user')
-
-
 def title(event):
     return 'User [{}] has modified scheduled jobs'.format(
         event.get('user', 'USER_NOT_FOUND'))

--- a/gravitational_teleport_rules/teleport_suspicious_commands.py
+++ b/gravitational_teleport_rules/teleport_suspicious_commands.py
@@ -10,11 +10,6 @@ def rule(event):
     return event.get('program') in SUSPICIOUS_COMMANDS
 
 
-def dedup(event):
-    return '{}-{}'.format(event.get('user', 'USER_NOT_FOUND'),
-                          event.get('program', 'PROGRAM_NOT_FOUND'))
-
-
 def title(event):
     return 'User [{}] has executed the command [{}]'.format(
         event.get('user', 'USER_NOT_FOUND'),

--- a/gsuite_reports_rules/gsuite_advanced_protection.py
+++ b/gsuite_reports_rules/gsuite_advanced_protection.py
@@ -10,10 +10,6 @@ def rule(event):
     return False
 
 
-def dedup(event):
-    return event.get('actor', {}).get('email')
-
-
 def title(event):
     return 'Advanced protection was disabled for user [{}]'.format(
         event.get('actor', {}).get('email'))

--- a/gsuite_reports_rules/gsuite_brute_force_login.py
+++ b/gsuite_reports_rules/gsuite_brute_force_login.py
@@ -25,10 +25,6 @@ def rule(event):
     return False
 
 
-def dedup(event):
-    return event.get('actor', {}).get('email')
-
-
 def title(event):
     return 'User [{}] exceeded the failed logins threshold'.format(
         event.get('actor', {}).get('email'))

--- a/gsuite_reports_rules/gsuite_gov_attack.py
+++ b/gsuite_reports_rules/gsuite_gov_attack.py
@@ -10,10 +10,6 @@ def rule(event):
     return False
 
 
-def dedup(event):
-    return event.get('actor', {}).get('email')
-
-
 def title(event):
     return 'User [{}] may have been targeted by a government attack'.format(
         event.get('actor', {}).get('email'))

--- a/gsuite_reports_rules/gsuite_group_banned_user.py
+++ b/gsuite_reports_rules/gsuite_group_banned_user.py
@@ -10,10 +10,6 @@ def rule(event):
     return False
 
 
-def dedup(event):
-    return event.get('actor', {}).get('email')
-
-
 def title(event):
     return 'User [{}] banned another user from a group.'.format(
         event.get('actor', {}).get('email'))

--- a/gsuite_reports_rules/gsuite_leaked_password.py
+++ b/gsuite_reports_rules/gsuite_leaked_password.py
@@ -10,10 +10,6 @@ def rule(event):
     return False
 
 
-def dedup(event):
-    return event.get('actor', {}).get('email')
-
-
 def title(event):
     return 'User [{}]\'s account was disabled due to a password leak'.format(
         event.get('actor', {}).get('email'))

--- a/gsuite_reports_rules/gsuite_login_type.py
+++ b/gsuite_reports_rules/gsuite_login_type.py
@@ -24,10 +24,6 @@ def rule(event):
     return False
 
 
-def dedup(event):
-    return event.get('actor', {}).get('email')
-
-
 def title(event):
     return 'A login attempt of a non-approved type was detected for user [{}]'.format(
         event.get('actor', {}).get('email'))

--- a/gsuite_reports_rules/gsuite_mobile_device_compromise.py
+++ b/gsuite_reports_rules/gsuite_mobile_device_compromise.py
@@ -15,10 +15,6 @@ def rule(event):
     return False
 
 
-def dedup(event):
-    return event.get('actor', {}).get('email')
-
-
 def title(event):
     return 'User [{}]\'s device was compromised'.format(
         event.get('actor', {}).get('email'))

--- a/gsuite_reports_rules/gsuite_mobile_device_screen_unlock_fail.py
+++ b/gsuite_reports_rules/gsuite_mobile_device_screen_unlock_fail.py
@@ -18,10 +18,6 @@ def rule(event):
     return False
 
 
-def dedup(event):
-    return event.get('actor', {}).get('email')
-
-
 def title(event):
     return 'User [{}]\'s device had multiple failed unlock attempts'.format(
         event.get('actor', {}).get('email'))

--- a/gsuite_reports_rules/gsuite_mobile_device_suspicious_activity.py
+++ b/gsuite_reports_rules/gsuite_mobile_device_suspicious_activity.py
@@ -10,10 +10,6 @@ def rule(event):
     return False
 
 
-def dedup(event):
-    return event.get('actor', {}).get('email')
-
-
 def title(event):
     return 'User [{}]\'s device was compromised'.format(
         event.get('actor', {}).get('email'))

--- a/gsuite_reports_rules/gsuite_permissions_delegated.py
+++ b/gsuite_reports_rules/gsuite_permissions_delegated.py
@@ -10,10 +10,6 @@ def rule(event):
     return False
 
 
-def dedup(event):
-    return event.get('actor', {}).get('email')
-
-
 def title(event):
     return 'User [{}] was delegated new administrator privileges'.format(
         event.get('actor', {}).get('email'))

--- a/gsuite_reports_rules/gsuite_suspicious_logins.py
+++ b/gsuite_reports_rules/gsuite_suspicious_logins.py
@@ -17,10 +17,6 @@ def rule(event):
     return False
 
 
-def dedup(event):
-    return event.get('actor', {}).get('email')
-
-
 def title(event):
     return 'A suspicious login was reported for user [{}]'.format(
         event.get('actor', {}).get('email'))

--- a/gsuite_reports_rules/gsuite_two_step_verification.py
+++ b/gsuite_reports_rules/gsuite_two_step_verification.py
@@ -10,10 +10,6 @@ def rule(event):
     return False
 
 
-def dedup(event):
-    return event.get('actor', {}).get('email')
-
-
 def title(event):
     return 'Two step verification was disabled for user [{}]'.format(
         event.get('actor', {}).get('email'))

--- a/gsuite_reports_rules/gsuite_user_suspended.py
+++ b/gsuite_reports_rules/gsuite_user_suspended.py
@@ -18,10 +18,6 @@ def rule(event):
     return False
 
 
-def dedup(event):
-    return event.get('actor').get('email')
-
-
 def title(event):
     return 'User [{}]\'s account was disabled'.format(
         event.get('actor', {}).get('email'))

--- a/osquery_rules/osquery_linux_aws_commands.py
+++ b/osquery_rules/osquery_linux_aws_commands.py
@@ -24,12 +24,6 @@ def rule(event):
     return False
 
 
-def dedup(event):
-    user = event['columns'].get('username')
-    host = event['hostIdentifier']
-    return '{}-{}'.format(user, host)
-
-
 def title(event):
     return 'User [{}] issued sensitive `aws` command on [{}]'.format(
         event['columns'].get('username'), event['hostIdentifier'])

--- a/osquery_rules/osquery_linux_logins_non_office.py
+++ b/osquery_rules/osquery_linux_logins_non_office.py
@@ -35,15 +35,6 @@ def rule(event):
     return _login_from_non_office_network(host_ip)
 
 
-def dedup(event):
-    # Dedup by user to view lateral movement
-    user = event['columns'].get('user')
-    username = event['columns'].get('username')
-    if user is None:
-        return username
-    return user
-
-
 def title(event):
     msg = 'User [{}] has logged into production from a non-office network'
     user = event['columns'].get('user')

--- a/osquery_rules/osquery_mac_application_firewall.py
+++ b/osquery_rules/osquery_mac_application_firewall.py
@@ -17,9 +17,5 @@ def rule(event):
         int(event['columns'].get('stealth_enabled')) == 0)
 
 
-def dedup(event):
-    return event.get('hostIdentifier')
-
-
 def title(event):
     return 'MacOS firewall disabled on [{}]'.format(event.get('hostIdentifier'))

--- a/osquery_rules/osquery_mac_osx_attacks.py
+++ b/osquery_rules/osquery_mac_osx_attacks.py
@@ -12,9 +12,5 @@ def rule(event):
     return True
 
 
-def dedup(event):
-    return event.get('hostIdentifier')
-
-
 def title(event):
     return 'MacOS malware detected on [{}]'.format(event.get('hostIdentifier'))

--- a/osquery_rules/osquery_mac_osx_attacks_keyboard_events.py
+++ b/osquery_rules/osquery_mac_osx_attacks_keyboard_events.py
@@ -34,10 +34,6 @@ def rule(event):
     return not any([fnmatch(process_path, p) for p in APPROVED_PROCESS_PATHS])
 
 
-def dedup(event):
-    return event.get('hostIdentifier')
-
-
 def title(event):
     return 'Keylogger malware detected on [{}]'.format(
         event.get('hostIdentifier'))

--- a/osquery_rules/osquery_mac_unwanted_chrome_extensions.py
+++ b/osquery_rules/osquery_mac_unwanted_chrome_extensions.py
@@ -3,10 +3,6 @@ def rule(event):
             event['action'] == 'added')
 
 
-def dedup(event):
-    return event.get('hostIdentifier')
-
-
 def title(event):
     return 'Unwanted Chrome extension(s) detected on [{}]'.format(
         event['hostIdentifier'])

--- a/osquery_rules/osquery_ossec.py
+++ b/osquery_rules/osquery_ossec.py
@@ -2,9 +2,5 @@ def rule(event):
     return 'ossec-rootkit' in event['name'] and event['action'] == 'added'
 
 
-def dedup(event):
-    return event.get('hostIdentifier')
-
-
 def title(event):
     return 'OSSEC rootkit found on [{}]'.format(event.get('hostIdentifier'))

--- a/osquery_rules/osquery_outdated.py
+++ b/osquery_rules/osquery_outdated.py
@@ -7,10 +7,6 @@ def rule(event):
             event['action'] == 'added')
 
 
-def dedup(event):
-    return event['columns'].get('version')
-
-
 def title(event):
     return 'Osquery Version {} is Outdated'.format(
         event['columns'].get('version'))

--- a/osquery_rules/osquery_suspicious_cron.py
+++ b/osquery_rules/osquery_suspicious_cron.py
@@ -43,9 +43,5 @@ def rule(event):
     return any([suspicious_cmd_args(command), suspicious_cmd_pairs(command)])
 
 
-def dedup(event):
-    return event.get('hostIdentifier')
-
-
 def title(event):
     return 'Suspicious cron found on [{}]'.format(event.get('hostIdentifier'))


### PR DESCRIPTION
### Background

With panther v1.8.0, the title functions serves as the dedup string if there is no dedup function definition.  This changes cleans up rules by removing the dedup methods that rely on the exact same event fields as the title functions.  

### Changes

* Removed dedup methods in various rule files

### Testing

* `make ci`
