### PR TITLE
Removed duplicate summary attribute

### DIFF
--- a/aws_s3_rules/aws_s3_access_error.yml
+++ b/aws_s3_rules/aws_s3_access_error.yml
@@ -22,7 +22,6 @@ SummaryAttributes:
   - requester
   - remoteip
   - operation
-  - key
   - errorCode
 Tests:
   -


### PR DESCRIPTION
### Background

This rule had a duplicate summary attribute value, which was causing it to fail to upload because dynamo (correctly) determined this was not actually a set.

Resolves https://github.com/panther-labs/panther/issues/1685.

Opened https://github.com/panther-labs/panther_analysis_tool/issues/54 to address the inadequate specification file validation in Pat.

### Changes

* Removed duplicate value

### Testing

* Uploaded entire repo to Panther to verify no other rules have this issue
