### PR TITLE
Remove problematic test case

### DIFF
--- a/aws_s3_policies/aws_s3_bucket_action_restrictions.yml
+++ b/aws_s3_policies/aws_s3_bucket_action_restrictions.yml
@@ -86,40 +86,6 @@ Tests:
         "Versioning": null
       }
   -
-    Name: Bucket Does Not Restrict Any Actions Expanded
-    ExpectedResult: false
-    Resource:
-      {
-        "CreationDate": "2019-01-01T00:00:00Z",
-        "EncryptionRules": [
-          {
-            "ApplyServerSideEncryptionByDefault": {
-              "KMSMasterKeyID": null,
-              "SSEAlgorithm": "AES256"
-            }
-          }
-        ],
-        "Grants": null,
-        "LifecycleRules": null,
-        "Location": "us-east-2",
-        "LoggingPolicy": null,
-        "MFADelete": null,
-        "Name": "bucket-name",
-        "Owner": {
-          "DisplayName": "user.name",
-          "ID": "11112223334445556667778899aaabbbcccdddeeee"
-        },
-        "Policy": "{  \"Id\": \"Policy1574269747554\",  \"Version\": \"2012-10-17\", \"Statement\": [{\"Sid\": \"Stmt1596652125779\",\"Action\": [\"s3:AbortMultipartUpload\",\"s3:BypassGovernanceRetention\",\"s3:CreateAccessPoint\",\"s3:CreateBucket\",\"s3:CreateJob\",\"s3:DeleteAccessPoint\",\"s3:DeleteAccessPointPolicy\",\"s3:DeleteBucket\",\"s3:DeleteBucketPolicy\",\"s3:DeleteBucketWebsite\",\"s3:DeleteJobTagging\",\"s3:DeleteObject\",\"s3:DeleteObjectTagging\",\"s3:DeleteObjectVersion\",\"s3:DeleteObjectVersionTagging\",\"s3:DescribeJob\",\"s3:GetAccelerateConfiguration\",\"s3:GetAccessPoint\",\"s3:GetAccessPointPolicy\",\"s3:GetAccessPointPolicyStatus\",\"s3:GetAccountPublicAccessBlock\",\"s3:GetAnalyticsConfiguration\",\"s3:GetBucketAcl\",\"s3:GetBucketCORS\",\"s3:GetBucketLocation\",\"s3:GetBucketLogging\",\"s3:GetBucketNotification\",\"s3:GetBucketObjectLockConfiguration\",\"s3:GetBucketPolicy\",\"s3:GetBucketPolicyStatus\",\"s3:GetBucketPublicAccessBlock\",\"s3:GetBucketRequestPayment\",\"s3:GetBucketTagging\",\"s3:GetBucketVersioning\",\"s3:GetBucketWebsite\",\"s3:GetEncryptionConfiguration\",\"s3:GetInventoryConfiguration\",\"s3:GetJobTagging\",\"s3:GetLifecycleConfiguration\",\"s3:GetMetricsConfiguration\",\"s3:GetObject\",\"s3:GetObjectAcl\",\"s3:GetObjectLegalHold\",\"s3:GetObjectRetention\",\"s3:GetObjectTagging\",\"s3:GetObjectTorrent\",\"s3:GetObjectVersion\",\"s3:GetObjectVersionAcl\",\"s3:GetObjectVersionForReplication\",\"s3:GetObjectVersionTagging\",\"s3:GetObjectVersionTorrent\",\"s3:GetReplicationConfiguration\",\"s3:HeadBucket\",\"s3:ListAccessPoints\",\"s3:ListAllMyBuckets\",\"s3:ListBucket\",\"s3:ListBucketMultipartUploads\",\"s3:ListBucketVersions\",\"s3:ListJobs\",\"s3:ListMultipartUploadParts\",\"s3:ObjectOwnerOverrideToBucketOwner\",\"s3:PutAccelerateConfiguration\",\"s3:PutAccessPointPolicy\",\"s3:PutAccountPublicAccessBlock\",\"s3:PutAnalyticsConfiguration\",\"s3:PutBucketAcl\",\"s3:PutBucketCORS\",\"s3:PutBucketLogging\",\"s3:PutBucketNotification\",\"s3:PutBucketObjectLockConfiguration\",\"s3:PutBucketPolicy\",\"s3:PutBucketPublicAccessBlock\",\"s3:PutBucketRequestPayment\",\"s3:PutBucketTagging\",\"s3:PutBucketVersioning\",\"s3:PutBucketWebsite\",\"s3:PutEncryptionConfiguration\",\"s3:PutInventoryConfiguration\",\"s3:PutJobTagging\",\"s3:PutLifecycleConfiguration\",\"s3:PutMetricsConfiguration\",\"s3:PutObject\",\"s3:PutObjectAcl\",\"s3:PutObjectLegalHold\",\"s3:PutObjectRetention\",\"s3:PutObjectTagging\",\"s3:PutObjectVersionAcl\",\"s3:PutObjectVersionTagging\",\"s3:PutReplicationConfiguration\",\"s3:ReplicateDelete\",\"s3:ReplicateObject\",\"s3:ReplicateTags\",\"s3:RestoreObject\",\"s3:UpdateJobPriority\",\"s3:UpdateJobStatus\"],\"Effect\": \"Allow\",\"Resource\": \"*\",\"Principal\": \"*\"}]
-}",
-        "PublicAccessBlockConfiguration": {
-          "BlockPublicAcls": false,
-          "BlockPublicPolicy": false,
-          "IgnorePublicAcls": false,
-          "RestrictPublicBuckets": false
-        },
-        "Versioning": null
-      }
-  -
     Name: Bucket Restricts Action With Deny Statement
     ExpectedResult: true
     Resource:


### PR DESCRIPTION
### Background

This test case breaks every time AWS adds a new s3 permission, which is usually once every few months. Now that we're enforcing passing test cases in both the CLI tool and the web UI, we should be more cognizant of potentially failing unit tests outside of our control. I'm just going to remove this test.

### Changes

* Removed test that fails when dependency is updated

### Testing

* `panther_analysis_tool test`
