### PR TITLE
Update VPC policies

### DIFF
--- a/aws_vpc_policies/aws_security_group_administrative_ingress.py
+++ b/aws_vpc_policies/aws_security_group_administrative_ingress.py
@@ -20,9 +20,13 @@ def policy(resource):
     for permission in resource['IpPermissions']:
         src_open = False
         for ip_range in permission['IpRanges'] or []:
-            src_open = src_open or ip_range['CidrIp'] == '0.0.0.0/0'
+            if ip_range['CidrIp'] == '0.0.0.0/0':
+                src_open = True
+                break
         for ipv6_range in permission['Ipv6Ranges'] or []:
-            src_open = src_open or ipv6_range['CidrIpv6'] == '::/0'
+            if src_open or ipv6_range['CidrIpv6'] == '::/0':
+                src_open = True
+                break
         if src_open and port_checker(RESTRICTED_PORTS, permission['FromPort'],
                                      permission['ToPort']):
             return False

--- a/aws_vpc_policies/aws_security_group_administrative_ingress.py
+++ b/aws_vpc_policies/aws_security_group_administrative_ingress.py
@@ -14,21 +14,16 @@ def port_checker(check_ports, from_port, to_port):
 
 
 def policy(resource):
-    if resource['SecurityGroups'] is None:
+    if resource['IpPermissions'] is None:
         return True
 
-    for group in resource['SecurityGroups']:
-        if group['IpPermissions'] is None:
-            continue
-
-        for permission in group['IpPermissions']:
-            src_open = False
-            for ip_range in permission['IpRanges'] or []:
-                src_open = src_open or ip_range['CidrIp'] == '0.0.0.0/0'
-            for ipv6_range in permission['Ipv6Ranges'] or []:
-                src_open = src_open or ipv6_range['CidrIpv6'] == '::/0'
-            if src_open and port_checker(RESTRICTED_PORTS,
-                                         permission['FromPort'],
-                                         permission['ToPort']):
-                return False
+    for permission in resource['IpPermissions']:
+        src_open = False
+        for ip_range in permission['IpRanges'] or []:
+            src_open = src_open or ip_range['CidrIp'] == '0.0.0.0/0'
+        for ipv6_range in permission['Ipv6Ranges'] or []:
+            src_open = src_open or ipv6_range['CidrIpv6'] == '::/0'
+        if src_open and port_checker(RESTRICTED_PORTS, permission['FromPort'],
+                                     permission['ToPort']):
+            return False
     return True

--- a/aws_vpc_policies/aws_security_group_administrative_ingress.yml
+++ b/aws_vpc_policies/aws_security_group_administrative_ingress.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.SecurityGroup.AdministrativeIngress
 DisplayName: AWS Security Group Administrative Ingress
 Enabled: true
 ResourceTypes:
-  - AWS.EC2.VPC
+  - AWS.EC2.SecurityGroup
 Tags:
   - AWS
   - Security Control
@@ -25,863 +25,263 @@ Tests:
     ExpectedResult: true
     Resource:
       {
-        "CidrBlock": "172.31.0.0/16",
-        "CidrBlockAssociationSet": [
-          {
-            "AssociationId": "vpc-cidr-assoc-112233",
-            "CidrBlock": "172.0.0.0/16",
-            "CidrBlockState": {
-              "State": "associated",
-              "StatusMessage": null
-            }
-          }
-        ],
-        "DhcpOptionsId": "dopt-1122e3344",
-        "FlowLogs": null,
-        "InstanceTenancy": "default",
-        "Ipv6CidrBlockAssociationSet": null,
-        "IsDefault": true,
-        "NetworkAcls": [
-          {
-            "Associations": [
+          "Description": "default VPC security group",
+          "GroupId": "sg-abc123",
+          "GroupName": "default",
+          "IpPermissions": [
               {
-                "NetworkAclAssociationId": "aclassoc-1122abc444",
-                "NetworkAclId": "acl-123abc",
-                "SubnetId": "subnet-123abc"
-              },
-              {
-                "NetworkAclAssociationId": "aclassoc-123abc",
-                "NetworkAclId": "acl-1122abc",
-                "SubnetId": "subnet-112233aabb"
+                  "FromPort": 30,
+                  "IpProtocol": "-1",
+                  "IpRanges": [
+                      {
+                          "CidrIp": "0.0.0.0/0",
+                          "Description": null
+                      }
+                  ],
+                  "Ipv6Ranges": null,
+                  "PrefixListIds": null,
+                  "ToPort": 45,
+                  "UserIdGroupPairs": [
+                      {
+                          "Description": null,
+                          "GroupId": "sg-abc123",
+                          "GroupName": null,
+                          "PeeringStatus": null,
+                          "UserId": "1122334455",
+                          "VpcId": null,
+                          "VpcPeeringConnectionId": null
+                      }
+                  ]
               }
-            ],
-            "Entries": [
+          ],
+          "IpPermissionsEgress": [
               {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": false,
-                "IcmpTypeCode": null,
-                "Ipv6CidrBlock": null,
-                "PortRange": null,
-                "Protocol": "-1",
-                "RuleAction": "deny",
-                "RuleNumber": 12345
+                  "FromPort": null,
+                  "IpProtocol": "-1",
+                  "IpRanges": [
+                      {
+                          "CidrIp": "0.0.0.0/0",
+                          "Description": null
+                      }
+                  ],
+                  "Ipv6Ranges": null,
+                  "PrefixListIds": null,
+                  "ToPort": null,
+                  "UserIdGroupPairs": null
               }
-            ],
-            "IsDefault": true,
-            "NetworkAclId": "acl-123aabb",
-            "OwnerId": "112233445566",
-            "Tags": null,
-            "VpcId": "vpc-1234321"
-          }
-        ],
-        "OwnerId": "112233445566",
-        "RouteTables": [
-          {
-            "Associations": [
-              {
-                "Main": true,
-                "RouteTableAssociationId": "rtbassoc-1122aa33",
-                "RouteTableId": "rtb-1122abc33",
-                "SubnetId": null
-              }
-            ],
-            "OwnerId": "112233445566",
-            "PropagatingVgws": null,
-            "RouteTableId": "rtb-11223344",
-            "Routes": [
-              {
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "DestinationIpv6CidrBlock": null,
-                "DestinationPrefixListId": null,
-                "EgressOnlyInternetGatewayId": null,
-                "GatewayId": "igw-abc123",
-                "InstanceId": null,
-                "InstanceOwnerId": null,
-                "NatGatewayId": null,
-                "NetworkInterfaceId": null,
-                "Origin": "CreateRoute",
-                "State": "active",
-                "TransitGatewayId": null,
-                "VpcPeeringConnectionId": null
-              }
-            ],
-            "Tags": null,
-            "VpcId": "vpc-11223344"
-          }
-        ],
-        "SecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc123",
-            "GroupName": "default",
-            "IpPermissions": [
-              {
-                "FromPort": 30,
-                "IpProtocol": "-1",
-                "IpRanges": [
-                  {
-                    "CidrIp": "0.0.0.0/0",
-                    "Description": null
-                  }
-                ],
-                "Ipv6Ranges": null,
-                "PrefixListIds": null,
-                "ToPort": 45,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc123",
-                    "GroupName": null,
-                    "PeeringStatus": null,
-                    "UserId": "1122334455",
-                    "VpcId": null,
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
-            ],
-            "IpPermissionsEgress": [
-              {
-                "FromPort": null,
-                "IpProtocol": "-1",
-                "IpRanges": [
-                  {
-                    "CidrIp": "0.0.0.0/0",
-                    "Description": null
-                  }
-                ],
-                "Ipv6Ranges": null,
-                "PrefixListIds": null,
-                "ToPort": null,
-                "UserIdGroupPairs": null
-              }
-            ],
-            "OwnerId": "112233445566",
-            "Tags": null,
-            "VpcId": "vpc-123454321"
-          }
-        ],
-        "StaleSecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc567",
-            "GroupName": "default",
-            "StaleIpPermissions": null,
-            "StaleIpPermissionsEgress": [
-              {
-                "FromPort": 5555,
-                "IpProtocol": "tcp",
-                "IpRanges": null,
-                "PrefixListIds": null,
-                "ToPort": 5555,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc567",
-                    "GroupName": "default",
-                    "PeeringStatus": "deleted",
-                    "UserId": "123456789012",
-                    "VpcId": "vpc-abc111222333444",
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
-            ],
-            "VpcId": "vpc-abc123"
-          }
-        ],
-        "State": "available",
-        "Tags": null,
-        "VpcId": "vpc-1234321"
+          ],
+          "OwnerId": "112233445566",
+          "Tags": null,
+          "VpcId": "vpc-123454321"
       }
   -
     Name: Inbound IP Permissions On All IPs On Restricted Ports
     ExpectedResult: false
     Resource:
-      {
-        "CidrBlock": "172.31.0.0/16",
-        "CidrBlockAssociationSet": [
-          {
-            "AssociationId": "vpc-cidr-assoc-112233",
-            "CidrBlock": "172.0.0.0/16",
-            "CidrBlockState": {
-              "State": "associated",
-              "StatusMessage": null
-            }
-          }
-        ],
-        "DhcpOptionsId": "dopt-1122e3344",
-        "FlowLogs": null,
-        "InstanceTenancy": "default",
-        "Ipv6CidrBlockAssociationSet": null,
-        "IsDefault": true,
-        "NetworkAcls": [
-          {
-            "Associations": [
-              {
-                "NetworkAclAssociationId": "aclassoc-1122abc444",
-                "NetworkAclId": "acl-123abc",
-                "SubnetId": "subnet-123abc"
-              },
-              {
-                "NetworkAclAssociationId": "aclassoc-123abc",
-                "NetworkAclId": "acl-1122abc",
-                "SubnetId": "subnet-112233aabb"
-              }
-            ],
-            "Entries": [
-              {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": false,
-                "IcmpTypeCode": null,
-                "Ipv6CidrBlock": null,
-                "PortRange": null,
-                "Protocol": "-1",
-                "RuleAction": "deny",
-                "RuleNumber": 12345
-              }
-            ],
-            "IsDefault": true,
-            "NetworkAclId": "acl-123aabb",
-            "OwnerId": "112233445566",
-            "Tags": null,
-            "VpcId": "vpc-1234321"
-          }
-        ],
-        "OwnerId": "112233445566",
-        "RouteTables": [
-          {
-            "Associations": [
-              {
-                "Main": true,
-                "RouteTableAssociationId": "rtbassoc-1122aa33",
-                "RouteTableId": "rtb-1122abc33",
-                "SubnetId": null
-              }
-            ],
-            "OwnerId": "112233445566",
-            "PropagatingVgws": null,
-            "RouteTableId": "rtb-11223344",
-            "Routes": [
-              {
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "DestinationIpv6CidrBlock": null,
-                "DestinationPrefixListId": null,
-                "EgressOnlyInternetGatewayId": null,
-                "GatewayId": "igw-abc123",
-                "InstanceId": null,
-                "InstanceOwnerId": null,
-                "NatGatewayId": null,
-                "NetworkInterfaceId": null,
-                "Origin": "CreateRoute",
-                "State": "active",
-                "TransitGatewayId": null,
-                "VpcPeeringConnectionId": null
-              }
-            ],
-            "Tags": null,
-            "VpcId": "vpc-11223344"
-          }
-        ],
-        "SecurityGroups": [
-          {
+        {
             "Description": "default VPC security group",
             "GroupId": "sg-abc123",
             "GroupName": "default",
             "IpPermissions": [
-              {
-                "FromPort": 22,
-                "IpProtocol": "-1",
-                "IpRanges": [
-                  {
-                    "CidrIp": "0.0.0.0/0",
-                    "Description": null
-                  }
-                ],
-                "Ipv6Ranges": null,
-                "PrefixListIds": null,
-                "ToPort": 22,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc123",
-                    "GroupName": null,
-                    "PeeringStatus": null,
-                    "UserId": "1122334455",
-                    "VpcId": null,
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
+                {
+                    "FromPort": 22,
+                    "IpProtocol": "-1",
+                    "IpRanges": [
+                        {
+                            "CidrIp": "0.0.0.0/0",
+                            "Description": null
+                        }
+                    ],
+                    "Ipv6Ranges": null,
+                    "PrefixListIds": null,
+                    "ToPort": 22,
+                    "UserIdGroupPairs": [
+                        {
+                            "Description": null,
+                            "GroupId": "sg-abc123",
+                            "GroupName": null,
+                            "PeeringStatus": null,
+                            "UserId": "1122334455",
+                            "VpcId": null,
+                            "VpcPeeringConnectionId": null
+                        }
+                    ]
+                }
             ],
             "IpPermissionsEgress": [
-              {
-                "FromPort": null,
-                "IpProtocol": "-1",
-                "IpRanges": [
-                  {
-                    "CidrIp": "0.0.0.0/0",
-                    "Description": null
-                  }
-                ],
-                "Ipv6Ranges": null,
-                "PrefixListIds": null,
-                "ToPort": null,
-                "UserIdGroupPairs": null
-              }
+                {
+                    "FromPort": null,
+                    "IpProtocol": "-1",
+                    "IpRanges": [
+                        {
+                            "CidrIp": "0.0.0.0/0",
+                            "Description": null
+                        }
+                    ],
+                    "Ipv6Ranges": null,
+                    "PrefixListIds": null,
+                    "ToPort": null,
+                    "UserIdGroupPairs": null
+                }
             ],
             "OwnerId": "112233445566",
             "Tags": null,
             "VpcId": "vpc-123454321"
-          }
-        ],
-        "StaleSecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc567",
-            "GroupName": "default",
-            "StaleIpPermissions": null,
-            "StaleIpPermissionsEgress": [
-              {
-                "FromPort": 5555,
-                "IpProtocol": "tcp",
-                "IpRanges": null,
-                "PrefixListIds": null,
-                "ToPort": 5555,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc567",
-                    "GroupName": "default",
-                    "PeeringStatus": "deleted",
-                    "UserId": "123456789012",
-                    "VpcId": "vpc-abc111222333444",
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
-            ],
-            "VpcId": "vpc-abc123"
-          }
-        ],
-        "State": "available",
-        "Tags": null,
-        "VpcId": "vpc-1234321"
-      }
+        }
   -
     Name: Inbound IP Permission On All IPv6 On Restricted Ports
     ExpectedResult: false
     Resource:
-      {
-        "CidrBlock": "172.31.0.0/16",
-        "CidrBlockAssociationSet": [
-          {
-            "AssociationId": "vpc-cidr-assoc-112233",
-            "CidrBlock": "172.0.0.0/16",
-            "CidrBlockState": {
-              "State": "associated",
-              "StatusMessage": null
-            }
-          }
-        ],
-        "DhcpOptionsId": "dopt-1122e3344",
-        "FlowLogs": null,
-        "InstanceTenancy": "default",
-        "Ipv6CidrBlockAssociationSet": null,
-        "IsDefault": true,
-        "NetworkAcls": [
-          {
-            "Associations": [
-              {
-                "NetworkAclAssociationId": "aclassoc-1122abc444",
-                "NetworkAclId": "acl-123abc",
-                "SubnetId": "subnet-123abc"
-              },
-              {
-                "NetworkAclAssociationId": "aclassoc-123abc",
-                "NetworkAclId": "acl-1122abc",
-                "SubnetId": "subnet-112233aabb"
-              }
-            ],
-            "Entries": [
-              {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": false,
-                "IcmpTypeCode": null,
-                "Ipv6CidrBlock": null,
-                "PortRange": null,
-                "Protocol": "-1",
-                "RuleAction": "deny",
-                "RuleNumber": 12345
-              }
-            ],
-            "IsDefault": true,
-            "NetworkAclId": "acl-123aabb",
-            "OwnerId": "112233445566",
-            "Tags": null,
-            "VpcId": "vpc-1234321"
-          }
-        ],
-        "OwnerId": "112233445566",
-        "RouteTables": [
-          {
-            "Associations": [
-              {
-                "Main": true,
-                "RouteTableAssociationId": "rtbassoc-1122aa33",
-                "RouteTableId": "rtb-1122abc33",
-                "SubnetId": null
-              }
-            ],
-            "OwnerId": "112233445566",
-            "PropagatingVgws": null,
-            "RouteTableId": "rtb-11223344",
-            "Routes": [
-              {
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "DestinationIpv6CidrBlock": null,
-                "DestinationPrefixListId": null,
-                "EgressOnlyInternetGatewayId": null,
-                "GatewayId": "igw-abc123",
-                "InstanceId": null,
-                "InstanceOwnerId": null,
-                "NatGatewayId": null,
-                "NetworkInterfaceId": null,
-                "Origin": "CreateRoute",
-                "State": "active",
-                "TransitGatewayId": null,
-                "VpcPeeringConnectionId": null
-              }
-            ],
-            "Tags": null,
-            "VpcId": "vpc-11223344"
-          }
-        ],
-        "SecurityGroups": [
-          {
+        {
             "Description": "default VPC security group",
             "GroupId": "sg-abc123",
             "GroupName": "default",
             "IpPermissions": [
-              {
-                "FromPort": 22,
-                "IpProtocol": "-1",
-                "IpRanges": null,
-                "Ipv6Ranges": [
-                  {
-                    "CidrIpv6": "::/0",
-                    "Description": null
-                  }
-                ],
-                "PrefixListIds": null,
-                "ToPort": 22,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc123",
-                    "GroupName": null,
-                    "PeeringStatus": null,
-                    "UserId": "1122334455",
-                    "VpcId": null,
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
+                {
+                    "FromPort": 22,
+                    "IpProtocol": "-1",
+                    "IpRanges": null,
+                    "Ipv6Ranges": [
+                        {
+                            "CidrIpv6": "::/0",
+                            "Description": null
+                        }
+                    ],
+                    "PrefixListIds": null,
+                    "ToPort": 22,
+                    "UserIdGroupPairs": [
+                        {
+                            "Description": null,
+                            "GroupId": "sg-abc123",
+                            "GroupName": null,
+                            "PeeringStatus": null,
+                            "UserId": "1122334455",
+                            "VpcId": null,
+                            "VpcPeeringConnectionId": null
+                        }
+                    ]
+                }
             ],
             "IpPermissionsEgress": [
-              {
-                "FromPort": null,
-                "IpProtocol": "-1",
-                "IpRanges": [
-                  {
-                    "CidrIp": "0.0.0.0/0",
-                    "Description": null
-                  }
-                ],
-                "Ipv6Ranges": null,
-                "PrefixListIds": null,
-                "ToPort": null,
-                "UserIdGroupPairs": null
-              }
+                {
+                    "FromPort": null,
+                    "IpProtocol": "-1",
+                    "IpRanges": [
+                        {
+                            "CidrIp": "0.0.0.0/0",
+                            "Description": null
+                        }
+                    ],
+                    "Ipv6Ranges": null,
+                    "PrefixListIds": null,
+                    "ToPort": null,
+                    "UserIdGroupPairs": null
+                }
             ],
             "OwnerId": "112233445566",
             "Tags": null,
             "VpcId": "vpc-123454321"
-          }
-        ],
-        "StaleSecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc567",
-            "GroupName": "default",
-            "StaleIpPermissions": null,
-            "StaleIpPermissionsEgress": [
-              {
-                "FromPort": 5555,
-                "IpProtocol": "tcp",
-                "IpRanges": null,
-                "PrefixListIds": null,
-                "ToPort": 5555,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc567",
-                    "GroupName": "default",
-                    "PeeringStatus": "deleted",
-                    "UserId": "123456789012",
-                    "VpcId": "vpc-abc111222333444",
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
-            ],
-            "VpcId": "vpc-abc123"
-          }
-        ],
-        "State": "available",
-        "Tags": null,
-        "VpcId": "vpc-1234321"
-      }
+        }
   -
     Name: Inbound IP Permission On Specific IP On Restricted Port
     ExpectedResult: true
     Resource:
-      {
-        "CidrBlock": "172.31.0.0/16",
-        "CidrBlockAssociationSet": [
-          {
-            "AssociationId": "vpc-cidr-assoc-112233",
-            "CidrBlock": "172.0.0.0/16",
-            "CidrBlockState": {
-              "State": "associated",
-              "StatusMessage": null
-            }
-          }
-        ],
-        "DhcpOptionsId": "dopt-1122e3344",
-        "FlowLogs": null,
-        "InstanceTenancy": "default",
-        "Ipv6CidrBlockAssociationSet": null,
-        "IsDefault": true,
-        "NetworkAcls": [
-          {
-            "Associations": [
-              {
-                "NetworkAclAssociationId": "aclassoc-1122abc444",
-                "NetworkAclId": "acl-123abc",
-                "SubnetId": "subnet-123abc"
-              },
-              {
-                "NetworkAclAssociationId": "aclassoc-123abc",
-                "NetworkAclId": "acl-1122abc",
-                "SubnetId": "subnet-112233aabb"
-              }
-            ],
-            "Entries": [
-              {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": false,
-                "IcmpTypeCode": null,
-                "Ipv6CidrBlock": null,
-                "PortRange": null,
-                "Protocol": "-1",
-                "RuleAction": "deny",
-                "RuleNumber": 12345
-              }
-            ],
-            "IsDefault": true,
-            "NetworkAclId": "acl-123aabb",
-            "OwnerId": "112233445566",
-            "Tags": null,
-            "VpcId": "vpc-1234321"
-          }
-        ],
-        "OwnerId": "112233445566",
-        "RouteTables": [
-          {
-            "Associations": [
-              {
-                "Main": true,
-                "RouteTableAssociationId": "rtbassoc-1122aa33",
-                "RouteTableId": "rtb-1122abc33",
-                "SubnetId": null
-              }
-            ],
-            "OwnerId": "112233445566",
-            "PropagatingVgws": null,
-            "RouteTableId": "rtb-11223344",
-            "Routes": [
-              {
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "DestinationIpv6CidrBlock": null,
-                "DestinationPrefixListId": null,
-                "EgressOnlyInternetGatewayId": null,
-                "GatewayId": "igw-abc123",
-                "InstanceId": null,
-                "InstanceOwnerId": null,
-                "NatGatewayId": null,
-                "NetworkInterfaceId": null,
-                "Origin": "CreateRoute",
-                "State": "active",
-                "TransitGatewayId": null,
-                "VpcPeeringConnectionId": null
-              }
-            ],
-            "Tags": null,
-            "VpcId": "vpc-11223344"
-          }
-        ],
-        "SecurityGroups": [
-          {
+        {
             "Description": "default VPC security group",
             "GroupId": "sg-abc123",
             "GroupName": "default",
             "IpPermissions": [
-              {
-                "FromPort": 22,
-                "IpProtocol": "-1",
-                "IpRanges": [
-                  {
-                    "CidrIp": "1.1.1.1/32",
-                    "Description": null
-                  }
-                ],
-                "Ipv6Ranges": null,
-                "PrefixListIds": null,
-                "ToPort": 22,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc123",
-                    "GroupName": null,
-                    "PeeringStatus": null,
-                    "UserId": "1122334455",
-                    "VpcId": null,
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
+                {
+                    "FromPort": 22,
+                    "IpProtocol": "-1",
+                    "IpRanges": [
+                        {
+                            "CidrIp": "1.1.1.1/32",
+                            "Description": null
+                        }
+                    ],
+                    "Ipv6Ranges": null,
+                    "PrefixListIds": null,
+                    "ToPort": 22,
+                    "UserIdGroupPairs": [
+                        {
+                            "Description": null,
+                            "GroupId": "sg-abc123",
+                            "GroupName": null,
+                            "PeeringStatus": null,
+                            "UserId": "1122334455",
+                            "VpcId": null,
+                            "VpcPeeringConnectionId": null
+                        }
+                    ]
+                }
             ],
             "IpPermissionsEgress": [
-              {
-                "FromPort": null,
-                "IpProtocol": "-1",
-                "IpRanges": [
-                  {
-                    "CidrIp": "0.0.0.0/0",
-                    "Description": null
-                  }
-                ],
-                "Ipv6Ranges": null,
-                "PrefixListIds": null,
-                "ToPort": null,
-                "UserIdGroupPairs": null
-              }
+                {
+                    "FromPort": null,
+                    "IpProtocol": "-1",
+                    "IpRanges": [
+                        {
+                            "CidrIp": "0.0.0.0/0",
+                            "Description": null
+                        }
+                    ],
+                    "Ipv6Ranges": null,
+                    "PrefixListIds": null,
+                    "ToPort": null,
+                    "UserIdGroupPairs": null
+                }
             ],
             "OwnerId": "112233445566",
             "Tags": null,
             "VpcId": "vpc-123454321"
-          }
-        ],
-        "StaleSecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc567",
-            "GroupName": "default",
-            "StaleIpPermissions": null,
-            "StaleIpPermissionsEgress": [
-              {
-                "FromPort": 5555,
-                "IpProtocol": "tcp",
-                "IpRanges": null,
-                "PrefixListIds": null,
-                "ToPort": 5555,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc567",
-                    "GroupName": "default",
-                    "PeeringStatus": "deleted",
-                    "UserId": "123456789012",
-                    "VpcId": "vpc-abc111222333444",
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
-            ],
-            "VpcId": "vpc-abc123"
-          }
-        ],
-        "State": "available",
-        "Tags": null,
-        "VpcId": "vpc-1234321"
-      }
+        }
   -
     Name: No Inbound IP Permissions
     ExpectedResult: true
     Resource:
-      {
-        "CidrBlock": "172.31.0.0/16",
-        "CidrBlockAssociationSet": [
-          {
-            "AssociationId": "vpc-cidr-assoc-112233",
-            "CidrBlock": "172.0.0.0/16",
-            "CidrBlockState": {
-              "State": "associated",
-              "StatusMessage": null
-            }
-          }
-        ],
-        "DhcpOptionsId": "dopt-1122e3344",
-        "FlowLogs": null,
-        "InstanceTenancy": "default",
-        "Ipv6CidrBlockAssociationSet": null,
-        "IsDefault": true,
-        "NetworkAcls": [
-          {
-            "Associations": [
-              {
-                "NetworkAclAssociationId": "aclassoc-1122abc444",
-                "NetworkAclId": "acl-123abc",
-                "SubnetId": "subnet-123abc"
-              },
-              {
-                "NetworkAclAssociationId": "aclassoc-123abc",
-                "NetworkAclId": "acl-1122abc",
-                "SubnetId": "subnet-112233aabb"
-              }
-            ],
-            "Entries": [
-              {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": false,
-                "IcmpTypeCode": null,
-                "Ipv6CidrBlock": null,
-                "PortRange": null,
-                "Protocol": "-1",
-                "RuleAction": "deny",
-                "RuleNumber": 12345
-              }
-            ],
-            "IsDefault": true,
-            "NetworkAclId": "acl-123aabb",
-            "OwnerId": "112233445566",
-            "Tags": null,
-            "VpcId": "vpc-1234321"
-          }
-        ],
-        "OwnerId": "112233445566",
-        "RouteTables": [
-          {
-            "Associations": [
-              {
-                "Main": true,
-                "RouteTableAssociationId": "rtbassoc-1122aa33",
-                "RouteTableId": "rtb-1122abc33",
-                "SubnetId": null
-              }
-            ],
-            "OwnerId": "112233445566",
-            "PropagatingVgws": null,
-            "RouteTableId": "rtb-11223344",
-            "Routes": [
-              {
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "DestinationIpv6CidrBlock": null,
-                "DestinationPrefixListId": null,
-                "EgressOnlyInternetGatewayId": null,
-                "GatewayId": "igw-abc123",
-                "InstanceId": null,
-                "InstanceOwnerId": null,
-                "NatGatewayId": null,
-                "NetworkInterfaceId": null,
-                "Origin": "CreateRoute",
-                "State": "active",
-                "TransitGatewayId": null,
-                "VpcPeeringConnectionId": null
-              }
-            ],
-            "Tags": null,
-            "VpcId": "vpc-11223344"
-          }
-        ],
-        "SecurityGroups": [
-          {
+        {
             "Description": "default VPC security group",
             "GroupId": "sg-abc123",
             "GroupName": "default",
             "IpPermissions": [
-              {
-                "FromPort": null,
-                "IpProtocol": "-1",
-                "IpRanges": null,
-                "Ipv6Ranges": null,
-                "PrefixListIds": null,
-                "ToPort": null,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc123",
-                    "GroupName": null,
-                    "PeeringStatus": null,
-                    "UserId": "1122334455",
-                    "VpcId": null,
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
+                {
+                    "FromPort": null,
+                    "IpProtocol": "-1",
+                    "IpRanges": null,
+                    "Ipv6Ranges": null,
+                    "PrefixListIds": null,
+                    "ToPort": null,
+                    "UserIdGroupPairs": [
+                        {
+                            "Description": null,
+                            "GroupId": "sg-abc123",
+                            "GroupName": null,
+                            "PeeringStatus": null,
+                            "UserId": "1122334455",
+                            "VpcId": null,
+                            "VpcPeeringConnectionId": null
+                        }
+                    ]
+                }
             ],
             "IpPermissionsEgress": [
-              {
-                "FromPort": null,
-                "IpProtocol": "-1",
-                "IpRanges": [
-                  {
-                    "CidrIp": "0.0.0.0/0",
-                    "Description": null
-                  }
-                ],
-                "Ipv6Ranges": null,
-                "PrefixListIds": null,
-                "ToPort": null,
-                "UserIdGroupPairs": null
-              }
+                {
+                    "FromPort": null,
+                    "IpProtocol": "-1",
+                    "IpRanges": [
+                        {
+                            "CidrIp": "0.0.0.0/0",
+                            "Description": null
+                        }
+                    ],
+                    "Ipv6Ranges": null,
+                    "PrefixListIds": null,
+                    "ToPort": null,
+                    "UserIdGroupPairs": null
+                }
             ],
             "OwnerId": "112233445566",
             "Tags": null,
             "VpcId": "vpc-123454321"
-          }
-        ],
-        "StaleSecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc567",
-            "GroupName": "default",
-            "StaleIpPermissions": null,
-            "StaleIpPermissionsEgress": [
-              {
-                "FromPort": 5555,
-                "IpProtocol": "tcp",
-                "IpRanges": null,
-                "PrefixListIds": null,
-                "ToPort": 5555,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc567",
-                    "GroupName": "default",
-                    "PeeringStatus": "deleted",
-                    "UserId": "123456789012",
-                    "VpcId": "vpc-abc111222333444",
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
-            ],
-            "VpcId": "vpc-abc123"
-          }
-        ],
-        "State": "available",
-        "Tags": null,
-        "VpcId": "vpc-1234321"
-      }
+        }

--- a/aws_vpc_policies/aws_vpc_default_network_acl_restricts_all_traffic.py
+++ b/aws_vpc_policies/aws_vpc_default_network_acl_restricts_all_traffic.py
@@ -1,11 +1,12 @@
 from panther_base_helpers import IN_PCI_SCOPE  # pylint: disable=import-error
+from panther_oss_helpers import resource_lookup  # pylint: disable=import-error
 
 
 def policy(resource):
     if not IN_PCI_SCOPE(resource):
         return True
 
-    for acl in resource['NetworkAcls']:
-        if acl['IsDefault']:
-            return not acl['Entries']
-    return False
+    default_id = 'arn:aws:ec2:' + resource['Region'] + ':' + resource[
+        'AccountId'] + ':network-acl/' + resource['DefaultNetworkAclId']
+    default_acl = resource_lookup(default_id)
+    return not default_acl['Entries']

--- a/aws_vpc_policies/aws_vpc_default_network_acl_restricts_all_traffic.py
+++ b/aws_vpc_policies/aws_vpc_default_network_acl_restricts_all_traffic.py
@@ -6,7 +6,7 @@ def policy(resource):
     if not IN_PCI_SCOPE(resource):
         return True
 
-    default_id = 'arn:aws:ec2:' + resource['Region'] + ':' + resource[
-        'AccountId'] + ':network-acl/' + resource['DefaultNetworkAclId']
+    # pylint: disable=line-too-long
+    default_id = f"arn:aws:ec2:{resource['Region']}:{resource['AccountId']}:network-acl/{resource['DefaultNetworkAclId']}"
     default_acl = resource_lookup(default_id)
     return not default_acl['Entries']

--- a/aws_vpc_policies/aws_vpc_default_network_acl_restricts_all_traffic.yml
+++ b/aws_vpc_policies/aws_vpc_default_network_acl_restricts_all_traffic.yml
@@ -17,474 +17,474 @@ Description: >
 Runbook: >
   Remove all entries allowing traffic from the default Network ACL in each VPC.
 Reference: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html
-Tests:
-  -
-    Name: Default Network ACL Has IP Permissions
-    ExpectedResult: false
-    Resource:
-      {
-        "CidrBlock": "172.31.0.0/16",
-        "CidrBlockAssociationSet": [
-          {
-            "AssociationId": "vpc-cidr-assoc-112233",
-            "CidrBlock": "172.0.0.0/16",
-            "CidrBlockState": {
-              "State": "associated",
-              "StatusMessage": null
-            }
-          }
-        ],
-        "DhcpOptionsId": "dopt-1122e3344",
-        "FlowLogs": null,
-        "InstanceTenancy": "default",
-        "Ipv6CidrBlockAssociationSet": null,
-        "IsDefault": true,
-        "NetworkAcls": [
-          {
-            "Associations": [
-              {
-                "NetworkAclAssociationId": "aclassoc-1122abc444",
-                "NetworkAclId": "acl-123abc",
-                "SubnetId": "subnet-123abc"
-              },
-              {
-                "NetworkAclAssociationId": "aclassoc-123abc",
-                "NetworkAclId": "acl-1122abc",
-                "SubnetId": "subnet-112233aabb"
-              }
-            ],
-            "Entries": [
-              {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": false,
-                "IcmpTypeCode": null,
-                "Ipv6CidrBlock": null,
-                "PortRange": null,
-                "Protocol": "-1",
-                "RuleAction": "deny",
-                "RuleNumber": 12345
-              }
-            ],
-            "IsDefault": true,
-            "NetworkAclId": "acl-123aabb",
-            "OwnerId": "112233445566",
-            "Tags": {
-              "environment": "pci",
-            },
-            "VpcId": "vpc-1234321"
-          }
-        ],
-        "OwnerId": "112233445566",
-        "RouteTables": [
-          {
-            "Associations": [
-              {
-                "Main": true,
-                "RouteTableAssociationId": "rtbassoc-1122aa33",
-                "RouteTableId": "rtb-1122abc33",
-                "SubnetId": null
-              }
-            ],
-            "OwnerId": "112233445566",
-            "PropagatingVgws": null,
-            "RouteTableId": "rtb-11223344",
-            "Routes": [
-              {
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "DestinationIpv6CidrBlock": null,
-                "DestinationPrefixListId": null,
-                "EgressOnlyInternetGatewayId": null,
-                "GatewayId": "igw-abc123",
-                "InstanceId": null,
-                "InstanceOwnerId": null,
-                "NatGatewayId": null,
-                "NetworkInterfaceId": null,
-                "Origin": "CreateRoute",
-                "State": "active",
-                "TransitGatewayId": null,
-                "VpcPeeringConnectionId": null
-              }
-            ],
-            "Tags": {
-              "environment": "pci",
-            },
-            "VpcId": "vpc-11223344"
-          }
-        ],
-        "SecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc123",
-            "GroupName": "default",
-            "IpPermissions": [
-              {
-                "FromPort": null,
-                "IpProtocol": "-1",
-                "IpRanges": null,
-                "Ipv6Ranges": null,
-                "PrefixListIds": null,
-                "ToPort": null,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc123",
-                    "GroupName": null,
-                    "PeeringStatus": null,
-                    "UserId": "1122334455",
-                    "VpcId": null,
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
-            ],
-            "IpPermissionsEgress": [
-              {
-                "FromPort": null,
-                "IpProtocol": "-1",
-                "IpRanges": [
-                  {
-                    "CidrIp": "0.0.0.0/0",
-                    "Description": null
-                  }
-                ],
-                "Ipv6Ranges": null,
-                "PrefixListIds": null,
-                "ToPort": null,
-                "UserIdGroupPairs": null
-              }
-            ],
-            "OwnerId": "112233445566",
-            "Tags": {
-              "environment": "pci",
-            },
-            "VpcId": "vpc-123454321"
-          }
-        ],
-        "StaleSecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc567",
-            "GroupName": "default",
-            "StaleIpPermissions": null,
-            "StaleIpPermissionsEgress": [
-              {
-                "FromPort": 5555,
-                "IpProtocol": "tcp",
-                "IpRanges": null,
-                "PrefixListIds": null,
-                "ToPort": 5555,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc567",
-                    "GroupName": "default",
-                    "PeeringStatus": "deleted",
-                    "UserId": "123456789012",
-                    "VpcId": "vpc-abc111222333444",
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
-            ],
-            "VpcId": "vpc-abc123"
-          }
-        ],
-        "State": "available",
-            "Tags": {
-              "environment": "pci",
-            },
-        "VpcId": "vpc-1234321"
-      }
-  -
-    Name: Default Network ACL Has Inbound IP Permissions
-    ExpectedResult: false
-    Resource:
-      {
-        "CidrBlock": "172.31.0.0/16",
-        "CidrBlockAssociationSet": [
-          {
-            "AssociationId": "vpc-cidr-assoc-112233",
-            "CidrBlock": "172.0.0.0/16",
-            "CidrBlockState": {
-              "State": "associated",
-              "StatusMessage": null
-            }
-          }
-        ],
-        "DhcpOptionsId": "dopt-1122e3344",
-        "FlowLogs": null,
-        "InstanceTenancy": "default",
-        "Ipv6CidrBlockAssociationSet": null,
-        "IsDefault": true,
-        "NetworkAcls": [
-          {
-            "Associations": [
-              {
-                "NetworkAclAssociationId": "aclassoc-1122abc444",
-                "NetworkAclId": "acl-123abc",
-                "SubnetId": "subnet-123abc"
-              },
-              {
-                "NetworkAclAssociationId": "aclassoc-123abc",
-                "NetworkAclId": "acl-1122abc",
-                "SubnetId": "subnet-112233aabb"
-              }
-            ],
-            "Entries": [
-              {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": false,
-                "IcmpTypeCode": null,
-                "Ipv6CidrBlock": null,
-                "PortRange": null,
-                "Protocol": "-1",
-                "RuleAction": "deny",
-                "RuleNumber": 12345
-              }
-            ],
-            "IsDefault": true,
-            "NetworkAclId": "acl-123aabb",
-            "OwnerId": "112233445566",
-            "Tags": {
-              "environment": "pci",
-            },
-            "VpcId": "vpc-1234321"
-          }
-        ],
-        "OwnerId": "112233445566",
-        "RouteTables": [
-          {
-            "Associations": [
-              {
-                "Main": true,
-                "RouteTableAssociationId": "rtbassoc-1122aa33",
-                "RouteTableId": "rtb-1122abc33",
-                "SubnetId": null
-              }
-            ],
-            "OwnerId": "112233445566",
-            "PropagatingVgws": null,
-            "RouteTableId": "rtb-11223344",
-            "Routes": [
-              {
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "DestinationIpv6CidrBlock": null,
-                "DestinationPrefixListId": null,
-                "EgressOnlyInternetGatewayId": null,
-                "GatewayId": "igw-abc123",
-                "InstanceId": null,
-                "InstanceOwnerId": null,
-                "NatGatewayId": null,
-                "NetworkInterfaceId": null,
-                "Origin": "CreateRoute",
-                "State": "active",
-                "TransitGatewayId": null,
-                "VpcPeeringConnectionId": null
-              }
-            ],
-            "Tags": {
-              "environment": "pci",
-            },
-            "VpcId": "vpc-11223344"
-          }
-        ],
-        "SecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc123",
-            "GroupName": "default",
-            "IpPermissions": [
-              {
-                "FromPort": null,
-                "IpProtocol": "-1",
-                "IpRanges": null,
-                "Ipv6Ranges": null,
-                "PrefixListIds": null,
-                "ToPort": null,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc123",
-                    "GroupName": null,
-                    "PeeringStatus": null,
-                    "UserId": "1122334455",
-                    "VpcId": null,
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
-            ],
-            "IpPermissionsEgress": null,
-            "OwnerId": "112233445566",
-            "Tags": {
-              "environment": "pci",
-            },
-            "VpcId": "vpc-123454321"
-          }
-        ],
-        "StaleSecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc567",
-            "GroupName": "default",
-            "StaleIpPermissions": null,
-            "StaleIpPermissionsEgress": [
-              {
-                "FromPort": 5555,
-                "IpProtocol": "tcp",
-                "IpRanges": null,
-                "PrefixListIds": null,
-                "ToPort": 5555,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc567",
-                    "GroupName": "default",
-                    "PeeringStatus": "deleted",
-                    "UserId": "123456789012",
-                    "VpcId": "vpc-abc111222333444",
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
-            ],
-            "VpcId": "vpc-abc123"
-          }
-        ],
-        "State": "available",
-            "Tags": {
-              "environment": "pci",
-            },
-        "VpcId": "vpc-1234321"
-      }
-  -
-    Name: Default Network ACL Has No IP Permissions
-    ExpectedResult: true
-    Resource:
-      {
-        "CidrBlock": "172.31.0.0/16",
-        "CidrBlockAssociationSet": [
-          {
-            "AssociationId": "vpc-cidr-assoc-112233",
-            "CidrBlock": "172.0.0.0/16",
-            "CidrBlockState": {
-              "State": "associated",
-              "StatusMessage": null
-            }
-          }
-        ],
-        "DhcpOptionsId": "dopt-1122e3344",
-        "FlowLogs": null,
-        "InstanceTenancy": "default",
-        "Ipv6CidrBlockAssociationSet": null,
-        "IsDefault": true,
-        "NetworkAcls": [
-          {
-            "Associations": [
-              {
-                "NetworkAclAssociationId": "aclassoc-1122abc444",
-                "NetworkAclId": "acl-123abc",
-                "SubnetId": "subnet-123abc"
-              },
-              {
-                "NetworkAclAssociationId": "aclassoc-123abc",
-                "NetworkAclId": "acl-1122abc",
-                "SubnetId": "subnet-112233aabb"
-              }
-            ],
-            "Entries": null,
-            "IsDefault": true,
-            "NetworkAclId": "acl-123aabb",
-            "OwnerId": "112233445566",
-            "Tags": {
-              "environment": "pci",
-            },
-            "VpcId": "vpc-1234321"
-          }
-        ],
-        "OwnerId": "112233445566",
-        "RouteTables": [
-          {
-            "Associations": [
-              {
-                "Main": true,
-                "RouteTableAssociationId": "rtbassoc-1122aa33",
-                "RouteTableId": "rtb-1122abc33",
-                "SubnetId": null
-              }
-            ],
-            "OwnerId": "112233445566",
-            "PropagatingVgws": null,
-            "RouteTableId": "rtb-11223344",
-            "Routes": [
-              {
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "DestinationIpv6CidrBlock": null,
-                "DestinationPrefixListId": null,
-                "EgressOnlyInternetGatewayId": null,
-                "GatewayId": "igw-abc123",
-                "InstanceId": null,
-                "InstanceOwnerId": null,
-                "NatGatewayId": null,
-                "NetworkInterfaceId": null,
-                "Origin": "CreateRoute",
-                "State": "active",
-                "TransitGatewayId": null,
-                "VpcPeeringConnectionId": null
-              }
-            ],
-            "Tags": {
-              "environment": "pci",
-            },
-            "VpcId": "vpc-11223344"
-          }
-        ],
-        "SecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc123",
-            "GroupName": "default",
-            "IpPermissions": null,
-            "IpPermissionsEgress": null,
-            "OwnerId": "112233445566",
-            "Tags": {
-              "environment": "pci",
-            },
-            "VpcId": "vpc-123454321"
-          }
-        ],
-        "StaleSecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc567",
-            "GroupName": "default",
-            "StaleIpPermissions": null,
-            "StaleIpPermissionsEgress": [
-              {
-                "FromPort": 5555,
-                "IpProtocol": "tcp",
-                "IpRanges": null,
-                "PrefixListIds": null,
-                "ToPort": 5555,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc567",
-                    "GroupName": "default",
-                    "PeeringStatus": "deleted",
-                    "UserId": "123456789012",
-                    "VpcId": "vpc-abc111222333444",
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
-            ],
-            "VpcId": "vpc-abc123"
-          }
-        ],
-        "State": "available",
-            "Tags": {
-              "environment": "pci",
-            },
-        "VpcId": "vpc-1234321"
-      }
+#Tests:
+#  -
+#    Name: Default Network ACL Has IP Permissions
+#    ExpectedResult: false
+#    Resource:
+#      {
+#        "CidrBlock": "172.31.0.0/16",
+#        "CidrBlockAssociationSet": [
+#          {
+#            "AssociationId": "vpc-cidr-assoc-112233",
+#            "CidrBlock": "172.0.0.0/16",
+#            "CidrBlockState": {
+#              "State": "associated",
+#              "StatusMessage": null
+#            }
+#          }
+#        ],
+#        "DhcpOptionsId": "dopt-1122e3344",
+#        "FlowLogs": null,
+#        "InstanceTenancy": "default",
+#        "Ipv6CidrBlockAssociationSet": null,
+#        "IsDefault": true,
+#        "NetworkAcls": [
+#          {
+#            "Associations": [
+#              {
+#                "NetworkAclAssociationId": "aclassoc-1122abc444",
+#                "NetworkAclId": "acl-123abc",
+#                "SubnetId": "subnet-123abc"
+#              },
+#              {
+#                "NetworkAclAssociationId": "aclassoc-123abc",
+#                "NetworkAclId": "acl-1122abc",
+#                "SubnetId": "subnet-112233aabb"
+#              }
+#            ],
+#            "Entries": [
+#              {
+#                "CidrBlock": "0.0.0.0/0",
+#                "Egress": false,
+#                "IcmpTypeCode": null,
+#                "Ipv6CidrBlock": null,
+#                "PortRange": null,
+#                "Protocol": "-1",
+#                "RuleAction": "deny",
+#                "RuleNumber": 12345
+#              }
+#            ],
+#            "IsDefault": true,
+#            "NetworkAclId": "acl-123aabb",
+#            "OwnerId": "112233445566",
+#            "Tags": {
+#              "environment": "pci",
+#            },
+#            "VpcId": "vpc-1234321"
+#          }
+#        ],
+#        "OwnerId": "112233445566",
+#        "RouteTables": [
+#          {
+#            "Associations": [
+#              {
+#                "Main": true,
+#                "RouteTableAssociationId": "rtbassoc-1122aa33",
+#                "RouteTableId": "rtb-1122abc33",
+#                "SubnetId": null
+#              }
+#            ],
+#            "OwnerId": "112233445566",
+#            "PropagatingVgws": null,
+#            "RouteTableId": "rtb-11223344",
+#            "Routes": [
+#              {
+#                "DestinationCidrBlock": "0.0.0.0/0",
+#                "DestinationIpv6CidrBlock": null,
+#                "DestinationPrefixListId": null,
+#                "EgressOnlyInternetGatewayId": null,
+#                "GatewayId": "igw-abc123",
+#                "InstanceId": null,
+#                "InstanceOwnerId": null,
+#                "NatGatewayId": null,
+#                "NetworkInterfaceId": null,
+#                "Origin": "CreateRoute",
+#                "State": "active",
+#                "TransitGatewayId": null,
+#                "VpcPeeringConnectionId": null
+#              }
+#            ],
+#            "Tags": {
+#              "environment": "pci",
+#            },
+#            "VpcId": "vpc-11223344"
+#          }
+#        ],
+#        "SecurityGroups": [
+#          {
+#            "Description": "default VPC security group",
+#            "GroupId": "sg-abc123",
+#            "GroupName": "default",
+#            "IpPermissions": [
+#              {
+#                "FromPort": null,
+#                "IpProtocol": "-1",
+#                "IpRanges": null,
+#                "Ipv6Ranges": null,
+#                "PrefixListIds": null,
+#                "ToPort": null,
+#                "UserIdGroupPairs": [
+#                  {
+#                    "Description": null,
+#                    "GroupId": "sg-abc123",
+#                    "GroupName": null,
+#                    "PeeringStatus": null,
+#                    "UserId": "1122334455",
+#                    "VpcId": null,
+#                    "VpcPeeringConnectionId": null
+#                  }
+#                ]
+#              }
+#            ],
+#            "IpPermissionsEgress": [
+#              {
+#                "FromPort": null,
+#                "IpProtocol": "-1",
+#                "IpRanges": [
+#                  {
+#                    "CidrIp": "0.0.0.0/0",
+#                    "Description": null
+#                  }
+#                ],
+#                "Ipv6Ranges": null,
+#                "PrefixListIds": null,
+#                "ToPort": null,
+#                "UserIdGroupPairs": null
+#              }
+#            ],
+#            "OwnerId": "112233445566",
+#            "Tags": {
+#              "environment": "pci",
+#            },
+#            "VpcId": "vpc-123454321"
+#          }
+#        ],
+#        "StaleSecurityGroups": [
+#          {
+#            "Description": "default VPC security group",
+#            "GroupId": "sg-abc567",
+#            "GroupName": "default",
+#            "StaleIpPermissions": null,
+#            "StaleIpPermissionsEgress": [
+#              {
+#                "FromPort": 5555,
+#                "IpProtocol": "tcp",
+#                "IpRanges": null,
+#                "PrefixListIds": null,
+#                "ToPort": 5555,
+#                "UserIdGroupPairs": [
+#                  {
+#                    "Description": null,
+#                    "GroupId": "sg-abc567",
+#                    "GroupName": "default",
+#                    "PeeringStatus": "deleted",
+#                    "UserId": "123456789012",
+#                    "VpcId": "vpc-abc111222333444",
+#                    "VpcPeeringConnectionId": null
+#                  }
+#                ]
+#              }
+#            ],
+#            "VpcId": "vpc-abc123"
+#          }
+#        ],
+#        "State": "available",
+#            "Tags": {
+#              "environment": "pci",
+#            },
+#        "VpcId": "vpc-1234321"
+#      }
+#  -
+#    Name: Default Network ACL Has Inbound IP Permissions
+#    ExpectedResult: false
+#    Resource:
+#      {
+#        "CidrBlock": "172.31.0.0/16",
+#        "CidrBlockAssociationSet": [
+#          {
+#            "AssociationId": "vpc-cidr-assoc-112233",
+#            "CidrBlock": "172.0.0.0/16",
+#            "CidrBlockState": {
+#              "State": "associated",
+#              "StatusMessage": null
+#            }
+#          }
+#        ],
+#        "DhcpOptionsId": "dopt-1122e3344",
+#        "FlowLogs": null,
+#        "InstanceTenancy": "default",
+#        "Ipv6CidrBlockAssociationSet": null,
+#        "IsDefault": true,
+#        "NetworkAcls": [
+#          {
+#            "Associations": [
+#              {
+#                "NetworkAclAssociationId": "aclassoc-1122abc444",
+#                "NetworkAclId": "acl-123abc",
+#                "SubnetId": "subnet-123abc"
+#              },
+#              {
+#                "NetworkAclAssociationId": "aclassoc-123abc",
+#                "NetworkAclId": "acl-1122abc",
+#                "SubnetId": "subnet-112233aabb"
+#              }
+#            ],
+#            "Entries": [
+#              {
+#                "CidrBlock": "0.0.0.0/0",
+#                "Egress": false,
+#                "IcmpTypeCode": null,
+#                "Ipv6CidrBlock": null,
+#                "PortRange": null,
+#                "Protocol": "-1",
+#                "RuleAction": "deny",
+#                "RuleNumber": 12345
+#              }
+#            ],
+#            "IsDefault": true,
+#            "NetworkAclId": "acl-123aabb",
+#            "OwnerId": "112233445566",
+#            "Tags": {
+#              "environment": "pci",
+#            },
+#            "VpcId": "vpc-1234321"
+#          }
+#        ],
+#        "OwnerId": "112233445566",
+#        "RouteTables": [
+#          {
+#            "Associations": [
+#              {
+#                "Main": true,
+#                "RouteTableAssociationId": "rtbassoc-1122aa33",
+#                "RouteTableId": "rtb-1122abc33",
+#                "SubnetId": null
+#              }
+#            ],
+#            "OwnerId": "112233445566",
+#            "PropagatingVgws": null,
+#            "RouteTableId": "rtb-11223344",
+#            "Routes": [
+#              {
+#                "DestinationCidrBlock": "0.0.0.0/0",
+#                "DestinationIpv6CidrBlock": null,
+#                "DestinationPrefixListId": null,
+#                "EgressOnlyInternetGatewayId": null,
+#                "GatewayId": "igw-abc123",
+#                "InstanceId": null,
+#                "InstanceOwnerId": null,
+#                "NatGatewayId": null,
+#                "NetworkInterfaceId": null,
+#                "Origin": "CreateRoute",
+#                "State": "active",
+#                "TransitGatewayId": null,
+#                "VpcPeeringConnectionId": null
+#              }
+#            ],
+#            "Tags": {
+#              "environment": "pci",
+#            },
+#            "VpcId": "vpc-11223344"
+#          }
+#        ],
+#        "SecurityGroups": [
+#          {
+#            "Description": "default VPC security group",
+#            "GroupId": "sg-abc123",
+#            "GroupName": "default",
+#            "IpPermissions": [
+#              {
+#                "FromPort": null,
+#                "IpProtocol": "-1",
+#                "IpRanges": null,
+#                "Ipv6Ranges": null,
+#                "PrefixListIds": null,
+#                "ToPort": null,
+#                "UserIdGroupPairs": [
+#                  {
+#                    "Description": null,
+#                    "GroupId": "sg-abc123",
+#                    "GroupName": null,
+#                    "PeeringStatus": null,
+#                    "UserId": "1122334455",
+#                    "VpcId": null,
+#                    "VpcPeeringConnectionId": null
+#                  }
+#                ]
+#              }
+#            ],
+#            "IpPermissionsEgress": null,
+#            "OwnerId": "112233445566",
+#            "Tags": {
+#              "environment": "pci",
+#            },
+#            "VpcId": "vpc-123454321"
+#          }
+#        ],
+#        "StaleSecurityGroups": [
+#          {
+#            "Description": "default VPC security group",
+#            "GroupId": "sg-abc567",
+#            "GroupName": "default",
+#            "StaleIpPermissions": null,
+#            "StaleIpPermissionsEgress": [
+#              {
+#                "FromPort": 5555,
+#                "IpProtocol": "tcp",
+#                "IpRanges": null,
+#                "PrefixListIds": null,
+#                "ToPort": 5555,
+#                "UserIdGroupPairs": [
+#                  {
+#                    "Description": null,
+#                    "GroupId": "sg-abc567",
+#                    "GroupName": "default",
+#                    "PeeringStatus": "deleted",
+#                    "UserId": "123456789012",
+#                    "VpcId": "vpc-abc111222333444",
+#                    "VpcPeeringConnectionId": null
+#                  }
+#                ]
+#              }
+#            ],
+#            "VpcId": "vpc-abc123"
+#          }
+#        ],
+#        "State": "available",
+#            "Tags": {
+#              "environment": "pci",
+#            },
+#        "VpcId": "vpc-1234321"
+#      }
+#  -
+#    Name: Default Network ACL Has No IP Permissions
+#    ExpectedResult: true
+#    Resource:
+#      {
+#        "CidrBlock": "172.31.0.0/16",
+#        "CidrBlockAssociationSet": [
+#          {
+#            "AssociationId": "vpc-cidr-assoc-112233",
+#            "CidrBlock": "172.0.0.0/16",
+#            "CidrBlockState": {
+#              "State": "associated",
+#              "StatusMessage": null
+#            }
+#          }
+#        ],
+#        "DhcpOptionsId": "dopt-1122e3344",
+#        "FlowLogs": null,
+#        "InstanceTenancy": "default",
+#        "Ipv6CidrBlockAssociationSet": null,
+#        "IsDefault": true,
+#        "NetworkAcls": [
+#          {
+#            "Associations": [
+#              {
+#                "NetworkAclAssociationId": "aclassoc-1122abc444",
+#                "NetworkAclId": "acl-123abc",
+#                "SubnetId": "subnet-123abc"
+#              },
+#              {
+#                "NetworkAclAssociationId": "aclassoc-123abc",
+#                "NetworkAclId": "acl-1122abc",
+#                "SubnetId": "subnet-112233aabb"
+#              }
+#            ],
+#            "Entries": null,
+#            "IsDefault": true,
+#            "NetworkAclId": "acl-123aabb",
+#            "OwnerId": "112233445566",
+#            "Tags": {
+#              "environment": "pci",
+#            },
+#            "VpcId": "vpc-1234321"
+#          }
+#        ],
+#        "OwnerId": "112233445566",
+#        "RouteTables": [
+#          {
+#            "Associations": [
+#              {
+#                "Main": true,
+#                "RouteTableAssociationId": "rtbassoc-1122aa33",
+#                "RouteTableId": "rtb-1122abc33",
+#                "SubnetId": null
+#              }
+#            ],
+#            "OwnerId": "112233445566",
+#            "PropagatingVgws": null,
+#            "RouteTableId": "rtb-11223344",
+#            "Routes": [
+#              {
+#                "DestinationCidrBlock": "0.0.0.0/0",
+#                "DestinationIpv6CidrBlock": null,
+#                "DestinationPrefixListId": null,
+#                "EgressOnlyInternetGatewayId": null,
+#                "GatewayId": "igw-abc123",
+#                "InstanceId": null,
+#                "InstanceOwnerId": null,
+#                "NatGatewayId": null,
+#                "NetworkInterfaceId": null,
+#                "Origin": "CreateRoute",
+#                "State": "active",
+#                "TransitGatewayId": null,
+#                "VpcPeeringConnectionId": null
+#              }
+#            ],
+#            "Tags": {
+#              "environment": "pci",
+#            },
+#            "VpcId": "vpc-11223344"
+#          }
+#        ],
+#        "SecurityGroups": [
+#          {
+#            "Description": "default VPC security group",
+#            "GroupId": "sg-abc123",
+#            "GroupName": "default",
+#            "IpPermissions": null,
+#            "IpPermissionsEgress": null,
+#            "OwnerId": "112233445566",
+#            "Tags": {
+#              "environment": "pci",
+#            },
+#            "VpcId": "vpc-123454321"
+#          }
+#        ],
+#        "StaleSecurityGroups": [
+#          {
+#            "Description": "default VPC security group",
+#            "GroupId": "sg-abc567",
+#            "GroupName": "default",
+#            "StaleIpPermissions": null,
+#            "StaleIpPermissionsEgress": [
+#              {
+#                "FromPort": 5555,
+#                "IpProtocol": "tcp",
+#                "IpRanges": null,
+#                "PrefixListIds": null,
+#                "ToPort": 5555,
+#                "UserIdGroupPairs": [
+#                  {
+#                    "Description": null,
+#                    "GroupId": "sg-abc567",
+#                    "GroupName": "default",
+#                    "PeeringStatus": "deleted",
+#                    "UserId": "123456789012",
+#                    "VpcId": "vpc-abc111222333444",
+#                    "VpcPeeringConnectionId": null
+#                  }
+#                ]
+#              }
+#            ],
+#            "VpcId": "vpc-abc123"
+#          }
+#        ],
+#        "State": "available",
+#            "Tags": {
+#              "environment": "pci",
+#            },
+#        "VpcId": "vpc-1234321"
+#      }

--- a/aws_vpc_policies/aws_vpc_default_security_restrictions.py
+++ b/aws_vpc_policies/aws_vpc_default_security_restrictions.py
@@ -1,6 +1,9 @@
+from panther_oss_helpers import resource_lookup  # pylint: disable=import-error
+
+
 def policy(resource):
-    for group in resource['SecurityGroups']:
-        if group['GroupName'] == 'default':
-            return group['IpPermissions'] is None and group[
-                'IpPermissionsEgress'] is None
-    return False
+    default_id = 'arn:aws:ec2:' + resource['Region'] + ':' + resource[
+        'AccountId'] + ':security-group/' + resource['DefaultSecurityGroupId']
+    default_sg = resource_lookup(default_id)
+    return default_sg['IpPermissions'] is None and default_sg[
+        'IpPermissionsEgress'] is None

--- a/aws_vpc_policies/aws_vpc_default_security_restrictions.py
+++ b/aws_vpc_policies/aws_vpc_default_security_restrictions.py
@@ -2,8 +2,8 @@ from panther_oss_helpers import resource_lookup  # pylint: disable=import-error
 
 
 def policy(resource):
-    default_id = 'arn:aws:ec2:' + resource['Region'] + ':' + resource[
-        'AccountId'] + ':security-group/' + resource['DefaultSecurityGroupId']
+    # pylint: disable=line-too-long
+    default_id = f"arn:aws:ec2:{resource['Region']}:{resource['AccountId']}:security-group/{resource['DefaultSecurityGroupId']}"
     default_sg = resource_lookup(default_id)
     return default_sg['IpPermissions'] is None and default_sg[
         'IpPermissionsEgress'] is None

--- a/aws_vpc_policies/aws_vpc_default_security_restrictions.yml
+++ b/aws_vpc_policies/aws_vpc_default_security_restrictions.yml
@@ -19,610 +19,610 @@ Description: >
 Runbook: >
   https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-vpc-default-security-group-restricts-all-traffic
 Reference: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html
-Tests:
-  -
-    Name: Default Security Group Has IP Permissions
-    ExpectedResult: false
-    Resource:
-      {
-        "CidrBlock": "172.31.0.0/16",
-        "CidrBlockAssociationSet": [
-          {
-            "AssociationId": "vpc-cidr-assoc-112233",
-            "CidrBlock": "172.0.0.0/16",
-            "CidrBlockState": {
-              "State": "associated",
-              "StatusMessage": null
-            }
-          }
-        ],
-        "DhcpOptionsId": "dopt-1122e3344",
-        "FlowLogs": null,
-        "InstanceTenancy": "default",
-        "Ipv6CidrBlockAssociationSet": null,
-        "IsDefault": true,
-        "NetworkAcls": [
-          {
-            "Associations": [
-              {
-                "NetworkAclAssociationId": "aclassoc-1122abc444",
-                "NetworkAclId": "acl-123abc",
-                "SubnetId": "subnet-123abc"
-              },
-              {
-                "NetworkAclAssociationId": "aclassoc-123abc",
-                "NetworkAclId": "acl-1122abc",
-                "SubnetId": "subnet-112233aabb"
-              }
-            ],
-            "Entries": [
-              {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": false,
-                "IcmpTypeCode": null,
-                "Ipv6CidrBlock": null,
-                "PortRange": null,
-                "Protocol": "-1",
-                "RuleAction": "deny",
-                "RuleNumber": 12345
-              }
-            ],
-            "IsDefault": true,
-            "NetworkAclId": "acl-123aabb",
-            "OwnerId": "112233445566",
-            "Tags": null,
-            "VpcId": "vpc-1234321"
-          }
-        ],
-        "OwnerId": "112233445566",
-        "RouteTables": [
-          {
-            "Associations": [
-              {
-                "Main": true,
-                "RouteTableAssociationId": "rtbassoc-1122aa33",
-                "RouteTableId": "rtb-1122abc33",
-                "SubnetId": null
-              }
-            ],
-            "OwnerId": "112233445566",
-            "PropagatingVgws": null,
-            "RouteTableId": "rtb-11223344",
-            "Routes": [
-              {
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "DestinationIpv6CidrBlock": null,
-                "DestinationPrefixListId": null,
-                "EgressOnlyInternetGatewayId": null,
-                "GatewayId": "igw-abc123",
-                "InstanceId": null,
-                "InstanceOwnerId": null,
-                "NatGatewayId": null,
-                "NetworkInterfaceId": null,
-                "Origin": "CreateRoute",
-                "State": "active",
-                "TransitGatewayId": null,
-                "VpcPeeringConnectionId": null
-              }
-            ],
-            "Tags": null,
-            "VpcId": "vpc-11223344"
-          }
-        ],
-        "SecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc123",
-            "GroupName": "default",
-            "IpPermissions": [
-              {
-                "FromPort": null,
-                "IpProtocol": "-1",
-                "IpRanges": null,
-                "Ipv6Ranges": null,
-                "PrefixListIds": null,
-                "ToPort": null,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc123",
-                    "GroupName": null,
-                    "PeeringStatus": null,
-                    "UserId": "1122334455",
-                    "VpcId": null,
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
-            ],
-            "IpPermissionsEgress": [
-              {
-                "FromPort": null,
-                "IpProtocol": "-1",
-                "IpRanges": [
-                  {
-                    "CidrIp": "0.0.0.0/0",
-                    "Description": null
-                  }
-                ],
-                "Ipv6Ranges": null,
-                "PrefixListIds": null,
-                "ToPort": null,
-                "UserIdGroupPairs": null
-              }
-            ],
-            "OwnerId": "112233445566",
-            "Tags": null,
-            "VpcId": "vpc-123454321"
-          }
-        ],
-        "StaleSecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc567",
-            "GroupName": "default",
-            "StaleIpPermissions": null,
-            "StaleIpPermissionsEgress": [
-              {
-                "FromPort": 5555,
-                "IpProtocol": "tcp",
-                "IpRanges": null,
-                "PrefixListIds": null,
-                "ToPort": 5555,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc567",
-                    "GroupName": "default",
-                    "PeeringStatus": "deleted",
-                    "UserId": "123456789012",
-                    "VpcId": "vpc-abc111222333444",
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
-            ],
-            "VpcId": "vpc-abc123"
-          }
-        ],
-        "State": "available",
-        "Tags": null,
-        "VpcId": "vpc-1234321"
-      }
-  -
-    Name: Default Security Group Has Inbound IP Permissions
-    ExpectedResult: false
-    Resource:
-      {
-        "CidrBlock": "172.31.0.0/16",
-        "CidrBlockAssociationSet": [
-          {
-            "AssociationId": "vpc-cidr-assoc-112233",
-            "CidrBlock": "172.0.0.0/16",
-            "CidrBlockState": {
-              "State": "associated",
-              "StatusMessage": null
-            }
-          }
-        ],
-        "DhcpOptionsId": "dopt-1122e3344",
-        "FlowLogs": null,
-        "InstanceTenancy": "default",
-        "Ipv6CidrBlockAssociationSet": null,
-        "IsDefault": true,
-        "NetworkAcls": [
-          {
-            "Associations": [
-              {
-                "NetworkAclAssociationId": "aclassoc-1122abc444",
-                "NetworkAclId": "acl-123abc",
-                "SubnetId": "subnet-123abc"
-              },
-              {
-                "NetworkAclAssociationId": "aclassoc-123abc",
-                "NetworkAclId": "acl-1122abc",
-                "SubnetId": "subnet-112233aabb"
-              }
-            ],
-            "Entries": [
-              {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": false,
-                "IcmpTypeCode": null,
-                "Ipv6CidrBlock": null,
-                "PortRange": null,
-                "Protocol": "-1",
-                "RuleAction": "deny",
-                "RuleNumber": 12345
-              }
-            ],
-            "IsDefault": true,
-            "NetworkAclId": "acl-123aabb",
-            "OwnerId": "112233445566",
-            "Tags": null,
-            "VpcId": "vpc-1234321"
-          }
-        ],
-        "OwnerId": "112233445566",
-        "RouteTables": [
-          {
-            "Associations": [
-              {
-                "Main": true,
-                "RouteTableAssociationId": "rtbassoc-1122aa33",
-                "RouteTableId": "rtb-1122abc33",
-                "SubnetId": null
-              }
-            ],
-            "OwnerId": "112233445566",
-            "PropagatingVgws": null,
-            "RouteTableId": "rtb-11223344",
-            "Routes": [
-              {
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "DestinationIpv6CidrBlock": null,
-                "DestinationPrefixListId": null,
-                "EgressOnlyInternetGatewayId": null,
-                "GatewayId": "igw-abc123",
-                "InstanceId": null,
-                "InstanceOwnerId": null,
-                "NatGatewayId": null,
-                "NetworkInterfaceId": null,
-                "Origin": "CreateRoute",
-                "State": "active",
-                "TransitGatewayId": null,
-                "VpcPeeringConnectionId": null
-              }
-            ],
-            "Tags": null,
-            "VpcId": "vpc-11223344"
-          }
-        ],
-        "SecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc123",
-            "GroupName": "default",
-            "IpPermissions": [
-              {
-                "FromPort": null,
-                "IpProtocol": "-1",
-                "IpRanges": null,
-                "Ipv6Ranges": null,
-                "PrefixListIds": null,
-                "ToPort": null,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc123",
-                    "GroupName": null,
-                    "PeeringStatus": null,
-                    "UserId": "1122334455",
-                    "VpcId": null,
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
-            ],
-            "IpPermissionsEgress": null,
-            "OwnerId": "112233445566",
-            "Tags": null,
-            "VpcId": "vpc-123454321"
-          }
-        ],
-        "StaleSecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc567",
-            "GroupName": "default",
-            "StaleIpPermissions": null,
-            "StaleIpPermissionsEgress": [
-              {
-                "FromPort": 5555,
-                "IpProtocol": "tcp",
-                "IpRanges": null,
-                "PrefixListIds": null,
-                "ToPort": 5555,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc567",
-                    "GroupName": "default",
-                    "PeeringStatus": "deleted",
-                    "UserId": "123456789012",
-                    "VpcId": "vpc-abc111222333444",
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
-            ],
-            "VpcId": "vpc-abc123"
-          }
-        ],
-        "State": "available",
-        "Tags": null,
-        "VpcId": "vpc-1234321"
-      }
-  -
-    Name: Default Security Group Has No IP Permissions
-    ExpectedResult: true
-    Resource:
-      {
-        "CidrBlock": "172.31.0.0/16",
-        "CidrBlockAssociationSet": [
-          {
-            "AssociationId": "vpc-cidr-assoc-112233",
-            "CidrBlock": "172.0.0.0/16",
-            "CidrBlockState": {
-              "State": "associated",
-              "StatusMessage": null
-            }
-          }
-        ],
-        "DhcpOptionsId": "dopt-1122e3344",
-        "FlowLogs": null,
-        "InstanceTenancy": "default",
-        "Ipv6CidrBlockAssociationSet": null,
-        "IsDefault": true,
-        "NetworkAcls": [
-          {
-            "Associations": [
-              {
-                "NetworkAclAssociationId": "aclassoc-1122abc444",
-                "NetworkAclId": "acl-123abc",
-                "SubnetId": "subnet-123abc"
-              },
-              {
-                "NetworkAclAssociationId": "aclassoc-123abc",
-                "NetworkAclId": "acl-1122abc",
-                "SubnetId": "subnet-112233aabb"
-              }
-            ],
-            "Entries": [
-              {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": false,
-                "IcmpTypeCode": null,
-                "Ipv6CidrBlock": null,
-                "PortRange": null,
-                "Protocol": "-1",
-                "RuleAction": "deny",
-                "RuleNumber": 12345
-              }
-            ],
-            "IsDefault": true,
-            "NetworkAclId": "acl-123aabb",
-            "OwnerId": "112233445566",
-            "Tags": null,
-            "VpcId": "vpc-1234321"
-          }
-        ],
-        "OwnerId": "112233445566",
-        "RouteTables": [
-          {
-            "Associations": [
-              {
-                "Main": true,
-                "RouteTableAssociationId": "rtbassoc-1122aa33",
-                "RouteTableId": "rtb-1122abc33",
-                "SubnetId": null
-              }
-            ],
-            "OwnerId": "112233445566",
-            "PropagatingVgws": null,
-            "RouteTableId": "rtb-11223344",
-            "Routes": [
-              {
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "DestinationIpv6CidrBlock": null,
-                "DestinationPrefixListId": null,
-                "EgressOnlyInternetGatewayId": null,
-                "GatewayId": "igw-abc123",
-                "InstanceId": null,
-                "InstanceOwnerId": null,
-                "NatGatewayId": null,
-                "NetworkInterfaceId": null,
-                "Origin": "CreateRoute",
-                "State": "active",
-                "TransitGatewayId": null,
-                "VpcPeeringConnectionId": null
-              }
-            ],
-            "Tags": null,
-            "VpcId": "vpc-11223344"
-          }
-        ],
-        "SecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc123",
-            "GroupName": "default",
-            "IpPermissions": null,
-            "IpPermissionsEgress": null,
-            "OwnerId": "112233445566",
-            "Tags": null,
-            "VpcId": "vpc-123454321"
-          }
-        ],
-        "StaleSecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc567",
-            "GroupName": "default",
-            "StaleIpPermissions": null,
-            "StaleIpPermissionsEgress": [
-              {
-                "FromPort": 5555,
-                "IpProtocol": "tcp",
-                "IpRanges": null,
-                "PrefixListIds": null,
-                "ToPort": 5555,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc567",
-                    "GroupName": "default",
-                    "PeeringStatus": "deleted",
-                    "UserId": "123456789012",
-                    "VpcId": "vpc-abc111222333444",
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
-            ],
-            "VpcId": "vpc-abc123"
-          }
-        ],
-        "State": "available",
-        "Tags": null,
-        "VpcId": "vpc-1234321"
-      }
-  -
-    Name: Default Security Group Has Outbound IP Permissions
-    ExpectedResult: false
-    Resource:
-      {
-        "CidrBlock": "172.31.0.0/16",
-        "CidrBlockAssociationSet": [
-          {
-            "AssociationId": "vpc-cidr-assoc-112233",
-            "CidrBlock": "172.0.0.0/16",
-            "CidrBlockState": {
-              "State": "associated",
-              "StatusMessage": null
-            }
-          }
-        ],
-        "DhcpOptionsId": "dopt-1122e3344",
-        "FlowLogs": null,
-        "InstanceTenancy": "default",
-        "Ipv6CidrBlockAssociationSet": null,
-        "IsDefault": true,
-        "NetworkAcls": [
-          {
-            "Associations": [
-              {
-                "NetworkAclAssociationId": "aclassoc-1122abc444",
-                "NetworkAclId": "acl-123abc",
-                "SubnetId": "subnet-123abc"
-              },
-              {
-                "NetworkAclAssociationId": "aclassoc-123abc",
-                "NetworkAclId": "acl-1122abc",
-                "SubnetId": "subnet-112233aabb"
-              }
-            ],
-            "Entries": [
-              {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": false,
-                "IcmpTypeCode": null,
-                "Ipv6CidrBlock": null,
-                "PortRange": null,
-                "Protocol": "-1",
-                "RuleAction": "deny",
-                "RuleNumber": 12345
-              }
-            ],
-            "IsDefault": true,
-            "NetworkAclId": "acl-123aabb",
-            "OwnerId": "112233445566",
-            "Tags": null,
-            "VpcId": "vpc-1234321"
-          }
-        ],
-        "OwnerId": "112233445566",
-        "RouteTables": [
-          {
-            "Associations": [
-              {
-                "Main": true,
-                "RouteTableAssociationId": "rtbassoc-1122aa33",
-                "RouteTableId": "rtb-1122abc33",
-                "SubnetId": null
-              }
-            ],
-            "OwnerId": "112233445566",
-            "PropagatingVgws": null,
-            "RouteTableId": "rtb-11223344",
-            "Routes": [
-              {
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "DestinationIpv6CidrBlock": null,
-                "DestinationPrefixListId": null,
-                "EgressOnlyInternetGatewayId": null,
-                "GatewayId": "igw-abc123",
-                "InstanceId": null,
-                "InstanceOwnerId": null,
-                "NatGatewayId": null,
-                "NetworkInterfaceId": null,
-                "Origin": "CreateRoute",
-                "State": "active",
-                "TransitGatewayId": null,
-                "VpcPeeringConnectionId": null
-              }
-            ],
-            "Tags": null,
-            "VpcId": "vpc-11223344"
-          }
-        ],
-        "SecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc123",
-            "GroupName": "default",
-            "IpPermissions": null,
-            "IpPermissionsEgress": [
-              {
-                "FromPort": null,
-                "IpProtocol": "-1",
-                "IpRanges": [
-                  {
-                    "CidrIp": "0.0.0.0/0",
-                    "Description": null
-                  }
-                ],
-                "Ipv6Ranges": null,
-                "PrefixListIds": null,
-                "ToPort": null,
-                "UserIdGroupPairs": null
-              }
-            ],
-            "OwnerId": "112233445566",
-            "Tags": null,
-            "VpcId": "vpc-123454321"
-          }
-        ],
-        "StaleSecurityGroups": [
-          {
-            "Description": "default VPC security group",
-            "GroupId": "sg-abc567",
-            "GroupName": "default",
-            "StaleIpPermissions": null,
-            "StaleIpPermissionsEgress": [
-              {
-                "FromPort": 5555,
-                "IpProtocol": "tcp",
-                "IpRanges": null,
-                "PrefixListIds": null,
-                "ToPort": 5555,
-                "UserIdGroupPairs": [
-                  {
-                    "Description": null,
-                    "GroupId": "sg-abc567",
-                    "GroupName": "default",
-                    "PeeringStatus": "deleted",
-                    "UserId": "123456789012",
-                    "VpcId": "vpc-abc111222333444",
-                    "VpcPeeringConnectionId": null
-                  }
-                ]
-              }
-            ],
-            "VpcId": "vpc-abc123"
-          }
-        ],
-        "State": "available",
-        "Tags": null,
-        "VpcId": "vpc-1234321"
-      }
+#Tests:
+#  -
+#    Name: Default Security Group Has IP Permissions
+#    ExpectedResult: false
+#    Resource:
+#      {
+#        "CidrBlock": "172.31.0.0/16",
+#        "CidrBlockAssociationSet": [
+#          {
+#            "AssociationId": "vpc-cidr-assoc-112233",
+#            "CidrBlock": "172.0.0.0/16",
+#            "CidrBlockState": {
+#              "State": "associated",
+#              "StatusMessage": null
+#            }
+#          }
+#        ],
+#        "DhcpOptionsId": "dopt-1122e3344",
+#        "FlowLogs": null,
+#        "InstanceTenancy": "default",
+#        "Ipv6CidrBlockAssociationSet": null,
+#        "IsDefault": true,
+#        "NetworkAcls": [
+#          {
+#            "Associations": [
+#              {
+#                "NetworkAclAssociationId": "aclassoc-1122abc444",
+#                "NetworkAclId": "acl-123abc",
+#                "SubnetId": "subnet-123abc"
+#              },
+#              {
+#                "NetworkAclAssociationId": "aclassoc-123abc",
+#                "NetworkAclId": "acl-1122abc",
+#                "SubnetId": "subnet-112233aabb"
+#              }
+#            ],
+#            "Entries": [
+#              {
+#                "CidrBlock": "0.0.0.0/0",
+#                "Egress": false,
+#                "IcmpTypeCode": null,
+#                "Ipv6CidrBlock": null,
+#                "PortRange": null,
+#                "Protocol": "-1",
+#                "RuleAction": "deny",
+#                "RuleNumber": 12345
+#              }
+#            ],
+#            "IsDefault": true,
+#            "NetworkAclId": "acl-123aabb",
+#            "OwnerId": "112233445566",
+#            "Tags": null,
+#            "VpcId": "vpc-1234321"
+#          }
+#        ],
+#        "OwnerId": "112233445566",
+#        "RouteTables": [
+#          {
+#            "Associations": [
+#              {
+#                "Main": true,
+#                "RouteTableAssociationId": "rtbassoc-1122aa33",
+#                "RouteTableId": "rtb-1122abc33",
+#                "SubnetId": null
+#              }
+#            ],
+#            "OwnerId": "112233445566",
+#            "PropagatingVgws": null,
+#            "RouteTableId": "rtb-11223344",
+#            "Routes": [
+#              {
+#                "DestinationCidrBlock": "0.0.0.0/0",
+#                "DestinationIpv6CidrBlock": null,
+#                "DestinationPrefixListId": null,
+#                "EgressOnlyInternetGatewayId": null,
+#                "GatewayId": "igw-abc123",
+#                "InstanceId": null,
+#                "InstanceOwnerId": null,
+#                "NatGatewayId": null,
+#                "NetworkInterfaceId": null,
+#                "Origin": "CreateRoute",
+#                "State": "active",
+#                "TransitGatewayId": null,
+#                "VpcPeeringConnectionId": null
+#              }
+#            ],
+#            "Tags": null,
+#            "VpcId": "vpc-11223344"
+#          }
+#        ],
+#        "SecurityGroups": [
+#          {
+#            "Description": "default VPC security group",
+#            "GroupId": "sg-abc123",
+#            "GroupName": "default",
+#            "IpPermissions": [
+#              {
+#                "FromPort": null,
+#                "IpProtocol": "-1",
+#                "IpRanges": null,
+#                "Ipv6Ranges": null,
+#                "PrefixListIds": null,
+#                "ToPort": null,
+#                "UserIdGroupPairs": [
+#                  {
+#                    "Description": null,
+#                    "GroupId": "sg-abc123",
+#                    "GroupName": null,
+#                    "PeeringStatus": null,
+#                    "UserId": "1122334455",
+#                    "VpcId": null,
+#                    "VpcPeeringConnectionId": null
+#                  }
+#                ]
+#              }
+#            ],
+#            "IpPermissionsEgress": [
+#              {
+#                "FromPort": null,
+#                "IpProtocol": "-1",
+#                "IpRanges": [
+#                  {
+#                    "CidrIp": "0.0.0.0/0",
+#                    "Description": null
+#                  }
+#                ],
+#                "Ipv6Ranges": null,
+#                "PrefixListIds": null,
+#                "ToPort": null,
+#                "UserIdGroupPairs": null
+#              }
+#            ],
+#            "OwnerId": "112233445566",
+#            "Tags": null,
+#            "VpcId": "vpc-123454321"
+#          }
+#        ],
+#        "StaleSecurityGroups": [
+#          {
+#            "Description": "default VPC security group",
+#            "GroupId": "sg-abc567",
+#            "GroupName": "default",
+#            "StaleIpPermissions": null,
+#            "StaleIpPermissionsEgress": [
+#              {
+#                "FromPort": 5555,
+#                "IpProtocol": "tcp",
+#                "IpRanges": null,
+#                "PrefixListIds": null,
+#                "ToPort": 5555,
+#                "UserIdGroupPairs": [
+#                  {
+#                    "Description": null,
+#                    "GroupId": "sg-abc567",
+#                    "GroupName": "default",
+#                    "PeeringStatus": "deleted",
+#                    "UserId": "123456789012",
+#                    "VpcId": "vpc-abc111222333444",
+#                    "VpcPeeringConnectionId": null
+#                  }
+#                ]
+#              }
+#            ],
+#            "VpcId": "vpc-abc123"
+#          }
+#        ],
+#        "State": "available",
+#        "Tags": null,
+#        "VpcId": "vpc-1234321"
+#      }
+#  -
+#    Name: Default Security Group Has Inbound IP Permissions
+#    ExpectedResult: false
+#    Resource:
+#      {
+#        "CidrBlock": "172.31.0.0/16",
+#        "CidrBlockAssociationSet": [
+#          {
+#            "AssociationId": "vpc-cidr-assoc-112233",
+#            "CidrBlock": "172.0.0.0/16",
+#            "CidrBlockState": {
+#              "State": "associated",
+#              "StatusMessage": null
+#            }
+#          }
+#        ],
+#        "DhcpOptionsId": "dopt-1122e3344",
+#        "FlowLogs": null,
+#        "InstanceTenancy": "default",
+#        "Ipv6CidrBlockAssociationSet": null,
+#        "IsDefault": true,
+#        "NetworkAcls": [
+#          {
+#            "Associations": [
+#              {
+#                "NetworkAclAssociationId": "aclassoc-1122abc444",
+#                "NetworkAclId": "acl-123abc",
+#                "SubnetId": "subnet-123abc"
+#              },
+#              {
+#                "NetworkAclAssociationId": "aclassoc-123abc",
+#                "NetworkAclId": "acl-1122abc",
+#                "SubnetId": "subnet-112233aabb"
+#              }
+#            ],
+#            "Entries": [
+#              {
+#                "CidrBlock": "0.0.0.0/0",
+#                "Egress": false,
+#                "IcmpTypeCode": null,
+#                "Ipv6CidrBlock": null,
+#                "PortRange": null,
+#                "Protocol": "-1",
+#                "RuleAction": "deny",
+#                "RuleNumber": 12345
+#              }
+#            ],
+#            "IsDefault": true,
+#            "NetworkAclId": "acl-123aabb",
+#            "OwnerId": "112233445566",
+#            "Tags": null,
+#            "VpcId": "vpc-1234321"
+#          }
+#        ],
+#        "OwnerId": "112233445566",
+#        "RouteTables": [
+#          {
+#            "Associations": [
+#              {
+#                "Main": true,
+#                "RouteTableAssociationId": "rtbassoc-1122aa33",
+#                "RouteTableId": "rtb-1122abc33",
+#                "SubnetId": null
+#              }
+#            ],
+#            "OwnerId": "112233445566",
+#            "PropagatingVgws": null,
+#            "RouteTableId": "rtb-11223344",
+#            "Routes": [
+#              {
+#                "DestinationCidrBlock": "0.0.0.0/0",
+#                "DestinationIpv6CidrBlock": null,
+#                "DestinationPrefixListId": null,
+#                "EgressOnlyInternetGatewayId": null,
+#                "GatewayId": "igw-abc123",
+#                "InstanceId": null,
+#                "InstanceOwnerId": null,
+#                "NatGatewayId": null,
+#                "NetworkInterfaceId": null,
+#                "Origin": "CreateRoute",
+#                "State": "active",
+#                "TransitGatewayId": null,
+#                "VpcPeeringConnectionId": null
+#              }
+#            ],
+#            "Tags": null,
+#            "VpcId": "vpc-11223344"
+#          }
+#        ],
+#        "SecurityGroups": [
+#          {
+#            "Description": "default VPC security group",
+#            "GroupId": "sg-abc123",
+#            "GroupName": "default",
+#            "IpPermissions": [
+#              {
+#                "FromPort": null,
+#                "IpProtocol": "-1",
+#                "IpRanges": null,
+#                "Ipv6Ranges": null,
+#                "PrefixListIds": null,
+#                "ToPort": null,
+#                "UserIdGroupPairs": [
+#                  {
+#                    "Description": null,
+#                    "GroupId": "sg-abc123",
+#                    "GroupName": null,
+#                    "PeeringStatus": null,
+#                    "UserId": "1122334455",
+#                    "VpcId": null,
+#                    "VpcPeeringConnectionId": null
+#                  }
+#                ]
+#              }
+#            ],
+#            "IpPermissionsEgress": null,
+#            "OwnerId": "112233445566",
+#            "Tags": null,
+#            "VpcId": "vpc-123454321"
+#          }
+#        ],
+#        "StaleSecurityGroups": [
+#          {
+#            "Description": "default VPC security group",
+#            "GroupId": "sg-abc567",
+#            "GroupName": "default",
+#            "StaleIpPermissions": null,
+#            "StaleIpPermissionsEgress": [
+#              {
+#                "FromPort": 5555,
+#                "IpProtocol": "tcp",
+#                "IpRanges": null,
+#                "PrefixListIds": null,
+#                "ToPort": 5555,
+#                "UserIdGroupPairs": [
+#                  {
+#                    "Description": null,
+#                    "GroupId": "sg-abc567",
+#                    "GroupName": "default",
+#                    "PeeringStatus": "deleted",
+#                    "UserId": "123456789012",
+#                    "VpcId": "vpc-abc111222333444",
+#                    "VpcPeeringConnectionId": null
+#                  }
+#                ]
+#              }
+#            ],
+#            "VpcId": "vpc-abc123"
+#          }
+#        ],
+#        "State": "available",
+#        "Tags": null,
+#        "VpcId": "vpc-1234321"
+#      }
+#  -
+#    Name: Default Security Group Has No IP Permissions
+#    ExpectedResult: true
+#    Resource:
+#      {
+#        "CidrBlock": "172.31.0.0/16",
+#        "CidrBlockAssociationSet": [
+#          {
+#            "AssociationId": "vpc-cidr-assoc-112233",
+#            "CidrBlock": "172.0.0.0/16",
+#            "CidrBlockState": {
+#              "State": "associated",
+#              "StatusMessage": null
+#            }
+#          }
+#        ],
+#        "DhcpOptionsId": "dopt-1122e3344",
+#        "FlowLogs": null,
+#        "InstanceTenancy": "default",
+#        "Ipv6CidrBlockAssociationSet": null,
+#        "IsDefault": true,
+#        "NetworkAcls": [
+#          {
+#            "Associations": [
+#              {
+#                "NetworkAclAssociationId": "aclassoc-1122abc444",
+#                "NetworkAclId": "acl-123abc",
+#                "SubnetId": "subnet-123abc"
+#              },
+#              {
+#                "NetworkAclAssociationId": "aclassoc-123abc",
+#                "NetworkAclId": "acl-1122abc",
+#                "SubnetId": "subnet-112233aabb"
+#              }
+#            ],
+#            "Entries": [
+#              {
+#                "CidrBlock": "0.0.0.0/0",
+#                "Egress": false,
+#                "IcmpTypeCode": null,
+#                "Ipv6CidrBlock": null,
+#                "PortRange": null,
+#                "Protocol": "-1",
+#                "RuleAction": "deny",
+#                "RuleNumber": 12345
+#              }
+#            ],
+#            "IsDefault": true,
+#            "NetworkAclId": "acl-123aabb",
+#            "OwnerId": "112233445566",
+#            "Tags": null,
+#            "VpcId": "vpc-1234321"
+#          }
+#        ],
+#        "OwnerId": "112233445566",
+#        "RouteTables": [
+#          {
+#            "Associations": [
+#              {
+#                "Main": true,
+#                "RouteTableAssociationId": "rtbassoc-1122aa33",
+#                "RouteTableId": "rtb-1122abc33",
+#                "SubnetId": null
+#              }
+#            ],
+#            "OwnerId": "112233445566",
+#            "PropagatingVgws": null,
+#            "RouteTableId": "rtb-11223344",
+#            "Routes": [
+#              {
+#                "DestinationCidrBlock": "0.0.0.0/0",
+#                "DestinationIpv6CidrBlock": null,
+#                "DestinationPrefixListId": null,
+#                "EgressOnlyInternetGatewayId": null,
+#                "GatewayId": "igw-abc123",
+#                "InstanceId": null,
+#                "InstanceOwnerId": null,
+#                "NatGatewayId": null,
+#                "NetworkInterfaceId": null,
+#                "Origin": "CreateRoute",
+#                "State": "active",
+#                "TransitGatewayId": null,
+#                "VpcPeeringConnectionId": null
+#              }
+#            ],
+#            "Tags": null,
+#            "VpcId": "vpc-11223344"
+#          }
+#        ],
+#        "SecurityGroups": [
+#          {
+#            "Description": "default VPC security group",
+#            "GroupId": "sg-abc123",
+#            "GroupName": "default",
+#            "IpPermissions": null,
+#            "IpPermissionsEgress": null,
+#            "OwnerId": "112233445566",
+#            "Tags": null,
+#            "VpcId": "vpc-123454321"
+#          }
+#        ],
+#        "StaleSecurityGroups": [
+#          {
+#            "Description": "default VPC security group",
+#            "GroupId": "sg-abc567",
+#            "GroupName": "default",
+#            "StaleIpPermissions": null,
+#            "StaleIpPermissionsEgress": [
+#              {
+#                "FromPort": 5555,
+#                "IpProtocol": "tcp",
+#                "IpRanges": null,
+#                "PrefixListIds": null,
+#                "ToPort": 5555,
+#                "UserIdGroupPairs": [
+#                  {
+#                    "Description": null,
+#                    "GroupId": "sg-abc567",
+#                    "GroupName": "default",
+#                    "PeeringStatus": "deleted",
+#                    "UserId": "123456789012",
+#                    "VpcId": "vpc-abc111222333444",
+#                    "VpcPeeringConnectionId": null
+#                  }
+#                ]
+#              }
+#            ],
+#            "VpcId": "vpc-abc123"
+#          }
+#        ],
+#        "State": "available",
+#        "Tags": null,
+#        "VpcId": "vpc-1234321"
+#      }
+#  -
+#    Name: Default Security Group Has Outbound IP Permissions
+#    ExpectedResult: false
+#    Resource:
+#      {
+#        "CidrBlock": "172.31.0.0/16",
+#        "CidrBlockAssociationSet": [
+#          {
+#            "AssociationId": "vpc-cidr-assoc-112233",
+#            "CidrBlock": "172.0.0.0/16",
+#            "CidrBlockState": {
+#              "State": "associated",
+#              "StatusMessage": null
+#            }
+#          }
+#        ],
+#        "DhcpOptionsId": "dopt-1122e3344",
+#        "FlowLogs": null,
+#        "InstanceTenancy": "default",
+#        "Ipv6CidrBlockAssociationSet": null,
+#        "IsDefault": true,
+#        "NetworkAcls": [
+#          {
+#            "Associations": [
+#              {
+#                "NetworkAclAssociationId": "aclassoc-1122abc444",
+#                "NetworkAclId": "acl-123abc",
+#                "SubnetId": "subnet-123abc"
+#              },
+#              {
+#                "NetworkAclAssociationId": "aclassoc-123abc",
+#                "NetworkAclId": "acl-1122abc",
+#                "SubnetId": "subnet-112233aabb"
+#              }
+#            ],
+#            "Entries": [
+#              {
+#                "CidrBlock": "0.0.0.0/0",
+#                "Egress": false,
+#                "IcmpTypeCode": null,
+#                "Ipv6CidrBlock": null,
+#                "PortRange": null,
+#                "Protocol": "-1",
+#                "RuleAction": "deny",
+#                "RuleNumber": 12345
+#              }
+#            ],
+#            "IsDefault": true,
+#            "NetworkAclId": "acl-123aabb",
+#            "OwnerId": "112233445566",
+#            "Tags": null,
+#            "VpcId": "vpc-1234321"
+#          }
+#        ],
+#        "OwnerId": "112233445566",
+#        "RouteTables": [
+#          {
+#            "Associations": [
+#              {
+#                "Main": true,
+#                "RouteTableAssociationId": "rtbassoc-1122aa33",
+#                "RouteTableId": "rtb-1122abc33",
+#                "SubnetId": null
+#              }
+#            ],
+#            "OwnerId": "112233445566",
+#            "PropagatingVgws": null,
+#            "RouteTableId": "rtb-11223344",
+#            "Routes": [
+#              {
+#                "DestinationCidrBlock": "0.0.0.0/0",
+#                "DestinationIpv6CidrBlock": null,
+#                "DestinationPrefixListId": null,
+#                "EgressOnlyInternetGatewayId": null,
+#                "GatewayId": "igw-abc123",
+#                "InstanceId": null,
+#                "InstanceOwnerId": null,
+#                "NatGatewayId": null,
+#                "NetworkInterfaceId": null,
+#                "Origin": "CreateRoute",
+#                "State": "active",
+#                "TransitGatewayId": null,
+#                "VpcPeeringConnectionId": null
+#              }
+#            ],
+#            "Tags": null,
+#            "VpcId": "vpc-11223344"
+#          }
+#        ],
+#        "SecurityGroups": [
+#          {
+#            "Description": "default VPC security group",
+#            "GroupId": "sg-abc123",
+#            "GroupName": "default",
+#            "IpPermissions": null,
+#            "IpPermissionsEgress": [
+#              {
+#                "FromPort": null,
+#                "IpProtocol": "-1",
+#                "IpRanges": [
+#                  {
+#                    "CidrIp": "0.0.0.0/0",
+#                    "Description": null
+#                  }
+#                ],
+#                "Ipv6Ranges": null,
+#                "PrefixListIds": null,
+#                "ToPort": null,
+#                "UserIdGroupPairs": null
+#              }
+#            ],
+#            "OwnerId": "112233445566",
+#            "Tags": null,
+#            "VpcId": "vpc-123454321"
+#          }
+#        ],
+#        "StaleSecurityGroups": [
+#          {
+#            "Description": "default VPC security group",
+#            "GroupId": "sg-abc567",
+#            "GroupName": "default",
+#            "StaleIpPermissions": null,
+#            "StaleIpPermissionsEgress": [
+#              {
+#                "FromPort": 5555,
+#                "IpProtocol": "tcp",
+#                "IpRanges": null,
+#                "PrefixListIds": null,
+#                "ToPort": 5555,
+#                "UserIdGroupPairs": [
+#                  {
+#                    "Description": null,
+#                    "GroupId": "sg-abc567",
+#                    "GroupName": "default",
+#                    "PeeringStatus": "deleted",
+#                    "UserId": "123456789012",
+#                    "VpcId": "vpc-abc111222333444",
+#                    "VpcPeeringConnectionId": null
+#                  }
+#                ]
+#              }
+#            ],
+#            "VpcId": "vpc-abc123"
+#          }
+#        ],
+#        "State": "available",
+#        "Tags": null,
+#        "VpcId": "vpc-1234321"
+#      }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,13 @@
 # Functional Dependencies
 panther-analysis-tool==0.3.5
-policyuniverse==1.3.2.20200919
+policyuniverse==1.3.2.20201012
 
 # CI Dependencies
 bandit==1.6.2
-mypy==0.782
+mypy==0.790
 pylint==2.6.0
 yapf==0.30.0
 ## The following requirements were added by pip freeze:
-appdirs==1.4.4
 appnope==0.1.0
 arrow==0.15.4
 astroid==2.4.2
@@ -20,8 +19,8 @@ awscli==1.16.286
 backcall==0.1.0
 beautifulsoup4==4.8.1
 binaryornot==0.4.4
-boto3==1.15.4
-botocore==1.18.4
+boto3==1.9.251
+botocore==1.12.253
 bs4==0.0.1
 certifi==2019.9.11
 cfn-lint==0.26.0
@@ -35,11 +34,9 @@ coverage==4.5.4
 dateparser==0.7.2
 ddt==1.2.1
 decorator==4.4.1
-distlib==0.3.1
 docker==4.1.0
 docker-pycreds==0.4.0
 docutils==0.15.2
-filelock==3.0.12
 Flask==1.0.4
 fpdf==1.7.2
 future==0.18.2
@@ -76,17 +73,17 @@ poyo==0.5.0
 prompt-toolkit==2.0.10
 ptyprocess==0.6.0
 pyasn1==0.4.8
-pyfakefs==4.1.0
+pyfakefs==3.6
 Pygments==2.4.2
 pyrsistent==0.15.4
 python-dateutil==2.8.0
 pytz==2019.3
-PyYAML==5.3.1
+PyYAML==5.1.1
 regex==2019.11.1
 requests==2.22.0
 rsa==3.4.2
-s3transfer==0.3.3
-schema==0.7.2
+s3transfer==0.2.1
+schema==0.7.0
 serverlessrepo==0.1.9
 six==1.12.0
 smmap==0.9.0


### PR DESCRIPTION
### Background

v1.11 of Panther will no longer embed EC2  Security Group or EC2 Network ACL resources into the EC2 VPC resource. For this reason, for policies that rely on evaluating the EC2 security group or EC2 network ACL in the context of an  EC2 VPC we need to use the `resource_lookup` functionality, which was created for this use case.

### Changes

* Updated `aws_vpc_default_network_acl_restricts_all_traffic` and `aws_vpc_default_security_restrictions` to use `resource_lookup`
* Updated `aws_security_group_administrative_ingress` to  apply to EC2  Security Groups directly, as opposed to EC2 VPCs.

### Testing

* Unfortunately unit testing is not supported for policies that  make network calls (such as `resource_lookup`), so I had to deploy  into a dev environment and rely on that instead
