### PR TITLE
[osquery] ignore darwin systems issuing AWS commands

### DIFF
--- a/osquery_rules/osquery_linux_aws_commands.py
+++ b/osquery_rules/osquery_linux_aws_commands.py
@@ -1,5 +1,7 @@
 import shlex
 
+PLATFORM_IGNORE_LIST = {'darwin'}
+
 
 def rule(event):
     if event['action'] != 'added':
@@ -8,14 +10,16 @@ def rule(event):
     if 'shell_history' not in event['name']:
         return False
 
-    #TODO: Extract this into a helper
+    if event.get('decorations', {}).get('platform') in PLATFORM_IGNORE_LIST:
+        return False
+
     command = event['columns'].get('command')
     if not command:
         return False
     try:
         command_args = shlex.split(command)
     except ValueError:
-        # "No escaped character" or "No closing quotation" - probably an invalid command
+        # "No escaped character" or "No closing quotation", probably an invalid command
         return False
 
     if command_args[0] == 'aws':
@@ -25,5 +29,5 @@ def rule(event):
 
 
 def title(event):
-    return 'User [{}] issued sensitive `aws` command on [{}]'.format(
+    return 'User [{}] issued an aws-cli command on [{}]'.format(
         event['columns'].get('username'), event['hostIdentifier'])

--- a/osquery_rules/osquery_linux_aws_commands.yml
+++ b/osquery_rules/osquery_linux_aws_commands.yml
@@ -12,13 +12,30 @@ Reports:
   MITRE ATT&CK:
     - Initial Access:Valid Accounts
 Severity: Medium
-Description: An aws command was executed on an EC2 instance
+Description: An AWS command was executed on a Linux instance
 Runbook: See which other commands were executed, and then remove IAM role causing the access
 Reference: https://attack.mitre.org/techniques/T1078/
 SummaryAttributes:
   - name
   - action
 Tests:
+  -
+    Name: AWS command executed on MacOS
+    ExpectedResult: false
+    Log:
+      {
+        "name": "pack_incident-response_shell_history",
+        "action": "added",
+        "decorations": {
+          "platform": "darwin"
+        },
+        "columns": {
+          "command": "aws sts get-caller-identity",
+          "uid": "1000",
+          "directory": "/home/ubuntu",
+          "username": "ubuntu"
+        }
+      }
   -
     Name: AWS command executed
     ExpectedResult: true


### PR DESCRIPTION
### Background

Add a quick condition to ignore `aws` commands coming from laptops, which is expected. Decorations can be added to osquery to provide additional context in events. 

### Changes

* Check if a platform decoration is added, and ignore if the platform is MacOS

### Testing

* CLI tool
