### PR TITLE
Tune threshold setting for failed AWS logins

### DIFF
--- a/aws_cloudtrail_rules/aws_console_login_failed.yml
+++ b/aws_cloudtrail_rules/aws_console_login_failed.yml
@@ -2,7 +2,7 @@ AnalysisType: rule
 Filename: aws_console_login_failed.py
 RuleID: AWS.Console.LoginFailed
 DisplayName: Failed Console Login
-DedupPeriodMinutes: 60 # 4 hours
+DedupPeriodMinutes: 60
 Enabled: true
 LogTypes:
   - AWS.CloudTrail

--- a/aws_cloudtrail_rules/aws_console_login_failed.yml
+++ b/aws_cloudtrail_rules/aws_console_login_failed.yml
@@ -2,7 +2,7 @@ AnalysisType: rule
 Filename: aws_console_login_failed.py
 RuleID: AWS.Console.LoginFailed
 DisplayName: Failed Console Login
-DedupPeriodMinutes: 240 # 4 hours
+DedupPeriodMinutes: 60 # 4 hours
 Enabled: true
 LogTypes:
   - AWS.CloudTrail
@@ -10,6 +10,7 @@ Tags:
   - AWS
   - Identity & Access Management
   - Authentication
+Threshold: 5
 Reports:
   CIS:
     - 3.6


### PR DESCRIPTION
### Background

The failed AWS logins was written before we had either the dynamo key/value store or thresholding supported, so it just alerted on every single failed login, deduped by account ID on a 4 hour period.

I changed the threshold to 5, and the dedup period to 1 hour. I think shortening the dedup period is appropriate because we're increasing the threshold. The dedup period was high before to reduce alert fatigue, but that should be less relevant if the alert is higher fidelity.

### Changes

* Tuned threshold and dedup period settings

### Testing

* Unit tests
