### PR TITLE
Fix rule dedup() returning None

### DIFF
--- a/aws_cloudtrail_rules/aws_unauthorized_api_call.py
+++ b/aws_cloudtrail_rules/aws_unauthorized_api_call.py
@@ -24,7 +24,7 @@ def dedup(event):
     user_identity = event['userIdentity']
     if user_identity.get('type') == 'AssumedRole':
         return aws_strip_role_session_id(user_identity.get('arn', ''))
-    return user_identity.get('arn')
+    return user_identity.get('arn', '')
 
 
 def title(event):


### PR DESCRIPTION
## Background

The `userIdentity.arn` field may be missing in some CloudTrail events.
Returning `None` by `dedup()` raises exception (we assert title/dedup
return `str`), which is logged, resulting in spamming the logs (which may trigger CloudWatch alarms)
with no real benefit. 
However, the system behavior is the same (a default value is used for title/dedup when they are missing or
return an empty string).

## Changes
Update the dedup() function of the rule to return empty string if the field is missing.


Added 1.12 for milestone but feel free to update it as necessary (same for the labels, not sure which to pick).