### PR TITLE
Filter out failed events when looking for bad activity

### DIFF
--- a/aws_cloudtrail_rules/aws_root_activity.py
+++ b/aws_cloudtrail_rules/aws_root_activity.py
@@ -6,12 +6,12 @@ EVENT_ALLOW_LIST = {'CreateServiceLinkedRole', 'ConsoleLogin'}
 def rule(event):
     return (event['userIdentity'].get('type') == 'Root' and
             event.get('errorMessage') is None and
-            event['userIdentity'].get('invokedBy') is None and
-            event['eventType'] != 'AwsServiceEvent' and
-            event['eventName'] not in EVENT_ALLOW_LIST)
+            event.get('userIdentity', {}).get('invokedBy') is None and
+            event.get('eventType') != 'AwsServiceEvent' and
+            event.get('eventName') not in EVENT_ALLOW_LIST)
 
 
 def title(event):
     return 'AWS root activity detected from [{ip}] in account [{account}]'.format(
-        ip=event['sourceIPAddress'],
+        ip=event.get('sourceIPAddress'),
         account=lookup_aws_account_name(event.get('recipientAccountId')))

--- a/aws_cloudtrail_rules/aws_root_activity.py
+++ b/aws_cloudtrail_rules/aws_root_activity.py
@@ -5,6 +5,7 @@ EVENT_ALLOW_LIST = {'CreateServiceLinkedRole', 'ConsoleLogin'}
 
 def rule(event):
     return (event['userIdentity'].get('type') == 'Root' and
+            event.get('errorMessage') is None and
             event['userIdentity'].get('invokedBy') is None and
             event['eventType'] != 'AwsServiceEvent' and
             event['eventName'] not in EVENT_ALLOW_LIST)

--- a/aws_cloudtrail_rules/aws_root_activity.yml
+++ b/aws_cloudtrail_rules/aws_root_activity.yml
@@ -176,3 +176,59 @@ Tests:
           "recipientAccountId": "123456789012",
           "vpcEndpointId": "vpce-1"
       }
+  -
+    Name: Root User Failed Activity
+    ExpectedResult: false
+    Log:
+      {
+          "awsRegion": "redacted",
+          "errorMessage": "Not a valid response for the provided request id: aws_ccV60redacted",
+          "eventID": "redacted",
+          "eventName": "ExternalIdPDirectoryLogin",
+          "eventSource": "signin.amazonaws.com",
+          "eventTime": "redacted",
+          "eventType": "AwsConsoleSignIn",
+          "eventVersion": "1.05",
+          "p_alert_creation_time": "redacted",
+          "p_alert_id": "redacted",
+          "p_alert_update_time": "redacted",
+          "p_any_aws_account_ids": [
+              "redacted"
+          ],
+          "p_any_aws_arns": [],
+          "p_any_ip_addresses": [
+              "redacted"
+          ],
+          "p_event_time": "redacted",
+          "p_log_type": "AWS.CloudTrail",
+          "p_parse_time": "redacted",
+          "p_row_id": "redacted",
+          "p_rule_error": null,
+          "p_rule_id": "AWS.Root.Activity",
+          "p_rule_reports": {
+              "CIS": [
+                  "3.3"
+              ]
+          },
+          "p_rule_tags": [
+              "AWS",
+              "Identity & Access Management"
+          ],
+          "p_source_id": "redacted",
+          "p_source_label": "CloudTrail",
+          "readOnly": false,
+          "recipientAccountId": "redacted",
+          "requestID": "redacted",
+          "responseElements": {
+              "ExternalIdPDirectoryLogin": "Failure"
+          },
+          "sourceIPAddress": "redacted",
+          "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "userIdentity": {
+              "accessKeyId": "",
+              "accountId": "redacted",
+              "arn": "",
+              "principalId": "redacted",
+              "type": "Root"
+          }
+      }

--- a/okta_rules/okta_geo_improbable_access.py
+++ b/okta_rules/okta_geo_improbable_access.py
@@ -6,8 +6,9 @@ PANTHER_TIME_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
 
 
 def rule(event):
-    # We only want to evaluate user logins
-    if event['eventType'] != 'user.session.start':
+    # We only want to successful evaluate user logins
+    if event['eventType'] != 'user.session.start' or event.get(
+            'outcome', {}).get('result') == 'FAILURE':
         return False
 
     # Generate a unique key for each user

--- a/okta_rules/okta_geo_improbable_access.yml
+++ b/okta_rules/okta_geo_improbable_access.yml
@@ -19,8 +19,108 @@ Tests:
     ExpectedResult: false
     Log:
       {
-      "eventType": "thingy"
+      "eventType": "logout"
       }
+  -
+    Name: Failed Login
+    ExpectedResult: false
+    Log:
+      {
+          "actor": {
+              "alternateId": "admin",
+              "displayName": "unknown",
+              "id": "unknown",
+              "type": "User"
+          },
+          "authenticationContext": {
+              "authenticationStep": 0,
+              "externalSessionId": "unknown"
+          },
+          "client": {
+              "device": "Computer",
+              "geographicalContext": {
+                  "city": "Dois Irmaos",
+                  "country": "Brazil",
+                  "geolocation": {
+                      "lat": -29.6116,
+                      "lon": -51.0933
+                  },
+                  "postalCode": "93950",
+                  "state": "Rio Grande do Sul"
+              },
+              "ipAddress": "redacted",
+              "userAgent": {
+                  "browser": "CHROME",
+                  "os": "Linux",
+                  "rawUserAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.135 Safari/537.36"
+              },
+              "zone": "null"
+          },
+          "debugContext": {
+              "debugData": {
+                  "loginResult": "VERIFICATION_ERROR",
+                  "requestId": "redacted",
+                  "requestUri": "redacted",
+                  "threatSuspected": "false",
+                  "url": "redacted"
+              }
+          },
+          "displayMessage": "User login to Okta",
+          "eventType": "user.session.start",
+          "legacyEventType": "core.user_auth.login_failed",
+          "outcome": {
+              "reason": "VERIFICATION_ERROR",
+              "result": "FAILURE"
+          },
+          "p_any_domain_names": [
+              "rnvtelecom.com.br"
+          ],
+          "p_any_ip_addresses": [
+              "redacted"
+          ],
+          "p_event_time": "redacted",
+          "p_log_type": "Okta.SystemLog",
+          "p_parse_time": "redacted",
+          "p_row_id": "redacted",
+          "p_source_id": "redacted",
+          "p_source_label": "Okta",
+          "published": "redacted",
+          "request": {
+              "ipChain": [
+                  {
+                      "geographicalContext": {
+                          "city": "Dois Irmaos",
+                          "country": "Brazil",
+                          "geolocation": {
+                              "lat": -29.6116,
+                              "lon": -51.0933
+                          },
+                          "postalCode": "93950",
+                          "state": "Rio Grande do Sul"
+                      },
+                      "ip": "redacted",
+                      "version": "V4"
+                  }
+              ]
+          },
+          "securityContext": {
+              "asNumber": 263297,
+              "asOrg": "renovare telecom",
+              "domain": "rnvtelecom.com.br",
+              "isProxy": false,
+              "isp": "renovare telecom"
+          },
+          "severity": "INFO",
+          "transaction": {
+              "detail": {},
+              "id": "redacted",
+              "type": "WEB"
+          },
+          "uuid": "redacted",
+          "version": "0"
+      }
+
+
 # These unit tests require AWS credentials to be configured to run properly.
 #
 # To use these tests, uncomment them and run panther_analysis_tool test with hAWS credentials configured.


### PR DESCRIPTION
### Background

Filter out failing events. Failed activity is probably indicative of a low effort bot trying to brute force logins more so than a serious threat.  Failed logins can be tracked with other lower severity rules related specifically to brute forcing. These rules should be high fidelity alerts that something actually did happen.

Closes #131.

### Changes

* Changed the root activity rule to ignore events with error messages
* Changed the okta geographically improbable login rule to ignore failed logins

### Testing

* Added two new test cases based on user reports
