### PR TITLE
Input validation for the S3 Bucket Read and Write

### DIFF
--- a/aws_s3_policies/aws_s3_bucket_public_read.py
+++ b/aws_s3_policies/aws_s3_bucket_public_read.py
@@ -6,9 +6,10 @@ PERMISSIONS = {'READ'}
 
 
 def policy(resource):
-    for grant in resource['Grants']:
-        if grant['Grantee']['URI'] in GRANTEES and grant[
-                'Permission'] in PERMISSIONS:
-            return False
+    if 'Grants' in resource and resource['Grants'] is not None:
+        for grant in resource['Grants']:
+            if grant['Grantee']['URI'] in GRANTEES and grant[
+                    'Permission'] in PERMISSIONS:
+                return False
 
     return True

--- a/aws_s3_policies/aws_s3_bucket_public_read.yml
+++ b/aws_s3_policies/aws_s3_bucket_public_read.yml
@@ -181,3 +181,36 @@ Tests:
         },
         "Versioning": null
       }
+  -
+    Name: Null Configuration
+    ExpectedResult: true
+    Resource:
+      {
+        “Arn”: “arn:aws:s3:::something-prodsec”,
+        “LoggingPolicy”: null,
+        “Policy”: null,
+        “MFADelete”: null,
+        “ObjectLockConfiguration”: null,
+        “LifecycleRules”: null,
+        “Grants”: null,
+        “Versioning”: null,
+        “EncryptionRules”: null,
+        “PublicAccessBlockConfiguration”: null,
+        “AccountId”: “123456789”,
+        “Tags”: {
+          “something”: “ttd”,
+          “user”: “prodsec”,
+          “service”: “-”,
+          “owner”: “-”,
+          “team”: “-”
+        },
+        “Region”: “us-west-2",
+        “ResourceType”: “AWS.S3.Bucket”,
+        “Name”: “something-prodsec”,
+        “ResourceId”: “arn:aws:s3:::something-prodsec”,
+        “TimeCreated”: “2020-06-27T00:11:11Z”,
+        “Owner”: {
+          “DisplayName”: “aws-corp”,
+          “ID”: “11112223334445556667778899aaabbbcccdddeeee”
+        }
+      }

--- a/aws_s3_policies/aws_s3_bucket_public_write.py
+++ b/aws_s3_policies/aws_s3_bucket_public_write.py
@@ -6,9 +6,10 @@ PERMISSIONS = {'WRITE', 'WRITE_ACP', 'FULL_CONTROL'}
 
 
 def policy(resource):
-    for grant in resource['Grants']:
-        if grant['Grantee']['URI'] in GRANTEES and grant[
-                'Permission'] in PERMISSIONS:
-            return False
+    if 'Grants' in resource and resource['Grants'] is not None:
+        for grant in resource['Grants']:
+            if grant['Grantee']['URI'] in GRANTEES and grant[
+                    'Permission'] in PERMISSIONS:
+                return False
 
     return True

--- a/aws_s3_policies/aws_s3_bucket_public_write.yml
+++ b/aws_s3_policies/aws_s3_bucket_public_write.yml
@@ -180,3 +180,36 @@ Tests:
         },
         "Versioning": null
       }
+  -
+    Name: Null Configuration
+    ExpectedResult: true
+    Resource:
+      {
+        “Arn”: “arn:aws:s3:::something-prodsec”,
+        “LoggingPolicy”: null,
+        “Policy”: null,
+        “MFADelete”: null,
+        “ObjectLockConfiguration”: null,
+        “LifecycleRules”: null,
+        “Grants”: null,
+        “Versioning”: null,
+        “EncryptionRules”: null,
+        “PublicAccessBlockConfiguration”: null,
+        “AccountId”: “123456789”,
+        “Tags”: {
+          “something”: “ttd”,
+          “user”: “prodsec”,
+          “service”: “-”,
+          “owner”: “-”,
+          “team”: “-”
+        },
+        “Region”: “us-west-2",
+        “ResourceType”: “AWS.S3.Bucket”,
+        “Name”: “something-prodsec”,
+        “ResourceId”: “arn:aws:s3:::something-prodsec”,
+        “TimeCreated”: “2020-06-27T00:11:11Z”,
+        “Owner”: {
+          “DisplayName”: “aws-corp”,
+          “ID”: “11112223334445556667778899aaabbbcccdddeeee”
+        }
+      }


### PR DESCRIPTION
### Background

Python function assumes that the key "Grants" is not Null, new resource example proves otherwise, handling the NoneType prevents an error from being thrown in panther UI under Cloud Security.

### Changes

* Add Key and NoneType check for both S3 read and write

### Testing

* make test-single pack=aws_s3_policies
