### PR TITLE
Tines Webinar Prep: Okta and CloudTrail Rules/Scenario

### DIFF
--- a/aws_cloudtrail_rules/aws_console_root_login.py
+++ b/aws_cloudtrail_rules/aws_console_root_login.py
@@ -11,3 +11,19 @@ def title(event):
     return 'AWS root login detected from [{ip}] in account [{account}]'.format(
         ip=event['sourceIPAddress'],
         account=lookup_aws_account_name(event.get('recipientAccountId')))
+
+
+def dedup(event):
+    # Each Root login should generate a unique alert
+    return '-'.join(
+        [event['recipientAccountId'], event['eventName'], event['eventTime']])
+
+
+def alert_context(event):
+    return {
+        'sourceIPAddress': event['sourceIPAddress'],
+        'userIdentityAccountId': event['userIdentity']['accountId'],
+        'userIdentityArn': event['userIdentity']['arn'],
+        'eventTime': event['eventTime'],
+        'mfaUsed': event.get('additionalEventData', {}).get('MFAUsed')
+    }

--- a/aws_cloudtrail_rules/aws_root_activity.py
+++ b/aws_cloudtrail_rules/aws_root_activity.py
@@ -15,3 +15,13 @@ def title(event):
     return 'AWS root activity detected from [{ip}] in account [{account}]'.format(
         ip=event.get('sourceIPAddress'),
         account=lookup_aws_account_name(event.get('recipientAccountId')))
+
+
+def alert_context(event):
+    return {
+        'sourceIPAddress': event['sourceIPAddress'],
+        'userIdentityAccountId': event['userIdentity']['accountId'],
+        'userIdentityArn': event['userIdentity']['arn'],
+        'eventTime': event['eventTime'],
+        'mfaUsed': event.get('additionalEventData', {}).get('MFAUsed')
+    }

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -130,3 +130,13 @@ def box_parse_additional_details(event):
         except ValueError:
             return {}
     return {}
+
+
+def okta_alert_context(event):
+    '''Returns common context for automation of Okta alerts'''
+    return {
+        'ips': event.get('p_any_ip_addresses', []),
+        'actor': event['actor'],
+        'target': event['target'],
+        'client': event['client'],
+    }

--- a/okta_rules/okta_admin_role_assigned.py
+++ b/okta_rules/okta_admin_role_assigned.py
@@ -1,0 +1,28 @@
+import re
+
+
+def rule(event):
+    return (
+        event['eventType'] == 'user.account.privilege.grant' and
+        event['outcome'].get('result', '') == 'SUCCESS' and bool(
+            re.search(
+                r'[aA]dministrator',
+                event['debugContext']['debugData'].get('privilegeGranted'))))
+
+
+def title(event):
+    title_str = '{} <{}> granted [{}] privileges to {} <{}>'
+    return title_str.format(
+        event['actor']['displayName'], event['actor']['alternateId'],
+        event['debugContext']['debugData'].get('privilegeGranted',
+                                               'PRIV_NOT_FOUND'),
+        event['target'][0]['displayName'], event['target'][0]['alternateId'])
+
+
+def alert_context(event):
+    return {
+        'ips': event.get('p_any_ip_addresses', []),
+        'actor': event['actor'],
+        'target': event['target'],
+        'client': event['client'],
+    }

--- a/okta_rules/okta_admin_role_assigned.py
+++ b/okta_rules/okta_admin_role_assigned.py
@@ -1,3 +1,4 @@
+from panther_base_helpers import okta_alert_context
 import re
 
 
@@ -10,6 +11,10 @@ def rule(event):
                 event['debugContext']['debugData'].get('privilegeGranted'))))
 
 
+def dedup(event):
+    return 'requestId-' + event['debugContext']['debugData'].get('requestId')
+
+
 def title(event):
     title_str = '{} <{}> granted [{}] privileges to {} <{}>'
     return title_str.format(
@@ -20,9 +25,4 @@ def title(event):
 
 
 def alert_context(event):
-    return {
-        'ips': event.get('p_any_ip_addresses', []),
-        'actor': event['actor'],
-        'target': event['target'],
-        'client': event['client'],
-    }
+    return okta_alert_context(event)

--- a/okta_rules/okta_admin_role_assigned.yml
+++ b/okta_rules/okta_admin_role_assigned.yml
@@ -8,6 +8,9 @@ LogTypes:
 Tags:
   - Identity & Access Management
 Severity: Info
+Description: A user has been granted administrative privileges in Okta
+Reference: https://help.okta.com/en/prod/Content/Topics/Security/administrators-admin-comparison.htm
+Runbook: Reach out to the user if needed to validate the activity
 SummaryAttributes:
   - eventType
   - severity

--- a/okta_rules/okta_admin_role_assigned.yml
+++ b/okta_rules/okta_admin_role_assigned.yml
@@ -11,10 +11,12 @@ Severity: Info
 Description: A user has been granted administrative privileges in Okta
 Reference: https://help.okta.com/en/prod/Content/Topics/Security/administrators-admin-comparison.htm
 Runbook: Reach out to the user if needed to validate the activity
+DedupPeriodMinutes: 15
 SummaryAttributes:
   - eventType
   - severity
   - displayMessage
+  - p_any_ip_addresses
 Tests:
   -
     Name: Admin Access Assigned

--- a/okta_rules/okta_admin_role_assigned.yml
+++ b/okta_rules/okta_admin_role_assigned.yml
@@ -1,0 +1,78 @@
+AnalysisType: rule
+Filename: okta_admin_role_assigned.py
+RuleID: Okta.AdminRoleAssigned
+DisplayName: Okta Admin Role Assigned
+Enabled: true
+LogTypes:
+  - Okta.SystemLog
+Tags:
+  - Identity & Access Management
+Severity: Info
+SummaryAttributes:
+  - eventType
+  - severity
+  - displayMessage
+Tests:
+  -
+    Name: Admin Access Assigned
+    ExpectedResult: true
+    Log:
+      {
+        "uuid": "2a992f80-d1ad-4f62-900e-8c68bb72a21b",
+        "published": "2020-11-25 21:27:03.496000000",
+        "eventType": "user.account.privilege.grant",
+        "version": "0",
+        "severity": "INFO",
+        "legacyEventType": "core.user.admin_privilege.granted",
+        "displayMessage": "Grant user privilege",
+        "actor": {
+          "id": "00uu1uuuuIlllaaaa356",
+          "type": "User",
+          "alternateId": "jack@acme.io",
+          "displayName": "Jack Naglieri"
+        },
+        "client": {
+          "userAgent": {
+            "browser": "CHROME",
+            "os": "Mac OS X",
+            "rawUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36"
+          },
+          "geographicalContext": {
+            "geolocation": {
+              "lat": 37.7852,
+              "lon": -122.3874
+            },
+            "city": "San Francisco",
+            "state": "California",
+            "country": "United States",
+            "postalCode": "94105"
+          },
+          "zone": "null",
+          "ipAddress": "136.24.229.58",
+          "device": "Computer"
+        },
+        "request": {},
+        "outcome": {
+          "result": "SUCCESS"
+        },
+        "target": [
+          {
+            "id": "00u6eup97mAJZWYmP357",
+            "type": "User",
+            "alternateId": "alice@acme.io",
+            "displayName": "Alice Green"
+          }
+        ],
+        "transaction": {},
+        "debugContext": {
+          "debugData": {
+            "privilegeGranted": "Organization administrator, Application administrator (all)",
+            "requestUri": "/api/internal/administrators/00u6eu8c68bb72a21b57",
+            "threatSuspected": "false",
+            "url": "/api/internal/administrators/00u6eu8c68bb72a21b57",
+            "requestId": "X777JJ9sssQQHHrrrQTyYQAABBE"
+          }
+        },
+        "authenticationContext": {},
+        "securityContext": {}
+      }

--- a/okta_rules/okta_brute_force_logins.py
+++ b/okta_rules/okta_brute_force_logins.py
@@ -1,12 +1,15 @@
-import re
+from panther_base_helpers import okta_alert_context
 
 
 def rule(event):
-    return (event['outcome']['result'] == 'FAILURE' and event['eventType'] == 'user.session.start')
+    return (event['outcome']['result'] == 'FAILURE' and
+            event['eventType'] == 'user.session.start')
 
 
 def title(event):
     return 'Suspected brute force Okta logins to account {} due to [{}]'.format(
-        event['actor']['alternateId'],
-        event['outcome']['reason']
-    )
+        event['actor']['alternateId'], event['outcome']['reason'])
+
+
+def alert_context(event):
+    return okta_alert_context(event)

--- a/okta_rules/okta_brute_force_logins.py
+++ b/okta_rules/okta_brute_force_logins.py
@@ -1,0 +1,12 @@
+import re
+
+
+def rule(event):
+    return (event['outcome']['result'] == 'FAILURE' and event['eventType'] == 'user.session.start')
+
+
+def title(event):
+    return 'Suspected brute force Okta logins to account {} due to [{}]'.format(
+        event['actor']['alternateId'],
+        event['outcome']['reason']
+    )

--- a/okta_rules/okta_brute_force_logins.yml
+++ b/okta_rules/okta_brute_force_logins.yml
@@ -1,0 +1,60 @@
+AnalysisType: rule
+Filename: okta_brute_force_logins.py
+RuleID: Okta.BruteForceLogins
+DisplayName: Okta Brute Force Logins
+Enabled: true
+LogTypes:
+  - Okta.SystemLog
+Tags:
+  - Identity & Access Management
+Severity: Medium
+Threshold: 5
+DedupPeriodMinutes: 15
+SummaryAttributes:
+  - eventType
+  - severity
+  - displayMessage
+Tests:
+  -
+    Name: Failed login
+    ExpectedResult: true
+    Log:
+      {
+        "uuid": "2a992f80-d1ad-4f62-900e-8c68bb72a21b",
+        "published": "2020-11-25 21:27:03.496000000",
+        "eventType": "user.session.start",
+        "version": "0",
+        "severity": "INFO",
+        "displayMessage": "User login to Okta",
+        "actor": {
+          "id": "00uu1uuuuIlllaaaa356",
+          "type": "User",
+          "alternateId": "jack@acme.io",
+          "displayName": "Jack Naglieri"
+        },
+        "client": {
+          "userAgent": {
+            "browser": "CHROME",
+            "os": "Mac OS X",
+            "rawUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36"
+          },
+          "geographicalContext": {
+            "geolocation": {
+              "lat": 37.7852,
+              "lon": -122.3874
+            },
+            "city": "San Francisco",
+            "state": "California",
+            "country": "United States",
+            "postalCode": "94105"
+          },
+          "zone": "null",
+          "ipAddress": "136.24.229.58",
+          "device": "Computer"
+        },
+        "request": {},
+        "outcome": {
+          "result": "FAILURE",
+          "reason": "VERIFICATION_ERROR"
+        }
+      }

--- a/okta_rules/okta_brute_force_logins.yml
+++ b/okta_rules/okta_brute_force_logins.yml
@@ -8,6 +8,9 @@ LogTypes:
 Tags:
   - Identity & Access Management
 Severity: Medium
+Description: A user has failed to login more than 5 times in 15 minutes
+Reference: https://developer.okta.com/docs/reference/api/system-log/#user-events
+Runbook: Reach out to the user if needed to validate the activity, and then block the IP
 Threshold: 5
 DedupPeriodMinutes: 15
 SummaryAttributes:

--- a/okta_rules/okta_brute_force_logins.yml
+++ b/okta_rules/okta_brute_force_logins.yml
@@ -17,6 +17,7 @@ SummaryAttributes:
   - eventType
   - severity
   - displayMessage
+  - p_any_ip_addresses
 Tests:
   -
     Name: Failed login

--- a/okta_rules/okta_geo_improbable_access.py
+++ b/okta_rules/okta_geo_improbable_access.py
@@ -2,6 +2,8 @@ from datetime import datetime, timedelta
 from json import dumps, loads
 from math import sin, cos, sqrt, asin, radians
 from panther_oss_helpers import get_string_set, put_string_set, set_key_expiration
+from panther_base_helpers import okta_alert_context
+
 PANTHER_TIME_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
 
 
@@ -97,3 +99,7 @@ def title(event):
 def dedup(event):
     # (Optional) Return a string which will de-duplicate similar alerts.
     return event['actor']['alternateId']
+
+
+def alert_context(event):
+    return okta_alert_context(event)

--- a/okta_rules/okta_geo_improbable_access.yml
+++ b/okta_rules/okta_geo_improbable_access.yml
@@ -8,6 +8,8 @@ LogTypes:
 Tags:
   - Identity & Access Management
 Severity: High
+Description: A user has subsequent logins from two geographic locations that are very far apart
+Runbook: Reach out to the user if needed to validate the activity, then lock the account
 SummaryAttributes:
   - eventType
   - severity

--- a/okta_rules/okta_geo_improbable_access.yml
+++ b/okta_rules/okta_geo_improbable_access.yml
@@ -1,5 +1,5 @@
 AnalysisType: rule
-Filename: okta_geo_improbable_access.py 
+Filename: okta_geo_improbable_access.py
 RuleID: Okta.GeographicallyImprobableAccess
 DisplayName: Geographically Improbable Okta Login
 Enabled: true
@@ -7,7 +7,7 @@ LogTypes:
   - Okta.SystemLog
 Tags:
   - Identity & Access Management
-Severity: Medium
+Severity: High
 SummaryAttributes:
   - eventType
   - severity

--- a/test_scenarios/enrichment-example/README.md
+++ b/test_scenarios/enrichment-example/README.md
@@ -1,0 +1,26 @@
+# Test Scenario - Data Enrichment with Tines
+
+## Usage
+
+This CloudTrail log is an example used for enrichment and feedback into Panther.
+
+```bash
+# Export some variables
+$ export BUCKET=my-bucket
+$ export AWSACCOUNTID=123456789012
+$ export AWS_REGION=us-east-1
+# Send the sample data
+$ python send_data.py --account-id $AWSACCOUNTID --region $AWS_REGION --compromise-datetime '2020-11-30T18:34:12+00:00' --bucket-name $BUCKET  --file enrichment-example/attacker_cloudtrail.yml
+```
+
+## Background Info
+
+These CloudTrail logs show failed logins, followed by a successful one, followed by some actions. The user IP is from a known malware list, which triggers findings in Threat Intel lookups.
+
+## Usernames
+
+N/A
+
+## Data
+
+- AWS.CloudTrail

--- a/test_scenarios/enrichment-example/attacker_cloudtrail.yml
+++ b/test_scenarios/enrichment-example/attacker_cloudtrail.yml
@@ -1,0 +1,175 @@
+---
+LogType: AWS.CloudTrail
+Format: json
+Logs:
+  -
+    additionalEventData:
+      LoginTo: "https://console.aws.amazon.com/console/"
+      MFAUsed: "No"
+      MobileVersion: "No"
+    awsRegion: us-east-1
+    eventID: "1"
+    eventName: ConsoleLogin
+    eventSource: signin.amazonaws.com
+    eventTime: "2020-10-30T23:25:32Z"
+    eventType: AwsConsoleSignIn
+    eventVersion: "1.05"
+    recipientAccountId: "493859302102"
+    requestParameters: ~
+    responseElements:
+      ConsoleLogin: Failure
+    sourceIPAddress: "200.58.83.179"
+    userAgent: Mozilla
+    userIdentity:
+      accountId: "493859302102"
+      arn: "arn:aws:iam::493859302102:root"
+      principalId: "493859302102"
+      type: Root
+      userName: root
+  -
+    additionalEventData:
+      LoginTo: "https://console.aws.amazon.com/console/"
+      MFAUsed: "No"
+      MobileVersion: "No"
+    awsRegion: us-east-1
+    eventID: "1"
+    eventName: ConsoleLogin
+    eventSource: signin.amazonaws.com
+    eventTime: "2020-10-31T10:32:00Z"
+    eventType: AwsConsoleSignIn
+    eventVersion: "1.05"
+    recipientAccountId: "493859302102"
+    requestParameters: ~
+    responseElements:
+      ConsoleLogin: Failure
+    sourceIPAddress: "200.58.83.179"
+    userAgent: Mozilla
+    userIdentity:
+      accountId: "493859302102"
+      arn: "arn:aws:iam::493859302102:root"
+      principalId: "493859302102"
+      type: Root
+      userName: root
+  -
+    additionalEventData:
+      LoginTo: "https://console.aws.amazon.com/console/"
+      MFAUsed: "No"
+      MobileVersion: "No"
+    awsRegion: us-east-1
+    eventID: "1"
+    eventName: ConsoleLogin
+    eventSource: signin.amazonaws.com
+    eventTime: "2020-10-31T14:45:00Z"
+    eventType: AwsConsoleSignIn
+    eventVersion: "1.05"
+    recipientAccountId: "493859302102"
+    requestParameters: ~
+    responseElements:
+      ConsoleLogin: Failure
+    sourceIPAddress: "200.58.83.179"
+    userAgent: console.amazonaws.com
+    userIdentity:
+      accountId: "493859302102"
+      arn: "arn:aws:iam::493859302102:root"
+      principalId: "493859302102"
+      type: Root
+      userName: root
+  -
+    additionalEventData:
+      LoginTo: "https://console.aws.amazon.com/console/"
+      MFAUsed: "No"
+      MobileVersion: "No"
+    awsRegion: us-east-1
+    eventID: "1"
+    eventName: ConsoleLogin
+    eventSource: signin.amazonaws.com
+    eventTime: "2020-11-01T08:29:10Z"
+    eventType: AwsConsoleSignIn
+    eventVersion: "1.05"
+    recipientAccountId: "493859302102"
+    requestParameters: ~
+    responseElements:
+      ConsoleLogin: Success
+    sourceIPAddress: "200.58.83.179"
+    userAgent: console.amazonaws.com
+    userIdentity:
+      accountId: "493859302102"
+      arn: "arn:aws:iam::493859302102:root"
+      principalId: "493859302102"
+      type: Root
+      userName: root
+  -
+    additionalEventData: ~
+    awsRegion: us-east-1
+    eventID: "1"
+    eventName: CreateAccessKey
+    eventSource: iam.amazonaws.com
+    eventTime: "2020-11-01T08:32:19Z"
+    eventType: AwsApiCall
+    eventVersion: "1.05"
+    recipientAccountId: "493859302102"
+    requestParameters: ~
+    responseElements:
+      accessKey:
+        accessKeyId: AKIA5ZZZK44445XXFFVB
+        createDate: Nov 1, 2020 8:30:20 AM
+        status: Active
+        userName: Root
+    sourceIPAddress: "200.58.83.179"
+    userAgent: console.amazonaws.com
+    userIdentity:
+      accountId: "493859302102"
+      arn: "arn:aws:iam::493859302102:root"
+      principalId: "493859302102"
+      type: Root
+      userName: root
+  -
+    additionalEventData: ~
+    awsRegion: us-east-1
+    eventID: "1"
+    eventName: CreateUser
+    eventSource: iam.amazonaws.com
+    eventTime: "2020-11-01T08:35:19Z"
+    eventType: AwsApiCall
+    eventVersion: "1.05"
+    recipientAccountId: "493859302102"
+    requestParameters:
+      path: "/"
+      userName: "tracy_stone"
+    responseElements:
+      user:
+        arn: arn:aws:iam::493859302102:user/tracy_stone
+        createDate: Nov 01, 2020 8:35:19 AM
+        path: "/"
+        userId: AIDA5ZXAKKKKQQ7PPPAYY
+        userName: tracy_stone
+    sourceIPAddress: "200.58.83.179"
+    userAgent: console.amazonaws.com
+    userIdentity:
+      accountId: "493859302102"
+      arn: "arn:aws:iam::493859302102:root"
+      principalId: "493859302102"
+      type: Root
+      userName: root
+  -
+    additionalEventData: ~
+    awsRegion: us-east-1
+    eventID: "1"
+    eventName: AttachUserPolicy
+    eventSource: iam.amazonaws.com
+    eventTime: "2020-11-01T08:36:02Z"
+    eventType: AwsApiCall
+    eventVersion: "1.05"
+    recipientAccountId: "493859302102"
+    requestParameters:
+      policyArn: "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
+      userName: "tracy_stone"
+    responseElements: ~
+    sourceIPAddress: "200.58.83.179"
+    userAgent: console.amazonaws.com
+    userIdentity:
+      accountId: "493859302102"
+      arn: "arn:aws:iam::493859302102:root"
+      principalId: "493859302102"
+      type: Root
+      userName: root

--- a/test_scenarios/enrichment-example/attacker_cloudtrail.yml
+++ b/test_scenarios/enrichment-example/attacker_cloudtrail.yml
@@ -135,14 +135,14 @@ Logs:
     recipientAccountId: "493859302102"
     requestParameters:
       path: "/"
-      userName: "tracy_stone"
+      userName: "jacknagz"
     responseElements:
       user:
-        arn: arn:aws:iam::493859302102:user/tracy_stone
+        arn: arn:aws:iam::493859302102:user/jacknagz
         createDate: Nov 01, 2020 8:35:19 AM
         path: "/"
         userId: AIDA5ZXAKKKKQQ7PPPAYY
-        userName: tracy_stone
+        userName: jacknagz
     sourceIPAddress: "200.58.83.179"
     userAgent: console.amazonaws.com
     userIdentity:
@@ -163,7 +163,7 @@ Logs:
     recipientAccountId: "493859302102"
     requestParameters:
       policyArn: "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
-      userName: "tracy_stone"
+      userName: "jacknagz"
     responseElements: ~
     sourceIPAddress: "200.58.83.179"
     userAgent: console.amazonaws.com

--- a/test_scenarios/okta-add-administrator/README.md
+++ b/test_scenarios/okta-add-administrator/README.md
@@ -1,0 +1,29 @@
+# Test Scenario - Okta Administrator
+
+## Usage
+
+Play the files in this order using the send_data.py script.
+
+```bash
+# Export some variables
+$ export BUCKET=my-bucket
+$ export AWSACCOUNTID=123456789012
+$ export AWS_REGION=us-east-1
+# Send the sample data
+$ python send_data.py --account-id $AWSACCOUNTID --region $AWS_REGION --compromise-datetime '2020-11-30T18:34:12+00:00' --bucket-name $BUCKET  --file okta-add-administrator/legit_login.yml
+$ python send_data.py --account-id $AWSACCOUNTID --region $AWS_REGION --compromise-datetime '2020-12-01T18:34:12+00:00' --bucket-name $BUCKET  --file okta-add-administrator/brute_force_logins.yml
+$ python send_data.py --account-id $AWSACCOUNTID --region $AWS_REGION --compromise-datetime '2020-12-01T19:11:42+00:00' --bucket-name $BUCKET  --file okta-add-administrator/admin_privs_assigned.yml
+```
+
+## Background Info
+
+This scenario shows brute force logins
+
+## Usernames
+
+jack.naglieri@tines.io
+thomas.kinsella@tines.io
+
+## Data
+
+- Okta.SystemLog

--- a/test_scenarios/okta-add-administrator/admin_privs_assigned.yml
+++ b/test_scenarios/okta-add-administrator/admin_privs_assigned.yml
@@ -1,0 +1,52 @@
+---
+LogType: Okta.SystemLog
+Format: jsonl
+Logs:
+  -
+    uuid: 2a992f80-d1ad-4f62-900e-8c68bb72a21b
+    published: '2020-11-25T21:27:03.490Z'
+    eventType: user.account.privilege.grant
+    version: '0'
+    severity: INFO
+    legacyEventType: core.user.admin_privilege.granted
+    displayMessage: Grant user privilege
+    actor:
+      id: 00uu1uuuuIlllaaaa356
+      type: User
+      alternateId: jack.naglieri@runpanther.io
+      displayName: Jack Naglieri
+    client:
+      userAgent:
+        browser: CHROME
+        os: Mac OS X
+        rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+          (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36
+      geographicalContext:
+        geolocation:
+          lat: 48.8916
+          lon: 2.7939
+        city: Coupvray
+        state: Ile-de-France
+        country: France
+        postalCode: '77700'
+      zone: 'null'
+      ipAddress: 194.88.246.242
+      device: Computer
+    request: {}
+    outcome:
+      result: SUCCESS
+    target:
+    - id: 00u6eup97mAJZWYmP357
+      type: User
+      alternateId: thomas@tines.io
+      displayName: Thomas Kinsella
+    transaction: {}
+    debugContext:
+      debugData:
+        privilegeGranted: Organization administrator, Application administrator (all)
+        requestUri: "/api/internal/administrators/00u6eu8c68bb72a21b57"
+        threatSuspected: 'false'
+        url: "/api/internal/administrators/00u6eu8c68bb72a21b57"
+        requestId: X777JJ9sssQQHHrrrQTyYQAABBA
+    authenticationContext: {}
+    securityContext: {}

--- a/test_scenarios/okta-add-administrator/brute_force_logins.yml
+++ b/test_scenarios/okta-add-administrator/brute_force_logins.yml
@@ -1,0 +1,234 @@
+---
+LogType: Okta.SystemLog
+Format: jsonl
+Logs:
+  -
+    uuid: 2a992f80-d1ad-4f62-900e-8c68bb72a21b
+    published: '2020-11-25T21:27:03.49Z'
+    eventType: user.session.start
+    version: '0'
+    severity: INFO
+    displayMessage: User login to Okta
+    actor:
+      id: 00uu1uuuuIlllaaaa356
+      type: User
+      alternateId: jack.naglieri@runpanther.io
+      displayName: Jack Naglieri
+    client:
+      userAgent:
+        browser: CHROME
+        os: Mac OS X
+        rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+          (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36
+      geographicalContext:
+        geolocation:
+          lat: 37.7852
+          lon: -122.3874
+        city: Wheelwright
+        state: Urquiza
+        country: Argentina
+        postalCode: '2722'
+      zone: 'null'
+      ipAddress: 195.154.58.200
+      device: Computer
+    request: {}
+    outcome:
+      result: FAILURE
+      reason: VERIFICATION_ERROR
+  -
+    uuid: 2a992f80-d1ad-4f62-900e-8c68bb72a21b
+    published: '2020-11-25T21:28:03.49Z'
+    eventType: user.session.start
+    version: '0'
+    severity: INFO
+    displayMessage: User login to Okta
+    actor:
+      id: 00uu1uuuuIlllaaaa356
+      type: User
+      alternateId: jack.naglieri@runpanther.io
+      displayName: Jack Naglieri
+    client:
+      userAgent:
+        browser: CHROME
+        os: Mac OS X
+        rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+          (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36
+      geographicalContext:
+        geolocation:
+          lat: 37.7852
+          lon: -122.3874
+        city: Tokyo
+        state: Chiyoda-ku
+        country: Japan
+        postalCode: '101-0047'
+      zone: 'null'
+      ipAddress: 157.7.164.178
+      device: Computer
+    request: {}
+    outcome:
+      result: FAILURE
+      reason: VERIFICATION_ERROR
+  -
+    uuid: 2a992f80-d1ad-4f62-900e-8c68bb72a21b
+    published: '2020-11-25T21:29:03.49Z'
+    eventType: user.session.start
+    version: '0'
+    severity: INFO
+    displayMessage: User login to Okta
+    actor:
+      id: 00uu1uuuuIlllaaaa356
+      type: User
+      alternateId: jack.naglieri@runpanther.io
+      displayName: Jack Naglieri
+    client:
+      userAgent:
+        browser: CHROME
+        os: Mac OS X
+        rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+          (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36
+      geographicalContext:
+        geolocation:
+          lat: 37.7852
+          lon: -122.3874
+        city: Ponte San Pietro
+        state: Bergano
+        country: Italy
+        postalCode: '24036'
+      zone: 'null'
+      ipAddress: 94.177.183.28
+      device: Computer
+    request: {}
+    outcome:
+      result: FAILURE
+      reason: VERIFICATION_ERROR
+  -
+    uuid: 2a992f80-d1ad-4f62-900e-8c68bb72a21b
+    published: '2020-11-25T21:30:03.49Z'
+    eventType: user.session.start
+    version: '0'
+    severity: INFO
+    displayMessage: User login to Okta
+    actor:
+      id: 00uu1uuuuIlllaaaa356
+      type: User
+      alternateId: jack.naglieri@runpanther.io
+      displayName: Jack Naglieri
+    client:
+      userAgent:
+        browser: CHROME
+        os: Mac OS X
+        rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+          (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36
+      geographicalContext:
+        geolocation:
+          lat: 37.7852
+          lon: -122.3874
+        city: Wheelwright
+        state: Urquiza
+        country: Argentina
+        postalCode: '2722'
+      zone: 'null'
+      ipAddress: 195.154.58.200
+      device: Computer
+    request: {}
+    outcome:
+      result: FAILURE
+      reason: VERIFICATION_ERROR
+  -
+    uuid: 2a992f80-d1ad-4f62-900e-8c68bb72a21b
+    published: '2020-11-25T21:31:03.49Z'
+    eventType: user.session.start
+    version: '0'
+    severity: INFO
+    displayMessage: User login to Okta
+    actor:
+      id: 00uu1uuuuIlllaaaa356
+      type: User
+      alternateId: jack.naglieri@runpanther.io
+      displayName: Jack Naglieri
+    client:
+      userAgent:
+        browser: CHROME
+        os: Mac OS X
+        rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+          (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36
+      geographicalContext:
+        geolocation:
+          lat: 37.7852
+          lon: -122.3874
+        city: Coupvray
+        state: Coupvray
+        country: France
+        postalCode: '77700'
+      zone: 'null'
+      ipAddress: 194.88.246.242
+      device: Computer
+    request: {}
+    outcome:
+      result: FAILURE
+      reason: VERIFICATION_ERROR
+  -
+    uuid: 2a992f80-d1ad-4f62-900e-8c68bb72a21b
+    published: '2020-11-25T21:32:03.49Z'
+    eventType: user.session.start
+    version: '0'
+    severity: INFO
+    displayMessage: User login to Okta
+    actor:
+      id: 00uu1uuuuIlllaaaa356
+      type: User
+      alternateId: jack.naglieri@runpanther.io
+      displayName: Jack Naglieri
+    client:
+      userAgent:
+        browser: CHROME
+        os: Mac OS X
+        rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+          (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36
+      geographicalContext:
+        geolocation:
+          lat: 37.7852
+          lon: -122.3874
+        city: Coupvray
+        state: Coupvray
+        country: France
+        postalCode: '77700'
+      zone: 'null'
+      ipAddress: 194.88.246.242
+      device: Computer
+    request: {}
+    outcome:
+      result: FAILURE
+      reason: VERIFICATION_ERROR
+  -
+    uuid: 2a992f80-d1ad-4f62-900e-8c68bb72a21b
+    published: '2020-11-25T21:33:03.49Z'
+    eventType: user.session.start
+    version: '0'
+    severity: INFO
+    displayMessage: User login to Okta
+    actor:
+      id: 00uu1uuuuIlllaaaa356
+      type: User
+      alternateId: jack.naglieri@runpanther.io
+      displayName: Jack Naglieri
+    client:
+      userAgent:
+        browser: CHROME
+        os: Mac OS X
+        rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+          (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36
+      geographicalContext:
+        geolocation:
+          lat: 37.7852
+          lon: -122.3874
+        city: Coupvray
+        state: Coupvray
+        country: France
+        postalCode: '77700'
+      zone: 'null'
+      ipAddress: 194.88.246.242
+      device: Computer
+    request: {}
+    outcome:
+      result: SUCCESS

--- a/test_scenarios/okta-add-administrator/legit_login.yml
+++ b/test_scenarios/okta-add-administrator/legit_login.yml
@@ -1,0 +1,36 @@
+---
+LogType: Okta.SystemLog
+Format: jsonl
+Logs:
+  -
+    uuid: 2a992f80-d1ad-4f62-900e-8c68bb72a21b
+    published: '2020-11-22T10:27:03.490Z'
+    eventType: user.session.start
+    version: '0'
+    severity: INFO
+    displayMessage: User login to Okta
+    actor:
+      id: 00uu1uuuuIlllaaaa356
+      type: User
+      alternateId: jack.naglieri@runpanther.io
+      displayName: Jack Naglieri
+    client:
+      userAgent:
+        browser: CHROME
+        os: Mac OS X
+        rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+          (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36
+      geographicalContext:
+        geolocation:
+          lat: 37.7852
+          lon: -122.3874
+        city: San Francisco
+        state: California
+        country: United States
+        postalCode: '94105'
+      zone: 'null'
+      ipAddress: 136.24.229.58
+      device: Computer
+    request: {}
+    outcome:
+      result: SUCCESS


### PR DESCRIPTION
### Background

Two sets of scenarios and rules for the upcoming Panther+Tines webinar!

### Changes

* Basic Okta rules
* Update CloudTrail dedup and alert contexts

### Testing

* Unit tests + full end-to-end testing with the `send_data` script (we should fold this functionality into the PAT at some point)
