### PR TITLE
Don't alert if access is denied to S3 putbucket.

### DIFF
--- a/aws_cloudtrail_rules/aws_resource_made_public.py
+++ b/aws_cloudtrail_rules/aws_resource_made_public.py
@@ -23,6 +23,10 @@ def rule(event):
 
     # S3
     if event['eventName'] == 'PutBucketPolicy':
+        # Don't alert if access is denied
+        if event.get('errorCode'):
+            if event['errorCode'] == "Access Denied":
+                return False
         return policy_is_not_acceptable(parameters.get('bucketPolicy', None))
 
     # ECR

--- a/aws_cloudtrail_rules/aws_resource_made_public.py
+++ b/aws_cloudtrail_rules/aws_resource_made_public.py
@@ -20,13 +20,11 @@ def rule(event):
 
     if not parameters:
         return False
-
+    if event.get('errorCode') == 'AccessDenied':
+        return False
     # S3
     if event['eventName'] == 'PutBucketPolicy':
         # Don't alert if access is denied
-        if event.get('errorCode'):
-            if event['errorCode'] == "AccessDenied":
-                return False
         return policy_is_not_acceptable(parameters.get('bucketPolicy', None))
 
     # ECR

--- a/aws_cloudtrail_rules/aws_resource_made_public.py
+++ b/aws_cloudtrail_rules/aws_resource_made_public.py
@@ -25,7 +25,7 @@ def rule(event):
     if event['eventName'] == 'PutBucketPolicy':
         # Don't alert if access is denied
         if event.get('errorCode'):
-            if event['errorCode'] == "Access Denied":
+            if event['errorCode'] == "AccessDenied":
                 return False
         return policy_is_not_acceptable(parameters.get('bucketPolicy', None))
 

--- a/aws_cloudtrail_rules/aws_resource_made_public.yml
+++ b/aws_cloudtrail_rules/aws_resource_made_public.yml
@@ -205,3 +205,72 @@ Tests:
           },
           "vpcEndpointId": "vpce-1111"
       }
+  -
+    Name: S3 Failed to made Publicly Accessible
+    ExpectedResult: false
+    Log:
+      {
+          "additionalEventData": {
+              "AuthenticationMethod": "AuthHeader",
+              "CipherSuite": "ECDHE-RSA-AES128-SHA",
+              "SignatureVersion": "SigV4",
+              "vpcEndpointId": "vpce-1111"
+          },
+          "errorCode":"AccessDenied",
+          "awsRegion": "us-west-2",
+          "eventID": "1111",
+          "eventName": "PutBucketPolicy",
+          "eventSource": "s3.amazonaws.com",
+          "eventTime": "2019-01-01T00:00:00Z",
+          "eventType": "AwsApiCall",
+          "eventVersion": "1.05",
+          "recipientAccountId": "123456789012",
+          "requestID": "1111",
+          "requestParameters": {
+              "bucketName": "example-bucket",
+              "bucketPolicy": {
+                  "Statement": [
+                      {
+                          "Action": "s3:GetBucketAcl",
+                          "Effect": "Allow",
+                          "Principal": {
+                              "AWS": "*"
+                          },
+                          "Resource": "arn:aws:s3:::example-bucket",
+                          "Sid": "Public Access"
+                      }
+                  ],
+                  "Version": "2012-10-17"
+              },
+              "host": [
+                  "s3.us-west-2.amazonaws.com"
+              ],
+              "policy": [
+                  ""
+              ]
+          },
+          "responseElements": null,
+          "sourceIPAddress": "111.111.111.111",
+          "userAgent": "Mozilla/2.0 (compatible; NEWT ActiveX; Win32)",
+          "userIdentity": {
+              "accessKeyId": "1111",
+              "accountId": "123456789012",
+              "arn": "arn:aws:sts::123456789012:assumed-role/example-role/example-user",
+              "principalId": "1111",
+              "sessionContext": {
+                  "attributes": {
+                      "creationDate": "2019-01-01T00:00:00Z",
+                      "mfaAuthenticated": "true"
+                  },
+                  "sessionIssuer": {
+                      "accountId": "123456789012",
+                      "arn": "arn:aws:iam::123456789012:role/example-role",
+                      "principalId": "1111",
+                      "type": "Role",
+                      "userName": "example-role"
+                  }
+              },
+              "type": "AssumedRole"
+          },
+          "vpcEndpointId": "vpce-1111"
+      }


### PR DESCRIPTION
### Background

If there is a failed attempt to make an S3 bucket public (due to access denied) the rule still fires today creating a lot of noise.

### Changes

* Added check for PutBucket if the access was denied

### Testing

* Added new test for the access denied log entry
* Ran test with  make test-single pack=aws_cloudtrail_rules and all passed