### PR TITLE
Global IOC Helpers

### DIFF
--- a/global_helpers/panther_iocs.py
+++ b/global_helpers/panther_iocs.py
@@ -1,6 +1,7 @@
-# SUNBURST IOCs https://github.com/fireeye/sunburst_countermeasures/blob/main/indicator_release/Indicator_Release_NBIs.csv
+# pylint: disable=line-too-long
+# SUNBURST IOCs: https://github.com/fireeye/sunburst_countermeasures/blob/main/indicator_release/Indicator_Release_NBIs.csv
 # Last accessed: 12-5-2020
-SUNBURST_FQDN_IOCS = [
+SUNBURST_FQDN_IOCS = {
     'databasegalore.com',
     'deftsecurity.com',
     'freescanonline.com',
@@ -16,13 +17,15 @@ SUNBURST_FQDN_IOCS = [
     'ihvpgv9psvq02ffo77et.appsync-api.us-east-2.avsvmcloud.com',
     'k5kcubuassl3alrf7gm3.appsync-api.eu-west-1.avsvmcloud.com',
     'mhdosoksaccf9sni9icp.appsync-api.eu-west-1.avsvmcloud.com',
-]
-SUNBURST_IP_IOCS = [
+}
+
+SUNBURST_IP_IOCS = {
     '5.252.177.21', '5.252.177.25', '13.59.205.66', '34.203.203.23',
     '51.89.125.18', '54.193.127.66', '54.215.192.52', '139.99.115.204',
     '167.114.213.199', '204.188.205.176'
-]
-SUNBURST_SHA256_IOCS = [
+}
+
+SUNBURST_SHA256_IOCS = {
     '019085a76ba7126fff22770d71bd901c325fc68ac55aa743327984e89f4b0134',
     '292327e5c94afa352cc5a02ca273df543f2020d0e76368ff96c84f4e90778712',
     '32519b85c0b422e4656de6e6c41878e95fd95026267daab4215ee59c107d6c77',
@@ -30,54 +33,24 @@ SUNBURST_SHA256_IOCS = [
     'c15abaf51e78ca56c0376522d699c978217bf041a3bd3c71d09193efa5717c71',
     'ce77d116a074dab7a22a0fd4f2c1ab475f16eec42e1ded3c0b0aa8211fe858d6',
     'd0d626deb3f9484e649294a8dfa814c5568f846d5aa02d4cdad5d041a29d5600'
-]
+}
 
 
-def intersection(first: list, second: list) -> list:
-    return list(set(first) & set(second))
+def ioc_match(indicators: list, known_iocs: set) -> list:
+    """Matches a set of indicators against known Indicators of Compromise
 
-
-def sunburst_fqdn_ioc_match(event: dict) -> bool:
-    """Matches a Fully Qualified Domain Name against known Sunburst Indicators of Compromise
-
-    :param event: Dictionary containing the event details
-    :return: Boolean indicating whether or not it was a match
+    :param indicators: List of potential indicators of compromise
+    :param known_iocs: Set of known indicators of compromise
+    :return: List of any indicator matches
     """
     # Check through the IP IOCs
-    if event.get("p_any_domain_names") is not None:
-        for each_fqdn in event.get("p_any_domain_names"):
-            if each_fqdn in SUNBURST_FQDN_IOCS:
-                return True
-    return False
+    return [ioc for ioc in (indicators or []) if ioc in known_iocs]
 
 
-def sunburst_ip_ioc_match(event: dict) -> bool:
-    """Matches an IP address against known Sunburst Indicators of Compromise
+def sanitize_domain(domain: str) -> str:
+    """Makes a potential malicous domain not render as a domain in most systems
 
-    :param event: Dictionary containing the event details
-    :return: Boolean indicating whether or not it was a match
+    :param domain: Original domain
+    :return: Sanitized domain
     """
-    # Check against src/dst addr
-    if event.get("srcaddr") in SUNBURST_IP_IOCS or event.get(
-            "dstaddr") in SUNBURST_IP_IOCS:
-        return True
-    # Check through the IP IOCs
-    if event.get("p_any_ip_addresses") is not None:
-        for each_ip in event.get("p_any_ip_addresses"):
-            if each_ip in SUNBURST_IP_IOCS:
-                return True
-    return False
-
-
-def sunburst_sha256_ioc_match(event: dict) -> bool:
-    """Matches a SHA-256 against known Sunburst Indicators of Compromise
-
-    :param event: Dictionary containing the event details
-    :return: Boolean indicating whether or not it was a match
-    """
-    # Check through the SHA-256 IOCs
-    if event.get("p_any_sha256_hashes") is not None:
-        for each_checksum in event.get("p_any_sha256_hashes"):
-            if each_checksum in SUNBURST_SHA256_IOCS:
-                return True
-    return False
+    return domain.replace('.', '[.]')

--- a/global_helpers/panther_iocs.py
+++ b/global_helpers/panther_iocs.py
@@ -33,6 +33,10 @@ SUNBURST_SHA256_IOCS = [
 ]
 
 
+def intersection(first: list, second: list) -> list:
+    return list(set(first) & set(second))
+
+
 def sunburst_fqdn_ioc_match(event: dict) -> bool:
     """Matches a Fully Qualified Domain Name against known Sunburst Indicators of Compromise
 

--- a/global_helpers/panther_iocs.py
+++ b/global_helpers/panther_iocs.py
@@ -1,0 +1,79 @@
+# SUNBURST IOCs https://github.com/fireeye/sunburst_countermeasures/blob/main/indicator_release/Indicator_Release_NBIs.csv
+# Last accessed: 12-5-2020
+SUNBURST_FQDN_IOCS = [
+    'databasegalore.com',
+    'deftsecurity.com',
+    'freescanonline.com',
+    'highdatabase.com',
+    'incomeupdate.com',
+    'panhardware.com',
+    'thedoccloud.com',
+    'websitetheme.com',
+    'zupertech.com',
+    '6a57jk2ba1d9keg15cbg.appsync-api.eu-west-1.avsvmcloud.com',
+    '7sbvaemscs0mc925tb99.appsync-api.us-west-2.avsvmcloud.com',
+    'gq1h856599gqh538acqn.appsync-api.us-west-2.avsvmcloud.com',
+    'ihvpgv9psvq02ffo77et.appsync-api.us-east-2.avsvmcloud.com',
+    'k5kcubuassl3alrf7gm3.appsync-api.eu-west-1.avsvmcloud.com',
+    'mhdosoksaccf9sni9icp.appsync-api.eu-west-1.avsvmcloud.com',
+]
+SUNBURST_IP_IOCS = [
+    '5.252.177.21', '5.252.177.25', '13.59.205.66', '34.203.203.23',
+    '51.89.125.18', '54.193.127.66', '54.215.192.52', '139.99.115.204',
+    '167.114.213.199', '204.188.205.176'
+]
+SUNBURST_SHA256_IOCS = [
+    '019085a76ba7126fff22770d71bd901c325fc68ac55aa743327984e89f4b0134',
+    '292327e5c94afa352cc5a02ca273df543f2020d0e76368ff96c84f4e90778712',
+    '32519b85c0b422e4656de6e6c41878e95fd95026267daab4215ee59c107d6c77',
+    '53f8dfc65169ccda021b72a62e0c22a4db7c4077f002fa742717d41b3c40f2c7',
+    'c15abaf51e78ca56c0376522d699c978217bf041a3bd3c71d09193efa5717c71',
+    'ce77d116a074dab7a22a0fd4f2c1ab475f16eec42e1ded3c0b0aa8211fe858d6',
+    'd0d626deb3f9484e649294a8dfa814c5568f846d5aa02d4cdad5d041a29d5600'
+]
+
+
+def sunburst_fqdn_ioc_match(event: dict) -> bool:
+    """Matches a Fully Qualified Domain Name against known Sunburst Indicators of Compromise
+
+    :param event: Dictionary containing the event details
+    :return: Boolean indicating whether or not it was a match
+    """
+    # Check through the IP IOCs
+    if event.get("p_any_domain_names") is not None:
+        for each_fqdn in event.get("p_any_domain_names"):
+            if each_fqdn in SUNBURST_FQDN_IOCS:
+                return True
+    return False
+
+
+def sunburst_ip_ioc_match(event: dict) -> bool:
+    """Matches an IP address against known Sunburst Indicators of Compromise
+
+    :param event: Dictionary containing the event details
+    :return: Boolean indicating whether or not it was a match
+    """
+    # Check against src/dst addr
+    if event.get("srcaddr") in SUNBURST_IP_IOCS or event.get(
+            "dstaddr") in SUNBURST_IP_IOCS:
+        return True
+    # Check through the IP IOCs
+    if event.get("p_any_ip_addresses") is not None:
+        for each_ip in event.get("p_any_ip_addresses"):
+            if each_ip in SUNBURST_IP_IOCS:
+                return True
+    return False
+
+
+def sunburst_sha256_ioc_match(event: dict) -> bool:
+    """Matches a SHA-256 against known Sunburst Indicators of Compromise
+
+    :param event: Dictionary containing the event details
+    :return: Boolean indicating whether or not it was a match
+    """
+    # Check through the SHA-256 IOCs
+    if event.get("p_any_sha256_hashes") is not None:
+        for each_checksum in event.get("p_any_sha256_hashes"):
+            if each_checksum in SUNBURST_SHA256_IOCS:
+                return True
+    return False

--- a/global_helpers/panther_iocs.yml
+++ b/global_helpers/panther_iocs.yml
@@ -1,0 +1,4 @@
+AnalysisType: global
+GlobalID: panther_iocs
+Filename: panther_iocs.py
+Description: Used to define global helpers and variables used for indicators of compromise (IOCs)

--- a/global_helpers/panther_iocs.yml
+++ b/global_helpers/panther_iocs.yml
@@ -1,4 +1,4 @@
 AnalysisType: global
 GlobalID: panther_iocs
 Filename: panther_iocs.py
-Description: Used to define global helpers and variables used for indicators of compromise (IOCs)
+Description: Global helpers and variables used for finding matches on known indicators of compromise (IOCs)

--- a/okta_rules/okta_admin_role_assigned.py
+++ b/okta_rules/okta_admin_role_assigned.py
@@ -1,5 +1,5 @@
-from panther_base_helpers import okta_alert_context
 import re
+from panther_base_helpers import okta_alert_context
 
 
 def rule(event):

--- a/panther_ioc_rules/sunburst_fqdn_iocs.py
+++ b/panther_ioc_rules/sunburst_fqdn_iocs.py
@@ -1,0 +1,9 @@
+from panther_iocs import sunburst_fqdn_ioc_match
+
+
+def rule(event):
+    return sunburst_fqdn_ioc_match(event)
+
+
+def title(event):
+    return "Sunburst Indicator of Compromise (FQDN) Detected"

--- a/panther_ioc_rules/sunburst_fqdn_iocs.py
+++ b/panther_ioc_rules/sunburst_fqdn_iocs.py
@@ -8,7 +8,8 @@ def rule(event):
 def title(event):
     title_str = "Sunburst Indicator of Compromise Detected"
     if "p_any_domain_names" in event:
-        matches = intersection(event.get("p_any_domain_names"), SUNBURST_FQDN_IOCS)
+        matches = intersection(event.get("p_any_domain_names"),
+                               SUNBURST_FQDN_IOCS)
         single_quote = '\''
         title_str += f" - {str(matches).replace('.', '[.]').replace(single_quote, '')}"
     return title_str

--- a/panther_ioc_rules/sunburst_fqdn_iocs.py
+++ b/panther_ioc_rules/sunburst_fqdn_iocs.py
@@ -6,7 +6,7 @@ def rule(event):
 
 
 def title(event):
-    # pylint: disable=line-too-long
+    domains = ','.join(
+        ioc_match(event.get('p_any_domain_names'), SUNBURST_FQDN_IOCS))
     return sanitize_domain(
-        f"Sunburst Indicator of Compromise Detected [Domains]: {','.join(ioc_match(event.get('p_any_domain_names'), SUNBURST_FQDN_IOCS))}"
-    )
+        f"Sunburst Indicator of Compromise Detected [Domains]: {domains}")

--- a/panther_ioc_rules/sunburst_fqdn_iocs.py
+++ b/panther_ioc_rules/sunburst_fqdn_iocs.py
@@ -1,15 +1,12 @@
-from panther_iocs import sunburst_fqdn_ioc_match, intersection, SUNBURST_FQDN_IOCS
+from panther_iocs import ioc_match, SUNBURST_FQDN_IOCS, sanitize_domain
 
 
 def rule(event):
-    return sunburst_fqdn_ioc_match(event)
+    return any(ioc_match(event.get('p_any_domain_names'), SUNBURST_FQDN_IOCS))
 
 
 def title(event):
-    title_str = "Sunburst Indicator of Compromise Detected"
-    if "p_any_domain_names" in event:
-        matches = intersection(event.get("p_any_domain_names"),
-                               SUNBURST_FQDN_IOCS)
-        single_quote = '\''
-        title_str += f" - {str(matches).replace('.', '[.]').replace(single_quote, '')}"
-    return title_str
+    # pylint: disable=line-too-long
+    return sanitize_domain(
+        f"Sunburst Indicator of Compromise Detected [Domains]: {','.join(ioc_match(event.get('p_any_domain_names'), SUNBURST_FQDN_IOCS))}"
+    )

--- a/panther_ioc_rules/sunburst_fqdn_iocs.py
+++ b/panther_ioc_rules/sunburst_fqdn_iocs.py
@@ -1,4 +1,4 @@
-from panther_iocs import sunburst_fqdn_ioc_match
+from panther_iocs import sunburst_fqdn_ioc_match, intersection, SUNBURST_FQDN_IOCS
 
 
 def rule(event):
@@ -6,4 +6,9 @@ def rule(event):
 
 
 def title(event):
-    return "Sunburst Indicator of Compromise (FQDN) Detected"
+    title_str = "Sunburst Indicator of Compromise Detected"
+    if "p_any_domain_names" in event:
+        matches = intersection(event.get("p_any_domain_names"), SUNBURST_FQDN_IOCS)
+        single_quote = '\''
+        title_str += f" - {str(matches).replace('.', '[.]').replace(single_quote, '')}"
+    return title_str

--- a/panther_ioc_rules/sunburst_fqdn_iocs.yml
+++ b/panther_ioc_rules/sunburst_fqdn_iocs.yml
@@ -28,7 +28,9 @@ Tags:
   - Osquery
 Severity: High
 Description: >
-  Alerts if any traffic is detected against known indicators of compromise (IOC). These IOCs indicate a potential breach and have been associated with a sophisticated nation-state actor.
+  Monitors for communication to known Sunburst Backdoor FQDNs. These IOCs indicate a potential breach and have been associated with a sophisticated nation-state actor.
+Reference: >
+  https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html
 Runbook: >
   Investigate the resources communicating with the matched IOC for signs of compromise or other malicious activity. Consider rotating credentials on any systems observed communicating with these known malicious systems.
 SummaryAttributes:

--- a/panther_ioc_rules/sunburst_fqdn_iocs.yml
+++ b/panther_ioc_rules/sunburst_fqdn_iocs.yml
@@ -1,0 +1,57 @@
+AnalysisType: rule
+Filename: sunburst_fqdn_iocs.py
+RuleID: IOC.SunburstFQDNIOCs
+DisplayName: Sunburst Indicators of Compromise (FQDN)
+Enabled: true
+LogTypes:
+  - AWS.ALB
+  - AWS.CloudTrail
+  - AWS.GuardDuty
+  - AWS.S3ServerAccess
+  - AWS.VPCFlow
+  - Box.Event
+  - CiscoUmbrella.DNS
+  - GCP.AuditLog
+  - Gravitational.TeleportAudit
+  - GSuite.Reports
+  - Okta.SystemLog
+  - OneLogin.Events
+  - Osquery.Differential
+Tags:
+  - AWS
+  - Box
+  - DNS
+  - GCP
+  - GSuite
+  - SSH
+  - OneLogin
+  - Osquery
+Severity: High
+Description: >
+  Alerts if any traffic is detected against known indicators of compromise (IOC). These IOCs indicate a potential breach and have been associated with a sophisticated nation-state actor.
+Runbook: >
+  Investigate the resources communicating with the matched IOC for signs of compromise or other malicious activity.
+SummaryAttributes:
+  - p_any_domain_names
+  - p_any_ip_addresses
+  - p_any_sha256_hashes
+Tests:
+  -
+    Name: Non-matching traffic
+    ExpectedResult: false
+    Log:
+      {
+        "dstport": 53,
+        "dstaddr": "1.1.1.1",
+        "srcaddr": "10.0.0.1",
+        "p_any_domain_names": ["example.com"],
+      }
+  -
+    Name: Sunburst Indicator of Compromise (FQDN) Detected
+    ExpectedResult: true
+    Log:
+      {
+        "srcaddr": "13.59.205.66",
+        "dstaddr": "10.0.0.1",
+        "p_any_domain_names": ["incomeupdate.com"],
+      }

--- a/panther_ioc_rules/sunburst_fqdn_iocs.yml
+++ b/panther_ioc_rules/sunburst_fqdn_iocs.yml
@@ -30,7 +30,7 @@ Severity: High
 Description: >
   Alerts if any traffic is detected against known indicators of compromise (IOC). These IOCs indicate a potential breach and have been associated with a sophisticated nation-state actor.
 Runbook: >
-  Investigate the resources communicating with the matched IOC for signs of compromise or other malicious activity.
+  Investigate the resources communicating with the matched IOC for signs of compromise or other malicious activity. Consider rotating credentials on any systems observed communicating with these known malicious systems.
 SummaryAttributes:
   - p_any_domain_names
   - p_any_ip_addresses

--- a/panther_ioc_rules/sunburst_ip_iocs.py
+++ b/panther_ioc_rules/sunburst_ip_iocs.py
@@ -6,5 +6,5 @@ def rule(event):
 
 
 def title(event):
-    # pylint: disable=line-too-long
-    return f"Sunburst Indicator of Compromise Detected [IPs]: {','.join(ioc_match(event.get('p_any_ip_addresses'), SUNBURST_IP_IOCS))}"
+    ips = ','.join(ioc_match(event.get('p_any_ip_addresses'), SUNBURST_IP_IOCS))
+    return f"Sunburst Indicator of Compromise Detected [IPs]: {ips}"

--- a/panther_ioc_rules/sunburst_ip_iocs.py
+++ b/panther_ioc_rules/sunburst_ip_iocs.py
@@ -1,15 +1,10 @@
-from panther_iocs import sunburst_ip_ioc_match, intersection, SUNBURST_IP_IOCS
+from panther_iocs import ioc_match, SUNBURST_IP_IOCS
 
 
 def rule(event):
-    return sunburst_ip_ioc_match(event)
+    return any(ioc_match(event.get('p_any_ip_addresses'), SUNBURST_IP_IOCS))
 
 
 def title(event):
-    title_str = "Sunburst Indicator of Compromise Detected"
-    if "p_any_ip_addresses" in event:
-        matches = intersection(event.get("p_any_ip_addresses"),
-                               SUNBURST_IP_IOCS)
-        single_quote = '\''
-        title_str += f" - {str(matches).replace('.', '[.]').replace(single_quote, '')}"
-    return title_str
+    # pylint: disable=line-too-long
+    return f"Sunburst Indicator of Compromise Detected [IPs]: {','.join(ioc_match(event.get('p_any_ip_addresses'), SUNBURST_IP_IOCS))}"

--- a/panther_ioc_rules/sunburst_ip_iocs.py
+++ b/panther_ioc_rules/sunburst_ip_iocs.py
@@ -8,7 +8,8 @@ def rule(event):
 def title(event):
     title_str = "Sunburst Indicator of Compromise Detected"
     if "p_any_ip_addresses" in event:
-        matches = intersection(event.get("p_any_ip_addresses"), SUNBURST_IP_IOCS)
+        matches = intersection(event.get("p_any_ip_addresses"),
+                               SUNBURST_IP_IOCS)
         single_quote = '\''
         title_str += f" - {str(matches).replace('.', '[.]').replace(single_quote, '')}"
     return title_str

--- a/panther_ioc_rules/sunburst_ip_iocs.py
+++ b/panther_ioc_rules/sunburst_ip_iocs.py
@@ -1,0 +1,9 @@
+from panther_iocs import sunburst_ip_ioc_match
+
+
+def rule(event):
+    return sunburst_ip_ioc_match(event)
+
+
+def title(event):
+    return "Sunburst Indicator of Compromise (IP) Detected"

--- a/panther_ioc_rules/sunburst_ip_iocs.py
+++ b/panther_ioc_rules/sunburst_ip_iocs.py
@@ -1,4 +1,4 @@
-from panther_iocs import sunburst_ip_ioc_match
+from panther_iocs import sunburst_ip_ioc_match, intersection, SUNBURST_IP_IOCS
 
 
 def rule(event):
@@ -6,4 +6,9 @@ def rule(event):
 
 
 def title(event):
-    return "Sunburst Indicator of Compromise (IP) Detected"
+    title_str = "Sunburst Indicator of Compromise Detected"
+    if "p_any_ip_addresses" in event:
+        matches = intersection(event.get("p_any_ip_addresses"), SUNBURST_IP_IOCS)
+        single_quote = '\''
+        title_str += f" - {str(matches).replace('.', '[.]').replace(single_quote, '')}"
+    return title_str

--- a/panther_ioc_rules/sunburst_ip_iocs.yml
+++ b/panther_ioc_rules/sunburst_ip_iocs.yml
@@ -28,7 +28,9 @@ Tags:
   - Osquery
 Severity: High
 Description: >
-  Alerts if any traffic is detected against known indicators of compromise (IOC). These IOCs indicate a potential breach and have been associated with a sophisticated nation-state actor.
+  Monitors for communication to known Sunburst Backdoor IPs. These IOCs indicate a potential breach and have been associated with a sophisticated nation-state actor.
+Reference: >
+  https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html
 Runbook: >
   Investigate the resources communicating with the matched IOC for signs of compromise or other malicious activity. Consider rotating credentials on any systems observed communicating with these known malicious systems.
 SummaryAttributes:

--- a/panther_ioc_rules/sunburst_ip_iocs.yml
+++ b/panther_ioc_rules/sunburst_ip_iocs.yml
@@ -52,4 +52,5 @@ Tests:
       {
         "srcaddr": "13.59.205.66",
         "dstaddr": "10.0.0.1",
+        "p_any_ip_addresses": ["13.59.205.66"],
       }

--- a/panther_ioc_rules/sunburst_ip_iocs.yml
+++ b/panther_ioc_rules/sunburst_ip_iocs.yml
@@ -1,0 +1,55 @@
+AnalysisType: rule
+Filename: sunburst_ip_iocs.py
+RuleID: IOC.SunburstIPIOCs
+DisplayName: Sunburst Indicators of Compromise (IP)
+Enabled: true
+LogTypes:
+  - AWS.ALB
+  - AWS.CloudTrail
+  - AWS.GuardDuty
+  - AWS.S3ServerAccess
+  - AWS.VPCFlow
+  - Box.Event
+  - CiscoUmbrella.DNS
+  - GCP.AuditLog
+  - Gravitational.TeleportAudit
+  - GSuite.Reports
+  - Okta.SystemLog
+  - OneLogin.Events
+  - Osquery.Differential
+Tags:
+  - AWS
+  - Box
+  - DNS
+  - GCP
+  - GSuite
+  - SSH
+  - OneLogin
+  - Osquery
+Severity: High
+Description: >
+  Alerts if any traffic is detected against known indicators of compromise (IOC). These IOCs indicate a potential breach and have been associated with a sophisticated nation-state actor.
+Runbook: >
+  Investigate the resources communicating with the matched IOC for signs of compromise or other malicious activity.
+SummaryAttributes:
+  - p_any_domain_names
+  - p_any_ip_addresses
+  - p_any_sha256_hashes
+Tests:
+  -
+    Name: Non-matching traffic
+    ExpectedResult: false
+    Log:
+      {
+        "dstport": 53,
+        "dstaddr": "1.1.1.1",
+        "srcaddr": "10.0.0.1"
+      }
+  -
+    Name: Sunburst Indicator of Compromise (IP) Detected
+    ExpectedResult: true
+    Log:
+      {
+        "srcaddr": "13.59.205.66",
+        "dstaddr": "10.0.0.1",
+      }

--- a/panther_ioc_rules/sunburst_ip_iocs.yml
+++ b/panther_ioc_rules/sunburst_ip_iocs.yml
@@ -30,7 +30,7 @@ Severity: High
 Description: >
   Alerts if any traffic is detected against known indicators of compromise (IOC). These IOCs indicate a potential breach and have been associated with a sophisticated nation-state actor.
 Runbook: >
-  Investigate the resources communicating with the matched IOC for signs of compromise or other malicious activity.
+  Investigate the resources communicating with the matched IOC for signs of compromise or other malicious activity. Consider rotating credentials on any systems observed communicating with these known malicious systems.
 SummaryAttributes:
   - p_any_domain_names
   - p_any_ip_addresses

--- a/panther_ioc_rules/sunburst_sha256_iocs.py
+++ b/panther_ioc_rules/sunburst_sha256_iocs.py
@@ -1,15 +1,11 @@
-from panther_iocs import sunburst_sha256_ioc_match, intersection, SUNBURST_SHA256_IOCS
+from panther_iocs import ioc_match, SUNBURST_SHA256_IOCS
 
 
 def rule(event):
-    return sunburst_sha256_ioc_match(event)
+    return any(ioc_match(event.get('p_any_sha256_hashes'),
+                         SUNBURST_SHA256_IOCS))
 
 
 def title(event):
-    title_str = "Sunburst Indicator of Compromise Detected"
-    if "p_any_sha256_hashes" in event:
-        matches = intersection(event.get("p_any_sha256_hashes"),
-                               SUNBURST_SHA256_IOCS)
-        single_quote = '\''
-        title_str += f" - {str(matches).replace(single_quote, '')}"
-    return title_str
+    # pylint: disable=line-too-long
+    return f"Sunburst Indicator of Compromise Detected [SHA256 hash]: {','.join(ioc_match(event.get('p_any_sha256_hashes'), SUNBURST_SHA256_IOCS))}"

--- a/panther_ioc_rules/sunburst_sha256_iocs.py
+++ b/panther_ioc_rules/sunburst_sha256_iocs.py
@@ -1,4 +1,4 @@
-from panther_iocs import sunburst_sha256_ioc_match
+from panther_iocs import sunburst_sha256_ioc_match, intersection, SUNBURST_SHA256_IOCS
 
 
 def rule(event):
@@ -6,4 +6,9 @@ def rule(event):
 
 
 def title(event):
-    return "Sunburst Indicator of Compromise (SHA-256) Detected"
+    title_str = "Sunburst Indicator of Compromise Detected"
+    if "p_any_sha256_hashes" in event:
+        matches = intersection(event.get("p_any_sha256_hashes"), SUNBURST_SHA256_IOCS)
+        single_quote = '\''
+        title_str += f" - {str(matches).replace(single_quote, '')}"
+    return title_str

--- a/panther_ioc_rules/sunburst_sha256_iocs.py
+++ b/panther_ioc_rules/sunburst_sha256_iocs.py
@@ -8,7 +8,8 @@ def rule(event):
 def title(event):
     title_str = "Sunburst Indicator of Compromise Detected"
     if "p_any_sha256_hashes" in event:
-        matches = intersection(event.get("p_any_sha256_hashes"), SUNBURST_SHA256_IOCS)
+        matches = intersection(event.get("p_any_sha256_hashes"),
+                               SUNBURST_SHA256_IOCS)
         single_quote = '\''
         title_str += f" - {str(matches).replace(single_quote, '')}"
     return title_str

--- a/panther_ioc_rules/sunburst_sha256_iocs.py
+++ b/panther_ioc_rules/sunburst_sha256_iocs.py
@@ -7,5 +7,6 @@ def rule(event):
 
 
 def title(event):
-    # pylint: disable=line-too-long
-    return f"Sunburst Indicator of Compromise Detected [SHA256 hash]: {','.join(ioc_match(event.get('p_any_sha256_hashes'), SUNBURST_SHA256_IOCS))}"
+    hashes = ','.join(
+        ioc_match(event.get('p_any_sha256_hashes'), SUNBURST_SHA256_IOCS))
+    return f"Sunburst Indicator of Compromise Detected [SHA256 hash]: {hashes}"

--- a/panther_ioc_rules/sunburst_sha256_iocs.py
+++ b/panther_ioc_rules/sunburst_sha256_iocs.py
@@ -1,0 +1,9 @@
+from panther_iocs import sunburst_sha256_ioc_match
+
+
+def rule(event):
+    return sunburst_sha256_ioc_match(event)
+
+
+def title(event):
+    return "Sunburst Indicator of Compromise (SHA-256) Detected"

--- a/panther_ioc_rules/sunburst_sha256_iocs.yml
+++ b/panther_ioc_rules/sunburst_sha256_iocs.yml
@@ -8,9 +8,7 @@ LogTypes:
   - AWS.CloudTrail
   - AWS.GuardDuty
   - AWS.S3ServerAccess
-  - AWS.VPCFlow
   - Box.Event
-  - CiscoUmbrella.DNS
   - GCP.AuditLog
   - Gravitational.TeleportAudit
   - GSuite.Reports

--- a/panther_ioc_rules/sunburst_sha256_iocs.yml
+++ b/panther_ioc_rules/sunburst_sha256_iocs.yml
@@ -28,7 +28,7 @@ Severity: High
 Description: >
   Alerts if any traffic is detected against known indicators of compromise (IOC). These IOCs indicate a potential breach and have been associated with a sophisticated nation-state actor.
 Runbook: >
-  Investigate the resources communicating with the matched IOC for signs of compromise or other malicious activity.
+  Investigate the resources communicating with the matched IOC for signs of compromise or other malicious activity. Consider rotating credentials on any systems observed communicating with these known malicious systems.
 SummaryAttributes:
   - p_any_domain_names
   - p_any_ip_addresses

--- a/panther_ioc_rules/sunburst_sha256_iocs.yml
+++ b/panther_ioc_rules/sunburst_sha256_iocs.yml
@@ -1,0 +1,57 @@
+AnalysisType: rule
+Filename: sunburst_sha256_iocs.py
+RuleID: IOC.SunburstSHA256IOCs
+DisplayName: Sunburst Indicators of Compromise (SHA-256)
+Enabled: true
+LogTypes:
+  - AWS.ALB
+  - AWS.CloudTrail
+  - AWS.GuardDuty
+  - AWS.S3ServerAccess
+  - AWS.VPCFlow
+  - Box.Event
+  - CiscoUmbrella.DNS
+  - GCP.AuditLog
+  - Gravitational.TeleportAudit
+  - GSuite.Reports
+  - Okta.SystemLog
+  - OneLogin.Events
+  - Osquery.Differential
+Tags:
+  - AWS
+  - Box
+  - DNS
+  - GCP
+  - GSuite
+  - SSH
+  - OneLogin
+  - Osquery
+Severity: High
+Description: >
+  Alerts if any traffic is detected against known indicators of compromise (IOC). These IOCs indicate a potential breach and have been associated with a sophisticated nation-state actor.
+Runbook: >
+  Investigate the resources communicating with the matched IOC for signs of compromise or other malicious activity.
+SummaryAttributes:
+  - p_any_domain_names
+  - p_any_ip_addresses
+  - p_any_sha256_hashes
+Tests:
+  -
+    Name: Non-matching traffic
+    ExpectedResult: false
+    Log:
+      {
+        "dstport": 53,
+        "dstaddr": "1.1.1.1",
+        "srcaddr": "10.0.0.1",
+        "p_any_sha256_hashes": ["98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"],
+      }
+  -
+    Name: Sunburst Indicator of Compromise (SHA-256) Detected
+    ExpectedResult: true
+    Log:
+      {
+        "srcaddr": "13.59.205.66",
+        "dstaddr": "10.0.0.1",
+        "p_any_sha256_hashes": ["019085a76ba7126fff22770d71bd901c325fc68ac55aa743327984e89f4b0134"],
+      }

--- a/panther_ioc_rules/sunburst_sha256_iocs.yml
+++ b/panther_ioc_rules/sunburst_sha256_iocs.yml
@@ -26,7 +26,9 @@ Tags:
   - Osquery
 Severity: High
 Description: >
-  Alerts if any traffic is detected against known indicators of compromise (IOC). These IOCs indicate a potential breach and have been associated with a sophisticated nation-state actor.
+  Monitors for hashes to known Sunburst Backdoor SHA256. These IOCs indicate a potential breach and have been associated with a sophisticated nation-state actor.
+Reference: >
+  https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html
 Runbook: >
   Investigate the resources communicating with the matched IOC for signs of compromise or other malicious activity. Consider rotating credentials on any systems observed communicating with these known malicious systems.
 SummaryAttributes:


### PR DESCRIPTION
### Background

A few simple rules to look for activity from known IOCs related to the sunburst compromise.

### Changes

* Created a new global helper: `panther_iocs` : `panther_iocs.py` 
* Created a new folder for IOC rules: `panther_ioc_rules`
* Added Sunburst IP/FQDN/SHA-256 IOC rules

### Testing

* `make test`
