### PR TITLE
AWS CloudTrail Rule Fix - Resource Made Public

### DIFF
--- a/aws_cloudtrail_rules/aws_resource_made_public.py
+++ b/aws_cloudtrail_rules/aws_resource_made_public.py
@@ -17,50 +17,53 @@ def policy_is_not_acceptable(json_policy):
 # pylint: disable=too-many-return-statements
 def rule(event):
     parameters = event.get('requestParameters', {})
+    event_name = event.get('eventName', "")
+    policy = ""
 
+    # Handle malformed events
     if not parameters:
         return False
-    if event.get('errorCode') == 'AccessDenied':
+    if event.get('errorCode') == 'AccessDenied' or event_name == "":
         return False
     # S3
-    if event['eventName'] == 'PutBucketPolicy':
-        # Don't alert if access is denied
+    # Don't alert if access is denied
+    if event_name == 'PutBucketPolicy':
         return policy_is_not_acceptable(parameters.get('bucketPolicy', None))
 
     # ECR
-    if event['eventName'] == 'SetRepositoryPolicy':
+    if event_name == 'SetRepositoryPolicy':
         policy = parameters.get('policyText', '{}')
 
     # Elasticsearch
-    if event['eventName'] in [
+    if event_name in [
             'CreateElasticsearchDomain', 'UpdateElasticsearchDomainConfig'
     ]:
         policy = parameters.get('accessPolicies', '{}')
 
     # KMS
-    if event['eventName'] in ['CreateKey', 'PutKeyPolicy']:
+    if event_name in ['CreateKey', 'PutKeyPolicy']:
         policy = parameters.get('policy', '{}')
 
     # S3 Glacier
-    if event['eventName'] == 'SetVaultAccessPolicy':
+    if event_name == 'SetVaultAccessPolicy':
         policy = parameters.get('policy', {}).get('policy', '{}')
 
     # SNS & SQS
-    if event['eventName'] in ['SetQueueAttributes', 'CreateTopic']:
+    if event_name in ['SetQueueAttributes', 'CreateTopic']:
         policy = parameters.get('attributes', {}).get('Policy', '{}')
 
     # SNS
-    if event['eventName'] == 'SetTopicAttributes':
+    if event_name == 'SetTopicAttributes':
         if parameters.get('attributeName') == 'Policy':
             policy = parameters.get('attributeValue', '{}')
             return policy_is_not_acceptable(json.loads(policy))
         return False
 
     # SecretsManager
-    if event['eventName'] == 'PutResourcePolicy':
+    if event_name == 'PutResourcePolicy':
         policy = parameters.get('resourcePolicy', '{}')
 
-    if len(policy) == 0:
+    if policy == "":
         return False
 
     return policy_is_not_acceptable(json.loads(policy))

--- a/aws_cloudtrail_rules/aws_resource_made_public.py
+++ b/aws_cloudtrail_rules/aws_resource_made_public.py
@@ -30,29 +30,24 @@ def rule(event):
     # ECR
     if event['eventName'] == 'SetRepositoryPolicy':
         policy = parameters.get('policyText', '{}')
-        return policy_is_not_acceptable(json.loads(policy))
 
     # Elasticsearch
     if event['eventName'] in [
             'CreateElasticsearchDomain', 'UpdateElasticsearchDomainConfig'
     ]:
         policy = parameters.get('accessPolicies', '{}')
-        return policy_is_not_acceptable(json.loads(policy))
 
     # KMS
     if event['eventName'] in ['CreateKey', 'PutKeyPolicy']:
         policy = parameters.get('policy', '{}')
-        return policy_is_not_acceptable(json.loads(policy))
 
     # S3 Glacier
     if event['eventName'] == 'SetVaultAccessPolicy':
         policy = parameters.get('policy', {}).get('policy', '{}')
-        return policy_is_not_acceptable(json.loads(policy))
 
     # SNS & SQS
     if event['eventName'] in ['SetQueueAttributes', 'CreateTopic']:
         policy = parameters.get('attributes', {}).get('Policy', '{}')
-        return policy_is_not_acceptable(json.loads(policy))
 
     # SNS
     if event['eventName'] == 'SetTopicAttributes':
@@ -64,6 +59,8 @@ def rule(event):
     # SecretsManager
     if event['eventName'] == 'PutResourcePolicy':
         policy = parameters.get('resourcePolicy', '{}')
-        return policy_is_not_acceptable(json.loads(policy))
 
-    return False
+    if len(policy) == 0:
+        return False
+
+    return policy_is_not_acceptable(json.loads(policy))

--- a/aws_cloudtrail_rules/aws_resource_made_public.yml
+++ b/aws_cloudtrail_rules/aws_resource_made_public.yml
@@ -206,7 +206,7 @@ Tests:
           "vpcEndpointId": "vpce-1111"
       }
   -
-    Name: S3 Failed to made Publicly Accessible
+    Name: S3 Failed to make Publicly Accessible
     ExpectedResult: false
     Log:
       {
@@ -273,4 +273,54 @@ Tests:
               "type": "AssumedRole"
           },
           "vpcEndpointId": "vpce-1111"
+      }
+  - Name: Empty Policy Payload
+    ExpectedResult: false
+    Log:
+      {
+        "additionalEventData": {
+          "AuthenticationMethod": "AuthHeader",
+          "CipherSuite": "ECDHE-RSA-AES128-SHA",
+          "SignatureVersion": "SigV4",
+          "vpcEndpointId": "vpce-1111"
+        },
+        "awsRegion": "us-west-2",
+        "eventID": "1111",
+        "eventName": "SetQueueAttributes",
+        "eventSource": "s3.amazonaws.com",
+        "eventTime": "2019-01-01T00:00:00Z",
+        "eventType": "AwsApiCall",
+        "eventVersion": "1.05",
+        "recipientAccountId": "123456789012",
+        "requestID": "1111",
+        "requestParameters": {
+          "attributes": {
+            "Policy": ""
+          },
+          "queueUrl": "https://sqs.us-east-1.amazonaws.com/123456789012/example-queue"
+        },
+        "responseElements": null,
+        "sourceIPAddress": "111.111.111.111",
+        "userAgent": "Mozilla/2.0 (compatible; NEWT ActiveX; Win32)",
+        "userIdentity": {
+          "accessKeyId": "1111",
+          "accountId": "123456789012",
+          "arn": "arn:aws:sts::123456789012:assumed-role/example-role/example-user",
+          "principalId": "1111",
+          "sessionContext": {
+            "attributes": {
+              "creationDate": "2019-01-01T00:00:00Z",
+              "mfaAuthenticated": "true"
+            },
+            "sessionIssuer": {
+              "accountId": "123456789012",
+              "arn": "arn:aws:iam::123456789012:role/example-role",
+              "principalId": "1111",
+              "type": "Role",
+              "userName": "example-role"
+            }
+          },
+          "type": "AssumedRole"
+        },
+        "vpcEndpointId": "vpce-1111"
       }


### PR DESCRIPTION
### Background

Passing an empty string to json.loads, i.e. `json.loads('')`, will raise a `JSONDecodeError`

We want to be able to handle edge cases where the policy we are expecting to be populated is empty.

Specifying the default value for `dict.get` is a good practice, but does not handle cases where that policy is an empty string.

### Changes

* Generalized the return statement for `aws_resource_made_public.py` 
* Added in a check to ensure we don't attempt to call `json.loads` on an empty string

### Testing

* `make test`
