### PR TITLE
BUG: TypeError thrown by fnmatch.fnmatch

### DIFF
--- a/aws_cloudtrail_rules/aws_iam_user_recon_denied.py
+++ b/aws_cloudtrail_rules/aws_iam_user_recon_denied.py
@@ -1,5 +1,6 @@
 from fnmatch import fnmatch
 from ipaddress import ip_address
+from panther_base_helpers import deep_get
 
 # service/event patterns to monitor
 RECON_ACTIONS = {
@@ -15,7 +16,7 @@ def rule(event):
     # Filter events
     if event.get('errorCode') != 'AccessDenied':
         return False
-    if event['userIdentity'].get('type') != 'IAMUser':
+    if deep_get(event, 'userIdentity', 'type') != 'IAMUser':
         return False
 
     # Validate the request came from outside of AWS
@@ -26,8 +27,8 @@ def rule(event):
 
     # Pattern match this event to the recon actions
     for event_source, event_patterns in RECON_ACTIONS.items():
-        if event['eventSource'].startswith(event_source) and any(
-                fnmatch(event['eventName'], event_pattern)
+        if event.get('eventSource', '').startswith(event_source) and any(
+                fnmatch(event.get('eventName', ''), event_pattern)
                 for event_pattern in event_patterns):
             return True
     return False

--- a/aws_cloudtrail_rules/aws_iam_user_recon_denied.py
+++ b/aws_cloudtrail_rules/aws_iam_user_recon_denied.py
@@ -35,7 +35,7 @@ def rule(event):
 
 
 def dedup(event):
-    return event['userIdentity'].get('arn')
+    return deep_get(event, 'userIdentity', 'arn')
 
 
 def title(event):

--- a/data_models/gcp_data_model.py
+++ b/data_models/gcp_data_model.py
@@ -16,7 +16,7 @@ def get_event_type(event):
     for delta in get_binding_deltas(event):
         if delta['action'] == 'ADD':
             if any([
-                    fnmatch(delta.get('role'), admin_role_pattern)
+                    fnmatch(delta.get('role', ''), admin_role_pattern)
                     for admin_role_pattern in ADMIN_ROLES
             ]):
                 return event_type.ADMIN_ROLE_ASSIGNED

--- a/gcp_audit_rules/gcp_iam_admin_role_assigned.py
+++ b/gcp_audit_rules/gcp_iam_admin_role_assigned.py
@@ -14,7 +14,7 @@ def rule(event):
         if delta['action'] != 'ADD':
             continue
         if any([
-                fnmatch(delta.get('role'), admin_role_pattern)
+                fnmatch(delta.get('role', ''), admin_role_pattern)
                 for admin_role_pattern in ADMIN_ROLES
         ]):
             return True

--- a/gcp_audit_rules/gcp_iam_admin_role_assigned.py
+++ b/gcp_audit_rules/gcp_iam_admin_role_assigned.py
@@ -11,7 +11,7 @@ ADMIN_ROLES = {
 
 def rule(event):
     for delta in get_binding_deltas(event):
-        if delta['action'] != 'ADD':
+        if delta.get('action') != 'ADD':
             continue
         if any([
                 fnmatch(delta.get('role', ''), admin_role_pattern)
@@ -23,5 +23,6 @@ def rule(event):
 
 def title(event):
     return 'An admin role has been configured in GCP project {}'.format(
-        event['resource'].get('labels', {}).get('project_id',
-                                                '<PROJECT_NOT_FOUND>'))
+        deep_get(event, 'resource', 'labels', 'project_id', 
+            default='<PROJECT_NOT_FOUND>'))
+

--- a/osquery_rules/osquery_mac_osx_attacks_keyboard_events.py
+++ b/osquery_rules/osquery_mac_osx_attacks_keyboard_events.py
@@ -1,4 +1,5 @@
 from fnmatch import fnmatch
+from panther_base_helpers import deep_get
 
 # sip protects against writing malware into the paths below.
 # additional apps can be added to this list based on your environments.
@@ -16,17 +17,17 @@ APPROVED_APPLICATION_NAMES = {'Adobe Photoshop CC 2019'}
 
 
 def rule(event):
-    if 'Keyboard_Event_Taps' not in event['name']:
+    if 'Keyboard_Event_Taps' not in event.get('name', ''):
         return False
 
-    if event['action'] != 'added':
+    if event.get('action') != 'added':
         return False
 
-    process_path = event['columns'].get('path')
-    if not process_path:
+    process_path = deep_get(event, 'columns', 'path', default='')
+    if process_path == '':
         return False
 
-    if event['columns'].get('name') in APPROVED_APPLICATION_NAMES:
+    if deep_get(event, 'columns', 'name') in APPROVED_APPLICATION_NAMES:
         return False
 
     # Alert if the process is running outside any of the approved paths


### PR DESCRIPTION
### Background

The rule `Account Security Configuration Changed` raised a `TypeError('expected str, bytes or os.PathLike object, not NoneType')`

This appears to be related the `fnmatch` function calling `os.path.normcase` which throws an exception when it gets a `None` 

### Changes

* Added default values to files using fnmatch so we return a default empty string instead of a None type to avoid an exception by fnmatch.
