### PR TITLE
fix: get default value to empty dict to allow the absence of the poli…

### DIFF
--- a/aws_cloudtrail_rules/aws_resource_made_public.py
+++ b/aws_cloudtrail_rules/aws_resource_made_public.py
@@ -31,34 +31,34 @@ def rule(event):
 
     # ECR
     if event['eventName'] == 'SetRepositoryPolicy':
-        policy = parameters.get('policyText', '{}')
+        policy = parameters.get('policyText', {})
 
     # Elasticsearch
     if event['eventName'] in [
             'CreateElasticsearchDomain', 'UpdateElasticsearchDomainConfig'
     ]:
-        policy = parameters.get('accessPolicies', '{}')
+        policy = parameters.get('accessPolicies', {})
 
     # KMS
     if event['eventName'] in ['CreateKey', 'PutKeyPolicy']:
-        policy = parameters.get('policy', '{}')
+        policy = parameters.get('policy', {})
 
     # S3 Glacier
     if event['eventName'] == 'SetVaultAccessPolicy':
-        policy = deep_get(parameters, 'policy', 'policy', default='{}')
+        policy = deep_get(parameters, 'policy', 'policy', default={})
 
     # SNS & SQS
     if event['eventName'] in ['SetQueueAttributes', 'CreateTopic']:
-        policy = deep_get(parameters, 'attributes', 'Policy', default='{}')
+        policy = deep_get(parameters, 'attributes', 'Policy', default={})
 
     # SNS
     if event['eventName'] == 'SetTopicAttributes' and parameters.get(
             'attributeName', '') == 'Policy':
-        policy = parameters.get('attributeValue', '{}')
+        policy = parameters.get('attributeValue', {})
 
     # SecretsManager
     if event['eventName'] == 'PutResourcePolicy':
-        policy = parameters.get('resourcePolicy', '{}')
+        policy = parameters.get('resourcePolicy', {})
 
     if not policy:
         return False


### PR DESCRIPTION
…cy to evaluate to false

Regarding the aws_resource_made_public.py rule:

There are particular scenarios where a Policy key won't be present in the request for these parameters (for example - SetQueueAttributes will not always contain a policy: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html ). The current rule has logic to short circuit the check at line 63 
```python
if not policy:
    return False
```

In most of the dict.get() function calls - we are setting a default value of `'{}'` - which will always evaluate to true, as it is a string. Replaced these with `{}`, so that if the policy attribute doesn't exist - it will evaluate to false, and the above check will function as designed.

