### PR TITLE
feat: create okta api key rules

### DIFF
--- a/okta_rules/okta_api_key_created.py
+++ b/okta_rules/okta_api_key_created.py
@@ -1,0 +1,21 @@
+from panther_base_helpers import deep_get, okta_alert_context  # pylint: disable=import-error
+
+
+def rule(event):
+    return (event.get('eventType', None) == 'system.api_token.create' and
+            deep_get(event, 'outcome', 'result') == 'SUCCESS')
+
+def title(event):
+    title_str = '{} <{}> created a new API key [{}]'
+
+    target = event.get('target', [{}])
+    display_name = target[0].get('displayName', 'MISSING DISPLAY NAME') if target else ''
+    
+    return title_str.format(
+        deep_get(event, 'actor', 'displayName'),
+        deep_get(event, 'actor', 'alternateId'),
+        display_name)
+
+
+def alert_context(event):
+    return okta_alert_context(event)

--- a/okta_rules/okta_api_key_created.yml
+++ b/okta_rules/okta_api_key_created.yml
@@ -1,0 +1,52 @@
+AnalysisType: rule
+Filename: okta_api_key_created.py
+RuleID: Okta.APIKeyCreated
+DisplayName: Okta API Key Created
+Enabled: true
+LogTypes:
+  - Okta.SystemLog
+Tags:
+  - Identity & Access Management
+Severity: Info
+Description: A user created an API Key in Okta
+Reference: https://help.okta.com/en/prod/Content/Topics/Security/API.htm
+Runbook: Reach out to the user if needed to validate the activity. 
+SummaryAttributes:
+  - eventType
+  - severity
+  - displayMessage
+  - p_any_ip_addresses
+Tests:
+  -
+    Name: API Key Created
+    ExpectedResult: true
+    Log:
+      {
+        "uuid": "2a992f80-d1ad-4f62-900e-8c68bb72a21b",
+        "published": "2021-01-08 21:28:34.875",
+        "eventType": "system.api_token.create",
+        "version": "0",
+        "severity": "INFO",
+        "legacyEventType": "api.token.create",
+        "displayMessage": "Create API token",
+        "actor": {
+          "alternateId": "user@stedi.com",
+          "displayName": "Test User",
+          "id": "00u3q14ei6KUOm4Xi2p4",
+          "type": "User"
+        },
+        "outcome": {
+          "result": "SUCCESS"
+        },
+        "request": {},
+        "debugContext": {},
+        "target": [
+          {
+            "id": "00Tpki36zlWjhjQ1u2p4", 
+            "type": "Token",
+            "alternateId": "unknown",
+            "displayName": "test_key", 
+            "details": null
+          }
+        ]
+      }

--- a/okta_rules/okta_api_key_revoked.py
+++ b/okta_rules/okta_api_key_revoked.py
@@ -1,0 +1,21 @@
+from panther_base_helpers import deep_get, okta_alert_context  # pylint: disable=import-error
+
+
+def rule(event):
+    return (event.get('eventType', None) == 'system.api_token.revoke' and
+            deep_get(event, 'outcome', 'result') == 'SUCCESS')
+
+def title(event):
+    title_str = '{} <{}> revoked the API key [{}]'
+
+    target = event.get('target', [{}])
+    display_name = target[0].get('displayName', 'MISSING DISPLAY NAME') if target else ''
+    
+    return title_str.format(
+        deep_get(event, 'actor', 'displayName'),
+        deep_get(event, 'actor', 'alternateId'),
+        display_name)
+
+
+def alert_context(event):
+    return okta_alert_context(event)

--- a/okta_rules/okta_api_key_revoked.yml
+++ b/okta_rules/okta_api_key_revoked.yml
@@ -1,0 +1,52 @@
+AnalysisType: rule
+Filename: okta_api_key_revoked.py
+RuleID: Okta.APIKeyRevoked
+DisplayName: Okta API Key Revoked
+Enabled: true
+LogTypes:
+  - Okta.SystemLog
+Tags:
+  - Identity & Access Management
+Severity: Info
+Description: A user has revoked an API Key in Okta
+Reference: https://help.okta.com/en/prod/Content/Topics/Security/API.htm
+Runbook: Validate this action was authorized. 
+SummaryAttributes:
+  - eventType
+  - severity
+  - displayMessage
+  - p_any_ip_addresses
+Tests:
+  -
+    Name: API Key Revoked
+    ExpectedResult: true
+    Log:
+      {
+        "uuid": "2a992f80-d1ad-4f62-900e-8c68bb72a21b",
+        "published": "2021-01-08 21:28:34.875",
+        "eventType": "system.api_token.revoke",
+        "version": "0",
+        "severity": "INFO",
+        "legacyEventType": "api.token.revoke",
+        "displayMessage": "Revoke API token",
+        "actor": {
+          "alternateId": "user@stedi.com",
+          "displayName": "Test User",
+          "id": "00u3q14ei6KUOm4Xi2p4",
+          "type": "User"
+        },
+        "outcome": {
+          "result": "SUCCESS"
+        },
+        "request": {},
+        "debugContext": {},
+        "target": [
+          {
+            "id": "00Tpki36zlWjhjQ1u2p4", 
+            "type": "Token",
+            "alternateId": "unknown",
+            "displayName": "test_key", 
+            "details": null
+          }
+        ]
+      }


### PR DESCRIPTION
### Background

Creates two new rules for to detect the creation and revocation of Okta API keys.

### Changes

* Creates two new rules: okta_api_key_created and okta_api_key_revoked to check for these conditions. 

### Testing

* The associated yml files for each rule contain a test case for the logging source.
* The rules in question are running on our production system. 
