### PR TITLE
[aws] update docs runbook rules

### DIFF
--- a/aws_account_policies/aws_password_policy_complexity_guidelines.yml
+++ b/aws_account_policies/aws_password_policy_complexity_guidelines.yml
@@ -19,10 +19,9 @@ Reports:
     - 8.2.3
 Severity: High
 Description: >
-  This policy validates that the account password policy enforces the recommended
-  password complexity requirements.
+  This policy validates that the account password policy enforces the recommended password complexity requirements.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-account-password-policy-enforces-complexity-guidelines
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-account-password-policy-enforces-complexity-guidelines
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 Tests:
   -

--- a/aws_account_policies/aws_password_policy_password_age_limit.yml
+++ b/aws_account_policies/aws_password_policy_password_age_limit.yml
@@ -18,7 +18,7 @@ Description: >
   This policy validates that the account password policy enforces a maximum password age of 90
   days or less.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-account-password-policy-enforces-password-age-limit-of-90-days-or-less
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-account-password-policy-enforces-password-age-limit-of-90-days-or-less
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 Tests:
   -

--- a/aws_account_policies/aws_password_policy_password_reuse.yml
+++ b/aws_account_policies/aws_password_policy_password_reuse.yml
@@ -18,7 +18,7 @@ Description: >
   This policy validates that the account password policy prevents users from re-using previous
   passwords, and prevents password reuse for 24 or more prior passwords.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-account-password-policy-prevents-password-reuse
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-account-password-policy-prevents-password-reuse
 Reference: >
   https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 Tests:

--- a/aws_account_policies/aws_resource_minimum_tags.yml
+++ b/aws_account_policies/aws_resource_minimum_tags.yml
@@ -16,7 +16,7 @@ Severity: Low
 Description: >
   This policy ensures that applicable resources have a minimum number of tags set.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-resource-has-minimum-number-of-tags
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-resource-has-minimum-number-of-tags
 Reference: https://aws.amazon.com/answers/account-management/aws-tagging-strategies/
 Tests:
   -

--- a/aws_account_policies/aws_resource_required_tags.yml
+++ b/aws_account_policies/aws_resource_required_tags.yml
@@ -16,7 +16,7 @@ Severity: Low
 Description: >
   This policy ensures that AWS resources have specific tags, dependent on their resource type.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-resource-has-required-tags
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-resource-has-required-tags
 Reference: https://aws.amazon.com/answers/account-management/aws-tagging-strategies/
 Tests:
    -

--- a/aws_acm_policies/aws_acm_certificate_expiration.yml
+++ b/aws_acm_policies/aws_acm_certificate_expiration.yml
@@ -12,7 +12,7 @@ Severity: Medium
 Description: >
   When a certificate is 60 days away from expiration, ACM automatically attempts to renew it every hour.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-acm-certificate-is-not-expired
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-acm-certificate-is-not-expired
 Reference: https://docs.aws.amazon.com/acm/latest/userguide/troubleshooting-renewal.html
 Tests:
   -

--- a/aws_cloudtrail_policies/aws_cloudtrail_cloudwatch_logs.yml
+++ b/aws_cloudtrail_policies/aws_cloudtrail_cloudwatch_logs.yml
@@ -16,7 +16,7 @@ Description: >
   CloudTrail supports sending data and management events to CloudWatch Logs. This setup can be
   used for real-time processing of all CloudTrail data events.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-cloudtrail-trails-integrated-with-cloudwatch-logs
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-cloudtrail-trails-integrated-with-cloudwatch-logs
 Reference: >
   https://docs.aws.amazon.com/awscloudtrail/latest/userguide/send-cloudtrail-events-to-cloudwatch-logs.html
 Tests:

--- a/aws_cloudtrail_policies/aws_cloudtrail_enabled.yml
+++ b/aws_cloudtrail_policies/aws_cloudtrail_enabled.yml
@@ -18,7 +18,7 @@ Description: >
   This policy ensures that CloudTrail is enabled in all regions and at least one of them has
   management (control plane) operations logged.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-cloudtrail-enabled-in-all-regions
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-cloudtrail-enabled-in-all-regions
 Reference: >
   https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-user-guide.html
 Tests:

--- a/aws_cloudtrail_policies/aws_cloudtrail_log_encryption.yml
+++ b/aws_cloudtrail_policies/aws_cloudtrail_log_encryption.yml
@@ -15,7 +15,7 @@ Severity: Medium
 Description: >
   This policy validates that CloudTrail Logs are encrypted at rest with customer managed KMS key.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-cloudtrail-logs-encrypted-using-kms-cmk
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-cloudtrail-logs-encrypted-using-kms-cmk
 Reference: >
   https://docs.aws.amazon.com/awscloudtrail/latest/userguide/encrypting-cloudtrail-log-files-with-aws-kms.html
 Tests:

--- a/aws_cloudtrail_policies/aws_cloudtrail_log_validation.yml
+++ b/aws_cloudtrail_policies/aws_cloudtrail_log_validation.yml
@@ -17,7 +17,7 @@ Severity: Medium
 Description: >
   This policy ensures that CloudTrail logs have file integrity validation enabled.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-cloudtrail-log-validation-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-cloudtrail-log-validation-enabled
 Reference: >
   https://amzn.to/2MMgE6W
 Tests:

--- a/aws_cloudtrail_policies/aws_cloudtrail_s3_bucket_access_logging.yml
+++ b/aws_cloudtrail_policies/aws_cloudtrail_s3_bucket_access_logging.yml
@@ -16,7 +16,7 @@ Description: >
   This policy validates that the bucket receiving CloudTrail Logs is configured with
   S3 Access Logging. This audits all creation, modification, or deletion to CloudTrail audit logs.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-cloudtrail-s3-bucket-has-access-logging-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-cloudtrail-s3-bucket-has-access-logging-enabled
 Reference: >
   https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerLogs.html
 # Unit testing not supported for policies that might network calls

--- a/aws_cloudtrail_policies/aws_cloudtrail_s3_bucket_public.yml
+++ b/aws_cloudtrail_policies/aws_cloudtrail_s3_bucket_public.yml
@@ -15,7 +15,7 @@ Severity: High
 Description: >
   This policy validates that CloudTrail S3 buckets are not publicly accessible.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-cloudtrail-logs-s3-bucket-not-publicly-accessible
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-cloudtrail-logs-s3-bucket-not-publicly-accessible
 Reference: >
   https://docs.aws.amazon.com/AmazonS3/latest/user-guide/block-public-access.html
 # Unit testing not supported for policies that might network calls

--- a/aws_cloudtrail_rules/aws_cloudtrail_created.yml
+++ b/aws_cloudtrail_rules/aws_cloudtrail_created.yml
@@ -14,7 +14,7 @@ Reports:
 Severity: Info
 Description: >
   A CloudTrail Trail was created, updated, or enabled.
-Runbook: https://docs.runpanther.io/log-analysis/rules/built-in-rule-runbooks/aws-cloudtrail-modified
+Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-cloudtrail-modified
 Reference: https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_Operations.html
 SummaryAttributes:
   - eventName

--- a/aws_cloudtrail_rules/aws_cloudtrail_stopped.yml
+++ b/aws_cloudtrail_rules/aws_cloudtrail_stopped.yml
@@ -15,7 +15,7 @@ Reports:
 Severity: Medium
 Description: >
   A CloudTrail Trail was modified.
-Runbook: https://docs.runpanther.io/log-analysis/rules/built-in-rule-runbooks/aws-cloudtrail-modified
+Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-cloudtrail-modified
 Reference: https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_Operations.html
 SummaryAttributes:
   - eventName

--- a/aws_cloudtrail_rules/aws_console_login_failed.yml
+++ b/aws_cloudtrail_rules/aws_console_login_failed.yml
@@ -17,7 +17,7 @@ Reports:
 Severity: Low
 Description: >
   A console login failed.
-Runbook: https://docs.runpanther.io/log-analysis/rules/built-in-rule-runbooks/aws-console-login-failed
+Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-console-login-failed
 Reference: https://amzn.to/3aMSmTd
 SummaryAttributes:
   - userAgent

--- a/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
+++ b/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
@@ -15,7 +15,7 @@ Reports:
     - 3.2
 Severity: High
 Description: An AWS console login was made without multi-factor authentication.
-Runbook: https://docs.runpanther.io/log-analysis/rules/built-in-rule-runbooks/aws-console-login-without-mfa
+Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-console-login-without-mfa
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html
 SummaryAttributes:
   - userAgent

--- a/aws_cloudtrail_rules/aws_console_root_login_failed.yml
+++ b/aws_cloudtrail_rules/aws_console_root_login_failed.yml
@@ -17,7 +17,7 @@ Reports:
     - 3.6
 Severity: High
 Description: A Root console login failed.
-Runbook: https://docs.runpanther.io/log-analysis/rules/built-in-rule-runbooks/aws-console-login-failed
+Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-console-login-failed
 Reference: https://amzn.to/3aMSmTd
 SummaryAttributes:
   - userAgent

--- a/aws_cloudtrail_rules/aws_ec2_gateway_modified.yml
+++ b/aws_cloudtrail_rules/aws_ec2_gateway_modified.yml
@@ -13,7 +13,7 @@ Reports:
     - 3.12
 Severity: Info
 Description: An EC2 Network Gateway was modified.
-Runbook: https://docs.runpanther.io/log-analysis/rules/built-in-rule-runbooks/aws-ec2-gateway-modified
+Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-ec2-gateway-modified
 Reference: reference.link
 SummaryAttributes:
   - eventName

--- a/aws_cloudtrail_rules/aws_ec2_network_acl_modified.yml
+++ b/aws_cloudtrail_rules/aws_ec2_network_acl_modified.yml
@@ -13,7 +13,7 @@ Reports:
     - 3.11
 Severity: Info
 Description: An EC2 Network ACL was modified.
-Runbook: https://docs.runpanther.io/log-analysis/rules/built-in-rule-runbooks/aws-ec2-network-acl-modified
+Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-ec2-network-acl-modified
 Reference: reference.link
 SummaryAttributes:
   - eventName

--- a/aws_cloudtrail_rules/aws_ec2_route_table_modified.yml
+++ b/aws_cloudtrail_rules/aws_ec2_route_table_modified.yml
@@ -12,7 +12,7 @@ Reports:
     - 3.13
 Severity: Info
 Description: An EC2 Route Table was modified.
-Runbook: https://docs.runpanther.io/log-analysis/rules/built-in-rule-runbooks/aws-ec2-route-table-modified
+Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-ec2-route-table-modified
 Reference: reference.link
 SummaryAttributes:
   - eventName

--- a/aws_cloudtrail_rules/aws_ec2_security_group_modified.yml
+++ b/aws_cloudtrail_rules/aws_ec2_security_group_modified.yml
@@ -14,7 +14,7 @@ Reports:
 Severity: Info
 Description: >
   An EC2 Security Group was modified.
-Runbook: https://docs.runpanther.io/log-analysis/rules/built-in-rule-runbooks/aws-ec2-securitygroup-modified
+Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-ec2-securitygroup-modified
 Reference: reference.link
 SummaryAttributes:
   - eventName

--- a/aws_cloudtrail_rules/aws_ec2_vpc_modified.yml
+++ b/aws_cloudtrail_rules/aws_ec2_vpc_modified.yml
@@ -13,7 +13,7 @@ Reports:
     - 3.14
 Severity: Info
 Description: An EC2 VPC was modified.
-Runbook: https://docs.runpanther.io/log-analysis/rules/built-in-rule-runbooks/aws-ec2-vpc-modified
+Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-ec2-vpc-modified
 Reference: reference.link
 SummaryAttributes:
   - eventName

--- a/aws_cloudtrail_rules/aws_iam_policy_modified.yml
+++ b/aws_cloudtrail_rules/aws_iam_policy_modified.yml
@@ -14,7 +14,7 @@ Reports:
 Severity: Info
 Description: >
   An IAM Policy was changed.
-Runbook: https://docs.runpanther.io/log-analysis/rules/built-in-rule-runbooks/aws-iam-policy-modified
+Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-iam-policy-modified
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html
 SummaryAttributes:
   - eventName

--- a/aws_cloudtrail_rules/aws_kms_cmk_loss.yml
+++ b/aws_cloudtrail_rules/aws_kms_cmk_loss.yml
@@ -14,7 +14,7 @@ Reports:
 Severity: Info
 Description: >
   A KMS Customer Managed Key was disabled or scheduled for deletion. This could potentially lead to permanent loss of encrypted data.
-Runbook: https://docs.runpanther.io/log-analysis/rules/built-in-rule-runbooks/aws-kms-cmk-loss
+Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-kms-cmk-loss
 Reference: https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html
 SummaryAttributes:
   - eventName

--- a/aws_cloudtrail_rules/aws_s3_bucket_policy_modified.yml
+++ b/aws_cloudtrail_rules/aws_s3_bucket_policy_modified.yml
@@ -14,7 +14,7 @@ Reports:
 Severity: Info
 Description: >
   An S3 Bucket was modified.
-Runbook: https://docs.runpanther.io/log-analysis/rules/built-in-rule-runbooks/aws-s3-bucket-policy-modified
+Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-s3-bucket-policy-modified
 Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html
 SummaryAttributes:
   - eventName

--- a/aws_cloudtrail_rules/aws_unauthorized_api_call.yml
+++ b/aws_cloudtrail_rules/aws_unauthorized_api_call.yml
@@ -13,7 +13,7 @@ Reports:
     - 3.1
 Severity: Info
 Description: An unauthorized AWS API call was made
-Runbook: https://docs.runpanther.io/log-analysis/rules/built-in-rule-runbooks/aws-unauthorized-api-call
+Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-unauthorized-api-call
 Reference: https://amzn.to/3aOukaA
 SummaryAttributes:
   - eventName

--- a/aws_config_policies/aws_config_global_resources.yml
+++ b/aws_config_policies/aws_config_global_resources.yml
@@ -13,7 +13,7 @@ Description: >
   You can have AWS Config record supported types of global resources, such as
   IAM users, groups, roles, and customer managed policies.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-config-is-enabled-for-global-resources
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-config-is-enabled-for-global-resources
 Reference: https://amzn.to/2MO8xXM
 Tests:
   -

--- a/aws_dynamodb_policies/aws_dynamodb_autoscaling.yml
+++ b/aws_dynamodb_policies/aws_dynamodb_autoscaling.yml
@@ -14,7 +14,7 @@ Description: >
   traffic patterns. This enables a table to increase its provisioned read and write capacity
   to handle sudden increases in traffic
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-dynamodb-table-has-autoscaling-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-dynamodb-table-has-autoscaling-enabled
 Reference: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/AutoScaling.html
 Tests:
   -

--- a/aws_dynamodb_policies/aws_dynamodb_autoscaling_configuration.yml
+++ b/aws_dynamodb_policies/aws_dynamodb_autoscaling_configuration.yml
@@ -15,7 +15,7 @@ Description: >
   traffic patterns. This enables a table to increase its provisioned read and write capacity
   to handle sudden increases in traffic
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-dynamodb-table-has-autoscaling-targets-configured
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-dynamodb-table-has-autoscaling-targets-configured
 Reference: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/AutoScaling.html
 Tests:
   -

--- a/aws_dynamodb_policies/aws_dynamodb_table_encryption.yml
+++ b/aws_dynamodb_policies/aws_dynamodb_table_encryption.yml
@@ -16,7 +16,7 @@ Description: >
   Table encryption provides an additional layer of data protection by securing from
   unauthorized access to the underlying storage
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-dynamodb-table-has-encryption-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-dynamodb-table-has-encryption-enabled
 Reference: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/EncryptionAtRest.html
 Tests:
   -

--- a/aws_ec2_policies/aws_ec2_ami_approved_host.yml
+++ b/aws_ec2_policies/aws_ec2_ami_approved_host.yml
@@ -12,7 +12,7 @@ Severity: Low
 Description: >
   Checks that AWS EC2 AMI's are only launched on approved dedicated hosts.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-ec2-ami-launched-on-approved-host
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-ec2-ami-launched-on-approved-host
 Reference: https://aws.amazon.com/ec2/dedicated-hosts/
 Tests:
   -

--- a/aws_ec2_policies/aws_ec2_ami_approved_instance_type.yml
+++ b/aws_ec2_policies/aws_ec2_ami_approved_instance_type.yml
@@ -12,7 +12,7 @@ Severity: Low
 Description: >
   This policy ensures that the EC2 instance is running with an instance type approved for its AMI.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-ec2-ami-launched-on-approved-instance-type
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-ec2-ami-launched-on-approved-instance-type
 Reference: https://aws.amazon.com/ec2/instance-types/
 Tests:
   -

--- a/aws_ec2_policies/aws_ec2_ami_approved_tenancy.yml
+++ b/aws_ec2_policies/aws_ec2_ami_approved_tenancy.yml
@@ -12,7 +12,7 @@ Severity: Low
 Description: >
   This policy ensures that the EC2 instance was launched with a tenancy approved for its AMI.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-ec2-ami-launched-with-approved-tenancy
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-ec2-ami-launched-with-approved-tenancy
 Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html
 Tests:
   -

--- a/aws_ec2_policies/aws_ec2_instance_approved_ami.yml
+++ b/aws_ec2_policies/aws_ec2_instance_approved_ami.yml
@@ -12,7 +12,7 @@ Severity: High
 Description: >
   This policy ensures the given EC2 instance is running an AMI from the approved list of AMI's.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-ec2-instance-running-on-approved-ami
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-ec2-instance-running-on-approved-ami
 Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html
 Tests:
   -

--- a/aws_ec2_policies/aws_ec2_instance_approved_host.yml
+++ b/aws_ec2_policies/aws_ec2_instance_approved_host.yml
@@ -12,7 +12,7 @@ Severity: Low
 Description: >
   This policy ensures the given EC2 Instance is running on an approved dedicated host.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-ec2-instance-running-on-approved-host
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-ec2-instance-running-on-approved-host
 Reference: https://aws.amazon.com/ec2/dedicated-hosts/
 Tests:
   -

--- a/aws_ec2_policies/aws_ec2_instance_approved_instance_type.yml
+++ b/aws_ec2_policies/aws_ec2_instance_approved_instance_type.yml
@@ -12,7 +12,7 @@ Severity: Low
 Description: >
   This policy ensures that the EC2 instance is running on one of the approved instance types.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-ec2-instance-running-on-approved-instance-type
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-ec2-instance-running-on-approved-instance-type
 Reference: https://aws.amazon.com/ec2/instance-types/
 Tests:
   -

--- a/aws_ec2_policies/aws_ec2_instance_approved_tenancy.yml
+++ b/aws_ec2_policies/aws_ec2_instance_approved_tenancy.yml
@@ -12,7 +12,7 @@ Severity: Low
 Description: >
   This policy ensures the given EC2 Instance is running with an approved tenancy option. The possible tenancy options are dedicated, host, and default.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-ec2-instance-running-with-approved-tenancy
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-ec2-instance-running-with-approved-tenancy
 Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html
 Tests:
   -

--- a/aws_ec2_policies/aws_ec2_instance_approved_vpc.yml
+++ b/aws_ec2_policies/aws_ec2_instance_approved_vpc.yml
@@ -12,7 +12,7 @@ Severity: High
 Description: >
   This policy ensures that the given EC2 Instance is running in an approved VPC.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-ec2-instance-running-in-approved-vpc
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-ec2-instance-running-in-approved-vpc
 Reference: https://aws.amazon.com/vpc/
 Tests:
   -

--- a/aws_ec2_policies/aws_ec2_instance_detailed_monitoring.yml
+++ b/aws_ec2_policies/aws_ec2_instance_detailed_monitoring.yml
@@ -12,7 +12,7 @@ Severity: Low
 Description: >
   This policy ensures that the AWS Instance has Detailed Monitoring Enabled
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-ec2-instance-has-detailed-monitoring-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-ec2-instance-has-detailed-monitoring-enabled
 Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html
 Tests:
   -

--- a/aws_ec2_policies/aws_ec2_instance_ebs_optimization.yml
+++ b/aws_ec2_policies/aws_ec2_instance_ebs_optimization.yml
@@ -12,7 +12,7 @@ Severity: Low
 Description: >
   This policy ensures EBS optimization is enabled for the given EC2 instance, if applicable.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-ec2-instance-is-ebs-optimized
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-ec2-instance-is-ebs-optimized
 Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-optimized.html
 Tests:
   -

--- a/aws_ec2_policies/aws_ec2_volume_encryption.yml
+++ b/aws_ec2_policies/aws_ec2_volume_encryption.yml
@@ -12,7 +12,7 @@ Severity: High
 Description: >
   You can encrypt both the boot and data volumes of an EC2 instance.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-ec2-instance-volumes-are-encrypted
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-ec2-instance-volumes-are-encrypted
 Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
 Tests:
   -

--- a/aws_ec2_policies/aws_ec2_volume_snapshot_encrypted.yml
+++ b/aws_ec2_policies/aws_ec2_volume_snapshot_encrypted.yml
@@ -12,7 +12,7 @@ Severity: High
 Description: >
   You can encrypt the snapshot of an EC2 volume to protect against accidental data loss
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-ec2-volume-is-encrypted
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-ec2-volume-is-encrypted
 Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
 Tests:
   -

--- a/aws_elb_policies/aws_application_load_balancer_web_acl.yml
+++ b/aws_elb_policies/aws_application_load_balancer_web_acl.yml
@@ -13,7 +13,7 @@ Severity: High
 Description: >
   This policy validates that all application load balancers have an associated Web ACl to enforce protections against various web attacks.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-application-load-balancer-has-web-acl
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-application-load-balancer-has-web-acl
 Reference: https://aws.amazon.com/blogs/aws/aws-web-application-firewall-waf-for-application-load-balancers/
 Tests:
   -

--- a/aws_guardduty_policies/aws_guardduty_enabled.yml
+++ b/aws_guardduty_policies/aws_guardduty_enabled.yml
@@ -12,7 +12,7 @@ Severity: High
 Description: >
   GuardDuty is a threat detection service that continuously monitors for malicious activity and unauthorized behavior.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-guardduty-is-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-guardduty-is-enabled
 Reference: https://aws.amazon.com/guardduty/
 Tests:
   -

--- a/aws_guardduty_policies/aws_guardduty_master_account.yml
+++ b/aws_guardduty_policies/aws_guardduty_master_account.yml
@@ -13,7 +13,7 @@ Severity: High
 Description: >
   Ensure that all GuardDuty logs are sending into a single Master account. This is a best practice for centralizing detection logic and useful data during an investigation.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-guardduty-is-logging-to-a-master-account
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-guardduty-is-logging-to-a-master-account
 Reference: https://aws.amazon.com/guardduty/
 Tests:
   -

--- a/aws_iam_policies/aws_access_key_rotation.yml
+++ b/aws_iam_policies/aws_access_key_rotation.yml
@@ -18,7 +18,7 @@ Description: >
   Rotating access keys will reduce the window of opportunity for an access key that
   is associated with a compromised or terminated account to be used.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-access-keys-rotated-every-90-days
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-access-keys-rotated-every-90-days
 Reference: >
   https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
 Tests:

--- a/aws_iam_policies/aws_access_key_unused.yml
+++ b/aws_iam_policies/aws_access_key_unused.yml
@@ -17,7 +17,7 @@ Severity: Low
 Description: >
   This policy validates that IAM user access keys are used at least once every 90 days.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-access-keys-used-every-90-days
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-access-keys-used-every-90-days
 Reference: >
   https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
 Tests:

--- a/aws_iam_policies/aws_access_keys_at_account_creation.yml
+++ b/aws_iam_policies/aws_access_keys_at_account_creation.yml
@@ -18,7 +18,7 @@ Description: >
   created during account creation. This results in excess keys being generated,
   and unnecessary management work in auditing and rotating these keys.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-access-keys-are-not-created-at-account-creation
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-access-keys-are-not-created-at-account-creation
 Reference: >
   https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
 Tests:

--- a/aws_iam_policies/aws_iam_group_users.yml
+++ b/aws_iam_policies/aws_iam_group_users.yml
@@ -13,7 +13,7 @@ Description: >
   This Policy ensures that all IAM groups have at least one IAM user. If they are vacant,
   they should be deleted.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-iam-group-has-users
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-iam-group-has-users
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 Tests:
   -

--- a/aws_iam_policies/aws_iam_policy_administrative_privileges.yml
+++ b/aws_iam_policies/aws_iam_policy_administrative_privileges.yml
@@ -16,7 +16,7 @@ Description: >
   This policy validates that there are no IAM policies that grant full administrative
   privileges to IAM users or groups.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-iam-policy-does-not-grant-full-administrative-privileges
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-iam-policy-does-not-grant-full-administrative-privileges
 Reference: >
   https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 Tests:

--- a/aws_iam_policies/aws_iam_policy_assigned_to_user.yml
+++ b/aws_iam_policies/aws_iam_policy_assigned_to_user.yml
@@ -19,7 +19,7 @@ Description: >
   This policy validates that there are no IAM policies assigned directly to users.
   Best practice suggests assigning to an IAM group and placing users within that group.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-iam-policy-not-assigned-directly-to-user
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-iam-policy-not-assigned-directly-to-user
 Reference: https://amzn.to/2Pss7Ln
 Tests:
   -

--- a/aws_iam_policies/aws_iam_policy_blacklist.yml
+++ b/aws_iam_policies/aws_iam_policy_blacklist.yml
@@ -15,7 +15,7 @@ Severity: Medium
 Description: >
   This detects the usage of highly permissive IAM Policies that should only be assigned to a small number of users, roles, or groups.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-iam-policy-blacklist-is-respected
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-iam-policy-blacklist-is-respected
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html
 Tests:
   -

--- a/aws_iam_policies/aws_iam_policy_role_mapping.yml
+++ b/aws_iam_policies/aws_iam_policy_role_mapping.yml
@@ -13,7 +13,7 @@ Severity: High
 Description: >
   This policy validates that policies that have been explicitly configured to be set to certain roles are still attached to those roles.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-iam-policy-role-mapping-is-respected
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-iam-policy-role-mapping-is-respected
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html 
 Tests:
   -

--- a/aws_iam_policies/aws_iam_user_mfa.yml
+++ b/aws_iam_policies/aws_iam_user_mfa.yml
@@ -18,7 +18,7 @@ Severity: High
 Description: >
   This policy validates that all AWS IAM users with access to the AWS Console have Multi-Factor Authentication (MFA) enabled.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-iam-user-has-mfa-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-iam-user-has-mfa-enabled
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable.html
 Tests:
   -

--- a/aws_iam_policies/aws_password_unused.yml
+++ b/aws_iam_policies/aws_password_unused.yml
@@ -17,7 +17,7 @@ Severity: Low
 Description: >
   This policy validates IAM users with console passwords have logged in within the past 90 days.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-password-used-every-90-days
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-password-used-every-90-days
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 Tests:
   -

--- a/aws_iam_policies/aws_root_account_access_keys.yml
+++ b/aws_iam_policies/aws_root_account_access_keys.yml
@@ -18,7 +18,7 @@ Severity: Critical
 Description: >
   This policy validates that no programmatic access keys exist for the root account.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-root-account-has-no-access-keys
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-root-account-has-no-access-keys
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 Tests:
   -

--- a/aws_iam_policies/aws_root_account_hardware_mfa.yml
+++ b/aws_iam_policies/aws_root_account_hardware_mfa.yml
@@ -18,7 +18,7 @@ Severity: High
 Description: >
   This policy validates that a hardware MFA device is in use for access to the root account.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-root-account-has-mfa-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-root-account-has-mfa-enabled
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 Tests:
   -

--- a/aws_iam_policies/aws_root_account_mfa.yml
+++ b/aws_iam_policies/aws_root_account_mfa.yml
@@ -18,7 +18,7 @@ Severity: Critical
 Description: >
   This policy validates that Multi Factor Authentication (MFA) is required for access to the root account.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-root-account-has-mfa-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-root-account-has-mfa-enabled
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
 Tests:
   -

--- a/aws_kms_policies/aws_cmk_key_rotation.yml
+++ b/aws_kms_policies/aws_cmk_key_rotation.yml
@@ -17,7 +17,7 @@ Severity: Low
 Description: >
   This policy validates that customer master keys (CMKs) have automatic key rotation enabled.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-customer-created-cmk-has-key-rotation-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-customer-created-cmk-has-key-rotation-enabled
 Reference: >
   https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html
 Tests:

--- a/aws_rds_policies/aws_rds_instance_backup.yml
+++ b/aws_rds_policies/aws_rds_instance_backup.yml
@@ -13,7 +13,7 @@ Description: >
   This Policy ensures that RDS Instances have Backups enabled. Backups are an important aspect
   of disaster recovery that can protect sensitive data from destruction.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-rds-instance-has-backups-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-rds-instance-has-backups-enabled
 Reference: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html
 Tests:
   -

--- a/aws_rds_policies/aws_rds_instance_encryption.yml
+++ b/aws_rds_policies/aws_rds_instance_encryption.yml
@@ -15,7 +15,7 @@ Severity: High
 Description: >
   This policy validates that RDS instances have encryption enabled.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-rds-instance-has-storage-encrypted
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-rds-instance-has-storage-encrypted
 Reference: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html
 Tests:
   -

--- a/aws_rds_policies/aws_rds_instance_high_availability.yml
+++ b/aws_rds_policies/aws_rds_instance_high_availability.yml
@@ -13,7 +13,7 @@ Description: >
   This Policy ensures that RDS Instances have are running in High Availability mode to provide
   redundancy in the event of an operational failure. For Aurora, storage is replicated across all the Availability Zones and doesn't require this setting.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-rds-instance-has-high-availability-configured
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-rds-instance-has-high-availability-configured
 Reference: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html
 Tests:
   -

--- a/aws_rds_policies/aws_rds_instance_public_access.yml
+++ b/aws_rds_policies/aws_rds_instance_public_access.yml
@@ -12,7 +12,7 @@ Severity: High
 Description: >
   This Policy checks that an RDS Instance is not accessible from the public internet.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-rds-instance-is-not-publicly-accessible
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-rds-instance-is-not-publicly-accessible
 Reference: https://docs.aws.amazon.com/en_pv/AmazonRDS/latest/UserGuide/USER_VPC.Scenarios.html
 Tests:
   -

--- a/aws_rds_policies/aws_rds_instance_snapshot_public_access.yml
+++ b/aws_rds_policies/aws_rds_instance_snapshot_public_access.yml
@@ -12,7 +12,7 @@ Severity: Critical
 Description: >
   This policy validates that RDS Instance snapshots are not publicly restorable. This would allow anyone to restore an old version of your database and have full access to its contents.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-rds-instance-snapshots-are-not-publicly-accessible
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-rds-instance-snapshots-are-not-publicly-accessible
 Reference: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html
 Tests:
   -

--- a/aws_redshift_policies/aws_redshift_cluster_encryption.yml
+++ b/aws_redshift_policies/aws_redshift_cluster_encryption.yml
@@ -15,7 +15,7 @@ Severity: High
 Description: >
   This policy validates that Redshift Clusters have encryption enabled.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-redshift-cluster-has-encryption-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-redshift-cluster-has-encryption-enabled
 Reference: https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-db-encryption.html
 Tests:
   -

--- a/aws_redshift_policies/aws_redshift_cluster_logging.yml
+++ b/aws_redshift_policies/aws_redshift_cluster_logging.yml
@@ -12,7 +12,7 @@ Severity: Medium
 Description: >
   This policy validates that Redshift Cluster have logging enabled. This includes audit logs.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-redshift-cluster-has-logging-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-redshift-cluster-has-logging-enabled
 Reference: https://aws.amazon.com/premiumsupport/knowledge-center/logs-redshift-database-cluster/
 Tests:
   -

--- a/aws_redshift_policies/aws_redshift_cluster_maintenance_window.yml
+++ b/aws_redshift_policies/aws_redshift_cluster_maintenance_window.yml
@@ -12,7 +12,7 @@ Severity: Info
 Description: >
   This policy validates that Redshift Clusters have the correct preferred maintenance window configured.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-redshift-cluster-has-correct-preferred-maintenance-window
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-redshift-cluster-has-correct-preferred-maintenance-window
 Reference: https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html#rs-maintenance-windows
 Tests:
   -

--- a/aws_redshift_policies/aws_redshift_cluster_snapshot_retention.yml
+++ b/aws_redshift_policies/aws_redshift_cluster_snapshot_retention.yml
@@ -12,7 +12,7 @@ Severity: Medium
 Description: >
   This policy validates that Redshift Clusters have sufficient snapshot retention periods, so that snapshots are not lost before they are needed.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-redshift-cluster-has-sufficient-snapshot-retention-period
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-redshift-cluster-has-sufficient-snapshot-retention-period
 Reference: https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-snapshots.html
 Tests:
   -

--- a/aws_redshift_policies/aws_redshift_cluster_version_upgrade.yml
+++ b/aws_redshift_policies/aws_redshift_cluster_version_upgrade.yml
@@ -15,7 +15,7 @@ Severity: Low
 Description: >
   This policy validates that Redshift Clusters automatically perform upgrades during scheduled maintenance windows.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-redshift-cluster-allows-version-upgrades
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-redshift-cluster-allows-version-upgrades
 Reference: https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html
 Tests:
   -

--- a/aws_s3_policies/aws_s3_bucket_action_restrictions.yml
+++ b/aws_s3_policies/aws_s3_bucket_action_restrictions.yml
@@ -16,7 +16,7 @@ Severity: Medium
 Description: >
   Ensures that the S3 bucket policy does not allow any action on the bucket, in accordance with the principal of least privilege.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-s3-bucket-policy-restricts-allowed-actions
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-s3-bucket-policy-restricts-allowed-actions
 Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html
 Tests:
   -

--- a/aws_s3_policies/aws_s3_bucket_encryption.yml
+++ b/aws_s3_policies/aws_s3_bucket_encryption.yml
@@ -16,7 +16,7 @@ Severity: High
 Description: >
   Ensures that the S3 bucket has encryption enabled.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-s3-encryption-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-s3-encryption-enabled
 Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html
 Tests:
   -

--- a/aws_s3_policies/aws_s3_bucket_lifecycle_configuration.yml
+++ b/aws_s3_policies/aws_s3_bucket_lifecycle_configuration.yml
@@ -17,7 +17,7 @@ Severity: Low
 Description: >
   Verifies that the S3 Bucket Object Lifecycle configuration expires data within 90 and 365 days.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-s3-bucket-lifecycle-configuration-expires-data
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-s3-bucket-lifecycle-configuration-expires-data
 Reference: https://amzn.to/2visoXr
 Tests:
   -

--- a/aws_s3_policies/aws_s3_bucket_logging.yml
+++ b/aws_s3_policies/aws_s3_bucket_logging.yml
@@ -13,7 +13,7 @@ Severity: Low
 Description: >
   Ensures that a logging policy is set for the S3 bucket.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-s3-logging-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-s3-logging-enabled
 Reference: https://blog.runpanther.io/s3-bucket-access-logging/
 Tests:
   -

--- a/aws_s3_policies/aws_s3_bucket_mfa_delete.yml
+++ b/aws_s3_policies/aws_s3_bucket_mfa_delete.yml
@@ -12,7 +12,7 @@ Severity: Low
 Description: >
   Ensures that MFA delete is enabled for a bucket so that all objects can only be deleted by users authenticated with MFA.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-s3-bucket-has-mfa-delete-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-s3-bucket-has-mfa-delete-enabled
 Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMFADelete.html
 Tests:
   -

--- a/aws_s3_policies/aws_s3_bucket_name_dns_compliance.yml
+++ b/aws_s3_policies/aws_s3_bucket_name_dns_compliance.yml
@@ -11,7 +11,7 @@ Severity: Info
 Description: >
   This policy validates that the AWS S3 bucket name is DNS compliant.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-s3-bucket-name-has-no-periods
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-s3-bucket-name-has-no-periods
 Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
 Tests:
   -

--- a/aws_s3_policies/aws_s3_bucket_policy_allow_with_not_principal.yml
+++ b/aws_s3_policies/aws_s3_bucket_policy_allow_with_not_principal.yml
@@ -12,7 +12,7 @@ Severity: High
 Description: >
   Prevents the use of a 'Not' principal in conjunction with an allow effect in an S3 bucket policy, which would allow global access for the resource besides the principals specified.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-s3-bucket-policy-does-not-use-allow-with-not-principal
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-s3-bucket-policy-does-not-use-allow-with-not-principal
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notprincipal.html
 Tests:
   -

--- a/aws_s3_policies/aws_s3_bucket_principal_restrictions.yml
+++ b/aws_s3_policies/aws_s3_bucket_principal_restrictions.yml
@@ -16,7 +16,7 @@ Severity: High
 Description: >
   Ensures the S3 bucket access policy does not allow any principal, in accordance with the principal of least privilege.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-s3-bucket-policy-restricts-principal
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-s3-bucket-policy-restricts-principal
 Reference: https://aws.amazon.com/premiumsupport/knowledge-center/secure-s3-resources/
 Tests:
   -

--- a/aws_s3_policies/aws_s3_bucket_public_access_block.yml
+++ b/aws_s3_policies/aws_s3_bucket_public_access_block.yml
@@ -15,7 +15,7 @@ Severity: Medium
 Description: >
   Ensures that a Public Access Block Configuration is set for the given S3 bucket.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-s3-public-access-block-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-s3-public-access-block-enabled
 Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html
 Tests:
   -

--- a/aws_s3_policies/aws_s3_bucket_public_read.yml
+++ b/aws_s3_policies/aws_s3_bucket_public_read.yml
@@ -16,7 +16,7 @@ Severity: High
 Description: >
   Ensures that the S3 bucket is not publicly readable.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-s3-bucket-not-publicly-readable
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-s3-bucket-not-publicly-readable
 Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html
 Tests:
   -

--- a/aws_s3_policies/aws_s3_bucket_public_write.yml
+++ b/aws_s3_policies/aws_s3_bucket_public_write.yml
@@ -15,7 +15,7 @@ Reports:
 Severity: Critical
 Description: Ensures that the S3 bucket is not publicly writeable.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-s3-bucket-not-publicly-writeable
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-s3-bucket-not-publicly-writeable
 Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html
 Tests:
   -

--- a/aws_s3_policies/aws_s3_bucket_secure_access.yml
+++ b/aws_s3_policies/aws_s3_bucket_secure_access.yml
@@ -16,7 +16,7 @@ Severity: Low
 Description: >
   Ensures access to S3 buckets is forced to use a secure (HTTPS) connection.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-s3-bucket-policy-enforces-secure-access
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-s3-bucket-policy-enforces-secure-access
 Reference: https://aws.amazon.com/premiumsupport/knowledge-center/secure-s3-resources/
 Tests:
   -

--- a/aws_s3_policies/aws_s3_bucket_versioning.yml
+++ b/aws_s3_policies/aws_s3_bucket_versioning.yml
@@ -16,7 +16,7 @@ Severity: Low
 Description: >
   Checks that object versioning is enabled in the S3 bucket.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-s3-bucket-versioning-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-s3-bucket-versioning-enabled
 Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html
 Tests:
   -

--- a/aws_vpc_policies/aws_security_group_administrative_ingress.yml
+++ b/aws_vpc_policies/aws_security_group_administrative_ingress.yml
@@ -17,7 +17,7 @@ Description: >
   This policy validates that AWS Security Groups don't allow unrestricted inbound traffic on
   port 3389 or 22, ports commonly used for the remote access protocols RDP and SSH respectively.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-securitygroup-restricts-ingress-on-administrative-ports
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-securitygroup-restricts-ingress-on-administrative-ports
 Reference: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html
 Tests:
   -

--- a/aws_vpc_policies/aws_vpc_default_security_restrictions.yml
+++ b/aws_vpc_policies/aws_vpc_default_security_restrictions.yml
@@ -17,7 +17,7 @@ Severity: Low
 Description: >
   This policy validates that the default Security Group for a given AWS VPC is restricting all inbound and outbound traffic.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-vpc-default-security-group-restricts-all-traffic
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-vpc-default-security-group-restricts-all-traffic
 Reference: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html
 #Tests:
 #  -

--- a/aws_vpc_policies/aws_vpc_flow_logs.yml
+++ b/aws_vpc_policies/aws_vpc_flow_logs.yml
@@ -15,7 +15,7 @@ Severity: Medium
 Description: >
   This policy validates that AWS VPCs (Virtual Private Clouds) have network flow logging enabled.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-vpc-flow-logging-enabled
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-vpc-flow-logging-enabled
 Reference: https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html
 Tests:
   -

--- a/aws_waf_policies/aws_waf_rule_ordering.yml
+++ b/aws_waf_policies/aws_waf_rule_ordering.yml
@@ -14,7 +14,7 @@ Severity: High
 Description: >
   This policy validates that all WAF's have the correct rule ordering. Incorrect rule ordering could lead to less restrictive rules being matched and allowing traffic through before more restrictive rules that should have blocked the traffic.
 Runbook: >
-  https://docs.runpanther.io/cloud-security/built-in-policy-runbooks/aws-waf-has-correct-rule-ordering
+  https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-waf-has-correct-rule-ordering
 Reference: https://docs.aws.amazon.com/waf/latest/developerguide/web-acl-rules.html
 Tests:
   -


### PR DESCRIPTION
### Background

To reduce friction, I'm going to keep the runbooks in our docs and just adjust the link once this PR merges:

https://github.com/panther-labs/panther-enterprise/pull/2259

### Changes

* Use a new URL for runbooks

### Testing

* Tested in the Gitbook branch in the browser
