### PR TITLE
Fix make managed-schemas.zip to have correct archive comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ managed-schemas:
 
 managed-schemas.zip: managed-schemas
 	rm -f dist/managed-schemas.zip; \
-	if [ -v "$(release)" ]; then \
+	if [ "$(release)" != "" ]; then \
 		echo "$(release)"; \
 	else \
 		echo "$(last_release)-$(rev)"; \


### PR DESCRIPTION
### Background

There was a mistake in the Makefile that zips the managed schemas, regarding the comment put into the archive to mark the release version. It was only possible to catch with a properly-formatted release tag (i.e. `vX.Y.X`) and was not caught during testing with the `vX.Y.Z-test` tags used during development.

### Changes

* Fix Makefile to put the correct release version in the archive comment

### Testing

* built with `make managed-schemas.zip`, added asset to `v1.15.0` release and updated managed schemas on panther through PAT