### PR TITLE
Tweak makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ deps-update:
 
 lint:
 	bandit -r $(dirs) --skip B101  # allow assert statements in tests
-	pylint $(dirs) --disable=missing-docstring,bad-continuation,duplicate-code,import-error,W0511 --max-line-length=100
+	pylint $(dirs) --disable=missing-docstring,duplicate-code,import-error,fixme --max-line-length=100
 
 venv:
 	virtualenv -p python3.7 venv


### PR DESCRIPTION
### Background

With some recent changes to our linter, we can update what things we ignore in the linting step.

### Changes

* Stop ignoring `bad-continuation` errors
* Use human readable name for skipping `fixme` errors

### Testing

* Ran `make lint` locally
