### PR TITLE
Format all schema YAML files with prettier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ venv:
 fmt:
 	pipenv run isort --profile=black $(dirs)
 	pipenv run black --line-length=100 $(dirs)
+	prettier -w schemas schemas/**/*.yml
 
 install:
 	pip3 install --user --upgrade pip

--- a/schemas/logs/apache/access_combined.yml
+++ b/schemas/logs/apache/access_combined.yml
@@ -6,37 +6,37 @@ description: Apache HTTP server access logs using the 'combined' format
 referenceURL: https://httpd.apache.org/docs/current/logs.html#combined
 version: 0
 fields:
-- name: remote_host_ip_address
-  description: This is the IP address of the client (remote host) which made the request to the server. If HostnameLookups is set to On, then the server will try to determine the hostname and log it in place of the IP address.
-  type: string
-- name: client_identity_rfc_1413
-  description: The RFC 1413 identity of the client determined by identd on the clients machine.
-  type: string
-- name: request_user
-  description: The userid of the person requesting the document as determined by HTTP authentication.
-  type: string
-- name: request_time
-  description: The time that the request was received.
-  type: timestamp
-  timeFormat: rfc3339
-- name: request_method
-  description: The HTTP request method
-  type: string
-- name: request_uri
-  description: The HTTP request URI
-  type: string
-- name: request_protocol
-  description: The HTTP request protocol
-  type: string
-- name: response_status
-  description: The HTTP status of the response
-  type: smallint
-- name: response_size
-  description: The size of the HTTP response in bytes
-  type: bigint
-- name: user_agent
-  description: The User-Agent HTTP header
-  type: string
-- name: referer
-  description: The Referer HTTP header
-  type: string
+  - name: remote_host_ip_address
+    description: This is the IP address of the client (remote host) which made the request to the server. If HostnameLookups is set to On, then the server will try to determine the hostname and log it in place of the IP address.
+    type: string
+  - name: client_identity_rfc_1413
+    description: The RFC 1413 identity of the client determined by identd on the clients machine.
+    type: string
+  - name: request_user
+    description: The userid of the person requesting the document as determined by HTTP authentication.
+    type: string
+  - name: request_time
+    description: The time that the request was received.
+    type: timestamp
+    timeFormat: rfc3339
+  - name: request_method
+    description: The HTTP request method
+    type: string
+  - name: request_uri
+    description: The HTTP request URI
+    type: string
+  - name: request_protocol
+    description: The HTTP request protocol
+    type: string
+  - name: response_status
+    description: The HTTP status of the response
+    type: smallint
+  - name: response_size
+    description: The size of the HTTP response in bytes
+    type: bigint
+  - name: user_agent
+    description: The User-Agent HTTP header
+    type: string
+  - name: referer
+    description: The Referer HTTP header
+    type: string

--- a/schemas/logs/aws/alb.yml
+++ b/schemas/logs/aws/alb.yml
@@ -65,10 +65,10 @@ fields:
     description: A User-Agent string that identifies the client that originated the request. The string consists of one or more product identifiers, product[/version]. If the string is longer than 8 KB, it is truncated.
     type: string
   - name: sslCipher
-    description: '[HTTPS listener] The SSL cipher. This value is set to NULL if the listener is not an HTTPS listener.'
+    description: "[HTTPS listener] The SSL cipher. This value is set to NULL if the listener is not an HTTPS listener."
     type: string
   - name: sslProtocol
-    description: '[HTTPS listener] The SSL protocol. This value is set to NULL if the listener is not an HTTPS listener.'
+    description: "[HTTPS listener] The SSL protocol. This value is set to NULL if the listener is not an HTTPS listener."
     type: string
   - name: targetGroupArn
     description: The Amazon Resource Name (ARN) of the target group.
@@ -77,10 +77,10 @@ fields:
     description: The contents of the X-Amzn-Trace-Id header.
     type: string
   - name: domainName
-    description: '[HTTPS listener] The SNI domain provided by the client during the TLS handshake. This value is set to NULL if the client doesn''t support SNI or the domain doesn''t match a certificate and the default certificate is presented to the client.'
+    description: "[HTTPS listener] The SNI domain provided by the client during the TLS handshake. This value is set to NULL if the client doesn't support SNI or the domain doesn't match a certificate and the default certificate is presented to the client."
     type: string
   - name: chosenCertArn
-    description: '[HTTPS listener] The ARN of the certificate presented to the client. This value is set to session-reused if the session is reused. This value is set to NULL if the listener is not an HTTPS listener.'
+    description: "[HTTPS listener] The ARN of the certificate presented to the client. This value is set to session-reused if the session is reused. This value is set to NULL if the listener is not an HTTPS listener."
     type: string
   - name: matchedRulePriority
     description: The priority value of the rule that matched the request. If a rule matched, this is a value from 1 to 50,000. If no rule matched and the default action was taken, this value is set to 0. If an error occurs during rules evaluation, it is set to -1. For any other error, it is set to NULL.

--- a/schemas/logs/aws/aurora_my_sql_audit.yml
+++ b/schemas/logs/aws/aurora_my_sql_audit.yml
@@ -27,7 +27,7 @@ fields:
     type: int
   - name: operation
     required: true
-    description: 'The recorded action type. Possible values are: CONNECT, QUERY, READ, WRITE, CREATE, ALTER, RENAME, and DROP.'
+    description: "The recorded action type. Possible values are: CONNECT, QUERY, READ, WRITE, CREATE, ALTER, RENAME, and DROP."
     type: string
   - name: database
     description: The active database, as set by the USE command.

--- a/schemas/logs/aws/cloud_trail.yml
+++ b/schemas/logs/aws/cloud_trail.yml
@@ -42,14 +42,14 @@ fields:
     isEventTime: true
   - name: eventType
     required: true
-    description: 'Identifies the type of event that generated the event record. This can be the one of the following values: AwsApiCall, AwsServiceEvent, AwsConsoleSignIn'
+    description: "Identifies the type of event that generated the event record. This can be the one of the following values: AwsApiCall, AwsServiceEvent, AwsConsoleSignIn"
     type: string
   - name: eventVersion
     required: true
     description: The version of the log event format.
     type: string
   - name: managementEvent
-    description: 'A Boolean value that identifies whether the event is a management event. managementEvent is shown in an event record if eventVersion is 1.06 or higher, and the event type is one of the following: AwsApiCall, AwsConsoleAction, AwsConsoleSignIn,  AwsServiceEvent'
+    description: "A Boolean value that identifies whether the event is a management event. managementEvent is shown in an event record if eventVersion is 1.06 or higher, and the event type is one of the following: AwsApiCall, AwsConsoleAction, AwsConsoleSignIn,  AwsServiceEvent"
     type: boolean
   - name: readOnly
     description: Identifies whether this operation is a read-only operation.

--- a/schemas/logs/aws/cloud_trail_insight.yml
+++ b/schemas/logs/aws/cloud_trail_insight.yml
@@ -26,7 +26,7 @@ fields:
     type: string
   - name: eventType
     required: true
-    description: 'Identifies the type of event that generated the event record. This can be the one of the following values: AwsApiCall, AwsServiceEvent, AwsConsoleSignIn'
+    description: "Identifies the type of event that generated the event record. This can be the one of the following values: AwsApiCall, AwsServiceEvent, AwsConsoleSignIn"
     type: string
   - name: recipientAccountId
     description: Represents the account ID that received this event. The recipientAccountID may be different from the CloudTrail userIdentity Element accountId. This can occur in cross-account resource access.

--- a/schemas/logs/aws/s_3_server_access.yml
+++ b/schemas/logs/aws/s_3_server_access.yml
@@ -78,7 +78,7 @@ fields:
     description: The endpoint used to connect to Amazon S3.
     type: string
   - name: tlsVersion
-    description: 'The Transport Layer Security (TLS) version negotiated by the client. The value is one of following: TLSv1, TLSv1.1, TLSv1.2; or NULL if TLS wasn''t used.'
+    description: "The Transport Layer Security (TLS) version negotiated by the client. The value is one of following: TLSv1, TLSv1.1, TLSv1.2; or NULL if TLS wasn't used."
     type: string
   - name: additionalFields
     description: The remaining columns in the record as an array.

--- a/schemas/logs/aws/tests/cloud_trail_digest_tests.yml
+++ b/schemas/logs/aws/tests/cloud_trail_digest_tests.yml
@@ -60,7 +60,7 @@ result: |
         ],
         "p_log_type": "AWS.CloudTrailDigest"
   	}
-results: [ ]
+results: []
 logType: AWS.CloudTrailDigest
 ---
 name: CloudTrail Digest logs first record
@@ -95,5 +95,5 @@ result: |
       "p_event_time": "2020-04-21T13:28:23Z",
       "p_log_type": "AWS.CloudTrailDigest"
   }
-results: [ ]
+results: []
 logType: AWS.CloudTrailDigest

--- a/schemas/logs/aws/tests/cloud_trail_tests.yml
+++ b/schemas/logs/aws/tests/cloud_trail_tests.yml
@@ -74,7 +74,7 @@ result: |
     "p_any_aws_account_ids": ["777777777777","888888888888"],
     "p_log_type": "AWS.CloudTrail"
   }
-results: [ ]
+results: []
 logType: AWS.CloudTrail
 ---
 name: cloud_trail_decrypt
@@ -176,5 +176,5 @@ result: |
     "p_any_ip_addresses": ["1.2.3.4"],
     "p_log_type": "AWS.CloudTrail"
   }
-results: [ ]
+results: []
 logType: AWS.CloudTrail

--- a/schemas/logs/aws/tests/vpc_dns_tests.yml
+++ b/schemas/logs/aws/tests/vpc_dns_tests.yml
@@ -117,5 +117,5 @@ result: |
     "p_any_ip_addresses": ["192.0.2.15", "192.0.2.44", "198.51.100.6", "203.0.113.8", "203.0.113.9"],
     "p_any_domain_names": ["api.example.com", "faß.com", "foo@bar.com", "static-someip.rackbank.com"]
   }
-results: [ ]
+results: []
 logType: AWS.VPCDns

--- a/schemas/logs/aws/tests/waf_web_acl_tests.yml
+++ b/schemas/logs/aws/tests/waf_web_acl_tests.yml
@@ -75,7 +75,7 @@ result: |
       "p_any_trace_ids": ["1-5ffd8ed7-1c9649c448649a15241ac25a"],
       "p_log_type": "AWS.WAFWebACL"
     }
-results: [ ]
+results: []
 logType: AWS.WAFWebACL
 ---
 name: waf_web_acl_rule_exclusion
@@ -178,7 +178,7 @@ result: |
     "p_any_trace_ids": ["1-5ffd8516-7f16578f3b0262c41c10f7a9"],
     "p_log_type": "AWS.WAFWebACL"
   }
-results: [ ]
+results: []
 logType: AWS.WAFWebACL
 ---
 name: waf_web_acl_non_terminating_rule
@@ -311,7 +311,7 @@ result: |
       "p_any_trace_ids": ["1-5ffd88c2-174f31437530757342a794dd"],
       "p_log_type": "AWS.WAFWebACL"
   }
-results: [ ]
+results: []
 logType: AWS.WAFWebACL
 ---
 name: waf_web_acl_regular_rule_block_action
@@ -399,7 +399,7 @@ result: |
      "p_any_trace_ids": ["1-5ffd6549-297a96021598ace405676378"],
      "p_log_type": "AWS.WAFWebACL"
   }
-results: [ ]
+results: []
 logType: AWS.WAFWebACL
 ---
 name: waf_web_acl_rate_based_rule_block_action
@@ -496,7 +496,7 @@ result: |
       "p_any_trace_ids": ["1-5ffc731b-3b2ebfc665f7de91566b9199"],
       "p_log_type": "AWS.WAFWebACL"
   }
-results: [ ]
+results: []
 logType: AWS.WAFWebACL
 ---
 name: waf_web_rule_group_block_action
@@ -617,5 +617,5 @@ result: |
     "p_any_trace_ids": ["1-5ffc73eb-280dd24d31bf31450ebdb518"],
     "p_log_type": "AWS.WAFWebACL"
   }
-results: [ ]
+results: []
 logType: AWS.WAFWebACL

--- a/schemas/logs/aws/vpc_flow.yml
+++ b/schemas/logs/aws/vpc_flow.yml
@@ -47,11 +47,11 @@ fields:
     type: timestamp
     timeFormat: rfc3339
   - name: action
-    description: 'The action that is associated with the traffic. ACCEPT: The recorded traffic was permitted by the security groups or network ACLs. REJECT: The recorded traffic was not permitted by the security groups or network ACLs.'
+    description: "The action that is associated with the traffic. ACCEPT: The recorded traffic was permitted by the security groups or network ACLs. REJECT: The recorded traffic was not permitted by the security groups or network ACLs."
     type: string
   - name: status
     required: true
-    description: 'The logging status of the flow log. OK: Data is logging normally to the chosen destinations. NODATA: There was no network traffic to or from the network interface during the capture window. SKIPDATA: Some flow log records were skipped during the capture window. This may be because of an internal capacity constraint, or an internal error.'
+    description: "The logging status of the flow log. OK: Data is logging normally to the chosen destinations. NODATA: There was no network traffic to or from the network interface during the capture window. SKIPDATA: Some flow log records were skipped during the capture window. This may be because of an internal capacity constraint, or an internal error."
     type: string
   - name: vpcId
     description: The ID of the VPC that contains the network interface for which the traffic is recorded.
@@ -63,10 +63,10 @@ fields:
     description: The ID of the instance that's associated with network interface for which the traffic is recorded, if the instance is owned by you. Returns a '-' symbol for a requester-managed network interface; for example, the network interface for a NAT gateway.
     type: string
   - name: tcpFlags
-    description: 'The bitmask value for the following TCP flags: SYN: 2, SYN-ACK: 18, FIN: 1, RST: 4. ACK is reported only when it''s accompanied with SYN. TCP flags can be OR-ed during the aggregation interval. For short connections, the flags might be set on the same line in the flow log record, for example, 19 for SYN-ACK and FIN, and 3 for SYN and FIN.'
+    description: "The bitmask value for the following TCP flags: SYN: 2, SYN-ACK: 18, FIN: 1, RST: 4. ACK is reported only when it's accompanied with SYN. TCP flags can be OR-ed during the aggregation interval. For short connections, the flags might be set on the same line in the flow log record, for example, 19 for SYN-ACK and FIN, and 3 for SYN and FIN."
     type: int
   - name: trafficType
-    description: 'The type of traffic: IPv4, IPv6, or EFA.'
+    description: "The type of traffic: IPv4, IPv6, or EFA."
     type: string
   - name: pktSrcAddr
     description: The packet-level (original) source IP address of the traffic. Use this field with the srcaddr field to distinguish between the IP address of an intermediate layer through which traffic flows, and the original source IP address of the traffic. For example, when traffic flows through a network interface for a NAT gateway, or where the IP address of a pod in Amazon EKS is different from the IP address of the network interface of the instance node on which the pod is running.

--- a/schemas/logs/aws/waf_web_acl.yml
+++ b/schemas/logs/aws/waf_web_acl.yml
@@ -8,7 +8,7 @@ version: 0
 fields:
   - name: action
     required: true
-    description: 'The action applied by WAF. Possible values for a terminating rule: ALLOW and BLOCK. COUNT is not a valid value for a terminating rule.'
+    description: "The action applied by WAF. Possible values for a terminating rule: ALLOW and BLOCK. COUNT is not a valid value for a terminating rule."
     type: string
   - name: formatVersion
     description: The format version for the log.
@@ -67,7 +67,7 @@ fields:
     description: The source ID. This field shows the ID of the associated resource.
     type: string
   - name: httpSourceName
-    description: 'The source of the request. Possible values: CF for Amazon CloudFront, APIGW for Amazon API Gateway, ALB for Application Load Balancer, and APPSYNC for AWS AppSync.'
+    description: "The source of the request. Possible values: CF for Amazon CloudFront, APIGW for Amazon API Gateway, ALB for Application Load Balancer, and APPSYNC for AWS AppSync."
     type: string
   - name: nonTerminatingMatchingRules
     description: The list of non-terminating rules in the rule group that match the request. These are always COUNT rules (non-terminating rules that match).
@@ -105,7 +105,7 @@ fields:
       type: object
       fields:
         - name: limitKey
-          description: 'The field that AWS WAF uses to determine if requests are likely arriving from a single source and thus subject to rate monitoring. Possible value: IP.'
+          description: "The field that AWS WAF uses to determine if requests are likely arriving from a single source and thus subject to rate monitoring. Possible value: IP."
           type: string
         - name: limitValue
           description: The IP address used by a rate-based rule to aggregate requests for rate limiting. If a request contains an IP address that isn't valid, the limitvalue is INVALID.
@@ -224,7 +224,7 @@ fields:
           element:
             type: string
   - name: terminatingRuleType
-    description: 'The type of rule that terminated the request. Possible values: RATE_BASED, REGULAR, GROUP, and MANAGED_RULE_GROUP.'
+    description: "The type of rule that terminated the request. Possible values: RATE_BASED, REGULAR, GROUP, and MANAGED_RULE_GROUP."
     type: string
   - name: timestamp
     required: true

--- a/schemas/logs/cloudflare/firewall.yml
+++ b/schemas/logs/cloudflare/firewall.yml
@@ -24,7 +24,7 @@ fields:
     indicators:
       - ip
   - name: ClientIPClass
-    description: 'The classification of the visitor''s IP address, possible values are: unknown | clean | badHost | searchEngine | whitelist | greylist | monitoringService |securityScanner | noRecord | scan | backupService | mobilePlatform | tor'
+    description: "The classification of the visitor's IP address, possible values are: unknown | clean | badHost | searchEngine | whitelist | greylist | monitoringService |securityScanner | noRecord | scan | backupService | mobilePlatform | tor"
     type: string
   - name: ClientRefererHost
     description: The referer host
@@ -76,7 +76,7 @@ fields:
     description: HTTP response status code returned to browser
     type: smallint
   - name: Kind
-    description: 'The kind of event, currently only possible values are: firewall'
+    description: "The kind of event, currently only possible values are: firewall"
     type: string
   - name: MatchIndex
     description: Rules match index in the chain

--- a/schemas/logs/cloudflare/http_request.yml
+++ b/schemas/logs/cloudflare/http_request.yml
@@ -195,7 +195,7 @@ fields:
     description: Action taken by the WAF, if triggered
     type: string
   - name: WAFFlags
-    description: 'Additional configuration flags: simulate (0x1) | null'
+    description: "Additional configuration flags: simulate (0x1) | null"
     type: string
   - name: WAFMatchedVar
     description: The full name of the most-recently matched variable

--- a/schemas/logs/cloudflare/tests/firewall_tests.yml
+++ b/schemas/logs/cloudflare/tests/firewall_tests.yml
@@ -72,7 +72,7 @@ result: |
     "p_any_ip_addresses": ["128.127.128.127"],
     "p_any_trace_ids": ["originator-ray-id", "ray-id"]
   }
-results: [ ]
+results: []
 logType: Cloudflare.Firewall
 ---
 name: firewall required fields only
@@ -86,5 +86,5 @@ result: |
     "p_log_type": "Cloudflare.Firewall",
     "p_event_time":"2020-09-17T18:00:00Z"
   }
-results: [ ]
+results: []
 logType: Cloudflare.Firewall

--- a/schemas/logs/cloudflare/tests/http_request_tests.yml
+++ b/schemas/logs/cloudflare/tests/http_request_tests.yml
@@ -133,7 +133,7 @@ result: |
   	"p_any_ip_addresses": ["127.0.0.1", "127.127.127.127", "128.128.128.128"],
   	"p_any_trace_ids": ["parent-ray-id", "ray-id"]
   }
-results: [ ]
+results: []
 logType: Cloudflare.HttpRequest
 ---
 name: httprequest required fields only
@@ -147,5 +147,5 @@ result: |
     "p_log_type": "Cloudflare.HttpRequest",
     "p_event_time":"2020-09-17T18:00:00Z"
   }
-results: [ ]
+results: []
 logType: Cloudflare.HttpRequest

--- a/schemas/logs/cloudflare/tests/spectrum_tests.yml
+++ b/schemas/logs/cloudflare/tests/spectrum_tests.yml
@@ -71,7 +71,7 @@ result: |
   	"p_event_time":"2020-09-17T18:49:46.194526741Z",
   	"p_any_ip_addresses": ["127.127.127.127", "128.128.128.128"]
   }
-results: [ ]
+results: []
 logType: Cloudflare.Spectrum
 ---
 name: spectrum required fields only
@@ -85,5 +85,5 @@ result: |
     "p_log_type": "Cloudflare.Spectrum",
     "p_event_time":"2020-09-17T18:00:00Z"
   }
-results: [ ]
+results: []
 logType: Cloudflare.Spectrum

--- a/schemas/logs/crowdstrike/aid_master.yml
+++ b/schemas/logs/crowdstrike/aid_master.yml
@@ -14,7 +14,7 @@ fields:
     isEventTime: true
   - name: AgentLoadFlags
     required: true
-    description: 'Whether the sensor loaded during or after the Windows host''s boot process. Example values: 0, 1'
+    description: "Whether the sensor loaded during or after the Windows host's boot process. Example values: 0, 1"
     type: int
   - name: AgentLocalTime
     required: true
@@ -68,7 +68,7 @@ fields:
     description: Build number used as part of the ConfigID.
     type: string
   - name: event_platform
-    description: 'The platform the sensor is running on. Example values: ''Win'', ''Lin'', ''Mac''.'
+    description: "The platform the sensor is running on. Example values: 'Win', 'Lin', 'Mac'."
     type: string
   - name: FirstSeen
     description: The first time the sensor was seen by the CrowdStrike cloud in epoch format.
@@ -81,13 +81,13 @@ fields:
     description: The organizational unit of the host as seen by the sensor (defined by system admin).
     type: string
   - name: PointerSize
-    description: 'The processor architecture (in decimal, non-hex format): ''4'' for 32-bit, ''8'' for 64-bit, or ''none'' for unknown.'
+    description: "The processor architecture (in decimal, non-hex format): '4' for 32-bit, '8' for 64-bit, or 'none' for unknown."
     type: string
   - name: ProductType
-    description: 'The type of product (in decimal, non-hex format). Example values: ''1'' (Workstation), ''2'' (Domain Controller), ''3'' (Server).'
+    description: "The type of product (in decimal, non-hex format). Example values: '1' (Workstation), '2' (Domain Controller), '3' (Server)."
     type: string
   - name: ServicePackMajor
-    description: 'The major version # of the OS Service Pack (in decimal, non-hex format).'
+    description: "The major version # of the OS Service Pack (in decimal, non-hex format)."
     type: string
   - name: SiteName
     description: The site name of the domain to which the host is joined (defined by system admin).

--- a/schemas/logs/crowdstrike/group_identity.yml
+++ b/schemas/logs/crowdstrike/group_identity.yml
@@ -99,7 +99,7 @@ fields:
     type: string
   - name: AuthenticationId
     required: true
-    description: 'Values: INVALID_LUID (0), NETWORK_SERVICE (996), LOCAL_SERVICE (997), SYSTEM (999), RESERVED_LUID_MAX (1000)'
+    description: "Values: INVALID_LUID (0), NETWORK_SERVICE (996), LOCAL_SERVICE (997), SYSTEM (999), RESERVED_LUID_MAX (1000)"
     type: int
   - name: UserPrincipal
     required: true

--- a/schemas/logs/crowdstrike/managed_assets.yml
+++ b/schemas/logs/crowdstrike/managed_assets.yml
@@ -2,7 +2,7 @@ schema: Crowdstrike.ManagedAssets
 parser:
   native:
     name: Crowdstrike.ManagedAssets
-description: 'Sensor and Host information provided by Falcon Insight (Network Information: IP Address, LAN/Ethernet Interface, Gateway Address, MAC Address)'
+description: "Sensor and Host information provided by Falcon Insight (Network Information: IP Address, LAN/Ethernet Interface, Gateway Address, MAC Address)"
 referenceURL: https://developer.crowdstrike.com/crowdstrike/docs/falcon-data-replicator-guide#section-managedassets
 version: 0
 fields:

--- a/schemas/logs/crowdstrike/user_identity.yml
+++ b/schemas/logs/crowdstrike/user_identity.yml
@@ -87,7 +87,7 @@ fields:
     type: string
   - name: AuthenticationId
     required: true
-    description: 'Values: INVALID_LUID (0), NETWORK_SERVICE (996), LOCAL_SERVICE (997), SYSTEM (999), RESERVED_LUID_MAX (1000)'
+    description: "Values: INVALID_LUID (0), NETWORK_SERVICE (996), LOCAL_SERVICE (997), SYSTEM (999), RESERVED_LUID_MAX (1000)"
     type: int
   - name: UserPrincipal
     required: true
@@ -124,7 +124,7 @@ fields:
     description: AuthenticationPackage field
     type: string
   - name: LogonType
-    description: 'Values: INTERACTIVE (2), NETWORK (3), BATCH (4), SERVICE (5), PROXY (6), UNLOCK (7), NETWORK_CLEARTEXT (8), CACHED_UNLOCK (13), NEW_CREDENTIALS (9), REMOTE_INTERACTIVE (10), CACHED_INTERACTIVE (11), CACHED_REMOTE_INTERACTIVE (12)'
+    description: "Values: INTERACTIVE (2), NETWORK (3), BATCH (4), SERVICE (5), PROXY (6), UNLOCK (7), NETWORK_CLEARTEXT (8), CACHED_UNLOCK (13), NEW_CREDENTIALS (9), REMOTE_INTERACTIVE (10), CACHED_INTERACTIVE (11), CACHED_REMOTE_INTERACTIVE (12)"
     type: int
   - name: LogonTime
     description: LogonTime field
@@ -134,7 +134,7 @@ fields:
     description: LogonServer field
     type: string
   - name: UserFlags
-    description: 'Values: LOGON_OPTIMIZED (0x4000), LOGON_WINLOGON (0x8000), LOGON_PKINIT (0x10000), LOGON_NOT_OPTIMIZED (0x20000)'
+    description: "Values: LOGON_OPTIMIZED (0x4000), LOGON_WINLOGON (0x8000), LOGON_PKINIT (0x10000), LOGON_NOT_OPTIMIZED (0x20000)"
     type: bigint
   - name: PasswordLastSet
     description: PasswordLastSet field
@@ -152,5 +152,5 @@ fields:
     indicators:
       - trace_id
   - name: UserLogonFlags
-    description: 'Values: LOGON_IS_SYNTHETIC (0x00000001), USER_IS_ADMIN (0x00000002), USER_IS_LOCAL (0x00000004), USER_IS_BUILT_IN (0x00000008), USER_IDENTITY_MISSING (0x00000010)'
+    description: "Values: LOGON_IS_SYNTHETIC (0x00000001), USER_IS_ADMIN (0x00000002), USER_IS_LOCAL (0x00000004), USER_IS_BUILT_IN (0x00000008), USER_IDENTITY_MISSING (0x00000010)"
     type: int

--- a/schemas/logs/crowdstrike/user_info.yml
+++ b/schemas/logs/crowdstrike/user_info.yml
@@ -18,11 +18,11 @@ fields:
     type: string
   - name: AccountType
     required: true
-    description: 'The type of account set for the user: ''Domain User'', ''Domain Administrator'', ''Local User''.'
+    description: "The type of account set for the user: 'Domain User', 'Domain Administrator', 'Local User'."
     type: string
   - name: DomainUser
     required: true
-    description: 'Indicates if the user''s credentials are part of a domain controller: ''Yes'', ''No''.'
+    description: "Indicates if the user's credentials are part of a domain controller: 'Yes', 'No'."
     type: string
   - name: UserName
     required: true
@@ -38,7 +38,7 @@ fields:
     description: The host that was last logged into the system.
     type: string
   - name: LocalAdminAccess
-    description: 'Indicates whether a local user is an admin: ''Yes'', ''No''.'
+    description: "Indicates whether a local user is an admin: 'Yes', 'No'."
     type: string
   - name: LoggedOnHostCount
     description: The number of hosts logged in at _time.
@@ -51,7 +51,7 @@ fields:
     type: timestamp
     timeFormat: unix
   - name: LogonType
-    description: 'Values defined as follows, INTERACTIVE: The security principal is logging on interactively, NETWORK: The security principal is logging on using a network, TERMINAL SERVER: The security principal has logged in via a terminal server.'
+    description: "Values defined as follows, INTERACTIVE: The security principal is logging on interactively, NETWORK: The security principal is logging on using a network, TERMINAL SERVER: The security principal has logged in via a terminal server."
     type: string
   - name: monthsincereset
     description: The number of months since this user's password was last reset.

--- a/schemas/logs/g_suite/reports.yml
+++ b/schemas/logs/g_suite/reports.yml
@@ -98,7 +98,7 @@ fields:
                 element:
                   type: bigint
               - name: messageValue
-                description: 'Nested parameter value pairs associated with this parameter. Complex value type for a parameter are returned as a list of parameter values. For example, the address parameter may have a value as [{parameter: [{name: city, value: abc}]}]'
+                description: "Nested parameter value pairs associated with this parameter. Complex value type for a parameter are returned as a list of parameter values. For example, the address parameter may have a value as [{parameter: [{name: city, value: abc}]}]"
                 type: json
               - name: multiMessageValue
                 description: List of messageValue objects.

--- a/schemas/logs/g_suite/tests/reports_tests.yml
+++ b/schemas/logs/g_suite/tests/reports_tests.yml
@@ -135,5 +135,5 @@ result: |
    "p_any_emails": ["test@runpanther.io"],
    "p_log_type": "GSuite.Reports"
   }
-results: [ ]
+results: []
 logType: GSuite.Reports

--- a/schemas/logs/gcp/audit_log.yml
+++ b/schemas/logs/gcp/audit_log.yml
@@ -134,7 +134,7 @@ fields:
     description: The AuditLog payload
     type: object
     fields:
-      - name: '@type'
+      - name: "@type"
         required: true
         description: The type of payload
         type: string

--- a/schemas/logs/git_lab/tests/api_tests.yml
+++ b/schemas/logs/git_lab/tests/api_tests.yml
@@ -61,5 +61,5 @@ result: |
     "p_any_domain_names": ["localhost"],
     "p_log_type": "GitLab.API"
   }
-results: [ ]
+results: []
 logType: GitLab.API

--- a/schemas/logs/git_lab/tests/audit_tests.yml
+++ b/schemas/logs/git_lab/tests/audit_tests.yml
@@ -31,5 +31,5 @@ result: |
     "p_event_time": "2018-10-17T17:38:22.523Z",
     "p_log_type": "GitLab.Audit"
   }
-results: [ ]
+results: []
 logType: GitLab.Audit

--- a/schemas/logs/git_lab/tests/git_tests.yml
+++ b/schemas/logs/git_lab/tests/git_tests.yml
@@ -16,5 +16,5 @@ result: |
     "p_any_trace_ids": ["FeGxww5Hj64"],
     "p_log_type": "GitLab.Git"
   }
-results: [ ]
+results: []
 logType: GitLab.Git

--- a/schemas/logs/git_lab/tests/integrations_tests.yml
+++ b/schemas/logs/git_lab/tests/integrations_tests.yml
@@ -24,7 +24,7 @@ result: |
     "p_any_domain_names": ["jira.gitlap.com"],
     "p_log_type": "GitLab.Integrations"
   }
-results: [ ]
+results: []
 logType: GitLab.Integrations
 ---
 name: TestIntegrations
@@ -51,5 +51,5 @@ result: |
     "p_any_domain_names": ["jira.example.com"],
     "p_log_type": "GitLab.Integrations"
   }
-results: [ ]
+results: []
 logType: GitLab.Integrations

--- a/schemas/logs/git_lab/tests/production_tests.yml
+++ b/schemas/logs/git_lab/tests/production_tests.yml
@@ -56,7 +56,7 @@ result: |
     "p_any_usernames": ["admin"],
     "p_log_type": "GitLab.Production"
   }
-results: [ ]
+results: []
 logType: GitLab.Production
 ---
 name: TestGitLabProductionException
@@ -122,7 +122,7 @@ result: |
     "p_any_usernames": ["root"],
     "p_log_type": "GitLab.Production"
   }
-results: [ ]
+results: []
 logType: GitLab.Production
 ---
 name: TestGitLabProductionRedirect
@@ -178,7 +178,7 @@ result: |
     "p_any_trace_ids": ["DScuWzVUYA5"],
     "p_log_type": "GitLab.Production"
   }
-results: [ ]
+results: []
 logType: GitLab.Production
 ---
 name: TestProductionRedirect304
@@ -242,5 +242,5 @@ result: |
     "p_event_time": "2019-11-14T13:12:46.156Z",
     "p_log_type": "GitLab.Production"
   }
-results: [ ]
+results: []
 logType: GitLab.Production

--- a/schemas/logs/gravitational/tests/teleport_audit_tests.yml
+++ b/schemas/logs/gravitational/tests/teleport_audit_tests.yml
@@ -50,7 +50,7 @@ result: |
     "p_any_trace_ids": ["e527ab2a-d882-11ea-9f82-0a588c28e4c2"],
     "p_log_type": "{{.LogType}}"
   }
-results: [ ]
+results: []
 logType: Gravitational.TeleportAudit
 ---
 name: session.end
@@ -101,7 +101,7 @@ result: |
     "p_any_trace_ids": ["e527ab2a-d882-11ea-9f82-0a588c28e4c2"],
     "p_log_type": "{{.LogType}}"
   }
-results: [ ]
+results: []
 logType: Gravitational.TeleportAudit
 ---
 name: session.data
@@ -141,7 +141,7 @@ result: |
     "p_any_trace_ids": ["e527ab2a-d882-11ea-9f82-0a588c28e4c2"],
     "p_log_type": "{{.LogType}}"
   }
-results: [ ]
+results: []
 logType: Gravitational.TeleportAudit
 ---
 name: session.network
@@ -189,7 +189,7 @@ result: |
     "p_any_ip_addresses": ["1.1.1.1","2.1.1.1"],
     "p_log_type": "{{.LogType}}"
   }
-results: [ ]
+results: []
 logType: Gravitational.TeleportAudit
 ---
 name: session.command
@@ -240,7 +240,7 @@ result: |
     "p_any_trace_ids": ["e527ab2a-d882-11ea-9f82-0a588c28e4c2"],
     "p_log_type": "{{.LogType}}"
   }
-results: [ ]
+results: []
 logType: Gravitational.TeleportAudit
 ---
 name: user.create
@@ -270,7 +270,7 @@ result: |
     "p_event_time": "2020-08-07T07:39:42Z",
     "p_log_type": "{{.LogType}}"
   }
-results: [ ]
+results: []
 logType: Gravitational.TeleportAudit
 ---
 name: user.login
@@ -296,7 +296,7 @@ result: |
     "p_event_time": "2020-08-06T20:43:13Z",
     "p_log_type": "{{.LogType}}"
   }
-results: [ ]
+results: []
 logType: Gravitational.TeleportAudit
 ---
 name: github.created
@@ -320,7 +320,7 @@ result: |
     "p_event_time": "2020-08-06T20:34:17Z",
     "p_log_type": "{{.LogType}}"
   }
-results: [ ]
+results: []
 logType: Gravitational.TeleportAudit
 ---
 name: session.leave
@@ -351,7 +351,7 @@ result: |
     "p_any_trace_ids": ["49aa4466-d824-11ea-a94f-0a588c28e4c2"],
     "p_log_type": "{{.LogType}}"
   }
-results: [ ]
+results: []
 logType: Gravitational.TeleportAudit
 ---
 name: resize
@@ -386,5 +386,5 @@ result: |
     "p_any_trace_ids": ["e527ab2a-d882-11ea-9f82-0a588c28e4c2"],
     "p_log_type": "{{.LogType}}"
   }
-results: [ ]
+results: []
 logType: Gravitational.TeleportAudit

--- a/schemas/logs/okta/system_log.yml
+++ b/schemas/logs/okta/system_log.yml
@@ -28,7 +28,7 @@ fields:
     type: string
   - name: severity
     required: true
-    description: 'Indicates how severe the event is: DEBUG, INFO, WARN, ERROR'
+    description: "Indicates how severe the event is: DEBUG, INFO, WARN, ERROR"
     type: string
   - name: legacyEventType
     description: Associated Events API Action objectType attribute value
@@ -162,7 +162,7 @@ fields:
     type: object
     fields:
       - name: result
-        description: 'Result of the action: SUCCESS, FAILURE, SKIPPED, ALLOW, DENY, CHALLENGE, UNKNOWN'
+        description: "Result of the action: SUCCESS, FAILURE, SKIPPED, ALLOW, DENY, CHALLENGE, UNKNOWN"
         type: string
       - name: reason
         description: Reason for the result, for example INVALID_CREDENTIALS

--- a/schemas/logs/one_login/tests/events_tests.yml
+++ b/schemas/logs/one_login/tests/events_tests.yml
@@ -46,7 +46,7 @@ result: |
     "p_any_ip_addresses":["136.25.254.254"],
     "p_log_type": "OneLogin.Events"
   }
-results: [ ]
+results: []
 logType: OneLogin.Events
 ---
 name: TestOneLoginPriviledgeEvent
@@ -93,7 +93,7 @@ result: |
     "p_any_ip_addresses":["136.25.254.254"],
     "p_log_type": "OneLogin.Events"
   }
-results: [ ]
+results: []
 logType: OneLogin.Events
 ---
 name: TestOneLoginDirectorySync
@@ -135,7 +135,7 @@ result: |
     "p_any_usernames": [ "G Suite", "Jon Bixton" ],
     "p_log_type": "OneLogin.Events"
   }
-results: [ ]
+results: []
 logType: OneLogin.Events
 ---
 name: TestOneLoginRiskReasons
@@ -247,5 +247,5 @@ result: |
     "p_any_ip_addresses":["70.39.110.83"],
     "p_log_type": "OneLogin.Events"
   }
-results: [ ]
+results: []
 logType: OneLogin.Events

--- a/schemas/logs/sophos/tests/central_tests.yml
+++ b/schemas/logs/sophos/tests/central_tests.yml
@@ -44,7 +44,7 @@ result: |
       "p_any_ip_addresses": [ "192.168.4.25" ],
       "p_log_type":         "Sophos.Central"
   }
-results: [ ]
+results: []
 logType: Sophos.Central
 ---
 name: Event::Endpoint::DataLossPreventionUserAllowed
@@ -109,7 +109,7 @@ result: |
       "p_any_ip_addresses": [ "192.168.2.213" ],
       "p_log_type":         "Sophos.Central"
   }
-results: [ ]
+results: []
 logType: Sophos.Central
 ---
 name: Event::Endpoint::CorePuaDetection
@@ -177,7 +177,7 @@ result: |
       "p_any_sha256_hashes": [ "c1c0160ddeeb82388aaf1b9957112a3ac9dbcfce6ef3822a9a3250dce2efec11" ],
       "p_log_type":         "Sophos.Central"
   }
-results: [ ]
+results: []
 logType: Sophos.Central
 ---
 name: Event::Endpoint::Threat::CleanupFailed
@@ -232,5 +232,5 @@ result: |
       "p_any_ip_addresses": [ "192.168.1.68" ],
       "p_log_type":         "Sophos.Central"
   }
-results: [ ]
+results: []
 logType: Sophos.Central

--- a/schemas/logs/syslog/rfc_3164.yml
+++ b/schemas/logs/syslog/rfc_3164.yml
@@ -12,11 +12,11 @@ fields:
     type: smallint
   - name: facility
     required: true
-    description: 'Facility value helps determine which process created the message. Eg: 0 = kernel messages, 3 = system daemons.'
+    description: "Facility value helps determine which process created the message. Eg: 0 = kernel messages, 3 = system daemons."
     type: smallint
   - name: severity
     required: true
-    description: 'Severity indicates how severe the message is. Eg: 0=Emergency to 7=Debug.'
+    description: "Severity indicates how severe the message is. Eg: 0=Emergency to 7=Debug."
     type: smallint
   - name: timestamp
     description: Timestamp of the syslog message in UTC.

--- a/schemas/logs/syslog/rfc_5424.yml
+++ b/schemas/logs/syslog/rfc_5424.yml
@@ -12,11 +12,11 @@ fields:
     type: smallint
   - name: facility
     required: true
-    description: 'Facility value helps determine which process created the message. Eg: 0 = kernel messages, 3 = system daemons.'
+    description: "Facility value helps determine which process created the message. Eg: 0 = kernel messages, 3 = system daemons."
     type: smallint
   - name: severity
     required: true
-    description: 'Severity indicates how severe the message is. Eg: 0=Emergency to 7=Debug.'
+    description: "Severity indicates how severe the message is. Eg: 0=Emergency to 7=Debug."
     type: smallint
   - name: version
     required: true


### PR DESCRIPTION
### Background

When syncing schema files we need a common formatting standard for proper diffs.
The only working solution I found was to use `prettier`
This breaks the 'python-tools-only' approach of the repo.
I tried using `yamlfmt` but it does not support multi-document YAML files such as the test files.
Any formatting tool used should also be available in `panther` repository to allow proper diffs during syncs.
I went with prettier because it is used in `panther` repo.
We might add a `fmt-schemas` command to `panther-analysis` tool but that would require code.

### Changes

* Formatted all schemas with prettier
* Adds `prettier` to `make fmt` for schema files

### Testing

* N/A