### PR TITLE
prune and tune

### DIFF
--- a/aws_cloudtrail_policies/aws_cloudtrail_s3_bucket_access_logging.py
+++ b/aws_cloudtrail_policies/aws_cloudtrail_s3_bucket_access_logging.py
@@ -1,4 +1,4 @@
-from panther_oss_helpers import resource_lookup  # pylint: disable=import-error
+from panther_oss_helpers import resource_lookup
 
 
 def policy(resource):

--- a/aws_cloudtrail_rules/aws_console_login_failed.yml
+++ b/aws_cloudtrail_rules/aws_console_login_failed.yml
@@ -1,9 +1,9 @@
 AnalysisType: rule
 Filename: aws_console_login_failed.py
-RuleID: AWS.Console.LoginFailed
+RuleID: DEPRECATED RULE - AWS.Console.LoginFailed
 DisplayName: Failed Console Login
 DedupPeriodMinutes: 60
-Enabled: true
+Enabled: false
 LogTypes:
   - AWS.CloudTrail
 Tags:

--- a/aws_cloudtrail_rules/aws_ec2_security_group_modified.yml
+++ b/aws_cloudtrail_rules/aws_ec2_security_group_modified.yml
@@ -12,6 +12,7 @@ Reports:
   CIS:
     - 3.10
 Severity: Info
+DedupPeriodMinutes: 720 # 12 hours
 Description: >
   An EC2 Security Group was modified.
 Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-ec2-securitygroup-modified

--- a/aws_cloudtrail_rules/aws_ec2_vpc_modified.yml
+++ b/aws_cloudtrail_rules/aws_ec2_vpc_modified.yml
@@ -12,6 +12,7 @@ Reports:
   CIS:
     - 3.14
 Severity: Info
+DedupPeriodMinutes: 720 # 12 hours
 Description: An EC2 VPC was modified.
 Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-ec2-vpc-modified
 Reference: reference.link

--- a/aws_cloudtrail_rules/aws_iam_anything_changed.yml
+++ b/aws_cloudtrail_rules/aws_iam_anything_changed.yml
@@ -9,6 +9,7 @@ Tags:
   - AWS
   - Identity and Access Management
 Severity: Info
+DedupPeriodMinutes: 720 # 12 hours
 Description: >
   A change occurred in the IAM configuration. This could be a resource being created, deleted, or modified. This is a high level view of changes, helfpul to indicate how dynamic a certain IAM environment is.
 Runbook: >

--- a/aws_cloudtrail_rules/aws_iam_policy_modified.yml
+++ b/aws_cloudtrail_rules/aws_iam_policy_modified.yml
@@ -12,6 +12,7 @@ Reports:
   CIS:
     - 3.4
 Severity: Info
+DedupPeriodMinutes: 720 # 12 hours
 Description: >
   An IAM Policy was changed.
 Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-iam-policy-modified

--- a/aws_cloudtrail_rules/aws_s3_bucket_policy_modified.yml
+++ b/aws_cloudtrail_rules/aws_s3_bucket_policy_modified.yml
@@ -12,6 +12,7 @@ Reports:
   CIS:
     - 3.8
 Severity: Info
+DedupPeriodMinutes: 720 # 12 hours
 Description: >
   An S3 Bucket was modified.
 Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-s3-bucket-policy-modified

--- a/aws_ec2_policies/aws_ec2_cde_volume_encrypted.py
+++ b/aws_ec2_policies/aws_ec2_cde_volume_encrypted.py
@@ -1,4 +1,4 @@
-from panther_base_helpers import IN_PCI_SCOPE  # pylint: disable=import-error
+from panther_base_helpers import IN_PCI_SCOPE
 
 
 def policy(resource):

--- a/aws_load_balancer_policies/aws_elbv2_load_balancer_has_ssl_policy.py
+++ b/aws_load_balancer_policies/aws_elbv2_load_balancer_has_ssl_policy.py
@@ -1,4 +1,4 @@
-from panther_base_helpers import IN_PCI_SCOPE  # pylint: disable=import-error
+from panther_base_helpers import IN_PCI_SCOPE
 
 
 def policy(resource):

--- a/aws_rds_policies/aws_rds_instance_backup_retention_acceptable.py
+++ b/aws_rds_policies/aws_rds_instance_backup_retention_acceptable.py
@@ -1,4 +1,4 @@
-from panther_base_helpers import IN_PCI_SCOPE  # pylint: disable=import-error
+from panther_base_helpers import IN_PCI_SCOPE
 
 MAX_RETENTION_DAYS = 180
 MIN_RETENTION_DAYS = 7

--- a/aws_redshift_policies/aws_redshift_cluster_snapshot_retention_acceptable.py
+++ b/aws_redshift_policies/aws_redshift_cluster_snapshot_retention_acceptable.py
@@ -1,4 +1,4 @@
-from panther_base_helpers import IN_PCI_SCOPE  # pylint: disable=import-error
+from panther_base_helpers import IN_PCI_SCOPE
 
 # Retention period in days
 MIN_RETENTION_DAYS = 3

--- a/aws_s3_rules/aws_s3_access_error.yml
+++ b/aws_s3_rules/aws_s3_access_error.yml
@@ -9,7 +9,7 @@ LogTypes:
 Tags:
   - AWS
   - Security Control
-Severity: Low
+Severity: Info
 Description: >
   Checks for errors during S3 Object access.
   This could be due to insufficient access permissions, non-existant buckets, or other reasons.

--- a/aws_s3_rules/aws_s3_unknown_requester_get_object.yml
+++ b/aws_s3_rules/aws_s3_unknown_requester_get_object.yml
@@ -3,7 +3,7 @@ Filename: aws_s3_unknown_requester_get_object.py
 RuleID: AWS.S3.ServerAccess.UnknownRequester
 DisplayName: AWS S3 Unknown Requester
 DedupPeriodMinutes: 60 # 1 hour
-Enabled: true
+Enabled: false
 LogTypes:
   - AWS.S3ServerAccess
 Tags:

--- a/aws_vpc_policies/aws_network_acl_restricts_inbound_traffic.py
+++ b/aws_vpc_policies/aws_network_acl_restricts_inbound_traffic.py
@@ -1,6 +1,6 @@
 # This is a generic policy for checking inbound rules on a Network ACL.
 # It is recommended to add additional logic here based on your own use cases.
-from panther_base_helpers import IN_PCI_SCOPE  # pylint: disable=import-error
+from panther_base_helpers import IN_PCI_SCOPE
 
 
 def policy(resource):

--- a/aws_vpc_policies/aws_network_acl_restricts_outbound_traffic.py
+++ b/aws_vpc_policies/aws_network_acl_restricts_outbound_traffic.py
@@ -1,4 +1,4 @@
-from panther_base_helpers import IN_PCI_SCOPE  # pylint: disable=import-error
+from panther_base_helpers import IN_PCI_SCOPE
 
 # This is generic policy that checks outbound traffic rules on a Network ACL.
 # It is recommended you add additional logic for your own use cases.

--- a/aws_vpc_policies/aws_only_dmz_security_groups_publicly_accessible.py
+++ b/aws_vpc_policies/aws_only_dmz_security_groups_publicly_accessible.py
@@ -1,6 +1,6 @@
 from ipaddress import ip_network
 
-from panther_base_helpers import IS_DMZ  # pylint: disable=import-error
+from panther_base_helpers import IS_DMZ
 
 
 def policy(resource):

--- a/aws_vpc_policies/aws_security_group_restricts_access_to_cde.py
+++ b/aws_vpc_policies/aws_security_group_restricts_access_to_cde.py
@@ -1,6 +1,6 @@
 from ipaddress import ip_network
 
-from panther_base_helpers import IN_PCI_SCOPE  # pylint: disable=import-error
+from panther_base_helpers import IN_PCI_SCOPE
 
 
 def policy(resource):

--- a/aws_vpc_policies/aws_security_group_restricts_inbound_traffic.py
+++ b/aws_vpc_policies/aws_security_group_restricts_inbound_traffic.py
@@ -1,4 +1,4 @@
-from panther_base_helpers import IN_PCI_SCOPE  # pylint: disable=import-error
+from panther_base_helpers import IN_PCI_SCOPE
 
 # This is a generic policy that checks inbound permissions on a Security Group.
 # You may wish to add additional logic specific to your use cases.

--- a/aws_vpc_policies/aws_security_group_restricts_inter_security_group_traffic.py
+++ b/aws_vpc_policies/aws_security_group_restricts_inter_security_group_traffic.py
@@ -1,4 +1,4 @@
-from panther_base_helpers import IN_PCI_SCOPE  # pylint: disable=import-error
+from panther_base_helpers import IN_PCI_SCOPE
 
 
 def policy(resource):

--- a/aws_vpc_policies/aws_security_group_restricts_outbound_traffic.py
+++ b/aws_vpc_policies/aws_security_group_restricts_outbound_traffic.py
@@ -1,4 +1,4 @@
-from panther_base_helpers import IN_PCI_SCOPE  # pylint: disable=import-error
+from panther_base_helpers import IN_PCI_SCOPE
 
 # This is a generic policy that checks outbound permissions on Security Groups.
 # You may wish to add additional logic specific to your use case.

--- a/aws_vpc_policies/aws_security_group_restricts_traffic_leaving_cde.py
+++ b/aws_vpc_policies/aws_security_group_restricts_traffic_leaving_cde.py
@@ -1,6 +1,6 @@
 from ipaddress import ip_network
 
-from panther_base_helpers import IN_PCI_SCOPE  # pylint: disable=import-error
+from panther_base_helpers import IN_PCI_SCOPE
 
 
 def policy(resource):

--- a/aws_vpc_policies/aws_security_group_tightly_restricts_inbound_traffic.py
+++ b/aws_vpc_policies/aws_security_group_tightly_restricts_inbound_traffic.py
@@ -1,4 +1,4 @@
-from panther_base_helpers import IN_PCI_SCOPE  # pylint: disable=import-error
+from panther_base_helpers import IN_PCI_SCOPE
 
 MAX_PORTS_PER_PERMISSION = 10
 RESTRICTED_PORTS = [

--- a/aws_vpc_policies/aws_security_group_tightly_restricts_outbound_traffic.py
+++ b/aws_vpc_policies/aws_security_group_tightly_restricts_outbound_traffic.py
@@ -1,4 +1,4 @@
-from panther_base_helpers import IN_PCI_SCOPE  # pylint: disable=import-error
+from panther_base_helpers import IN_PCI_SCOPE
 
 MAX_PORTS_PER_PERMISSION = 10
 RESTRICTED_PORTS = [

--- a/aws_vpc_policies/aws_vpc_default_network_acl_restricts_all_traffic.py
+++ b/aws_vpc_policies/aws_vpc_default_network_acl_restricts_all_traffic.py
@@ -1,5 +1,5 @@
-from panther_base_helpers import IN_PCI_SCOPE  # pylint: disable=import-error
-from panther_oss_helpers import resource_lookup  # pylint: disable=import-error
+from panther_base_helpers import IN_PCI_SCOPE
+from panther_oss_helpers import resource_lookup
 
 
 def policy(resource):

--- a/aws_vpc_policies/aws_vpc_default_security_restrictions.py
+++ b/aws_vpc_policies/aws_vpc_default_security_restrictions.py
@@ -1,4 +1,4 @@
-from panther_oss_helpers import resource_lookup  # pylint: disable=import-error
+from panther_oss_helpers import resource_lookup
 
 
 def policy(resource):

--- a/box_rules/box_brute_force_login.yml
+++ b/box_rules/box_brute_force_login.yml
@@ -1,8 +1,8 @@
 AnalysisType: rule
 Filename: box_brute_force_login.py
 RuleID: Box.Brute.Force.Login
-DisplayName: Box Brute Force Login
-Enabled: true
+DisplayName: DEPRECATED RULE - Box Brute Force Login
+Enabled: false
 LogTypes:
   - Box.Event
 Tags:

--- a/gcp_audit_rules/gcp_iam_admin_role_assigned.yml
+++ b/gcp_audit_rules/gcp_iam_admin_role_assigned.yml
@@ -1,8 +1,8 @@
 AnalysisType: rule
 Filename: gcp_iam_admin_role_assigned.py
 RuleID: GCP.IAM.AdminRoleAssigned
-DisplayName: GCP IAM Admin Role Assigned
-Enabled: true
+DisplayName: DEPRECATED RULE - GCP IAM Admin Role Assigned
+Enabled: false
 LogTypes:
   - GCP.AuditLog
 Tags:

--- a/okta_rules/okta_api_key_created.py
+++ b/okta_rules/okta_api_key_created.py
@@ -1,7 +1,4 @@
-from panther_base_helpers import (  # pylint: disable=import-error
-    deep_get,
-    okta_alert_context,
-)
+from panther_base_helpers import deep_get, okta_alert_context
 
 
 def rule(event):

--- a/okta_rules/okta_api_key_created.py
+++ b/okta_rules/okta_api_key_created.py
@@ -1,4 +1,7 @@
-from panther_base_helpers import deep_get, okta_alert_context  # pylint: disable=import-error
+from panther_base_helpers import (  # pylint: disable=import-error
+    deep_get,
+    okta_alert_context,
+)
 
 
 def rule(event):

--- a/okta_rules/okta_api_key_revoked.py
+++ b/okta_rules/okta_api_key_revoked.py
@@ -1,7 +1,4 @@
-from panther_base_helpers import (  # pylint: disable=import-error
-    deep_get,
-    okta_alert_context,
-)
+from panther_base_helpers import deep_get, okta_alert_context
 
 
 def rule(event):

--- a/okta_rules/okta_api_key_revoked.py
+++ b/okta_rules/okta_api_key_revoked.py
@@ -1,4 +1,7 @@
-from panther_base_helpers import deep_get, okta_alert_context  # pylint: disable=import-error
+from panther_base_helpers import (  # pylint: disable=import-error
+    deep_get,
+    okta_alert_context,
+)
 
 
 def rule(event):

--- a/okta_rules/okta_brute_force_logins.yml
+++ b/okta_rules/okta_brute_force_logins.yml
@@ -1,8 +1,8 @@
 AnalysisType: rule
 Filename: okta_brute_force_logins.py
 RuleID: Okta.BruteForceLogins
-DisplayName: Okta Brute Force Logins
-Enabled: true
+DisplayName: DEPRECATED RULE - Okta Brute Force Logins
+Enabled: false
 LogTypes:
   - Okta.SystemLog
 Tags:

--- a/onelogin_rules/onelogin_admin_role_assigned.yml
+++ b/onelogin_rules/onelogin_admin_role_assigned.yml
@@ -1,8 +1,8 @@
 AnalysisType: rule
 Filename: onelogin_admin_role_assigned.py 
 RuleID: OneLogin.AdminRoleAssigned
-DisplayName: OneLogin Admin Role Assigned
-Enabled: true
+DisplayName:  DEPRECATED RULE - OneLogin Admin Role Assigned
+Enabled: false
 LogTypes:
   - OneLogin.Events
 Tags:

--- a/onelogin_rules/onelogin_brute_force_by_ip.yml
+++ b/onelogin_rules/onelogin_brute_force_by_ip.yml
@@ -1,8 +1,8 @@
 AnalysisType: rule
 Filename: onelogin_brute_force_by_ip.py
 RuleID: OneLogin.BruteForceByIP
-DisplayName: OneLogin Brute Force IP
-Enabled: true
+DisplayName: DEPRECATED RULE - OneLogin Brute Force IP
+Enabled: false
 LogTypes:
   - OneLogin.Events
 Tags:

--- a/onelogin_rules/onelogin_brute_force_by_username.yml
+++ b/onelogin_rules/onelogin_brute_force_by_username.yml
@@ -1,8 +1,8 @@
 AnalysisType: rule
 Filename: onelogin_brute_force_by_username.py
 RuleID: OneLogin.BruteForceByUsername
-DisplayName: OneLogin Brute Force Username
-Enabled: true
+DisplayName: DEPRECATED RULE - OneLogin Brute Force Username
+Enabled: false
 LogTypes:
   - OneLogin.Events
 Tags:

--- a/packs/standard_ruleset.yml
+++ b/packs/standard_ruleset.yml
@@ -1,4 +1,4 @@
-AnalysisType: Pack
+AnalysisType: pack
 PackID: PantherManaged.UniversalDetections
 Description: This pack groups the standard rules that leverage unified data models
 PackDefinition:

--- a/schemas/logs/salesforce/login-as.yml
+++ b/schemas/logs/salesforce/login-as.yml
@@ -113,4 +113,3 @@ fields:
     description: >-
       The 18-character case-insensitive ID of the user who’s using Salesforce services
       through the UI or API. In this case, the user who’s doing the impersonation.
-

--- a/schemas/logs/salesforce/login.yml
+++ b/schemas/logs/salesforce/login.yml
@@ -88,29 +88,29 @@ fields:
     required: false
     type: string
     description: >-
-        The identifier string returned by the browser used at login.
-        Example values are:
-            Go-http-client/1.1
-            Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv%3A50.0) Gecko/20100101 Firefox/50.0
-            Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36
+      The identifier string returned by the browser used at login.
+      Example values are:
+          Go-http-client/1.1
+          Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv%3A50.0) Gecko/20100101 Firefox/50.0
+          Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36
   - name: API_TYPE
     required: false
     type: string
     description: >-
-        The type of API request.
-        Possible values are:
-            D—Apex Class
-            E—SOAP Enterprise
-            I—SOAP Cross Instance
-            M—SOAP Metadata
-            O—Old SOAP
-            P—SOAP Partner
-            S—SOAP Apex
-            T—SOAP Tooling
-            X—XmlRPC
-            f—Feed
-            l—Live Agent
-            p—SOAP ClientSync
+      The type of API request.
+      Possible values are:
+          D—Apex Class
+          E—SOAP Enterprise
+          I—SOAP Cross Instance
+          M—SOAP Metadata
+          O—Old SOAP
+          P—SOAP Partner
+          S—SOAP Apex
+          T—SOAP Tooling
+          X—XmlRPC
+          f—Feed
+          l—Live Agent
+          p—SOAP ClientSync
   - name: API_VERSION
     required: false
     type: string
@@ -172,4 +172,3 @@ fields:
     indicators:
       - ip
     description: The source IP of the login request.
-

--- a/schemas/logs/salesforce/uri.yml
+++ b/schemas/logs/salesforce/uri.yml
@@ -137,4 +137,3 @@ fields:
     required: false
     type: string
     description: The 18-character case insensitive ID of the URI of the page that’s receiving the request.
-

--- a/standard_rules/unusual_login.py
+++ b/standard_rules/unusual_login.py
@@ -74,5 +74,5 @@ def get_key(event):
 def title(event):
     return (
         f"{event.get('p_log_type')}: Unusual access for user [{event.get('user_name', '<UNKNOWN_USER>')}]"
-        f" from [{event.get('p_row_id')}]"
+        f" from {EVENT_LOGIN_INFO[event.get('p_row_id')]}"
     )

--- a/standard_rules/unusual_login.py
+++ b/standard_rules/unusual_login.py
@@ -73,6 +73,7 @@ def get_key(event):
 
 def title(event):
     return (
-        f"{event.get('p_log_type')}: Unusual access for user [{event.get('user_name', '<UNKNOWN_USER>')}]"
+        f"{event.get('p_log_type')}: Unusual access for user"
+        f" [{event.get('user_name', '<UNKNOWN_USER>')}]"
         f" from {EVENT_LOGIN_INFO[event.get('p_row_id')]}"
     )

--- a/standard_rules/unusual_login.py
+++ b/standard_rules/unusual_login.py
@@ -8,6 +8,7 @@ from panther_oss_helpers import get_string_set, put_string_set
 FINGERPRINT_THRESHOLD = 5
 EVENT_LOGIN_INFO = {}
 
+
 def rule(event):
     # Pre-filter to save compute time where possible.
     if event.udm("event_type") != event_type.SUCCESSFUL_LOGIN:


### PR DESCRIPTION
### Background

Several log sources are quite noisy and the detections for those log sources can be quite noisy.  The first step in dealing with this is to 1. determine the noisy log sources 2. disable or tune "loud" detections for those log sources.  

### Changes

This PR partially addresses this by:
1. disable a rule that requires configuration
2. update deduplication period for several CloudTrail rules to a "working day" duration of 12 hours
3. downgrading a rule from LOW to INFO level because it seems to be more operational in nature. This will help down the line when we auto-resolve INFO-level detections.
4. disable rules that are now covered by a standard rule

### Testing

* `make ci`
