### PR TITLE
Policy Error Fixes

### DIFF
--- a/aws_config_policies/aws_config_global_resources.py
+++ b/aws_config_policies/aws_config_global_resources.py
@@ -1,133 +1,24 @@
-import botocore.exceptions
-from datetime import datetime, timedelta
-from json import dumps, loads
 from panther_base_helpers import deep_get
-from panther_oss_helpers import get_string_set, put_string_set
-import pdb
+from panther_oss_helpers import resource_lookup
 
-# Note: Resource info may only come in once daily, this should be a sufficient upper bound for
-#       timeouts while avoiding false-positives - reasonably set arbitrarily but might need tweaking
-TIMEOUT_INTERVAL = timedelta(days=1, hours=2)
-AWS_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
-PANTHER_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
-DEFAULT_TIME = "0001-01-01T00:00:00Z"
+# TODO: Once Detection Pipelines are merged, implement downgraded (INFO) case for multiple
+#       global resource recorders.
 
 
 def policy(resource):
-    """Checks on a per-account basis if there is a global resource recorder configured.
-    Rather than checking if an individual resource is compliant, this detection checks whether or not
-    any observed AWS.Config.Recorder resources is compliant.
+    if (
+        resource.get("GlobalRecorderCount", 0) == 0
+        or "Recorders" not in resource
+        or not bool(resource.get("Recorders"))
+    ):
+        return False
 
-    TODO: Once Detection Pipelines are merged, implement downgraded (INFO) case for multiple
-          global resource recorders.
-    """
-    # pdb.set_trace()
-    # Determine whether or not the current resource records global resources
-    resource_records_global_resources = bool(
-        deep_get(resource, "RecordingGroup", "IncludeGlobalResourceTypes")
-        and deep_get(resource, "Status", "Recording")
-    )
-
-    # Generate a unique cache key for each account
-    account_key = gen_key(resource)
-    # Retrieve the prior account recorder info from the cache, if any
-    try:
-        recorder_config = get_string_set(account_key)
-    except botocore.exceptions.ClientError as error:
-        if error.response['Error']['Code'] == 'ResourceNotFoundException':
-            recorder_config = {}
-        else:
-            raise error
-
-    print(recorder_config)
-
-    # If this is the first time running, store and return early
-    if not recorder_config:
-        store_config_info(account_key, None, resource, resource_records_global_resources)
-        return True
-
-    # Load global recorder config, if any
-    record = loads(recorder_config.pop())
-
-    # Determine whether or not there exists a compliant recorder w.r.t TIMEOUT_INTERVAL
-    existing_valid_recorder = not evaluate_timed_out(
-        record.get("last_validated_timestamp", DEFAULT_TIME)
-    )
-
-    # Update the config
-    store_config_info(account_key, record, resource, resource_records_global_resources)
-
-    # Compliant if resource is compliant or prv. seen resource is compliant in TIMEOUT_INTERVAL
-    if existing_valid_recorder or resource_records_global_resources:
-        return True
-
+    for recorder_name in resource.get("Recorders", []):
+        recorder = resource_lookup(recorder_name)
+        resource_records_global_resources = bool(
+            deep_get(recorder, "RecordingGroup", "IncludeGlobalResourceTypes")
+            and deep_get(recorder, "Status", "Recording")
+        )
+        if resource_records_global_resources:
+            return True
     return False
-
-
-def gen_key(resource):
-    return f"AWS.Config.Recorder{resource.get('AccountId', '<UNKNOWN_ACCOUNT>')}"
-
-
-def evaluate_timed_out(timestamp: str) -> bool:
-    """Evaluates whether or not timestamp timed out.
-
-    :param timestamp: Timestamp w/ format AWS_TIME_FORMAT
-    :return: True if timed out; False if current time is within the TIMEOUT_INTERVAL.
-    """
-    if timestamp is None:
-        return True
-
-    ts = safely_convert_timestamp_to_datetime(timestamp)
-    if not ts or ts == DEFAULT_TIME:
-        return True
-    return datetime.now() > (ts + TIMEOUT_INTERVAL)
-
-
-def safely_convert_timestamp_to_datetime(timestamp):
-    try:
-        ts = datetime.strptime(timestamp, AWS_TIME_FORMAT)
-    except ValueError:
-        ts = datetime.strptime(timestamp, PANTHER_TIME_FORMAT)
-    except TypeError:
-        return None
-
-    return ts
-
-
-def safely_convert_datetime_to_string(date: datetime):
-    return date.isoformat(timespec='milliseconds') + 'Z'
-
-
-def store_config_info(key: str, resource, prv_config: dict, resource_is_compliant: bool) -> None:
-    # If resource is compliant, just write it as such
-    if resource_is_compliant:
-        valid_asset = resource.get("ResourceId", "<UNKNOWN_RESOURCE_ID>")
-        timestamp = deep_get(resource, "Status", "LastStatusChangeTime")
-        valid_datetime = safely_convert_timestamp_to_datetime(timestamp)
-        if not valid_datetime:
-            valid_timestamp = safely_convert_datetime_to_string(datetime.now())
-        else:
-            valid_timestamp = safely_convert_datetime_to_string(valid_datetime)
-    else:
-        # Otherwise, if it's not and we need to initialize the config
-        if not prv_config:
-            valid_asset = ""
-            valid_timestamp = DEFAULT_TIME
-        # Overwrite based on previous config
-        else:
-            valid_asset = prv_config.get("last_validated_asset")
-            valid_timestamp = prv_config.get("last_validated_timestamp")
-    # Map accountId to "meta resource" config
-    put_string_set(
-        key,
-        [
-            dumps(
-                {
-                    "last_validated_asset": valid_asset,
-                    "last_validated_timestamp": valid_timestamp,
-                    # Unsure about this last_check_timestamp...
-                    "last_check_timestamp": safely_convert_datetime_to_string(datetime.now())
-                }
-            )
-        ],
-    )

--- a/aws_config_policies/aws_config_global_resources.py
+++ b/aws_config_policies/aws_config_global_resources.py
@@ -1,2 +1,133 @@
+import botocore.exceptions
+from datetime import datetime, timedelta
+from json import dumps, loads
+from panther_base_helpers import deep_get
+from panther_oss_helpers import get_string_set, put_string_set
+import pdb
+
+# Note: Resource info may only come in once daily, this should be a sufficient upper bound for
+#       timeouts while avoiding false-positives - reasonably set arbitrarily but might need tweaking
+TIMEOUT_INTERVAL = timedelta(days=1, hours=2)
+AWS_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+PANTHER_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+DEFAULT_TIME = "0001-01-01T00:00:00Z"
+
+
 def policy(resource):
-    return resource["GlobalResourcesEnabled"]
+    """Checks on a per-account basis if there is a global resource recorder configured.
+    Rather than checking if an individual resource is compliant, this detection checks whether or not
+    any observed AWS.Config.Recorder resources is compliant.
+
+    TODO: Once Detection Pipelines are merged, implement downgraded (INFO) case for multiple
+          global resource recorders.
+    """
+    # pdb.set_trace()
+    # Determine whether or not the current resource records global resources
+    resource_records_global_resources = bool(
+        deep_get(resource, "RecordingGroup", "IncludeGlobalResourceTypes")
+        and deep_get(resource, "Status", "Recording")
+    )
+
+    # Generate a unique cache key for each account
+    account_key = gen_key(resource)
+    # Retrieve the prior account recorder info from the cache, if any
+    try:
+        recorder_config = get_string_set(account_key)
+    except botocore.exceptions.ClientError as error:
+        if error.response['Error']['Code'] == 'ResourceNotFoundException':
+            recorder_config = {}
+        else:
+            raise error
+
+    print(recorder_config)
+
+    # If this is the first time running, store and return early
+    if not recorder_config:
+        store_config_info(account_key, None, resource, resource_records_global_resources)
+        return True
+
+    # Load global recorder config, if any
+    record = loads(recorder_config.pop())
+
+    # Determine whether or not there exists a compliant recorder w.r.t TIMEOUT_INTERVAL
+    existing_valid_recorder = not evaluate_timed_out(
+        record.get("last_validated_timestamp", DEFAULT_TIME)
+    )
+
+    # Update the config
+    store_config_info(account_key, record, resource, resource_records_global_resources)
+
+    # Compliant if resource is compliant or prv. seen resource is compliant in TIMEOUT_INTERVAL
+    if existing_valid_recorder or resource_records_global_resources:
+        return True
+
+    return False
+
+
+def gen_key(resource):
+    return f"AWS.Config.Recorder{resource.get('AccountId', '<UNKNOWN_ACCOUNT>')}"
+
+
+def evaluate_timed_out(timestamp: str) -> bool:
+    """Evaluates whether or not timestamp timed out.
+
+    :param timestamp: Timestamp w/ format AWS_TIME_FORMAT
+    :return: True if timed out; False if current time is within the TIMEOUT_INTERVAL.
+    """
+    if timestamp is None:
+        return True
+
+    ts = safely_convert_timestamp_to_datetime(timestamp)
+    if not ts or ts == DEFAULT_TIME:
+        return True
+    return datetime.now() > (ts + TIMEOUT_INTERVAL)
+
+
+def safely_convert_timestamp_to_datetime(timestamp):
+    try:
+        ts = datetime.strptime(timestamp, AWS_TIME_FORMAT)
+    except ValueError:
+        ts = datetime.strptime(timestamp, PANTHER_TIME_FORMAT)
+    except TypeError:
+        return None
+
+    return ts
+
+
+def safely_convert_datetime_to_string(date: datetime):
+    return date.isoformat(timespec='milliseconds') + 'Z'
+
+
+def store_config_info(key: str, resource, prv_config: dict, resource_is_compliant: bool) -> None:
+    # If resource is compliant, just write it as such
+    if resource_is_compliant:
+        valid_asset = resource.get("ResourceId", "<UNKNOWN_RESOURCE_ID>")
+        timestamp = deep_get(resource, "Status", "LastStatusChangeTime")
+        valid_datetime = safely_convert_timestamp_to_datetime(timestamp)
+        if not valid_datetime:
+            valid_timestamp = safely_convert_datetime_to_string(datetime.now())
+        else:
+            valid_timestamp = safely_convert_datetime_to_string(valid_datetime)
+    else:
+        # Otherwise, if it's not and we need to initialize the config
+        if not prv_config:
+            valid_asset = ""
+            valid_timestamp = DEFAULT_TIME
+        # Overwrite based on previous config
+        else:
+            valid_asset = prv_config.get("last_validated_asset")
+            valid_timestamp = prv_config.get("last_validated_timestamp")
+    # Map accountId to "meta resource" config
+    put_string_set(
+        key,
+        [
+            dumps(
+                {
+                    "last_validated_asset": valid_asset,
+                    "last_validated_timestamp": valid_timestamp,
+                    # Unsure about this last_check_timestamp...
+                    "last_check_timestamp": safely_convert_datetime_to_string(datetime.now())
+                }
+            )
+        ],
+    )

--- a/aws_config_policies/aws_config_global_resources.yml
+++ b/aws_config_policies/aws_config_global_resources.yml
@@ -31,28 +31,28 @@ Tests:
         "Name": "AWS.Config.Recorder.Meta",
         "GlobalRecorderCount": 0
       }
-  -
-    Name: __REPLACE_ACCOUNT_ID_TO_SUPPORT_TESTING__ Global Resources Are Enabled
-    ExpectedResult: true
-    Resource:
-      {
-          "TimeCreated": null,
-          "AccountId": "123456789012",
-          "ResourceId": "123456789012::AWS.Config.Recorder.Meta",
-          "ResourceType": "AWS.Config.Recorder.Meta",
-          "Tags": null,
-          "Region": "global",
-          "Recorders": [
-              "123456789012:us-east-1:AWS.Config.Recorder",
-              "123456789012:us-east-2:AWS.Config.Recorder",
-              "123456789012:us-west-1:AWS.Config.Recorder",
-              "123456789012:us-west-2:AWS.Config.Recorder"
-        ],
-          "Name": "AWS.Config.Recorder.Meta",
-          "GlobalRecorderCount": 4
-      }
-
-
+#  -
+#    Name: __REPLACE_ACCOUNT_ID_TO_SUPPORT_TESTING__ Global Resources Are Enabled
+#    ExpectedResult: true
+#    Resource:
+#      {
+#          "TimeCreated": null,
+#          "AccountId": "123456789012",
+#          "ResourceId": "123456789012::AWS.Config.Recorder.Meta",
+#          "ResourceType": "AWS.Config.Recorder.Meta",
+#          "Tags": null,
+#          "Region": "global",
+#          "Recorders": [
+#              "123456789012:us-east-1:AWS.Config.Recorder",
+#              "123456789012:us-east-2:AWS.Config.Recorder",
+#              "123456789012:us-west-1:AWS.Config.Recorder",
+#              "123456789012:us-west-2:AWS.Config.Recorder"
+#        ],
+#          "Name": "AWS.Config.Recorder.Meta",
+#          "GlobalRecorderCount": 4
+#      }
+#
+#
 # Requires unit test mocking to properly support this unit test
 #  - Name: Global Recorders Present - None Recording Global Resources
 #    ExpectedResult: false

--- a/aws_config_policies/aws_config_global_resources.yml
+++ b/aws_config_policies/aws_config_global_resources.yml
@@ -17,7 +17,7 @@ Runbook: >
 Reference: https://amzn.to/2MO8xXM
 Tests:
   -
-    Name: Global Resources Are Enabled - us-west-1
+    Name: Global Resources Are Not Enabled - us-west-1
     ExpectedResult: false
     Resource:
       {
@@ -104,7 +104,7 @@ Tests:
         "Tags": null
       }
   -
-    Name: Global Resources Are Enabled - us-east-2
+    Name: Global Resources Are Not Enabled - us-east-2
     ExpectedResult: false
     Resource:
       {

--- a/aws_config_policies/aws_config_global_resources.yml
+++ b/aws_config_policies/aws_config_global_resources.yml
@@ -17,118 +17,56 @@ Runbook: >
 Reference: https://amzn.to/2MO8xXM
 Tests:
   -
-    Name: Global Resources Are Not Enabled - us-west-1
+    Name: No Global Recoders Present
     ExpectedResult: false
     Resource:
       {
-        "Name": "Default",
-        "Status": {
-          "LastStatusChangeTime": "2021-03-02T18:44:20.599Z",
-          "LastErrorCode": null,
-          "LastStartTime": "2018-10-05T22:44:09.84Z",
-          "Recording": true,
-          "Name": "Default",
-          "LastStatus": "SUCCESS",
-          "LastStopTime": null,
-          "LastErrorMessage": null
-        },
-        "ResourceType": "AWS.Config.Recorder",
-        "AccountId": "123456789012",
-        "RoleARN": "arn:aws:iam::123456789012:role/BobertConfigRole",
-        "Tags": null,
         "TimeCreated": null,
-        "ResourceId": "123456789012:us-west-1:AWS.Config.Recorder",
-        "Region": "us-west-1",
-        "RecordingGroup": {
-          "ResourceTypes": null,
-          "AllSupported": true,
-          "IncludeGlobalResourceTypes": false
-        }
+        "AccountId": "123456789012",
+        "ResourceId": "123456789012::AWS.Config.Recorder.Meta",
+        "ResourceType": "AWS.Config.Recorder.Meta",
+        "Tags": null,
+        "Region": "global",
+        "Recorders": null,
+        "Name": "AWS.Config.Recorder.Meta",
+        "GlobalRecorderCount": 0
       }
   -
-    Name: Global Resources Are Enabled - us-west-2
+    Name: __REPLACE_ACCOUNT_ID_TO_SUPPORT_TESTING__ Global Resources Are Enabled
     ExpectedResult: true
     Resource:
       {
-        "Region": "us-west-2",
-        "Name": "Default",
-        "AccountId": "123456789012",
-        "ResourceType": "AWS.Config.Recorder",
-        "RecordingGroup": {
-          "AllSupported": true,
-          "IncludeGlobalResourceTypes": true,
-          "ResourceTypes": null
-        },
-        "ResourceId": "123456789012:us-west-2:AWS.Config.Recorder",
-        "TimeCreated": null,
-        "RoleARN": "arn:aws:iam::123456789012:role/BobertConfigRole",
-        "Tags": null,
-        "Status": {
-          "Name": "Default",
-          "LastStatus": "SUCCESS",
-          "LastStopTime": null,
-          "LastErrorMessage": null,
-          "LastStatusChangeTime": "2021-03-02T19:08:33.874Z",
-          "LastErrorCode": null,
-          "LastStartTime": "2018-10-05T21:51:28.665Z",
-          "Recording": true
-        }
+          "TimeCreated": null,
+          "AccountId": "123456789012",
+          "ResourceId": "123456789012::AWS.Config.Recorder.Meta",
+          "ResourceType": "AWS.Config.Recorder.Meta",
+          "Tags": null,
+          "Region": "global",
+          "Recorders": [
+              "123456789012:us-east-1:AWS.Config.Recorder",
+              "123456789012:us-east-2:AWS.Config.Recorder",
+              "123456789012:us-west-1:AWS.Config.Recorder",
+              "123456789012:us-west-2:AWS.Config.Recorder"
+        ],
+          "Name": "AWS.Config.Recorder.Meta",
+          "GlobalRecorderCount": 4
       }
-  -
-    Name: Global Resources Are Not Enabled - us-east-1
-    ExpectedResult: false
-    Resource:
-      {
-        "ResourceId": "123456789012:us-east-1:AWS.Config.Recorder",
-        "RecordingGroup": {
-          "AllSupported": true,
-          "IncludeGlobalResourceTypes": false,
-          "ResourceTypes": null
-        },
-        "RoleARN": "arn:aws:iam::123456789012:role/BobertConfigRole",
-        "AccountId": "123456789012",
-        "Region": "us-east-1",
-        "ResourceType": "AWS.Config.Recorder",
-        "Name": "Default",
-        "Status": {
-          "LastErrorMessage": null,
-          "LastStatusChangeTime": "2021-03-02T17:45:16.47Z",
-          "LastErrorCode": null,
-          "LastStartTime": "2018-10-05T22:45:01.838Z",
-          "Recording": true,
-          "Name": "Default",
-          "LastStatus": "SUCCESS",
-          "LastStopTime": null
-        },
-        "TimeCreated": null,
-        "Tags": null
-      }
-  -
-    Name: Global Resources Are Not Enabled - us-east-2
-    ExpectedResult: false
-    Resource:
-      {
-        "Name": "Default",
-        "ResourceId": "123456789012:us-east-2:AWS.Config.Recorder",
-        "TimeCreated": null,
-        "AccountId": "123456789012",
-        "Status": {
-          "Recording": true,
-          "Name": "Default",
-          "LastStatus": "SUCCESS",
-          "LastStopTime": null,
-          "LastErrorMessage": null,
-          "LastStatusChangeTime": "2021-03-02T19:45:33.138Z",
-          "LastErrorCode": null,
-          "LastStartTime": "2018-10-05T22:45:02.49Z"
-        },
-        "Tags": null,
-        "Region": "us-east-2",
-        "ResourceType": "AWS.Config.Recorder",
-        "RecordingGroup": {
-          "AllSupported": true,
-          "IncludeGlobalResourceTypes": false,
-          "ResourceTypes": null
-        },
-        "RoleARN": "arn:aws:iam::123456789012:role/BobertConfigRole"
-      }
+
+
+# Requires unit test mocking to properly support this unit test
+#  - Name: Global Recorders Present - None Recording Global Resources
+#    ExpectedResult: false
+#    Resource:
+#      {
+#        "TimeCreated": null,
+#        "Recorders": [
+#          "123456789012:us-west-2:AWS.Config.Recorder"
+#        ],
+#        "AccountId": "123456789012",
+#        "Name": "AWS.Config.Recorder.Meta",
+#        "GlobalRecorderCount": 1,
+#        "Tags": null,
+#        "Region": "global",
+#        "ResourceType": "AWS.Config.Recorder.Meta",
+#        "ResourceId": "123456789012::AWS.Config.Recorder.Meta"
+#      }

--- a/aws_config_policies/aws_config_global_resources.yml
+++ b/aws_config_policies/aws_config_global_resources.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.Config.GlobalResources
 DisplayName: AWS Config Global Resources
 Enabled: true
 ResourceTypes:
-  - AWS.Config.Recorder
+  - AWS.Config.Recorder.Meta
 Tags:
   - AWS
   - Security Control

--- a/aws_config_policies/aws_config_global_resources.yml
+++ b/aws_config_policies/aws_config_global_resources.yml
@@ -4,7 +4,7 @@ PolicyID: AWS.Config.GlobalResources
 DisplayName: AWS Config Global Resources
 Enabled: true
 ResourceTypes:
-  - AWS.Config.Recorder.Meta
+  - AWS.Config.Recorder
 Tags:
   - AWS
   - Security Control
@@ -17,18 +17,118 @@ Runbook: >
 Reference: https://amzn.to/2MO8xXM
 Tests:
   -
-    Name: Global Resources Are Enabled
-    ExpectedResult: true
-    Resource:
-      {
-        "GlobalRecorderCount": 4,
-        "GlobalResourcesEnabled": true
-      }
-  -
-    Name: Global Resources Are Not Enabled
+    Name: Global Resources Are Enabled - us-west-1
     ExpectedResult: false
     Resource:
       {
-        "GlobalRecorderCount": 4,
-        "GlobalResourcesEnabled": false
+        "Name": "Default",
+        "Status": {
+          "LastStatusChangeTime": "2021-03-02T18:44:20.599Z",
+          "LastErrorCode": null,
+          "LastStartTime": "2018-10-05T22:44:09.84Z",
+          "Recording": true,
+          "Name": "Default",
+          "LastStatus": "SUCCESS",
+          "LastStopTime": null,
+          "LastErrorMessage": null
+        },
+        "ResourceType": "AWS.Config.Recorder",
+        "AccountId": "123456789012",
+        "RoleARN": "arn:aws:iam::123456789012:role/BobertConfigRole",
+        "Tags": null,
+        "TimeCreated": null,
+        "ResourceId": "123456789012:us-west-1:AWS.Config.Recorder",
+        "Region": "us-west-1",
+        "RecordingGroup": {
+          "ResourceTypes": null,
+          "AllSupported": true,
+          "IncludeGlobalResourceTypes": false
+        }
+      }
+  -
+    Name: Global Resources Are Enabled - us-west-2
+    ExpectedResult: true
+    Resource:
+      {
+        "Region": "us-west-2",
+        "Name": "Default",
+        "AccountId": "123456789012",
+        "ResourceType": "AWS.Config.Recorder",
+        "RecordingGroup": {
+          "AllSupported": true,
+          "IncludeGlobalResourceTypes": true,
+          "ResourceTypes": null
+        },
+        "ResourceId": "123456789012:us-west-2:AWS.Config.Recorder",
+        "TimeCreated": null,
+        "RoleARN": "arn:aws:iam::123456789012:role/BobertConfigRole",
+        "Tags": null,
+        "Status": {
+          "Name": "Default",
+          "LastStatus": "SUCCESS",
+          "LastStopTime": null,
+          "LastErrorMessage": null,
+          "LastStatusChangeTime": "2021-03-02T19:08:33.874Z",
+          "LastErrorCode": null,
+          "LastStartTime": "2018-10-05T21:51:28.665Z",
+          "Recording": true
+        }
+      }
+  -
+    Name: Global Resources Are Not Enabled - us-east-1
+    ExpectedResult: false
+    Resource:
+      {
+        "ResourceId": "123456789012:us-east-1:AWS.Config.Recorder",
+        "RecordingGroup": {
+          "AllSupported": true,
+          "IncludeGlobalResourceTypes": false,
+          "ResourceTypes": null
+        },
+        "RoleARN": "arn:aws:iam::123456789012:role/BobertConfigRole",
+        "AccountId": "123456789012",
+        "Region": "us-east-1",
+        "ResourceType": "AWS.Config.Recorder",
+        "Name": "Default",
+        "Status": {
+          "LastErrorMessage": null,
+          "LastStatusChangeTime": "2021-03-02T17:45:16.47Z",
+          "LastErrorCode": null,
+          "LastStartTime": "2018-10-05T22:45:01.838Z",
+          "Recording": true,
+          "Name": "Default",
+          "LastStatus": "SUCCESS",
+          "LastStopTime": null
+        },
+        "TimeCreated": null,
+        "Tags": null
+      }
+  -
+    Name: Global Resources Are Enabled - us-east-2
+    ExpectedResult: false
+    Resource:
+      {
+        "Name": "Default",
+        "ResourceId": "123456789012:us-east-2:AWS.Config.Recorder",
+        "TimeCreated": null,
+        "AccountId": "123456789012",
+        "Status": {
+          "Recording": true,
+          "Name": "Default",
+          "LastStatus": "SUCCESS",
+          "LastStopTime": null,
+          "LastErrorMessage": null,
+          "LastStatusChangeTime": "2021-03-02T19:45:33.138Z",
+          "LastErrorCode": null,
+          "LastStartTime": "2018-10-05T22:45:02.49Z"
+        },
+        "Tags": null,
+        "Region": "us-east-2",
+        "ResourceType": "AWS.Config.Recorder",
+        "RecordingGroup": {
+          "AllSupported": true,
+          "IncludeGlobalResourceTypes": false,
+          "ResourceTypes": null
+        },
+        "RoleARN": "arn:aws:iam::123456789012:role/BobertConfigRole"
       }

--- a/aws_iam_policies/aws_access_keys_at_account_creation.py
+++ b/aws_iam_policies/aws_access_keys_at_account_creation.py
@@ -1,11 +1,10 @@
-import datetime
-
+from datetime import datetime, timedelta
 from panther_base_helpers import deep_get
 
 AWS_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 PANTHER_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DEFAULT_TIME = "0001-01-01T00:00:00Z"
-MAX_SECONDS_TO_AUTOGEN_KEY = datetime.timedelta(seconds=7)
+MAX_SECONDS_TO_AUTOGEN_KEY = timedelta(seconds=7)
 
 
 def policy(resource):
@@ -20,7 +19,10 @@ def policy(resource):
         return True
 
     create = resource["TimeCreated"]
-    key_rot_date = datetime.datetime.strptime(key_rot, AWS_TIME_FORMAT)
-    create_date = datetime.datetime.strptime(create, PANTHER_TIME_FORMAT)
+    key_rot_date = datetime.strptime(key_rot, AWS_TIME_FORMAT)
+    try:
+        create_date = datetime.strptime(create, PANTHER_TIME_FORMAT)
+    except ValueError:
+        create_date = datetime.strptime(create, AWS_TIME_FORMAT)
 
     return (key_rot_date - create_date) >= MAX_SECONDS_TO_AUTOGEN_KEY

--- a/aws_iam_policies/aws_access_keys_at_account_creation.yml
+++ b/aws_iam_policies/aws_access_keys_at_account_creation.yml
@@ -283,3 +283,51 @@ Tests:
         "UserName": "Bobert",
         "VirtualMFA": null
       }
+  -
+    Name: Observed - Timestamp Issues
+    ExpectedResult: true
+    Resource:
+      {
+        "AccountId": "123456789012",
+        "CredentialReport": {
+          "MfaActive": true,
+          "AccessKey1LastUsedRegion": "us-east-1",
+          "Cert2LastRotated": "0001-01-01T00:00:00Z",
+          "AccessKey2Active": false,
+          "AccessKey2LastRotated": "0001-01-01T00:00:00Z",
+          "AccessKey1LastRotated": "2021-02-07T09:18:42Z",
+          "AccessKey1LastUsedService": "sts",
+          "AccessKey1LastUsedDate": "2021-03-01T14:31:00Z",
+          "UserName": "bobert",
+          "PasswordEnabled": true,
+          "PasswordLastChanged": "2021-02-09T14:05:34Z",
+          "UserCreationTime": "2020-06-02T09:33:48Z",
+          "PasswordLastUsed": "2021-03-01T10:13:14Z",
+          "AccessKey2LastUsedDate": "0001-01-01T00:00:00Z",
+          "PasswordNextRotation": "2021-05-10T14:05:34Z",
+          "AccessKey1Active": true,
+          "ARN": "arn:aws:iam::123456789012:user/bobert",
+          "Cert1LastRotated": "0001-01-01T00:00:00Z",
+          "Cert1Active": false,
+          "AccessKey2LastUsedService": "N/A",
+          "Cert2Active": false,
+          "AccessKey2LastUsedRegion": "N/A"
+        },
+        "PasswordLastUsed": "2021-03-01T10:13:14Z",
+        "InlinePolicies": null,
+        "Id": "XXXXXXXXXXXXXXXXXXXXX",
+        "TimeCreated": "2020-06-02T09:33:48Z",
+        "Arn": "arn:aws:iam::123456789012:user/bobert",
+        "Path": "/",
+        "VirtualMFA": {
+          "SerialNumber": "arn:aws:iam::123456789012:mfa/bobert",
+          "EnableDate": "2020-06-02T10:10:10Z"
+        },
+        "PermissionsBoundary": null,
+        "Region": "global",
+        "Tags": null,
+        "ResourceId": "arn:aws:iam::123456789012:user/bobert",
+        "ResourceType": "AWS.IAM.User",
+        "Name": "bobert",
+        "ManagedPolicyNames": null
+      }

--- a/aws_load_balancer_policies/aws_alb_ssl_policy.py
+++ b/aws_load_balancer_policies/aws_alb_ssl_policy.py
@@ -10,9 +10,9 @@ TLS_1_2_POLICIES = {
 
 def policy(resource):
     # Ignore load balancers that aren't serving internet traffic
-    if resource["Scheme"] == "internal":
+    if resource.get("Scheme") == "internal":
         return True
 
-    return len(resource["Listeners"]) >= 1 and all(
-        (policy in TLS_1_2_POLICIES for policy in resource["SSLPolicies"].keys())
+    return len(resource.get("Listeners") if resource.get("Listeners") else []) >= 1 and all(
+        (each_policy in TLS_1_2_POLICIES for each_policy in resource.get("SSLPolicies", {}).keys())
     )

--- a/aws_load_balancer_policies/aws_alb_ssl_policy.yml
+++ b/aws_load_balancer_policies/aws_alb_ssl_policy.yml
@@ -508,3 +508,27 @@ Tests:
         "CanonicalHostedZonedId": "Z1H1FL5HABSF5",
         "ResourceType": "AWS.ELBV2.ApplicationLoadBalancer"
       }
+  -
+    Name: Observed - No Listeners len() issue
+    ExpectedResult: false
+    Resource:
+      {
+        "Listeners": null,
+        "Scheme": "internet-facing",
+        "SSLPolicies": {
+          "ELBSecurityPolicy-2016-08": {
+            "Ciphers": [
+              {
+                "Priority": 1,
+                "Name": "ECDHE-ECDSA-AES128-GCM-SHA256"
+              }
+            ],
+            "SslProtocols": [
+                "TLSv1",
+                "TLSv1.1",
+                "TLSv1.2"
+            ],
+            "Name": "ELBSecurityPolicy-2016-08"
+          }
+        }
+      }


### PR DESCRIPTION
### Background

@s0l0ist found 3 policies that were erroring out:

1. AWS.AccessKeys.AccountCreation
2. AWS.Config.GlobalResources
3. AWS.ELBv2.SSLPolicy

### Changes

- AWS.AccessKeys.AccountCreation
 - Wrapped the `datetime.strptime` in a try/except that attempts to use both the `PANTHER_TIME_FORMAT` and `AWS_TIME_FORMAT`
- AWS.Config.GlobalResources
 - Reworked the policy. Now checks if any of the recorders are configured for global resources on a per-account basis.
- AWS.ELBv2.SSLPolicy
 - Added conditionals for safe evaluation
 - Renamed iterator because of outer-scope shadow issue

### Testing

* `panther_analysis_tool test`
* Tested in live deployments with the resources causing issues created as unit tests
