### PR TITLE
Fixed token name for GitHub workflow automation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,14 +36,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ${{ env.SOURCE_REPO_CHECKOUT_PATH }}
-          token: ${{ secrets.PR_SYNC_TOKEN }}
+          token: ${{ secrets.PANTHER_ANALYSIS_PR_SYNC_TOKEN }}
 
       - name: Checkout Dest Repo
         uses: actions/checkout@v2
         with:
           path: ${{ env.DEST_REPO_CHECKOUT_PATH }}
           repository: ${{ env.DEST_REPO }}
-          token: ${{ secrets.PR_SYNC_TOKEN }}
+          token: ${{ secrets.PANTHER_ANALYSIS_PR_SYNC_TOKEN }}
 
       - name: Setup Git Credentials
         working-directory: ${{ env.DEST_REPO_CHECKOUT_PATH }}
@@ -71,4 +71,4 @@ jobs:
         with:
           repo: ${{ env.DEST_REPO }}
           head: ${{ env.HEAD }}
-          token: ${{ secrets.PR_SYNC_TOKEN }}
+          token: ${{ secrets.PANTHER_ANALYSIS_PR_SYNC_TOKEN }}


### PR DESCRIPTION
### Background

The Organization Token for synchronizing pull requests to the dogfood repo was created under a different name. 