### PR TITLE
panther aws pack

### DIFF
--- a/aws_account_policies/aws_password_policy_complexity_guidelines.py
+++ b/aws_account_policies/aws_password_policy_complexity_guidelines.py
@@ -2,20 +2,28 @@ IGNORED = {}
 
 
 def policy(resource):
-    if not resource["RequireUppercaseCharacters"] and "RequireUppercaseCharacters" not in IGNORED:
-        return False
-
-    if not resource["RequireLowercaseCharacters"] and "RequireLowercaseCharacters" not in IGNORED:
-        return False
-
-    if not resource["RequireSymbols"] and "RequireSymbols" not in IGNORED:
-        return False
-
-    if not resource["RequireNumbers"] and "RequireNumbers" not in IGNORED:
+    if (
+        not resource.get("RequireUppercaseCharacters")
+        and "RequireUppercaseCharacters" not in IGNORED
+    ):
         return False
 
     if (
-        not (resource["MinimumPasswordLength"] and resource["MinimumPasswordLength"] >= 14)
+        not resource.get("RequireLowercaseCharacters")
+        and "RequireLowercaseCharacters" not in IGNORED
+    ):
+        return False
+
+    if not resource.get("RequireSymbols") and "RequireSymbols" not in IGNORED:
+        return False
+
+    if not resource.get("RequireNumbers") and "RequireNumbers" not in IGNORED:
+        return False
+
+    if (
+        not (
+            resource.get("MinimumPasswordLength") and resource.get("MinimumPasswordLength", 0) >= 14
+        )
         and "MinimumPasswordLength" not in IGNORED
     ):
         return False

--- a/packs/aws.yml
+++ b/packs/aws.yml
@@ -1,0 +1,62 @@
+AnalysisType: pack
+PackID: PantherManaged.AWS.Core
+Description: Group of the most critical and high value detections pertinent to the aws environment
+PackDefinition:
+  IDs:
+    # Data Exposure
+    - AWS.AMI.Private
+    - AWS.CloudTrail.S3Bucket.Public
+    - AWS.IAM.AccessKeyCompromised
+    - AWS.KMS.RestrictsUsage
+    - AWS.RDS.Instance.PublicAccess
+    - AWS.RDS.Instance.SnapshotPublicAccess
+    - AWS.S3.Bucket.PublicRead
+    - AWS.S3.Bucket.PublicWrite
+    - AWS.S3.Bucket.PolicyAllowWithNotPrincipal
+    - AWS.S3.Bucket.PrincipalRestrictions
+    # Encryption Status
+    - AWS.DynamoDB.TableEncryption
+    - AWS.EC2.Volume.Encryption
+    - AWS.EC2.Volume.Snapshot.Encrypted
+    - AWS.Redshift.Cluster.Encryption
+    - AWS.RDS.Instance.Encryption
+    - AWS.S3.Bucket.Encryption
+    # Networking Policies
+    - AWS.NetworkACL.RestrictsInboundTraffic
+    - AWS.SecurityGroup.AdministrativeIngress
+    - AWS.SecurityGroup.OnlyDMZPubliclyAccessible
+    - AWS.SecurityGroup.RestrictsInboundTraffic
+    # Root Activity
+    - AWS.Console.RootLogin
+    - AWS.Console.RootLoginFailed
+    - AWS.Root.Activity
+    - AWS.CloudTrail.RootAccessKeyCreated
+    - AWS.CloudTrail.RootPasswordChanged
+    - AWS.RootAccount.AccessKeys
+    - AWS.RootAccount.MFA
+    # User and Account Policies and Rules
+    - AWS.Console.LoginWithoutMFA
+    - AWS.IAM.Entity.InlinePolicyDoesNotGrantNetworkAdminAccess
+    - AWS.IAM.User.MFA
+    - AWS.PasswordPolicy.ComplexityGuidelines
+    # General Policies and Rules
+    - AWS.ACM.Certificate.Valid
+    - AWS.CloudTrail.Enabled
+    - AWS.Config.RecordingEnabled
+    - AWS.IAM.Policy.AdministrativePrivileges
+    - AWS.GuardDuty.Enabled
+    - AWS.GuardDuty.HighSeverityFinding
+    - AWS.ELBV2.LoadBalancer.HasSSLPolicy
+    - AWS.WAF.HasXSSPredicate
+    # Standard Rules applicable to AWS
+    - Standard.BruteForceByIP
+    # AWS DataModels
+    - Standard.AWS.ALB
+    - Standard.AWS.CloudTrail
+    - Standard.AWS.S3ServerAccess
+    - Standard.AWS.VPCFlow
+    # Globals used in these rules/policies
+    - panther_base_helpers
+    - panther_event_type_helpers
+    - panther_oss_helpers
+DisplayName: Panther Core AWS Pack

--- a/packs/aws.yml
+++ b/packs/aws.yml
@@ -5,6 +5,7 @@ PackDefinition:
   IDs:
     # Data Exposure
     - AWS.AMI.Private
+    - AWS.CloudTrail.AMIModifiedForPublicAccess
     - AWS.CloudTrail.S3Bucket.Public
     - AWS.IAM.AccessKeyCompromised
     - AWS.KMS.RestrictsUsage
@@ -38,11 +39,14 @@ PackDefinition:
     - AWS.Console.LoginWithoutMFA
     - AWS.IAM.Entity.InlinePolicyDoesNotGrantNetworkAdminAccess
     - AWS.IAM.User.MFA
+    - AWS.Password.Unused
     - AWS.PasswordPolicy.ComplexityGuidelines
+    - AWS.PasswordPolicy.PasswordAgeLimit
     # General Policies and Rules
     - AWS.ACM.Certificate.Valid
     - AWS.CloudTrail.Enabled
     - AWS.Config.RecordingEnabled
+    - AWS.Config.RecordingNoErrors
     - AWS.IAM.Policy.AdministrativePrivileges
     - AWS.GuardDuty.Enabled
     - AWS.GuardDuty.HighSeverityFinding


### PR DESCRIPTION
### Background

Asana URL: Closes https://app.asana.com/0/1199940726973121/1199936510096869/f

Interest in creating a panther-managed "aws" pack that consists of the most critical, high value detections that can be used out of the box.

### Changes

* created core panther aws pack

### Testing

* `make ci`

![image](https://user-images.githubusercontent.com/43453975/111375605-b0208800-865b-11eb-8fa6-43e7ffefe753.png)

![image](https://user-images.githubusercontent.com/43453975/111375635-bb73b380-865b-11eb-9ddf-1597d73de28c.png)

### Additional Details
- Included _all_ High & Critical Sev Policies & Rules
    - **_Except_**: those with "Configuration Required" Tags
- Included the following Medium Severity Rules:
    - AWS.Password.Unused
    - AWS.PasswordPolicy.PasswordAgeLimit
    - AWS.CloudTrail.AMIModifiedForPublicAccess
    - AWS.Config.RecordingNoErrors
        - nice to combine with High Sev `AWS.Config.RecordingEnabled` detection
    - Standard.BruteForceByIP
- Excluded:
    - Anything already auto-disabled out of the box
    - All INFO level severities
        - **_Note_**: in the future, it would be cool to define an "informational aws pack" that has a pack definition like... `LogType: aws.* ResourceType: aws.* Severity: INFO` 
            - this would be especially nice when combine with the auto-resolve INFO level alerts feature
    - AWS.NetworkACL.RestrictedSHH
        - SSH isn't guaranteed to be running, so perhaps don't default enable this
    - AWS.RootAccount.HardwareMFA
        - MFA for root account is monitored via `AWS.RootAccount.MFA` this is just icing on the cake

