### PR TITLE
Migrate Lacework schema and tests

### DIFF
--- a/schemas/logs/lacework/events.yml
+++ b/schemas/logs/lacework/events.yml
@@ -1,7 +1,4 @@
 schema: Lacework.Events
-parser:
-  native:
-    name: Lacework.Events
 description: Lacework.Events represents the content of an exported Lacework Alert S3 Object.
 referenceURL: https://www.lacework.com/platform-overview/
 version: 0
@@ -166,6 +163,8 @@ fields:
                       - name: IP_ADDRESS
                         description: SourceIPAddress field
                         type: string
+                        indicators:
+                          - ip
                       - name: TOTAL_IN_BYTES
                         description: TotalINBytes field
                         type: float
@@ -274,6 +273,8 @@ fields:
                       - name: IP_ADDRESS
                         description: SourceIPAddress field
                         type: string
+                        indicators:
+                          - ip
                       - name: REGION
                         description: Region field
                         type: string
@@ -427,7 +428,8 @@ fields:
     required: true
     description: The event start time.
     type: timestamp
-    timeFormat: rfc3339
+    timeFormat: '%d %b %Y %H:%M %Z'
+    isEventTime: true
   - name: SUMMARY
     required: true
     description: The alert title and quick summary

--- a/schemas/logs/lacework/tests/lacework_tests.yml
+++ b/schemas/logs/lacework/tests/lacework_tests.yml
@@ -1,0 +1,141 @@
+name: Lacework.AWS
+logType: Lacework.Events
+input: |
+  {
+  		"EVENT_CATEGORY": "App",
+  		"EVENT_DETAILS": {
+  			"data": [
+  				{
+  					"START_TIME": "2020-07-08T09:00:00Z",
+  					"END_TIME": "2020-07-08T09:00:00Z",
+  					"EVENT_MODEL": "PtypeConn",
+  					"EVENT_TYPE": "NewInternalConnection",
+  					"ENTITY_MAP": {
+  						"Container": [
+  							{
+  								"HAS_EXTERNAL_CONNS": 0,
+  								"IMAGE_TAG": "xxx",
+  								"IS_SERVER": 1,
+  								"FIRST_SEEN_TIME": "2020-07-08T09:00:00Z",
+  								"IMAGE_REPO": "xxx",
+  								"IS_CLIENT": 0
+  							}
+  						],
+  						"User": [
+  							{
+  								"MACHINE_HOSTNAME": "ip-10-0-64-135",
+  								"USERNAME": "root"
+  							}
+  						],
+  						"Process": [
+  							{
+  								"HOSTNAME": "ip-10-0-64-135",
+  								"CMDLINE": "xxx",
+  								"PROCESS_START_TIME": "2020-07-08T09:00:00Z",
+  								"CPU_PERCENTAGE": 0.02,
+  								"PROCESS_ID": 25325
+  							}
+  						],
+  						"Machine": [
+  							{
+  								"EXTERNAL_IP": "",
+  								"CPU_PERCENTAGE": 10.61
+  							}
+  						],
+  						"SourceIpAddress": [
+  							{
+  								"IP_ADDRESS": "169.254.169.254"
+  							}
+  						],
+  						"IpAddress": [
+  							{
+  								"IP_ADDRESS": "0.0.0.0"
+  							}
+  						]
+  					},
+  					"EVENT_ACTOR": "App",
+  					"EVENT_ID": "16206"
+  				}
+  			]
+  		},
+  		"SEVERITY": 5,
+  		"START_TIME": "08 Jul 2020 09:00 GMT",
+  		"SUMMARY": "xxx",
+  		"EVENT_TYPE": "NewInternalConnection",
+  		"EVENT_NAME": "New Internal Connection",
+  		"LINK": "www.example.com",
+  		"EVENT_ID": 16206,
+  		"ACCOUNT": "HCP",
+  		"SOURCE": "Lacework Agent"
+  	}
+result: |
+  {
+  		"EVENT_CATEGORY": "App",
+  		"EVENT_DETAILS": {
+  			"data": [
+  				{
+  					"START_TIME": "2020-07-08T09:00:00Z",
+  					"END_TIME": "2020-07-08T09:00:00Z",
+  					"EVENT_MODEL": "PtypeConn",
+  					"EVENT_TYPE": "NewInternalConnection",
+  					"ENTITY_MAP": {
+  						"Container": [
+  							{
+  								"HAS_EXTERNAL_CONNS": 0,
+  								"IMAGE_TAG": "xxx",
+  								"IS_SERVER": 1,
+  								"FIRST_SEEN_TIME": "2020-07-08T09:00:00Z",
+  								"IMAGE_REPO": "xxx",
+  								"IS_CLIENT": 0
+  							}
+  						],
+  						"User": [
+  							{
+  								"MACHINE_HOSTNAME": "ip-10-0-64-135",
+  								"USERNAME": "root"
+  							}
+  						],
+  						"Process": [
+  							{
+  								"HOSTNAME": "ip-10-0-64-135",
+  								"CMDLINE": "xxx",
+  								"PROCESS_START_TIME": "2020-07-08T09:00:00Z",
+  								"CPU_PERCENTAGE": 0.02,
+  								"PROCESS_ID": 25325
+  							}
+  						],
+  						"Machine": [
+  							{
+  								"EXTERNAL_IP": "",
+  								"CPU_PERCENTAGE": 10.61
+  							}
+  						],
+  						"SourceIpAddress": [
+  							{
+  								"IP_ADDRESS": "169.254.169.254"
+  							}
+  						],
+  						"IpAddress": [
+  							{
+  								"IP_ADDRESS": "0.0.0.0"
+  							}
+  						]
+  					},
+  					"EVENT_ACTOR": "App",
+  					"EVENT_ID": "16206"
+  				}
+  			]
+  		},
+  		"SEVERITY": 5,
+  		"START_TIME": "08 Jul 2020 09:00 GMT",
+  		"SUMMARY": "xxx",
+  		"EVENT_TYPE": "NewInternalConnection",
+  		"EVENT_NAME": "New Internal Connection",
+  		"LINK": "www.example.com",
+  		"EVENT_ID": 16206,
+  		"ACCOUNT": "HCP",
+  		"SOURCE": "Lacework Agent",
+        "p_log_type": "Lacework.Events",
+        "p_event_time": "2020-07-08T09:00:00Z",
+        "p_any_ip_addresses": ["0.0.0.0","169.254.169.254"]
+  	}


### PR DESCRIPTION
### Background
Closes https://app.asana.com/0/0/1200129853533114/f

### Changes

* Remove Lacework schema `native` parser
* Migrate tests from Go
* Fix time format to use strftime
* Add missing indicators

### Testing

* pantherlog test ./schemas
