### PR TITLE
Add pantherlog test to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,9 @@ commands:
     parameters:
       version:
         type: string
+        description: The version tag to download
     steps:
-        - run:
-            name: Download pantherlog binary
-            command: curl -sSO "https://panther-community-us-east-1.s3.amazonaws.com/<<parameters.version>>/tools/dev/pantherlog-linux-amd64 && mv pantherlog-linux-amd64 pantherlog && chmod +x pantherlog"
+        - run: curl -sSO "https://panther-community-us-east-1.s3.amazonaws.com/<<parameters.version>>/tools/dev/pantherlog-linux-amd64 && mv pantherlog-linux-amd64 pantherlog && chmod +x pantherlog"
 
 jobs:
   lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,15 @@
 version: 2
 
+commands:
+  download_pantherlog:
+    parameters:
+      version:
+        type: string
+    steps:
+        - run:
+            name: Download pantherlog binary
+            command: curl -sSO "https://panther-community-us-east-1.s3.amazonaws.com/<<parameters.version>>/tools/dev/pantherlog-linux-amd64 && mv pantherlog-linux-amd64 pantherlog && chmod +x pantherlog"
+
 jobs:
   lint:
     docker:
@@ -55,15 +65,14 @@ jobs:
           command: pipenv run -- make test
   schema_tests:
       docker:
-        - image: 'circleci/golang'
+        - image: 'circleci/python:3.7'
       steps:
         - checkout
-        - run:
-            name: Install pantherlog binary
-            command: curl -sSO https://panther-community-us-east-1.s3.amazonaws.com/v1.17.0-RC/tools/dev/pantherlog-linux-amd64 && mv pantherlog-linux-amd64 pantherlog && chmod +x pantherlog
+        - download_pantherlog:
+            version: v1.17.0-RC
         - run:
             name: Run schema tests
-            command: ./pantherlog test ./schemas
+            command: ./pantherlog -v && ./pantherlog test ./schemas
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       steps:
         - checkout
         - run:
-            name: Install panthelrog binary
+            name: Install pantherlog binary
             command: curl -sSO https://panther-community-us-east-1.s3.amazonaws.com/v1.17.0-RC/tools/dev/pantherlog-linux-amd64 && mv pantherlog-linux-amd64 pantherlog && chmod +x pantherlog
         - run:
             name: Run schema tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 commands:
-  run_schema_tests:
+  download_pantherlog_tool:
     parameters:
       version:
         type: string
@@ -9,10 +9,7 @@ commands:
     steps:
         - run:
             name: Download pantherlog tool
-            command: curl -sSO "https://panther-community-us-east-1.s3.amazonaws.com/<<parameters.version>>/tools/dev/pantherlog-linux-amd64 && mv pantherlog-linux-amd64 pantherlog && chmod +x pantherlog"
-        - run:
-            name: Run schema tests
-            command: ./pantherlog -v && ./pantherlog test ./schemas
+            command: curl -sSO "https://panther-community-us-east-1.s3.amazonaws.com/<<parameters.version>>/tools/dev/pantherlog-linux-amd64" && mv pantherlog-linux-amd64 pantherlog && chmod +x pantherlog
 
 jobs:
   lint:
@@ -72,8 +69,11 @@ jobs:
         - image: 'circleci/python:3.7'
       steps:
         - checkout
-        - run_schema_tests:
+        - download_pantherlog_tool:
             version: v1.17.0-RC
+        - run:
+            name: Run schema tests
+            command: ./pantherlog -v && ./pantherlog test ./schemas
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - run:
           name: Run unit tests
           command: pipenv run -- make test
-    schema_tests:
+  schema_tests:
       docker:
         - image: 'circleci/golang'
       steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 commands:
   download_pantherlog:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,18 @@
 version: 2.1
 
 commands:
-  download_pantherlog:
+  run_schema_tests:
     parameters:
       version:
         type: string
         description: The version tag to download
     steps:
-        - run: curl -sSO "https://panther-community-us-east-1.s3.amazonaws.com/<<parameters.version>>/tools/dev/pantherlog-linux-amd64 && mv pantherlog-linux-amd64 pantherlog && chmod +x pantherlog"
+        - run:
+            name: Download pantherlog tool
+		    command: curl -sSO "https://panther-community-us-east-1.s3.amazonaws.com/<<parameters.version>>/tools/dev/pantherlog-linux-amd64 && mv pantherlog-linux-amd64 pantherlog && chmod +x pantherlog"
+        - run:
+            name: Run schema tests
+            command: ./pantherlog -v && ./pantherlog test ./schemas
 
 jobs:
   lint:
@@ -67,11 +72,8 @@ jobs:
         - image: 'circleci/python:3.7'
       steps:
         - checkout
-        - download_pantherlog:
+        - run_schema_tests:
             version: v1.17.0-RC
-        - run:
-            name: Run schema tests
-            command: ./pantherlog -v && ./pantherlog test ./schemas
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,4 +71,4 @@ workflows:
     jobs:
       - lint
       - unit_tests
-	  - schema_tests
+      - schema_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,17 @@ jobs:
       - run:
           name: Run unit tests
           command: pipenv run -- make test
+	schema_tests:
+	  docker:
+	    - image: 'circleci/golang'
+	  steps:
+	    - checkout
+		- run:
+		    name: Install panthelrog binary
+		    command: curl -sSO https://panther-community-us-east-1.s3.amazonaws.com/v1.17.0-RC/tools/dev/pantherlog-linux-amd64 && mv pantherlog-linux-amd64 pantherlog && chmod +x pantherlog
+		- run:
+		    name: Run schema tests
+			command: ./pantherlog test ./schemas
 
 workflows:
   version: 2
@@ -60,3 +71,4 @@ workflows:
     jobs:
       - lint
       - unit_tests
+	  - schema_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,17 +53,17 @@ jobs:
       - run:
           name: Run unit tests
           command: pipenv run -- make test
-	schema_tests:
-	  docker:
-	    - image: 'circleci/golang'
-	  steps:
-	    - checkout
-		- run:
-		    name: Install panthelrog binary
-		    command: curl -sSO https://panther-community-us-east-1.s3.amazonaws.com/v1.17.0-RC/tools/dev/pantherlog-linux-amd64 && mv pantherlog-linux-amd64 pantherlog && chmod +x pantherlog
-		- run:
-		    name: Run schema tests
-			command: ./pantherlog test ./schemas
+    schema_tests:
+      docker:
+        - image: 'circleci/golang'
+      steps:
+        - checkout
+        - run:
+            name: Install panthelrog binary
+            command: curl -sSO https://panther-community-us-east-1.s3.amazonaws.com/v1.17.0-RC/tools/dev/pantherlog-linux-amd64 && mv pantherlog-linux-amd64 pantherlog && chmod +x pantherlog
+        - run:
+            name: Run schema tests
+            command: ./pantherlog test ./schemas
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
     steps:
         - run:
             name: Download pantherlog tool
-		    command: curl -sSO "https://panther-community-us-east-1.s3.amazonaws.com/<<parameters.version>>/tools/dev/pantherlog-linux-amd64 && mv pantherlog-linux-amd64 pantherlog && chmod +x pantherlog"
+            command: curl -sSO "https://panther-community-us-east-1.s3.amazonaws.com/<<parameters.version>>/tools/dev/pantherlog-linux-amd64 && mv pantherlog-linux-amd64 pantherlog && chmod +x pantherlog"
         - run:
             name: Run schema tests
             command: ./pantherlog -v && ./pantherlog test ./schemas


### PR DESCRIPTION
### Background

Closes https://app.asana.com/0/1199959010247953/1199936510096989/f

Adds a circleci action to run `pantherlog test ./schemas` on commit.
The tool will verify all schemas under ./schemas are valid and run any `*_tests.yml` files against them.
Now you cannot merge an invalid schema

Uses the binary from the public release URL for v1.17.0-RC

### Changes

* Adds circleci action for testing managed schemas

### Testing

* CircleCi green
