### PR TITLE
Revamped S3 Bucket Lifecycle Config Policy to use deep_get, dictionary

### DIFF
--- a/aws_acm_policies/aws_acm_certificate_expiration.py
+++ b/aws_acm_policies/aws_acm_certificate_expiration.py
@@ -1,4 +1,6 @@
 import datetime
+from panther_oss_helpers import resolve_timestamp_string
+
 
 AWS_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 EXPIRATION_BUFFER = datetime.timedelta(days=60)
@@ -7,9 +9,12 @@ EXPIRATION_BUFFER = datetime.timedelta(days=60)
 def policy(resource):
     if not resource.get("NotAfter"):
         return False
-    time_to_expiration = (
-        datetime.datetime.strptime(resource["NotAfter"], AWS_TIMESTAMP_FORMAT)
-        - datetime.datetime.now()
-    )
+
+    ts = resolve_timestamp_string(resource.get("NotAfter"))
+
+    if not ts:
+        return True
+
+    time_to_expiration = ts - datetime.datetime.now()
 
     return time_to_expiration >= EXPIRATION_BUFFER

--- a/aws_acm_policies/aws_acm_certificate_expiration.py
+++ b/aws_acm_policies/aws_acm_certificate_expiration.py
@@ -10,11 +10,11 @@ def policy(resource):
     if not resource.get("NotAfter"):
         return False
 
-    ts = resolve_timestamp_string(resource.get("NotAfter"))
+    timestamp = resolve_timestamp_string(resource.get("NotAfter"))
 
-    if not ts:
+    if not timestamp:
         return True
 
-    time_to_expiration = ts - datetime.datetime.now()
+    time_to_expiration = timestamp - datetime.datetime.now()
 
     return time_to_expiration >= EXPIRATION_BUFFER

--- a/aws_cloudtrail_policies/aws_cloudtrail_cloudwatch_logs.py
+++ b/aws_cloudtrail_policies/aws_cloudtrail_cloudwatch_logs.py
@@ -15,7 +15,9 @@ def policy(resource):
         return False
 
     # Check if the last log sent is within the allowable timeframe
-    last_log_time = resolve_timestamp_string(deep_get(resource, "Status", "LatestCloudWatchLogsDeliveryTime"))
+    last_log_time = resolve_timestamp_string(
+        deep_get(resource, "Status", "LatestCloudWatchLogsDeliveryTime")
+    )
 
     if not last_log_time:
         return True

--- a/aws_cloudtrail_policies/aws_cloudtrail_cloudwatch_logs.py
+++ b/aws_cloudtrail_policies/aws_cloudtrail_cloudwatch_logs.py
@@ -1,9 +1,9 @@
 import datetime
 
 from panther_base_helpers import deep_get
+from panther_oss_helpers import resolve_timestamp_string
 
 MAX_TIME_BETWEEN_LOGS = datetime.timedelta(hours=24)
-AWS_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
 def policy(resource):
@@ -15,7 +15,8 @@ def policy(resource):
         return False
 
     # Check if the last log sent is within the allowable timeframe
-    last_log_time = datetime.datetime.strptime(
-        deep_get(resource, "Status", "LatestCloudWatchLogsDeliveryTime"), AWS_TIMESTAMP_FORMAT
-    )
+    last_log_time = resolve_timestamp_string(deep_get(resource, "Status", "LatestCloudWatchLogsDeliveryTime"))
+
+    if not last_log_time:
+        return True
     return (datetime.datetime.utcnow() - last_log_time) <= MAX_TIME_BETWEEN_LOGS

--- a/aws_iam_policies/aws_access_key_rotation.py
+++ b/aws_iam_policies/aws_access_key_rotation.py
@@ -1,11 +1,16 @@
 import datetime
+from panther_oss_helpers import resolve_timestamp_string
+
 
 TIMEOUT_DAYS = datetime.timedelta(days=90)
-AWS_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
 def aged_out(timestamp):
-    datetime_ts = datetime.datetime.strptime(timestamp, AWS_TIMESTAMP_FORMAT)
+    if not timestamp:
+        return False
+    datetime_ts = resolve_timestamp_string(timestamp)
+    if not datetime_ts:
+        return False
     return (datetime.datetime.now() - datetime_ts) > TIMEOUT_DAYS
 
 
@@ -13,15 +18,15 @@ def policy(resource):
     # If a user is less than 4 hours old, it may not have a credential report generated yet.
     # It will be re-scanned periodically until a credential report is found, at which point this
     # policy will be properly evaluated.
-    report = resource["CredentialReport"]
+    report = resource.get("CredentialReport")
     if not report:
         return True
 
-    if report["AccessKey1Active"]:
-        if aged_out(report["AccessKey1LastRotated"]):
+    if report.get("AccessKey1Active"):
+        if aged_out(report.get("AccessKey1LastRotated")):
             return False
-    if report["AccessKey2Active"]:
-        if aged_out(report["AccessKey2LastRotated"]):
+    if report.get("AccessKey2Active"):
+        if aged_out(report.get("AccessKey2LastRotated")):
             return False
 
     return True

--- a/aws_iam_policies/aws_access_key_unused.py
+++ b/aws_iam_policies/aws_access_key_unused.py
@@ -1,12 +1,17 @@
 import datetime
+from panther_oss_helpers import resolve_timestamp_string
 
 TIMEOUT_DAYS = datetime.timedelta(days=90)
-AWS_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 DEFAULT_TIME = "0001-01-01T00:00:00Z"
 
 
 def aged_out(timestamp):
-    datetime_ts = datetime.datetime.strptime(timestamp, AWS_TIMESTAMP_FORMAT)
+    if not timestamp:
+        return False
+    datetime_ts = resolve_timestamp_string(timestamp)
+
+    if not datetime_ts:
+        return True
     return (datetime.datetime.now() - datetime_ts) > TIMEOUT_DAYS
 
 
@@ -14,26 +19,26 @@ def policy(resource):
     # If a user is less than 4 hours old, it may not have a credential report generated yet.
     # It will be re-scanned periodically until a credential report is found, at which point this
     # policy will be properly evaluated.
-    report = resource["CredentialReport"]
+    report = resource.get("CredentialReport")
     if not report:
         return True
 
-    if report["AccessKey1Active"]:
-        if report["AccessKey1LastUsedDate"] != DEFAULT_TIME and aged_out(
-            report["AccessKey1LastUsedDate"]
+    if report.get("AccessKey1Active"):
+        if report.get("AccessKey1LastUsedDate") != DEFAULT_TIME and aged_out(
+            report.get("AccessKey1LastUsedDate")
         ):
             return False
-        if report["AccessKey1LastUsedDate"] == DEFAULT_TIME and aged_out(
-            report["AccessKey1LastRotated"]
+        if report.get("AccessKey1LastUsedDate") == DEFAULT_TIME and aged_out(
+            report.get("AccessKey1LastRotated")
         ):
             return False
-    if report["AccessKey2Active"]:
-        if report["AccessKey2LastUsedDate"] != DEFAULT_TIME and aged_out(
-            report["AccessKey2LastUsedDate"]
+    if report.get("AccessKey2Active"):
+        if report.get("AccessKey2LastUsedDate") != DEFAULT_TIME and aged_out(
+            report.get("AccessKey2LastUsedDate")
         ):
             return False
-        if report["AccessKey2LastUsedDate"] == DEFAULT_TIME and aged_out(
-            report["AccessKey2LastRotated"]
+        if report.get("AccessKey2LastUsedDate") == DEFAULT_TIME and aged_out(
+            report.get("AccessKey2LastRotated")
         ):
             return False
 

--- a/aws_iam_policies/aws_access_keys_at_account_creation.py
+++ b/aws_iam_policies/aws_access_keys_at_account_creation.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timedelta
 
 from panther_base_helpers import deep_get
+from panther_oss_helpers import resolve_timestamp_string
 
 AWS_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
-PANTHER_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DEFAULT_TIME = "0001-01-01T00:00:00Z"
 MAX_SECONDS_TO_AUTOGEN_KEY = timedelta(seconds=7)
 
@@ -12,18 +12,18 @@ def policy(resource):
     # If a user is less than 4 hours old, it may not have a credential report generated yet.
     # It will be re-scanned periodically until a credential report is found, at which point this
     # policy will be properly evaluated.
-    if not resource["CredentialReport"]:
+    if not resource.get("CredentialReport"):
         return True
 
     key_rot = deep_get(resource, "CredentialReport", "AccessKey1LastRotated")
     if key_rot == DEFAULT_TIME:
         return True
 
-    create = resource["TimeCreated"]
+    create = resource.get("TimeCreated", "")
     key_rot_date = datetime.strptime(key_rot, AWS_TIME_FORMAT)
-    try:
-        create_date = datetime.strptime(create, PANTHER_TIME_FORMAT)
-    except ValueError:
-        create_date = datetime.strptime(create, AWS_TIME_FORMAT)
+    create_date = resolve_timestamp_string(create)
+
+    if not key_rot_date or not create_date:
+        return True
 
     return (key_rot_date - create_date) >= MAX_SECONDS_TO_AUTOGEN_KEY

--- a/aws_iam_policies/aws_access_keys_at_account_creation.py
+++ b/aws_iam_policies/aws_access_keys_at_account_creation.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from panther_base_helpers import deep_get
 from panther_oss_helpers import resolve_timestamp_string

--- a/aws_iam_policies/aws_access_keys_at_account_creation.py
+++ b/aws_iam_policies/aws_access_keys_at_account_creation.py
@@ -20,7 +20,7 @@ def policy(resource):
         return True
 
     create = resource.get("TimeCreated", "")
-    key_rot_date = datetime.strptime(key_rot, AWS_TIME_FORMAT)
+    key_rot_date = resolve_timestamp_string(key_rot)
     create_date = resolve_timestamp_string(create)
 
     if not key_rot_date or not create_date:

--- a/aws_iam_policies/aws_password_unused.py
+++ b/aws_iam_policies/aws_password_unused.py
@@ -1,12 +1,14 @@
 import datetime
+from panther_oss_helpers import resolve_timestamp_string
 
 TIMEOUT_DAYS = datetime.timedelta(days=90)
-AWS_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 DEFAULT_TIME = "0001-01-01T00:00:00Z"
 
 
 def aged_out(timestamp):
-    datetime_ts = datetime.datetime.strptime(timestamp, AWS_TIMESTAMP_FORMAT)
+    datetime_ts = resolve_timestamp_string(timestamp)
+    if not datetime_ts:
+        return False
     return (datetime.datetime.now() - datetime_ts) > TIMEOUT_DAYS
 
 
@@ -14,14 +16,14 @@ def policy(resource):
     # If a user is less than 4 hours old, it may not have a credential report generated yet.
     # It will be re-scanned periodically until a credential report is found, at which point this
     # policy will be properly evaluated.
-    report = resource["CredentialReport"]
+    report = resource.get("CredentialReport")
     if not report:
         return True
 
-    if report["PasswordEnabled"]:
-        if report["PasswordLastUsed"] != DEFAULT_TIME and aged_out(report["PasswordLastUsed"]):
+    if report.get("PasswordEnabled"):
+        if report.get("PasswordLastUsed") != DEFAULT_TIME and aged_out(report.get("PasswordLastUsed")):
             return False
-        if report["PasswordLastUsed"] == DEFAULT_TIME and aged_out(report["PasswordLastChanged"]):
+        if report.get("PasswordLastUsed") == DEFAULT_TIME and aged_out(report.get("PasswordLastChanged")):
             return False
 
     return True

--- a/aws_iam_policies/aws_password_unused.py
+++ b/aws_iam_policies/aws_password_unused.py
@@ -21,9 +21,11 @@ def policy(resource):
         return True
 
     if report.get("PasswordEnabled"):
-        if report.get("PasswordLastUsed") != DEFAULT_TIME and aged_out(report.get("PasswordLastUsed")):
+        if report.get("PasswordLastUsed") != DEFAULT_TIME \
+                and aged_out(report.get("PasswordLastUsed")):
             return False
-        if report.get("PasswordLastUsed") == DEFAULT_TIME and aged_out(report.get("PasswordLastChanged")):
+        if report.get("PasswordLastUsed") == DEFAULT_TIME\
+                and aged_out(report.get("PasswordLastChanged")):
             return False
 
     return True

--- a/aws_s3_policies/aws_s3_bucket_lifecycle_configuration.py
+++ b/aws_s3_policies/aws_s3_bucket_lifecycle_configuration.py
@@ -1,15 +1,23 @@
+from panther_base_helpers import deep_get
+
 MAX_RETENTION_PERIOD = 365
 MIN_RETENTION_PERIOD = 90
 
 
 def policy(resource):
-    if resource["LifecycleRules"] is None:
+    if resource.get("LifecycleRules") is None:
         return False
 
-    for lifecycle_rule in resource["LifecycleRules"]:
-        if lifecycle_rule["Expiration"] is None or lifecycle_rule["Status"] != "Enabled":
+    for lifecycle_rule in resource.get("LifecycleRules", []):
+        if lifecycle_rule.get("Expiration") is None or lifecycle_rule.get("Status") != "Enabled":
             continue
-        if MIN_RETENTION_PERIOD <= lifecycle_rule["Expiration"]["Days"] <= MAX_RETENTION_PERIOD:
+
+        rule_retention_period_days = deep_get(lifecycle_rule, "Expiration", "Days", default=0)
+
+        if rule_retention_period_days is None:
+            continue
+
+        if MIN_RETENTION_PERIOD <= rule_retention_period_days <= MAX_RETENTION_PERIOD:
             return True
 
     return False

--- a/aws_s3_policies/aws_s3_bucket_lifecycle_configuration.py
+++ b/aws_s3_policies/aws_s3_bucket_lifecycle_configuration.py
@@ -9,7 +9,7 @@ def policy(resource):
         return False
 
     for lifecycle_rule in resource.get("LifecycleRules", []):
-        if lifecycle_rule.get("Expiration") is None or lifecycle_rule.get("Status") != "Enabled":
+        if lifecycle_rule.get("Status") != "Enabled":
             continue
 
         rule_retention_period_days = deep_get(lifecycle_rule, "Expiration", "Days", default=0)

--- a/aws_s3_policies/aws_s3_bucket_lifecycle_configuration.py
+++ b/aws_s3_policies/aws_s3_bucket_lifecycle_configuration.py
@@ -12,9 +12,9 @@ def policy(resource):
         if lifecycle_rule.get("Status") != "Enabled":
             continue
 
-        rule_retention_period_days = deep_get(lifecycle_rule, "Expiration", "Days", default=0)
+        rule_retention_period_days = deep_get(lifecycle_rule, "Expiration", "Days")
 
-        if rule_retention_period_days is None:
+        if not rule_retention_period_days:
             continue
 
         if MIN_RETENTION_PERIOD <= rule_retention_period_days <= MAX_RETENTION_PERIOD:

--- a/aws_s3_policies/aws_s3_bucket_lifecycle_configuration.yml
+++ b/aws_s3_policies/aws_s3_bucket_lifecycle_configuration.yml
@@ -163,3 +163,59 @@ Tests:
         },
         "Versioning": null
       }
+  -
+    Name: Lifecycle Configuration Null Test
+    ExpectedResult: false
+    Resource:
+      {
+        "CreationDate": "2019-01-01T00:00:00Z",
+        "EncryptionRules": [
+          {
+            "ApplyServerSideEncryptionByDefault": {
+              "KMSMasterKeyID": null,
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ],
+        "Grants": null,
+        "LifecycleRules": [
+          {
+            "AbortIncompleteMultipartUpload": null,
+            "Expiration": {
+              "Date": null,
+              "Days": null,
+              "ExpiredObjectDeleteMarker": null
+            },
+            "Filter": {
+              "And": null,
+              "Prefix": "",
+              "Tag": null
+            },
+            "ID": "ExpireAfter1Year",
+            "NoncurrentVersionExpiration": {
+              "NoncurrentDays": null
+            },
+            "NoncurrentVersionTransitions": null,
+            "Prefix": null,
+            "Status": "Enabled",
+            "Transitions": null
+          }
+        ],
+        "Location": "us-east-2",
+        "LoggingPolicy": null,
+        "MFADelete": null,
+        "Name": "bucket-name",
+        "Owner": {
+          "DisplayName": "user.name",
+          "ID": "11112223334445556667778899aaabbbcccdddeeee"
+        },
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789012:root\"},\"Action\":[\"s3:ListBucket\",\"s3:PutObject\"],\"Resource\":[\"arn:aws:s3:::test-bucket/*\",\"arn:aws:s3:::test-bucket\"]}]}",
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": false,
+          "BlockPublicPolicy": false,
+          "IgnorePublicAcls": false,
+          "RestrictPublicBuckets": false
+        },
+        "Versioning": null
+      }
+

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -1,13 +1,75 @@
 """Utility functions provided to policies and rules during execution."""
+import re
 import os
 import time
-from typing import Any, Dict, Sequence, Set, Union
+from datetime import datetime
+from typing import Any, Dict, Sequence, Set, Union, Optional
 
 import boto3
 
 _RESOURCE_TABLE = None  # boto3.Table resource, lazily constructed
 FIPS_ENABLED = os.getenv("ENABLE_FIPS", "").lower() == "true"
 FIPS_SUFFIX = "-fips." + os.getenv("AWS_REGION", "") + ".amazonaws.com"
+
+# Auto Time Resolution Parameters
+EPOCH_REGEX = r"[^0-9\-]+([-]?[0-9]{,12})"
+TIME_FORMATS = {
+    "%Y-%m-%dT%H:%M:%SZ",  # AWS Timestamp
+    "%Y-%m-%dT%H:%M:%S.%fZ",  # Panther Timestamp
+    "%Y-%m-%dT%H:%M:%S*%f%z",
+    "%Y %b %d %H:%M:%S.%f %Z",
+    "%b %d %H:%M:%S %z %Y",
+    "%d/%b/%Y:%H:%M:%S %z",
+    "%b %d, %Y %I:%M:%S %p",
+    "%b %d %Y %H:%M:%S",
+    "%b %d %H:%M:%S %Y",
+    "%b %d %H:%M:%S %z",
+    "%b %d %H:%M:%S",
+    "%Y-%m-%dT%H:%M:%S%z",
+    "%Y-%m-%dT%H:%M:%S.%f%z",
+    "%Y-%m-%d %H:%M:%S %z",
+    "%Y-%m-%d %H:%M:%S%z",
+    "%Y-%m-%d %H:%M:%S,%f",
+    "%Y/%m/%d*%H:%M:%S",
+    "%Y %b %d %H:%M:%S.%f*%Z",
+    "%Y %b %d %H:%M:%S.%f",
+    "%Y-%m-%d %H:%M:%S,%f%z",
+    "%Y-%m-%d %H:%M:%S.%f",
+    "%Y-%m-%d %H:%M:%S.%f%z",
+    "%Y-%m-%dT%H:%M:%S.%f",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%dT%H:%M:%S%z",
+    "%Y-%m-%dT%H:%M:%S.%f",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%d*%H:%M:%S:%f",
+    "%Y-%m-%d*%H:%M:%S",
+    "%y-%m-%d %H:%M:%S,%f %z",
+    "%y-%m-%d %H:%M:%S,%f",
+    "%y-%m-%d %H:%M:%S",
+    "%y/%m/%d %H:%M:%S",
+    "%y%m%d %H:%M:%S",
+    "%Y%m%d %H:%M:%S.%f",
+    "%m/%d/%y*%H:%M:%S",
+    "%m/%d/%Y*%H:%M:%S",
+    "%m/%d/%Y*%H:%M:%S*%f",
+    "%m/%d/%y %H:%M:%S %z",
+    "%m/%d/%Y %H:%M:%S %z",
+    "%H:%M:%S",
+    "%H:%M:%S.%f",
+    "%H:%M:%S,%f",
+    "%d/%b %H:%M:%S,%f",
+    "%d/%b/%Y:%H:%M:%S",
+    "%d/%b/%Y %H:%M:%S",
+    "%d-%b-%Y %H:%M:%S",
+    "%d-%b-%Y %H:%M:%S.%f",
+    "%d %b %Y %H:%M:%S",
+    "%d %b %Y %H:%M:%S*%f",
+    "%m%d_%H:%M:%S",
+    "%m%d_%H:%M:%S.%f",
+    "%m/%d/%Y %I:%M:%S %p:%f",
+    "%m/%d/%Y %I:%M:%S %p",
+}
+
 
 
 class BadLookup(Exception):
@@ -16,6 +78,28 @@ class BadLookup(Exception):
 
 class PantherBadInput(Exception):
     """Error returned when a Panther helper function is provided bad input."""
+
+
+def resolve_timestamp_string(timestamp: str) -> Optional[datetime]:
+    """Auto Time Resolution"""
+    if not timestamp:
+        return None
+    # Attempt to resolve timestamp format
+    for each_format in TIME_FORMATS:
+        try:
+            return datetime.strptime(timestamp.replace("\'", ""), each_format).replace(tzinfo=None)
+        except Exception:  # pylint: disable=broad-except
+            continue
+
+    # Attempt to resolve epoch format
+    # Since datetime.utcfromtimestamp supports 9 through 12 digit epoch timestamps, we only want the first 12 digits.
+    match = re.match(EPOCH_REGEX, timestamp)
+    if match.group(1) != "":
+        try:
+            return datetime.utcfromtimestamp(int(match))
+        except Exception:  # pylint: disable=broad-except
+            return None
+    return None
 
 
 def get_s3_arn_by_name(name: str) -> str:

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -83,7 +83,9 @@ def resolve_timestamp_string(timestamp: str) -> Optional[datetime]:
     """Auto Time Resolution"""
     if not timestamp:
         return None
-    ts_format = timestamp.replace("\'", "")  # Removes weird single-quotes used in some timestamp formats
+
+    # Removes weird single-quotes used in some timestamp formats
+    ts_format = timestamp.replace("\'", "")
     # Attempt to resolve timestamp format
     for each_format in TIME_FORMATS:
         try:

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -13,7 +13,7 @@ FIPS_SUFFIX = "-fips." + os.getenv("AWS_REGION", "") + ".amazonaws.com"
 
 # Auto Time Resolution Parameters
 EPOCH_REGEX = r"[^0-9\-]+([-]?[0-9]{,12})"
-TIME_FORMATS = {
+TIME_FORMATS = [
     "%Y-%m-%dT%H:%M:%SZ",  # AWS Timestamp
     "%Y-%m-%dT%H:%M:%S.%fZ",  # Panther Timestamp
     "%Y-%m-%dT%H:%M:%S*%f%z",
@@ -68,7 +68,7 @@ TIME_FORMATS = {
     "%m%d_%H:%M:%S.%f",
     "%m/%d/%Y %I:%M:%S %p:%f",
     "%m/%d/%Y %I:%M:%S %p",
-}
+]
 
 
 

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -71,7 +71,6 @@ TIME_FORMATS = [
 ]
 
 
-
 class BadLookup(Exception):
     """Error returned when a resource lookup fails."""
 

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -87,12 +87,13 @@ def resolve_timestamp_string(timestamp: str) -> Optional[datetime]:
     # Attempt to resolve timestamp format
     for each_format in TIME_FORMATS:
         try:
-            return datetime.strptime(timestamp.replace("\'", ""), each_format).replace(tzinfo=None)
+            return datetime.strptime(timestamp.replace("\'", ""), each_format)
         except (ValueError, TypeError):
             continue
 
     # Attempt to resolve epoch format
-    # Since datetime.utcfromtimestamp supports 9 through 12 digit epoch timestamps, we only want the first 12 digits.
+    # Since datetime.utcfromtimestamp supports 9 through 12 digit epoch timestamps
+    # and we only want the first 12 digits.
     match = re.match(EPOCH_REGEX, timestamp)
     if match.group(1) != "":
         try:

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -88,7 +88,7 @@ def resolve_timestamp_string(timestamp: str) -> Optional[datetime]:
     for each_format in TIME_FORMATS:
         try:
             return datetime.strptime(timestamp.replace("\'", ""), each_format).replace(tzinfo=None)
-        except Exception:  # pylint: disable=broad-except
+        except (ValueError, TypeError):
             continue
 
     # Attempt to resolve epoch format
@@ -97,7 +97,7 @@ def resolve_timestamp_string(timestamp: str) -> Optional[datetime]:
     if match.group(1) != "":
         try:
             return datetime.utcfromtimestamp(int(match))
-        except Exception:  # pylint: disable=broad-except
+        except (ValueError, TypeError):
             return None
     return None
 


### PR DESCRIPTION
Closes https://app.asana.com/0/1200175800812961/1200142437417326/f

### Background

Concern around S3 Bucket Lifecycle Rule Configurations (Days to Expiration) not being parsed correctly by Panther.

This PR is meant to bring this policy up-to-date with best practice with an added check to avoid a policy error.

### Changes

* Changed policy to use deep_get and dictionary `.get` method
* Added check to avoid `int-None` comparison

### Testing

* `make test`
