### PR TITLE
Fix RuleTypeError

### DIFF
--- a/standard_rules/unusual_login.py
+++ b/standard_rules/unusual_login.py
@@ -43,7 +43,7 @@ def rule(event):
     # Lookup & store persistent data
     event_key = get_key(event)
     last_login_info = get_string_set(event_key)
-    fingerprint_timestamp = datetime.datetime.now()
+    fingerprint_timestamp = str(datetime.datetime.now())
     if not last_login_info:
         # Store this as the first login if we've never seen this user login before
         put_string_set(event_key, [json.dumps({login_tuple: fingerprint_timestamp})])


### PR DESCRIPTION
### Background

Rule has TypeError('Object of type datetime is not JSON serializable'). You can not dump a datetime object, casting to string to make things work.

### Changes

* ```datetime.datetime.now()``` -> ```str(datetime.datetime.now())```

### Testing

* panther_analysis_tool test --path ./standard_rules
* local python testing
