### PR TITLE
add glerb as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @nhakmiller @lindsey-w @wey-chiang @jacknagz @alxarch @kostaspap
+*       @nhakmiller @lindsey-w @wey-chiang @jacknagz @alxarch @kostaspap @glerb


### PR DESCRIPTION
### Background

This is a request to add Patrick @glerb as codeowner so he is automatically tagged as a PR reviewer.

### Changes

* add glerb

### Testing

* n/a
