### PR TITLE
Remove Cloudtrail rule patch for Panther 1.15.x

### DIFF
--- a/aws_cloudtrail_rules/aws_resource_made_public.py
+++ b/aws_cloudtrail_rules/aws_resource_made_public.py
@@ -4,18 +4,6 @@ from panther import aws_cloudtrail_success
 from panther_base_helpers import deep_get
 from policyuniverse.policy import Policy
 
-try:
-    # This is a temporary workaround so that the rule doesn't break in Panther 1.15.x.
-    # It can be removed either by using the deep-copy methods
-    # defined in https://github.com/panther-labs/panther/pull/2630
-    # or by upgrading to a new policyuniverse release.
-    # For details see: https://github.com/panther-labs/panther/issues/2550
-    from src.enriched_event import PantherEvent
-
-    PANTHER_JSON_ENCODER = PantherEvent.json_encoder
-except ImportError:
-    PANTHER_JSON_ENCODER = None
-
 
 # Check that the IAM policy allows resource accessibility via the Internet
 def policy_is_internet_accessible(json_policy):
@@ -41,9 +29,7 @@ def rule(event):
 
     # S3
     if event["eventName"] == "PutBucketPolicy":
-        return policy_is_internet_accessible(
-            json.loads(json.dumps(parameters.get("bucketPolicy"), default=PANTHER_JSON_ENCODER))
-        )
+        return policy_is_internet_accessible(parameters.get("bucketPolicy"))
 
     # ECR
     if event["eventName"] == "SetRepositoryPolicy":


### PR DESCRIPTION
### Background

Due to a bug in 1.15, the Cloudtrail rule had to include custom logic to transparently work around the issue with `policyuniverse` type checking. This PR reverts https://github.com/panther-labs/panther-analysis/pull/191.

### Changes

* Remove conversion to native object via JSON serialization/deserialization for S3 bucket policy. 

### Testing

* `panther_analysis_tool test --path ./`