### PR TITLE
Add new fields for Salesforce schemas

### DIFF
--- a/schemas/logs/salesforce/login.yml
+++ b/schemas/logs/salesforce/login.yml
@@ -1,10 +1,10 @@
 schema: Salesforce.Login
 version: 0
 referenceURL: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_eventlogfile_login.htm
-description: "Login events contain details about your org’s user login history."
+description: 'Login events contain details about your org’s user login history.'
 parser:
   csv:
-    delimiter: ","
+    delimiter: ','
     hasHeader: true
     columns:
       - EVENT_TYPE
@@ -17,6 +17,7 @@ parser:
       - URI
       - SESSION_KEY
       - LOGIN_KEY
+      - USER_TYPE
       - REQUEST_STATUS
       - DB_TOTAL_TIME
       - BROWSER_TYPE
@@ -32,37 +33,35 @@ parser:
       - URI_ID_DERIVED
       - LOGIN_STATUS
       - SOURCE_IP
+
 fields:
   - name: EVENT_TYPE
     type: string
     required: true
     validate:
-      allow: ["Login"]
+      allow: ['Login']
     description: The type of event. The value is always Login.
   - name: TIMESTAMP
     required: false
     type: timestamp
-    timeFormat: "%Y%m%d%H%M%S.%f"
-    description: "The access time of Salesforce services in GMT. For example: 20130715233322.670."
+    timeFormat: '%Y%m%d%H%M%S.%f'
+    description: 'The access time of Salesforce services in GMT. For example: 20130715233322.670.'
   - name: REQUEST_ID
     required: false
     type: string
     indicators:
       - trace_id
     description: >-
-      The unique ID of a single transaction. A transaction can contain one or more events.
-      Each event in a given transaction has the same REQUEST_ID.
-      For example: 3nWgxWbDKWWDIk0FKfF5DV.
+      The unique ID of a single transaction. A transaction can contain one or more events. Each event in a given transaction has the same REQUEST_ID. For example: 3nWgxWbDKWWDIk0FKfF5DV.
   - name: ORGANIZATION_ID
     required: true
     type: string
-    description: "The 15-character ID of the organization. For example: 00D000000000123."
+    description: 'The 15-character ID of the organization. For example: 00D000000000123.'
   - name: USER_ID
     required: false
     type: string
     description: >-
-      The 15-character ID of the user who’s using Salesforce services through the UI or the API.
-      For example: 00530000009M943
+      The 15-character ID of the user who’s using Salesforce services through the UI or the API. For example: 00530000009M943
   - name: RUN_TIME
     required: false
     type: bigint
@@ -71,32 +70,28 @@ fields:
     required: false
     type: bigint
     description: >-
-      The CPU time in milliseconds used to complete the request.
-      This field indicates the amount of activity taking place in the app server layer.
+      The CPU time in milliseconds used to complete the request. This field indicates the amount of activity taking place in the app server layer.
   - name: URI
     required: false
     type: string
-    description: "The URI of the page that’s receiving the request. For example: /home/home.jsp."
+    description: 'The URI of the page that’s receiving the request. For example: /home/home.jsp.'
   - name: SESSION_KEY
     required: false
     type: string
     description: >-
-      The user’s unique session ID. You can use this value to identify all user events within a session.
-      When a user logs out and logs in again, a new session is started. For Login Event Type,
-      this field is usually null because the event is captured before a session is created.
-      Example d7DEq/ANa7nNZZVD
+      The user’s unique session ID. You can use this value to identify all user events within a session. When a user logs out and logs in again, a new session is started. For Login Event Type, this field is usually null because the event is captured before a session is created. Example d7DEq/ANa7nNZZVD
   - name: LOGIN_KEY
     required: false
     type: string
     description: >-
-      The string that ties together all events in a given user’s login session. It starts with a login event and
-      ends with either a logout event or the user session expiring. For example: GeJCsym5eyvtEK2I.
+      The string that ties together all events in a given user’s login session. It starts with a login event and ends with either a logout event or the user session expiring. For example: GeJCsym5eyvtEK2I.
   - name: REQUEST_STATUS
     required: false
     type: string
     description: >-
-      The status of the request for a page view or user interface action.
-      Possible values are:
+      The status of the request for a page view or user interface action. Possible values are:
+
+
         S—Success. Salesforce handled the request successfully. If an Apex controller throws an exception, this status is also returned.
         F—Failure. Typically 4xx or 5xx HTTP codes, such as no permission to view page, page took too long to render, page is read-only.
         U—Undefined
@@ -107,15 +102,14 @@ fields:
     required: false
     type: bigint
     description: >-
-      The time in nanoseconds for a database round trip. Includes time spent in the JDBC driver,
-      network to the database, and DB_CPU_TIME. Compare this field to CPU_TIME to determine whether
-      performance issues are occurring in the database layer or in your own code.
+      The time in nanoseconds for a database round trip. Includes time spent in the JDBC driver, network to the database, and DB_CPU_TIME. Compare this field to CPU_TIME to determine whether performance issues are occurring in the database layer or in your own code.
   - name: BROWSER_TYPE
     required: false
     type: string
     description: >-
-      The identifier string returned by the browser used at login.
-      Example values are:
+      The identifier string returned by the browser used at login. Example values are:
+
+
           Go-http-client/1.1
           Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv%3A50.0) Gecko/20100101 Firefox/50.0
           Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36
@@ -123,8 +117,9 @@ fields:
     required: false
     type: string
     description: >-
-      The type of API request.
-      Possible values are:
+      The type of API request. Possible values are:
+
+
           D—Apex Class
           E—SOAP Enterprise
           I—SOAP Cross Instance
@@ -140,7 +135,7 @@ fields:
   - name: API_VERSION
     required: false
     type: string
-    description: "The version of the API that’s being used. For example: 36.0."
+    description: 'The version of the API that’s being used. For example: 36.0.'
   - name: USER_NAME
     required: false
     type: string
@@ -150,37 +145,31 @@ fields:
   - name: TLS_PROTOCOL
     required: false
     type: string
-    description: "The TLS protocol used for the login. There are 3 possible values: 1.0, 1.1, 1.2"
+    description: 'The TLS protocol used for the login. There are 3 possible values: 1.0, 1.1, 1.2'
   - name: CIPHER_SUITE
     required: false
     type: string
     description: >-
-      The TLS cipher suite used for the login. Values are OpenSSL-style cipher suite names,
-      with hyphen delimiters. For more information, see OpenSSL Cryptography and SSL/TLS Toolkit.
+      The TLS cipher suite used for the login. Values are OpenSSL-style cipher suite names, with hyphen delimiters. For more information, see OpenSSL Cryptography and SSL/TLS Toolkit.
   - name: TIMESTAMP_DERIVED
     required: true
     type: timestamp
     timeFormat: rfc3339
     isEventTime: true
     description: >-
-      The access time of Salesforce services in ISO8601-compatible format (YYYY-MM-DDTHH:MM:SS.sssZ).
-      For example: 2015-07-27T11:32:59.555Z. Timezone is GMT.
+      The access time of Salesforce services in ISO8601-compatible format (YYYY-MM-DDTHH:MM:SS.sssZ). For example: 2015-07-27T11:32:59.555Z. Timezone is GMT.
   - name: USER_ID_DERIVED
     required: false
     type: string
     description: >-
-      The 18-character case insensitive ID of the user who’s using Salesforce services through the UI or the API.
-      For example: 00590000000I1SNIA0.
+      The 18-character case insensitive ID of the user who’s using Salesforce services through the UI or the API. For example: 00590000000I1SNIA0.
   - name: CLIENT_IP
     required: false
     type: string
     indicators:
       - ip
     description: >-
-      The IP address of the client that’s using Salesforce services.
-      A Salesforce internal IP (such as a login from Salesforce Workbench
-      or AppExchange) is shown as "Salesforce.com IP".
-      For example: 10.0.0.1.
+      The IP address of the client that’s using Salesforce services. A Salesforce internal IP (such as a login from Salesforce Workbench or AppExchange) is shown as "Salesforce.com IP". For example: 10.0.0.1.
   - name: URI_ID_DERIVED
     required: false
     type: string
@@ -189,12 +178,27 @@ fields:
     required: false
     type: string
     description: >-
-      The status of the login attempt. For successful logins, the value is LOGIN_NO_ERROR.
-      All other values indicate errors or authentication issues.
-      For details, see https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_eventlogfile_login_status.htm
+      The status of the login attempt. For successful logins, the value is LOGIN_NO_ERROR. All other values indicate errors or authentication issues. For details, see https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_eventlogfile_login_status.htm
   - name: SOURCE_IP
     required: false
     type: string
     indicators:
       - ip
     description: The source IP of the login request.
+  - name: AUTHENTICATION_METHOD_REFERENCE
+    type: string
+    description: >-
+      The authentication method used by a third-party identification provider for an OpenID Connect single sign-on protocol. This field is available in API version 51.0 and later.
+  - name: USER_TYPE
+    type: string
+    description: >-
+      The category of user license.
+      Possible values are:
+          CsnOnly — Users whose access to the application is limited to Chatter. This user type includes Chatter Free and Chatter moderator users.
+          CspLitePortal — CSP Lite Portal license. Users whose access is limited because they’re organization customers and access the application through a customer portal or an Experience Cloud site.
+          CustomerSuccess — Customer Success license. Users whose access is limited because they’re organization customers and access the application through a customer portal.
+          Guest — Users whose access is limited so that your customers can view and interact with your site without logging in.
+          PowerCustomerSuccess — Power Customer Success license. Users whose access is limited because they’re organization customers and access the application through a customer portal. Users with this license type can view and edit data they directly own or data owned by or shared with users below them in the customer portal role hierarchy.
+          PowerPartner — Power Partner license. Users whose access is limited because they’re partners and typically access the application through a partner portal or site.
+          SelfService — Users whose access is limited because they’re organization customers and access the application through a self-service portal.
+          Standard — Standard user license. This user type also includes Salesforce Platform and Salesforce Platform One user licenses, and admins for this org.

--- a/schemas/logs/salesforce/login_as.yml
+++ b/schemas/logs/salesforce/login_as.yml
@@ -1,10 +1,10 @@
 schema: Salesforce.LoginAs
 version: 0
 referenceURL: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_eventlogfile_loginas.htm
-description: "Login As events contain details about what a Salesforce admin did while logged in as another user."
+description: 'Login As events contain details about what a Salesforce admin did while logged in as another user.'
 parser:
   csv:
-    delimiter: ","
+    delimiter: ','
     hasHeader: true
     columns:
       - EVENT_TYPE
@@ -29,32 +29,29 @@ fields:
     required: true
     type: string
     validate:
-      allow: ["LoginAs"]
+      allow: ['LoginAs']
     description: The type of event. The value is always LoginAs.
   - name: TIMESTAMP
     required: false
     type: timestamp
-    timeFormat: "%Y%m%d%H%M%S.%f"
-    description: "The access time of Salesforce services in GMT. For example: 20130715233322.670."
+    timeFormat: '%Y%m%d%H%M%S.%f'
+    description: 'The access time of Salesforce services in GMT. For example: 20130715233322.670.'
   - name: REQUEST_ID
     required: false
     type: string
     description: >-
-      The unique ID of a single transaction. A transaction can contain one or more events.
-      Each event in a given transaction has the same REQUEST_ID.
-      For example: 3nWgxWbDKWWDIk0FKfF5DV.
+      The unique ID of a single transaction. A transaction can contain one or more events. Each event in a given transaction has the same REQUEST_ID. For example: 3nWgxWbDKWWDIk0FKfF5DV.
     indicators:
       - trace_id
   - name: ORGANIZATION_ID
     required: true
     type: string
-    description: "The 15-character ID of the organization. For example: 00D000000000123."
+    description: 'The 15-character ID of the organization. For example: 00D000000000123.'
   - name: USER_ID
     required: true
     type: string
     description: >-
-      The 15-character ID of the user who’s using Salesforce services through the UI or the API.
-      For example: 00530000009M943
+      The 15-character ID of the user who’s using Salesforce services through the UI or the API. For example: 00530000009M943
   - name: RUN_TIME
     required: false
     type: bigint
@@ -63,64 +60,52 @@ fields:
     required: false
     type: bigint
     description: >-
-      The CPU time in milliseconds used to complete the request.
-      This field indicates the amount of activity taking place in the app server layer.
+      The CPU time in milliseconds used to complete the request. This field indicates the amount of activity taking place in the app server layer.
   - name: URI
     required: false
     type: string
-    description: "The URI of the page that’s receiving the request. For example: /home/home.jsp."
+    description: 'The URI of the page that’s receiving the request. For example: /home/home.jsp.'
   - name: SESSION_KEY
     required: false
     type: string
     description: >-
-      The user’s unique session ID. You can use this value to identify all
-      user events within a session. When a user logs out and logs in again, a new session is started.
-      For example: d7DEq/ANa7nNZZVD.
+      The user’s unique session ID. You can use this value to identify all user events within a session. When a user logs out and logs in again, a new session is started. For example: d7DEq/ANa7nNZZVD.
   - name: LOGIN_KEY
     required: false
     type: string
     description: >-
-      The string that ties together all events in a given user’s login session.
-      It starts with a login event and ends with either a logout event or the user session expiring.
-      For example: GeJCsym5eyvtEK2I.
+      The string that ties together all events in a given user’s login session. It starts with a login event and ends with either a logout event or the user session expiring. For example: GeJCsym5eyvtEK2I.
   - name: DELEGATED_USER_NAME
     required: false
     type: string
     description: >-
-      The username of the user who’s using Salesforce services through the UI or API.
-      In this case, the user who’s doing the impersonation.
+      The username of the user who’s using Salesforce services through the UI or API. In this case, the user who’s doing the impersonation.
     indicators:
       - username
   - name: DELEGATED_USER_ID
     required: true
     type: string
     description: >-
-      The 15-character ID of the user who’s using Salesforce services through the UI or API.
-      In this case, the user who’s doing the impersonation.
+      The 15-character ID of the user who’s using Salesforce services through the UI or API. In this case, the user who’s doing the impersonation.
   - name: TIMESTAMP_DERIVED
     required: true
     type: timestamp
     timeFormat: rfc3339
     isEventTime: true
     description: >-
-      The access time of Salesforce services in ISO8601-compatible format (YYYY-MM-DDTHH:MM:SS.sssZ).
-      For example: 2015-07-27T11:32:59.555Z. Timezone is GMT.
+      The access time of Salesforce services in ISO8601-compatible format (YYYY-MM-DDTHH:MM:SS.sssZ). For example: 2015-07-27T11:32:59.555Z. Timezone is GMT.
   - name: USER_ID_DERIVED
     required: false
     type: string
     description: >-
-      The 18-character case insensitive ID of the user who’s using Salesforce services through the UI or the API.
-      For example: 00590000000I1SNIA0.
+      The 18-character case insensitive ID of the user who’s using Salesforce services through the UI or the API. For example: 00590000000I1SNIA0.
   - name: CLIENT_IP
     required: false
     type: string
     indicators:
       - ip
     description: >-
-      The IP address of the client that’s using Salesforce services.
-      A Salesforce internal IP (such as a login from Salesforce Workbench
-      or AppExchange) is shown as "Salesforce.com IP".
-      For example: 10.0.0.1.
+      The IP address of the client that’s using Salesforce services. A Salesforce internal IP (such as a login from Salesforce Workbench or AppExchange) is shown as "Salesforce.com IP". For example: 10.0.0.1.
   - name: URI_ID_DERIVED
     required: false
     type: string
@@ -129,5 +114,4 @@ fields:
     required: false
     type: string
     description: >-
-      The 18-character case-insensitive ID of the user who’s using Salesforce services
-      through the UI or API. In this case, the user who’s doing the impersonation.
+      The 18-character case-insensitive ID of the user who’s using Salesforce services through the UI or API. In this case, the user who’s doing the impersonation.

--- a/schemas/logs/salesforce/logout.yml
+++ b/schemas/logs/salesforce/logout.yml
@@ -4,7 +4,7 @@ referenceURL: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sfo
 description: Logout events contain details of user logouts.
 parser:
   csv:
-    delimiter: ","
+    delimiter: ','
     hasHeader: true
     columns:
       - EVENT_TYPE
@@ -33,38 +33,36 @@ fields:
     required: true
     type: string
     validate:
-      allow: ["Logout"]
+      allow: ['Logout']
     description: The type of event. The value is always Logout.
   - name: TIMESTAMP
     required: false
     type: timestamp
-    timeFormat: "%Y%m%d%H%M%S.%f"
-    description: "The access time of Salesforce services in GMT. For example: 20130715233322.670."
+    timeFormat: '%Y%m%d%H%M%S.%f'
+    description: 'The access time of Salesforce services in GMT. For example: 20130715233322.670.'
   - name: REQUEST_ID
     required: false
     type: string
     indicators:
       - trace_id
     description: >-
-      The unique ID of a single transaction. A transaction can contain one or more events.
-      Each event in a given transaction has the same REQUEST_ID.
-      For example: 3nWgxWbDKWWDIk0FKfF5DV.
+      The unique ID of a single transaction. A transaction can contain one or more events. Each event in a given transaction has the same REQUEST_ID. For example: 3nWgxWbDKWWDIk0FKfF5DV.
   - name: ORGANIZATION_ID
     required: true
     type: string
-    description: "The 15-character ID of the organization. For example: 00D000000000123."
+    description: 'The 15-character ID of the organization. For example: 00D000000000123.'
   - name: USER_ID
     required: true
     type: string
     description: >-
-      The 15-character ID of the user who’s using Salesforce services through the UI or the API.
-      For example: 00530000009M943
+      The 15-character ID of the user who’s using Salesforce services through the UI or the API. For example: 00530000009M943
   - name: USER_TYPE
     required: false
     type: string
     description: >-
-      The category of user license of the user that logged out.
-      Possible Values:
+      The category of user license of the user that logged out. Possible Values:
+
+
         A: Automated Process
         b: High Volume Portal
         C: Customer Portal User
@@ -85,6 +83,8 @@ fields:
     type: string
     description: >-
       The session type that was used when logging out. Possible Values:
+
+
         A: API
         I: APIOnlyUser
         N: ChatterNetworks
@@ -107,14 +107,14 @@ fields:
     required: false
     type: string
     description: >-
-      The security level of the session that was used when logging out.
-      Possible Values: 1: Standard Session, 2: High-Assurance Session
+      The security level of the session that was used when logging out. Possible Values: 1: Standard Session, 2: High-Assurance Session
   - name: BROWSER_TYPE
     required: false
     type: string
     description: >-
-      The identifier string returned by the browser used at login.
-      Example values are:
+      The identifier string returned by the browser used at login. Example values are:
+
+
           Go-http-client/1.1
           Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv%3A50.0) Gecko/20100101 Firefox/50.0
           Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36
@@ -122,8 +122,9 @@ fields:
     required: false
     type: bigint
     description: >-
-      The code for the client platform. If a timeout caused the logout, this field is null.
-      Example Values:
+      The code for the client platform. If a timeout caused the logout, this field is null. Example Values:
+
+
         1000: Windows
         2003: Macintosh/Apple OSX
         5005: Android
@@ -137,8 +138,9 @@ fields:
     required: false
     type: string
     description: >-
-      The application type that was in use upon logging out.
-      Example Values:
+      The application type that was in use upon logging out. Example Values:
+
+
         1007: SFDC Application
         1014: Chat
         2501: CTI
@@ -152,8 +154,9 @@ fields:
     required: false
     type: string
     description: >-
-      The type of API request.
-      Possible values are:
+      The type of API request. Possible values are:
+
+
           D—Apex Class
           E—SOAP Enterprise
           I—SOAP Cross Instance
@@ -169,48 +172,38 @@ fields:
   - name: API_VERSION
     required: false
     type: string
-    description: "The version of the API that’s being used. For example: 36.0."
+    description: 'The version of the API that’s being used. For example: 36.0.'
   - name: USER_INITIATED_LOGOUT
     required: false
     type: boolean
     description: >-
-      The value is 1 if the user intentionally logged out of the organization by clicking the Logout button.
-      If the user’s session timed out due to inactivity or another implicit logout action, the value is 0.
+      The value is 1 if the user intentionally logged out of the organization by clicking the Logout button. If the user’s session timed out due to inactivity or another implicit logout action, the value is 0.
   - name: SESSION_KEY
     required: false
     type: string
     description: >-
-      The user’s unique session ID. You can use this value to identify all user events
-      within a session. When a user logs out and logs in again, a new session is started.
-      For example: d7DEq/ANa7nNZZVD.
+      The user’s unique session ID. You can use this value to identify all user events within a session. When a user logs out and logs in again, a new session is started. For example: d7DEq/ANa7nNZZVD.
   - name: LOGIN_KEY
     required: false
     type: string
     description: >-
-      The string that ties together all events in a given user’s login session.
-      It starts with a login event and ends with either a logout event or the user session expiring.
-      For example: GeJCsym5eyvtEK2I.
+      The string that ties together all events in a given user’s login session. It starts with a login event and ends with either a logout event or the user session expiring. For example: GeJCsym5eyvtEK2I.
   - name: TIMESTAMP_DERIVED
     required: true
     type: timestamp
     isEventTime: true
     timeFormat: rfc3339
     description: >-
-      The access time of Salesforce services in ISO8601-compatible format (YYYY-MM-DDTHH:MM:SS.sssZ).
-      For example: 2015-07-27T11:32:59.555Z. Timezone is GMT.
+      The access time of Salesforce services in ISO8601-compatible format (YYYY-MM-DDTHH:MM:SS.sssZ). For example: 2015-07-27T11:32:59.555Z. Timezone is GMT.
   - name: USER_ID_DERIVED
     required: false
     type: string
     description: >-
-      The 18-character case insensitive ID of the user who’s using Salesforce services through the UI or the API.
-      For example: 00590000000I1SNIA0.
+      The 18-character case insensitive ID of the user who’s using Salesforce services through the UI or the API. For example: 00590000000I1SNIA0.
   - name: CLIENT_IP
     required: false
     type: string
     indicators:
       - ip
     description: >-
-      The IP address of the client that’s using Salesforce services.
-      A Salesforce internal IP (such as a login from Salesforce Workbench
-      or AppExchange) is shown as "Salesforce.com IP".
-      For example: 10.0.0.1.
+      The IP address of the client that’s using Salesforce services. A Salesforce internal IP (such as a login from Salesforce Workbench or AppExchange) is shown as "Salesforce.com IP". For example: 10.0.0.1.

--- a/schemas/logs/salesforce/uri.yml
+++ b/schemas/logs/salesforce/uri.yml
@@ -1,10 +1,10 @@
 schema: Salesforce.URI
 version: 0
 referenceURL: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_eventlogfile_uri.htm
-description: "URI events contain details about user interaction with the web browser UI."
+description: 'URI events contain details about user interaction with the web browser UI.'
 parser:
   csv:
-    delimiter: ","
+    delimiter: ','
     hasHeader: true
     columns:
       - EVENT_TYPE
@@ -26,78 +26,66 @@ parser:
       - USER_ID_DERIVED
       - CLIENT_IP
       - URI_ID_DERIVED
+      - USER_TYPE
 fields:
   - name: EVENT_TYPE
     required: true
     type: string
     validate:
-      allow: ["URI"]
+      allow: ['URI']
     description: The type of event. The value is always URI.
   - name: TIMESTAMP
     required: false
     type: timestamp
-    timeFormat: "%Y%m%d%H%M%S.%f"
-    description: "The access time of Salesforce services in GMT. For example: 20130715233322.670."
+    timeFormat: '%Y%m%d%H%M%S.%f'
+    description: 'The access time of Salesforce services in GMT. For example: 20130715233322.670.'
   - name: REQUEST_ID
     required: false
     type: string
     indicators:
       - trace_id
     description: >-
-      The unique ID of a single transaction. A transaction can contain one or more events.
-      Each event in a given transaction has the same REQUEST_ID.
-      For example: 3nWgxWbDKWWDIk0FKfF5DV.
+      The unique ID of a single transaction. A transaction can contain one or more events. Each event in a given transaction has the same REQUEST_ID. For example: 3nWgxWbDKWWDIk0FKfF5DV.
   - name: ORGANIZATION_ID
     required: true
     type: string
-    description: "The 15-character ID of the organization. For example: 00D000000000123."
+    description: 'The 15-character ID of the organization. For example: 00D000000000123.'
   - name: USER_ID
     required: false
     type: string
     description: >-
-      The 15-character ID of the user who’s using Salesforce services through the UI or the API.
-      For example: 00530000009M943
+      The 15-character ID of the user who’s using Salesforce services through the UI or the API. For example: 00530000009M943
   - name: RUN_TIME
     required: false
     type: bigint
-    description: "The amount of time that the request took in milliseconds."
+    description: 'The amount of time that the request took in milliseconds.'
   - name: CPU_TIME
     required: false
     type: bigint
     description: >-
-      The CPU time in milliseconds used to complete the request.
-      This field indicates the amount of activity taking place in the app server layer.
+      The CPU time in milliseconds used to complete the request. This field indicates the amount of activity taking place in the app server layer.
   - name: URI
     required: true
     type: string
     description: >-
-      The URI of the page that’s receiving the request. For more granular URI information for Lightning Experience
-      and the Salesforce app, see the Lightning Error, Lightning Interaction, Lightning Page View,
-      and Lightning Performance event types.
-      Examples:
-      /aura (Lightning Experience),
-      /lightning (Lightning Experience and the Salesforce app),
-      /home/home.jsp (Salesforce Classic)
+      The URI of the page that’s receiving the request. For more granular URI information for Lightning Experience and the Salesforce app, see the Lightning Error, Lightning Interaction, Lightning Page View, and Lightning Performance event types. Examples: /aura (Lightning Experience), /lightning (Lightning Experience and the Salesforce app), /home/home.jsp (Salesforce Classic)
   - name: SESSION_KEY
     required: false
     type: string
     description: >-
-      The user’s unique session ID. You can use this value to identify all user events within a session.
-      When a user logs out and logs in again, a new session is started. For Login Event Type,
-      this field is usually null because the event is captured before a session is created.
-      Example d7DEq/ANa7nNZZVD
+      The user’s unique session ID. You can use this value to identify all user events within a session. When a user logs out and logs in again, a new session is started. For Login Event Type, this field is usually null because the event is captured before a session is created. Example d7DEq/ANa7nNZZVD
   - name: LOGIN_KEY
     required: false
     type: string
     description: >-
-      The string that ties together all events in a given user’s login session. It starts with a login event and
-      ends with either a logout event or the user session expiring. For example: GeJCsym5eyvtEK2I.
+      The string that ties together all events in a given user’s login session. It starts with a login event and ends with either a logout event or the user session expiring. For example: GeJCsym5eyvtEK2I.
   - name: REQUEST_STATUS
     required: false
     type: string
     description: >-
-      The status of the request for a page view or user interface action.
-      Possible values are:
+      The status of the request for a page view or user interface action. Possible values are:
+
+
         S—Success. Salesforce handled the request successfully. If an Apex controller throws an exception, this status is also returned.
         F—Failure. Typically 4xx or 5xx HTTP codes, such as no permission to view page, page took too long to render, page is read-only.
         U—Undefined
@@ -108,23 +96,17 @@ fields:
     required: false
     type: bigint
     description: >-
-      The time in nanoseconds for a database round trip. Includes time spent in the JDBC driver,
-      network to the database, and DB_CPU_TIME. Compare this field to CPU_TIME to determine whether
-      performance issues are occurring in the database layer or in your own code.
+      The time in nanoseconds for a database round trip. Includes time spent in the JDBC driver, network to the database, and DB_CPU_TIME. Compare this field to CPU_TIME to determine whether performance issues are occurring in the database layer or in your own code.
   - name: DB_BLOCKS
     required: false
     type: bigint
     description: >-
-      Indicates how much activity is occurring in the database.
-      A high value for this field suggests that adding indexes or
-      filters on your queries would benefit performance.
+      Indicates how much activity is occurring in the database. A high value for this field suggests that adding indexes or filters on your queries would benefit performance.
   - name: DB_CPU_TIME
     required: false
     type: bigint
     description: >-
-      The CPU time in milliseconds to complete the request.
-      Indicates the amount of activity taking place in the database
-      layer during the request.
+      The CPU time in milliseconds to complete the request. Indicates the amount of activity taking place in the database layer during the request.
   - name: REFERRER_URI
     required: false
     type: string
@@ -135,25 +117,33 @@ fields:
     timeFormat: rfc3339
     isEventTime: true
     description: >-
-      The access time of Salesforce services in ISO8601-compatible format (YYYY-MM-DDTHH:MM:SS.sssZ).
-      For example: 2015-07-27T11:32:59.555Z. Timezone is GMT.
+      The access time of Salesforce services in ISO8601-compatible format (YYYY-MM-DDTHH:MM:SS.sssZ). For example: 2015-07-27T11:32:59.555Z. Timezone is GMT.
   - name: USER_ID_DERIVED
     required: false
     type: string
     description: >-
-      The 18-character case insensitive ID of the user who’s using Salesforce services through the UI or the API.
-      For example: 00590000000I1SNIA0.
+      The 18-character case insensitive ID of the user who’s using Salesforce services through the UI or the API. For example: 00590000000I1SNIA0.
   - name: CLIENT_IP
     required: false
     type: string
     indicators:
       - ip
     description: >-
-      The IP address of the client that’s using Salesforce services.
-      A Salesforce internal IP (such as a login from Salesforce Workbench
-      or AppExchange) is shown as "Salesforce.com IP".
-      For example: 10.0.0.1.
+      The IP address of the client that’s using Salesforce services. A Salesforce internal IP (such as a login from Salesforce Workbench or AppExchange) is shown as "Salesforce.com IP". For example: 10.0.0.1.
   - name: URI_ID_DERIVED
     required: false
     type: string
     description: The 18-character case insensitive ID of the URI of the page that’s receiving the request.
+  - name: USER_TYPE
+    type: string
+    description: >-
+      The category of user license.
+      Possible values are:
+          CsnOnly — Users whose access to the application is limited to Chatter. This user type includes Chatter Free and Chatter moderator users.
+          CspLitePortal — CSP Lite Portal license. Users whose access is limited because they’re organization customers and access the application through a customer portal or an Experience Cloud site.
+          CustomerSuccess — Customer Success license. Users whose access is limited because they’re organization customers and access the application through a customer portal.
+          Guest — Users whose access is limited so that your customers can view and interact with your site without logging in.
+          PowerCustomerSuccess — Power Customer Success license. Users whose access is limited because they’re organization customers and access the application through a customer portal. Users with this license type can view and edit data they directly own or data owned by or shared with users below them in the customer portal role hierarchy.
+          PowerPartner — Power Partner license. Users whose access is limited because they’re partners and typically access the application through a partner portal or site.
+          SelfService — Users whose access is limited because they’re organization customers and access the application through a self-service portal.
+          Standard — Standard user license. This user type also includes Salesforce Platform and Salesforce Platform One user licenses, and admins for this org.


### PR DESCRIPTION

### Background

`USER_TYPE` and `AUTHENTICATION_METHOD_REFERENCE` were added in v52.0.

### Changes

* Add `USER_TYPE` and `AUTHENTICATION_METHOD_REFERENCE` fields in `Login` event type.
* Add `USER_TYPE` in `URI` event type.

### Testing

Tested in https://github.com/panther-labs/panther-enterprise/pull/3540.