### PR TITLE
Do not mark commit as failed on schema test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
             version: v1.17.0-RC
         - run:
             name: Run schema tests
-            command: ./pantherlog -v && ./pantherlog test ./schemas
+            command: ./pantherlog -v && ./pantherlog test ./schemas || true
 
 workflows:
   version: 2


### PR DESCRIPTION
### Background

The schema tests CI check was not required, but still the commit was marked as failed.

### Changes

Temporarily run the schema tests as advisory-only. 

Pending fixes to the pantherlog test runner will allow restoring the check soon.

