### PR TITLE
Deprecation message for OneLogin-specific version of this rule

### DIFF
--- a/onelogin_rules/onelogin_unusual_login.yml
+++ b/onelogin_rules/onelogin_unusual_login.yml
@@ -1,7 +1,7 @@
 AnalysisType: rule
 Filename: onelogin_unusual_login.py 
 RuleID: OneLogin.UnusualLogin
-DisplayName: Unusual OneLogin Login
+DisplayName: --DEPRECATED-- Unusual OneLogin Login
 # This rule is disabled by default because it makes API calls out to the internet. At high volumes
 # of OneLogin activity, this could get throttled unless you buy a subscription to ipinfo.
 Enabled: false
@@ -10,6 +10,7 @@ LogTypes:
 Tags:
   - Identity & Access Management
 Severity: Medium
+Description: Deprecated. Please see Standard.UnusualLogin instead.
 SummaryAttributes:
   - account_id
   - user_id


### PR DESCRIPTION
### Background

The standard rule, which accomodates multiple log types, was reworked in https://github.com/panther-labs/panther-analysis/pull/283. This older version of the rule does something completely different, and doesn't use the new geolocation helper, and doesn't have mocks.

### Changes

* Deprecation message in display message and description

### Testing

* n/a
