### PR TITLE
Add username to title of No MFA AWS login

### DIFF
--- a/aws_cloudtrail_rules/aws_console_login_without_mfa.py
+++ b/aws_cloudtrail_rules/aws_console_login_without_mfa.py
@@ -28,6 +28,8 @@ def rule(event):
 
 def title(event):
     return (
-        f"AWS logins detected without MFA in account "
+        "AWS login detected without MFA for user "
+        f"[{deep_get(event, 'userIdentity', 'userName')}] "
+        "in account "
         f"[{lookup_aws_account_name(event.get('recipientAccountId'))}]"
     )


### PR DESCRIPTION
### Background

Username was not included in the alert title.

### Changes

* Added the username to the title

### Testing

* `make fmt lint`
* `panther_analysis_tool --debug test --path aws_cloudtrail_rules`
* execution in live system
