### PR TITLE
Return bool type

### DIFF
--- a/box_rules/box_event_triggered_externally.py
+++ b/box_rules/box_event_triggered_externally.py
@@ -12,7 +12,7 @@ def rule(event):
         # user id 2 indicates an anonymous user
         if user.get("id", "") == "2":
             return True
-        return user.get("login") and not any(user.get("login", "").endswith(x) for x in DOMAINS)
+        return bool(user.get("login") and not any(user.get("login", "").endswith(x) for x in DOMAINS))
     return False
 
 

--- a/box_rules/box_event_triggered_externally.py
+++ b/box_rules/box_event_triggered_externally.py
@@ -12,7 +12,9 @@ def rule(event):
         # user id 2 indicates an anonymous user
         if user.get("id", "") == "2":
             return True
-        return bool(user.get("login") and not any(user.get("login", "").endswith(x) for x in DOMAINS))
+        return bool(
+            user.get("login") and not any(user.get("login", "").endswith(x) for x in DOMAINS)
+        )
     return False
 
 

--- a/box_rules/box_event_triggered_externally.yml
+++ b/box_rules/box_event_triggered_externally.yml
@@ -47,3 +47,12 @@ Tests:
         "type": "event",
         "ip_address": "1.2.3.4",
       }
+  -
+    Name: Missing Created By
+    ExpectedResult: false
+    Log:
+      {
+        "event_type": "PREVIEW",
+        "type": "event",
+        "ip_address": "1.2.3.4",
+      }


### PR DESCRIPTION
### Background

This rule would sometimes return `NoneType`, the default response from `.get()`,  instead of a `bool` due to python `and` short circuit evaluation.  This wraps the return in a cast to bool to ensure that doesn't happen.

### Changes

* Ensure bool  is always returned by wrapping return

### Testing

* new test case