### PR TITLE
Tweaks

### DIFF
--- a/aws_cloudtrail_rules/aws_console_login_without_mfa.py
+++ b/aws_cloudtrail_rules/aws_console_login_without_mfa.py
@@ -27,9 +27,17 @@ def rule(event):
 
 
 def title(event):
+    user_type = deep_get(event, "userIdentity", "type")
+    if user_type == "IAMUser":
+        user = deep_get(event, "userIdentity", "userName")
+    # root user
+    elif user_type == "Root":
+        user = user_type
+    else:
+        user = "<UNKNOWN_USER>"
     return (
         "AWS login detected without MFA for user "
-        f"[{deep_get(event, 'userIdentity', 'userName')}] "
+        f"[{user}] "
         "in account "
         f"[{lookup_aws_account_name(event.get('recipientAccountId'))}]"
     )

--- a/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
+++ b/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
@@ -60,30 +60,30 @@ Tests:
     ExpectedResult: true
     Log:
       {
-	      "additionalEventData": {
-		      "LoginTo": "https://console.aws.amazon.com/console/home",
-		      "MFAUsed": "No",
-		      "MobileVersion": "No"
-	      },
-	      "awsRegion": "us-east-1",
-	      "eventName": "ConsoleLogin",
-	      "eventSource": "signin.amazonaws.com",
-	      "eventTime": "2021-07-15 16:39:48.000000000",
-	      "eventType": "AwsConsoleSignIn",
-	      "managementEvent": true,
-	      "readOnly": false,
-	      "recipientAccountId": "123456789012",
-	      "responseElements": {
-		      "ConsoleLogin": "Success"
-	      },
-	      "sourceIPAddress": "1.1.1.1",
-	      "userIdentity": {
-		      "accessKeyId": "",
-		      "accountId": "123456789012",
-		      "arn": "arn:aws:iam::123456789012:root",
-		      "principalId": "123456789012",
-		      "type": "Root"
-	      }
+        "additionalEventData": {
+          "LoginTo": "https://console.aws.amazon.com/console/home",
+          "MFAUsed": "No",
+          "MobileVersion": "No"
+        },
+        "awsRegion": "us-east-1",
+        "eventName": "ConsoleLogin",
+        "eventSource": "signin.amazonaws.com",
+        "eventTime": "2021-07-15 16:39:48.000000000",
+        "eventType": "AwsConsoleSignIn",
+        "managementEvent": true,
+        "readOnly": false,
+        "recipientAccountId": "123456789012",
+        "responseElements": {
+          "ConsoleLogin": "Success"
+        },
+        "sourceIPAddress": "1.1.1.1",
+        "userIdentity": {
+          "accessKeyId": "",
+          "accountId": "123456789012",
+          "arn": "arn:aws:iam::123456789012:root",
+          "principalId": "123456789012",
+          "type": "Root"
+        }
       }
   -
     Name: MFA Login but with SAML

--- a/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
+++ b/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
@@ -24,7 +24,7 @@ SummaryAttributes:
   - p_any_aws_arns
 Tests:
   -
-    Name: No MFA Login
+    Name: No MFA Login - IAM User
     ExpectedResult: true
     Log:
       {
@@ -54,6 +54,36 @@ Tests:
         "eventID": "1",
         "eventType": "AwsConsoleSignIn",
         "recipientAccountId": "123456789012"
+      }
+  -
+    Name: No MFA Login - Root User
+    ExpectedResult: true
+    Log:
+      {
+	      "additionalEventData": {
+		      "LoginTo": "https://console.aws.amazon.com/console/home",
+		      "MFAUsed": "No",
+		      "MobileVersion": "No"
+	      },
+	      "awsRegion": "us-east-1",
+	      "eventName": "ConsoleLogin",
+	      "eventSource": "signin.amazonaws.com",
+	      "eventTime": "2021-07-15 16:39:48.000000000",
+	      "eventType": "AwsConsoleSignIn",
+	      "managementEvent": true,
+	      "readOnly": false,
+	      "recipientAccountId": "123456789012",
+	      "responseElements": {
+		      "ConsoleLogin": "Success"
+	      },
+	      "sourceIPAddress": "1.1.1.1",
+	      "userIdentity": {
+		      "accessKeyId": "",
+		      "accountId": "123456789012",
+		      "arn": "arn:aws:iam::123456789012:root",
+		      "principalId": "123456789012",
+		      "type": "Root"
+	      }
       }
   -
     Name: MFA Login but with SAML

--- a/aws_cloudtrail_rules/aws_iam_user_recon_denied.py
+++ b/aws_cloudtrail_rules/aws_iam_user_recon_denied.py
@@ -1,4 +1,3 @@
-from fnmatch import fnmatch
 from ipaddress import ip_address
 
 from panther import lookup_aws_account_name
@@ -6,11 +5,11 @@ from panther_base_helpers import deep_get
 
 # service/event patterns to monitor
 RECON_ACTIONS = {
-    "dynamodb": ["List*", "Describe*", "Get*"],
-    "ec2": ["Describe*", "Get*"],
-    "iam": ["List*", "Get*"],
-    "s3": ["List*", "Get*"],
-    "rds": ["Describe*", "List*"],
+    "dynamodb": ["List", "Describe", "Get"],
+    "ec2": ["Describe", "Get"],
+    "iam": ["List", "Get"],
+    "s3": ["List", "Get"],
+    "rds": ["Describe", "List"],
 }
 
 
@@ -30,7 +29,7 @@ def rule(event):
     # Pattern match this event to the recon actions
     for event_source, event_patterns in RECON_ACTIONS.items():
         if event.get("eventSource", "").startswith(event_source) and any(
-            fnmatch(event.get("eventName", ""), event_pattern) for event_pattern in event_patterns
+            event.get("eventName", "").startswith(event_pattern) for event_pattern in event_patterns
         ):
             return True
     return False

--- a/aws_cloudtrail_rules/aws_root_activity.py
+++ b/aws_cloudtrail_rules/aws_root_activity.py
@@ -15,19 +15,14 @@ def rule(event):
 
 
 def dedup(event):
-    return (
-        event.get("sourceIPAddress", "<UNKNOWN_IP>")
-        + ":"
-        + lookup_aws_account_name(event.get("recipientAccountId"))
-    )
+    return event.get("eventName") + ":" + lookup_aws_account_name(event.get("recipientAccountId"))
 
 
 def title(event):
-    action = "activity"
-    if event.get("eventName") == "ConsoleLogin":
-        action = "login"
     return (
-        f"AWS root {action} detected from [{event.get('sourceIPAddress')}] in account "
+        "AWS root user activity "
+        f"[{event.get('eventName')}] "
+        "in account "
         f"[{lookup_aws_account_name(event.get('recipientAccountId'))}]"
     )
 

--- a/global_helpers/panther_default.py
+++ b/global_helpers/panther_default.py
@@ -26,8 +26,10 @@ def lookup_aws_account_name(account_id):
 
     Returns:
         str: The name of the AWS account ID
+        or
+        str: The AWS account ID (unnamed account)
     """
-    return AWS_ACCOUNTS.get(account_id, account_id)
+    return AWS_ACCOUNTS.get(account_id, f"{account_id} (unnamed account)")
 
 
 def aws_cloudtrail_success(event):


### PR DESCRIPTION
### Background

Ongoing refinement of detections

### Changes

* `aws_console_login_without_mfa`: added ability to identify `Root` user in title, plus unit test
* `aws_iam_user_recon_denied`: 
-- added ability to identify `Root` user in title, and updated title syntax
-- removed unnecessary usage of `fnmatch` library
* `aws_root_activity`:
-- updated `title()` to include more useful info
-- updated `dedup()` string
*  `global_helpers/panther_default`
-- updated `lookup_aws_account_name()` to explicitly state that an account doesn't have an alias yet

### Testing

* `make fmt lint`
* running on live system
