### PR TITLE
chore: default github finidngs to enabled

### DIFF
--- a/github_rules/github_branch_policy_override.yml
+++ b/github_rules/github_branch_policy_override.yml
@@ -2,7 +2,7 @@ AnalysisType: rule
 Filename: github_branch_policy_override.py
 RuleID: GitHub.Branch.PolicyOverride
 DisplayName: GitHub Branch Protection Policy Override
-Enabled: false
+Enabled: true
 LogTypes:
   - GitHub.Audit
 Tags:

--- a/github_rules/github_branch_protection_disabled.yml
+++ b/github_rules/github_branch_protection_disabled.yml
@@ -2,7 +2,7 @@ AnalysisType: rule
 Filename: github_branch_protection_disabled.py
 RuleID: GitHub.Branch.ProtectionDisabled
 DisplayName: GitHub Branch Protection Disabled
-Enabled: false
+Enabled: true
 LogTypes:
   - GitHub.Audit
 Tags:

--- a/github_rules/github_org_modified.yml
+++ b/github_rules/github_org_modified.yml
@@ -2,7 +2,7 @@ AnalysisType: rule
 Filename: github_org_modified.py
 RuleID: GitHub.Org.Modified
 DisplayName: GitHub User Added or Removed from Org
-Enabled: false
+Enabled: true
 LogTypes:
   - GitHub.Audit
 Tags:

--- a/github_rules/github_repo_collaborator_change.yml
+++ b/github_rules/github_repo_collaborator_change.yml
@@ -2,7 +2,7 @@ AnalysisType: rule
 Filename: github_repo_collaborator_change.py
 RuleID: Github.Repo.CollaboratorChange
 DisplayName: GitHub Repository Visibility Change
-Enabled: false
+Enabled: true
 LogTypes:
   - GitHub.Audit
 Tags:

--- a/github_rules/github_repo_created.yml
+++ b/github_rules/github_repo_created.yml
@@ -2,7 +2,7 @@ AnalysisType: rule
 Filename: github_repo_created.py
 RuleID: Github.Repo.Created
 DisplayName: GitHub Repository Created
-Enabled: false
+Enabled: true
 LogTypes:
   - GitHub.Audit
 Tags:

--- a/github_rules/github_repo_hook_modified.yml
+++ b/github_rules/github_repo_hook_modified.yml
@@ -2,7 +2,7 @@ AnalysisType: rule
 Filename: github_repo_hook_modified.py
 RuleID: GitHub.Repo.HookModified
 DisplayName: GitHub Web Hook Modified
-Enabled: false
+Enabled: true
 LogTypes:
   - GitHub.Audit
 Tags:

--- a/github_rules/github_repo_initial_access.yml
+++ b/github_rules/github_repo_initial_access.yml
@@ -2,7 +2,7 @@ AnalysisType: rule
 Filename: github_repo_initial_access.py
 RuleID: GitHub.Repo.InitialAccess
 DisplayName: GitHub Branch Protection Policy Override
-Enabled: false
+Enabled: true
 LogTypes:
   - GitHub.Audit
 Tags:

--- a/github_rules/github_repo_visibility_change.yml
+++ b/github_rules/github_repo_visibility_change.yml
@@ -2,7 +2,7 @@ AnalysisType: rule
 Filename: github_repo_visibility_change.py
 RuleID: Github.Repo.VisibilityChange
 DisplayName: GitHub Repository Visibility Change
-Enabled: false
+Enabled: true
 LogTypes:
   - GitHub.Audit
 Tags:

--- a/github_rules/github_team_modified.yml
+++ b/github_rules/github_team_modified.yml
@@ -2,7 +2,7 @@ AnalysisType: rule
 Filename: github_team_modified.py
 RuleID: GitHub.Team.Modified
 DisplayName: GitHub Team Modified
-Enabled: false
+Enabled: true
 LogTypes:
   - GitHub.Audit
 Tags:

--- a/github_rules/github_user_access_key_created.yml
+++ b/github_rules/github_user_access_key_created.yml
@@ -2,7 +2,7 @@ AnalysisType: rule
 Filename: github_user_access_key_created.py
 RuleID: GitHub.User.AccessKeyCreated
 DisplayName: GitHub User Access Key Created
-Enabled: false
+Enabled: true
 LogTypes:
   - GitHub.Audit
 Tags:

--- a/github_rules/github_user_role_updated.yml
+++ b/github_rules/github_user_role_updated.yml
@@ -2,7 +2,7 @@ AnalysisType: rule
 Filename: github_user_role_updated.py
 RuleID: GitHub.User.RoleUpdated
 DisplayName: GitHub User Role Updated
-Enabled: false
+Enabled: true
 LogTypes:
   - GitHub.Audit
 Tags:


### PR DESCRIPTION
### Background

GitHub findings are set to disabled as default, that doesn't appear to be the case with other findings

### Changes

Sets the GitHub alerts to be enabled by default

### Testing

N/A