### PR TITLE
Do Not Alert on Child Documents When Parent Folder Permissions Update

### DIFF
--- a/gsuite_reports_rules/gsuite_drive_visibility_change.py
+++ b/gsuite_reports_rules/gsuite_drive_visibility_change.py
@@ -3,7 +3,7 @@ from panther_base_helpers import gsuite_parameter_lookup as param_lookup
 
 
 def rule(event):
-    # This set refers to events where documents have changed perms due to parent folder perm change
+    # This Tuple refers to events where documents have changed perms due to parent folder perm change
     inheritance_events = (
         "change_user_access_hierarchy_reconciled",
         "change_document_access_scope_hierarchy_reconciled",

--- a/gsuite_reports_rules/gsuite_drive_visibility_change.py
+++ b/gsuite_reports_rules/gsuite_drive_visibility_change.py
@@ -3,7 +3,7 @@ from panther_base_helpers import gsuite_parameter_lookup as param_lookup
 
 
 def rule(event):
-    # This Tuple refers to events where documents have changed perms due to parent folder perm change
+    # This Tuple refers to events where documents have changed perms due to parent folder change
     inheritance_events = (
         "change_user_access_hierarchy_reconciled",
         "change_document_access_scope_hierarchy_reconciled",

--- a/gsuite_reports_rules/gsuite_drive_visibility_change.py
+++ b/gsuite_reports_rules/gsuite_drive_visibility_change.py
@@ -1,17 +1,20 @@
 from panther_base_helpers import deep_get
 from panther_base_helpers import gsuite_parameter_lookup as param_lookup
 
+# This set refers to events where documents have changed perms due to parent folder change
+inheritance_events = {
+    "change_user_access_hierarchy_reconciled",
+    "change_document_access_scope_hierarchy_reconciled",
+}
 
 def rule(event):
-    # This Tuple refers to events where documents have changed perms due to parent folder change
-    inheritance_events = (
-        "change_user_access_hierarchy_reconciled",
-        "change_document_access_scope_hierarchy_reconciled",
-    )
-
     if deep_get(event, "id", "applicationName") != "drive":
         return False
-
+    # Events that have the types in inheritance_events are
+    # changes to documents and folders that occur due to
+    # a change in the parent folder's permission. We ignore
+    # these events to prevent every folder change from
+    # generating multiple alerts.
     if deep_get(event, "events", "name") in inheritance_events:
         return False
 

--- a/gsuite_reports_rules/gsuite_drive_visibility_change.py
+++ b/gsuite_reports_rules/gsuite_drive_visibility_change.py
@@ -3,7 +3,15 @@ from panther_base_helpers import gsuite_parameter_lookup as param_lookup
 
 
 def rule(event):
+    # This set refers to events where documents have changed perms due to parent folder perm change
+    inheritance_events = {
+        "change_user_access_hierarchy_reconciled", "change_document_access_scope_hierarchy_reconciled"
+    }
+
     if deep_get(event, "id", "applicationName") != "drive":
+        return False
+
+    if deep_get(event, "events", "name") in inheritance_events:
         return False
 
     for details in event.get("events", [{}]):

--- a/gsuite_reports_rules/gsuite_drive_visibility_change.py
+++ b/gsuite_reports_rules/gsuite_drive_visibility_change.py
@@ -4,9 +4,10 @@ from panther_base_helpers import gsuite_parameter_lookup as param_lookup
 
 def rule(event):
     # This set refers to events where documents have changed perms due to parent folder perm change
-    inheritance_events = {
-        "change_user_access_hierarchy_reconciled", "change_document_access_scope_hierarchy_reconciled"
-    }
+    inheritance_events = (
+        "change_user_access_hierarchy_reconciled",
+        "change_document_access_scope_hierarchy_reconciled",
+    )
 
     if deep_get(event, "id", "applicationName") != "drive":
         return False

--- a/gsuite_reports_rules/gsuite_drive_visibility_change.yml
+++ b/gsuite_reports_rules/gsuite_drive_visibility_change.yml
@@ -56,6 +56,7 @@ Tests:
         'id': {'applicationName': 'drive'},
         'events': [
           {
+            'name': "change_user_access",
             'type': 'acl_change',
             'parameters': [
               {'name': 'visibility_change', 'value': 'external'},
@@ -75,6 +76,38 @@ Tests:
         'id': {'applicationName': 'drive'},
         'events': [
           {
+            'type': 'acl_change',
+            'parameters': [{'name': 'visibility_change', 'value': 'internal'}]
+          }
+        ]
+      }
+  -
+    Name: Doc Inherits Folder Permissions
+    ExpectedResult: false
+    Log:
+      {
+        'p_row_id': '111222',
+        'actor': { 'email': 'bobert@example.com' },
+        'id': { 'applicationName': 'drive' },
+        "events": [
+          {
+            'name': "change_user_access_hierarchy_reconciled",
+            'type': 'acl_change',
+            'parameters': [{'name': 'visibility_change', 'value': 'internal'}]
+          }
+        ]
+      }
+  -
+    Name: Doc Inherits Folder Permissions - Sharing Link
+    ExpectedResult: false
+    Log:
+      {
+      'p_row_id': '111222',
+      'actor': { 'email': 'bobert@example.com' },
+      'id': { 'applicationName': 'drive' },
+        "events": [
+          {
+            'name': "change_document_access_scope_hierarchy_reconciled",
             'type': 'acl_change',
             'parameters': [{'name': 'visibility_change', 'value': 'internal'}]
           }


### PR DESCRIPTION
### Background

Drive will create an alert for every document contained within a folder as they inherit permissions from a change to the parent folder permissions. We do not want to alert on every document in that folder as that is only noise.

### Changes
In visibility change rule added tuple containing log event titles that indicate the inherited permissions update, then returned False for any event matching those types

### Testing 
Created two new unit tests based on events from security.panther.tools, test suite passes with old and new tests 


Closes https://app.asana.com/0/1200819885715474/1200720820393300/f