### PR TITLE
Standardize deprecations

### DIFF
--- a/aws_cloudtrail_rules/aws_console_login_failed.yml
+++ b/aws_cloudtrail_rules/aws_console_login_failed.yml
@@ -1,7 +1,7 @@
 AnalysisType: rule
 Filename: aws_console_login_failed.py
-RuleID: DEPRECATED RULE - AWS.Console.LoginFailed
-DisplayName: Failed Console Login
+RuleID: AWS.Console.LoginFailed
+DisplayName: --DEPRECATED-- Failed Console Login
 DedupPeriodMinutes: 60
 Enabled: false
 LogTypes:

--- a/box_rules/box_brute_force_login.yml
+++ b/box_rules/box_brute_force_login.yml
@@ -1,7 +1,7 @@
 AnalysisType: rule
 Filename: box_brute_force_login.py
 RuleID: Box.Brute.Force.Login
-DisplayName: DEPRECATED RULE - Box Brute Force Login
+DisplayName: --DEPRECATED -- Box Brute Force Login
 Enabled: false
 LogTypes:
   - Box.Event

--- a/gcp_audit_rules/gcp_iam_admin_role_assigned.yml
+++ b/gcp_audit_rules/gcp_iam_admin_role_assigned.yml
@@ -1,7 +1,7 @@
 AnalysisType: rule
 Filename: gcp_iam_admin_role_assigned.py
 RuleID: GCP.IAM.AdminRoleAssigned
-DisplayName: DEPRECATED RULE - GCP IAM Admin Role Assigned
+DisplayName: --DEPRECATED-- GCP IAM Admin Role Assigned
 Enabled: false
 LogTypes:
   - GCP.AuditLog

--- a/gsuite_reports_rules/gsuite_brute_force_login.yml
+++ b/gsuite_reports_rules/gsuite_brute_force_login.yml
@@ -1,7 +1,7 @@
 AnalysisType: rule
 Filename: gsuite_brute_force_login.py
 RuleID: GSuite.BruteForceLogin
-DisplayName: DEPRECATED RULE - GSuite Brute Force Login
+DisplayName: --DEPRECATED-- GSuite Brute Force Login
 Enabled: false
 LogTypes:
   - GSuite.Reports

--- a/okta_rules/okta_brute_force_logins.yml
+++ b/okta_rules/okta_brute_force_logins.yml
@@ -1,7 +1,7 @@
 AnalysisType: rule
 Filename: okta_brute_force_logins.py
 RuleID: Okta.BruteForceLogins
-DisplayName: DEPRECATED RULE - Okta Brute Force Logins
+DisplayName: --DEPRECATED-- Okta Brute Force Logins
 Enabled: false
 LogTypes:
   - Okta.SystemLog

--- a/onelogin_rules/onelogin_admin_role_assigned.yml
+++ b/onelogin_rules/onelogin_admin_role_assigned.yml
@@ -1,7 +1,7 @@
 AnalysisType: rule
 Filename: onelogin_admin_role_assigned.py 
 RuleID: OneLogin.AdminRoleAssigned
-DisplayName:  DEPRECATED RULE - OneLogin Admin Role Assigned
+DisplayName: --DEPRECATED-- OneLogin Admin Role Assigned
 Enabled: false
 LogTypes:
   - OneLogin.Events

--- a/onelogin_rules/onelogin_brute_force_by_ip.yml
+++ b/onelogin_rules/onelogin_brute_force_by_ip.yml
@@ -1,7 +1,7 @@
 AnalysisType: rule
 Filename: onelogin_brute_force_by_ip.py
 RuleID: OneLogin.BruteForceByIP
-DisplayName: DEPRECATED RULE - OneLogin Brute Force IP
+DisplayName: --DEPRECATED-- OneLogin Brute Force IP
 Enabled: false
 LogTypes:
   - OneLogin.Events

--- a/onelogin_rules/onelogin_brute_force_by_username.yml
+++ b/onelogin_rules/onelogin_brute_force_by_username.yml
@@ -1,7 +1,7 @@
 AnalysisType: rule
 Filename: onelogin_brute_force_by_username.py
 RuleID: OneLogin.BruteForceByUsername
-DisplayName: DEPRECATED RULE - OneLogin Brute Force Username
+DisplayName: --DEPRECATED-- OneLogin Brute Force Username
 Enabled: false
 LogTypes:
   - OneLogin.Events


### PR DESCRIPTION
### Background

Deprecation syntax wasn't standardized. Also, one rule ID was altered by a previous commit, which resulted in the original rule not being disabled.

### Changes

* Reverted Rule ID of `AWS.Console.LoginFailed` and moved deprecation warning to `DisplayName`
* Standardized deprecation message in `DisplayName` of other rules

### Testing

* n/a
