### PR TITLE
Create rule for external email forwarding

### DIFF
--- a/gsuite_activityevent_rules/gsuite_external_forwarding.py
+++ b/gsuite_activityevent_rules/gsuite_external_forwarding.py
@@ -1,0 +1,22 @@
+from panther_base_helpers import deep_get
+
+ALLOWED_DOMAINS = ["example.com"]  # List of external domains that are allowed to be forwarded to
+
+
+def rule(event):
+    if deep_get(event, "id", "applicationName") != "user_accounts":
+        return False
+
+    if event.get("name") == "email_forwarding_out_of_domain":
+        domain = deep_get(event, "parameters", "email_forwarding_destination_address").split("@")[1]
+        if domain not in ALLOWED_DOMAINS:
+            return True
+
+    return False
+
+
+def title(event):
+    external_address = deep_get(event, "parameters", "email_forwarding_destination_address")
+    user = deep_get(event, "actor", "email")
+
+    return f"An email forwarding rule was created by {user} to {external_address}"

--- a/gsuite_activityevent_rules/gsuite_external_forwarding.yml
+++ b/gsuite_activityevent_rules/gsuite_external_forwarding.yml
@@ -1,0 +1,75 @@
+AnalysisType: rule
+Filename: gsuite_external_forwarding.py
+RuleID: GSuite.ExternalMailForwarding
+DisplayName: Gsuite Mail forwarded to external domain
+Enabled: true
+LogTypes:
+  - GSuite.ActivityEvent
+Tags:
+  - GSuite
+Severity: High
+Description: >
+  A user has configured mail forwarding to an external domain
+Reports:
+  MITRE ATT&CK:
+    - Email Collection: Email Forwarding Rule
+Reference: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/login#email_forwarding_out_of_domain
+Runbook: >
+  Follow up with user to remove this forwarding rule if not allowed.
+SummaryAttributes:
+  - p_any_emails
+Tests:
+  -
+    Name: Forwarding to External Address
+    ExpectedResult: true
+    Log:
+      {
+      "id": {
+          "applicationName": "user_accounts",
+          "customerId": "C045p8dnk",
+        },
+        "actor": {
+          "email": "homer.simpson@.springfield.io",
+        },
+        "type": "email_forwarding_change",
+        "name": "email_forwarding_out_of_domain",
+        "parameters": {
+          "email_forwarding_destination_address": "HSimpson@gmail.com"
+        },
+      }
+
+  -
+    Name: Forwarding to External Address - Allowed Domain
+    ExpectedResult: false
+    Log:
+      {
+      "id": {
+          "applicationName": "user_accounts",
+          "customerId": "C045p8dnk",
+        },
+        "actor": {
+          "email": "homer.simpson@.springfield.io",
+        },
+        "type": "email_forwarding_change",
+        "name": "email_forwarding_out_of_domain",
+        "parameters": {
+          "email_forwarding_destination_address": "HSimpson@example.com"
+        },
+      }
+
+  -
+    Name: Non Forwarding Event
+    ExpectedResult: false
+    Log:
+      {
+      "id": {
+          "applicationName": "user_accounts",
+          "customerId": "C045p8dnk",
+        },
+        "actor": {
+          "email": "homer.simpson@.springfield.io",
+        },
+        "type": "2sv_change",
+        "name": "2sv_enroll",
+      }
+


### PR DESCRIPTION
### Background
Alerts on mail rules that forward to external domains. This is a common data exfiltration practice, as well as a general security concern as sensitive mail could be forwarded to personal addresses with poor protections.

### Changes
Created new rule and metadata

### Testing

* CI/CD, Unit tests

Closes https://app.asana.com/0/1200468368401002/1200974516002259/f