### PR TITLE
update isinstance check

### DIFF
--- a/aws_iam_policies/aws_iam_policy_administrative_privileges.py
+++ b/aws_iam_policies/aws_iam_policy_administrative_privileges.py
@@ -1,13 +1,5 @@
 import json
-
-
-# When a single item is loaded from json, it is loaded as a single item
-# When a list of items is loaded from json, it is loaded as a list of that item
-# When we want to iterate over something that could be a single item or a list
-# of items we can use listify and just continue as if it's always a list
-def listify(maybe_list):
-    return [maybe_list] if not isinstance(maybe_list, list) else maybe_list
-
+from panther_oss_helpers import listify
 
 def policy(resource):
     iam_policy = json.loads(resource["PolicyDocument"])

--- a/aws_iam_policies/aws_iam_policy_administrative_privileges.py
+++ b/aws_iam_policies/aws_iam_policy_administrative_privileges.py
@@ -1,5 +1,7 @@
 import json
+
 from panther_oss_helpers import listify
+
 
 def policy(resource):
     iam_policy = json.loads(resource["PolicyDocument"])
@@ -7,7 +9,6 @@ def policy(resource):
     for state in statements:
         actions = listify(state.get("Action", []))
         resources = listify(state.get("Resource", []))
-
         if state["Effect"] == "Allow" and "*" in actions and "*" in resources:
             return False
     return True

--- a/aws_rds_policies/aws_rds_instance_snapshot_public_access.py
+++ b/aws_rds_policies/aws_rds_instance_snapshot_public_access.py
@@ -1,9 +1,4 @@
-# When a single item is loaded from json, it is loaded as a single item
-# When a list of items is loaded from json, it is loaded as a list of that item
-# When we want to iterate over something that could be a single item or a list
-# of items we can use listify and just continue as if it's always a list
-def listify(maybe_list):
-    return [maybe_list] if not isinstance(maybe_list, list) else maybe_list
+from panther_oss_helpers import listify
 
 
 def policy(resource):

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import time
+from collections.abc import Sequence as sequence
 from datetime import datetime
 from ipaddress import ip_address
 from typing import Any, Dict, Optional, Sequence, Set, Union
@@ -415,6 +416,14 @@ def add_parse_delay(event, context: dict) -> dict:
 # alerts based on expected actions for a new user
 def check_new_user(user_id):
     return bool(get_string_set(user_id))
+
+
+# When a single item is loaded from json, it is loaded as a single item
+# When a list of items is loaded from json, it is loaded as a list of that item
+# When we want to iterate over something that could be a single item or a list
+# of items we can use listify and just continue as if it's always a list
+def listify(maybe_list):
+    return [maybe_list] if not isinstance(maybe_list, sequence) else maybe_list
 
 
 def _test_kv_store():

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -3,7 +3,6 @@ import json
 import os
 import re
 import time
-from collections.abc import Sequence as sequence
 from datetime import datetime
 from ipaddress import ip_address
 from typing import Any, Dict, Optional, Sequence, Set, Union
@@ -11,6 +10,7 @@ from typing import Any, Dict, Optional, Sequence, Set, Union
 import boto3
 import requests
 from dateutil import parser
+from panther_analysis_tool.immutable import ImmutableList
 
 _RESOURCE_TABLE = None  # boto3.Table resource, lazily constructed
 FIPS_ENABLED = os.getenv("ENABLE_FIPS", "").lower() == "true"
@@ -423,7 +423,7 @@ def check_new_user(user_id):
 # When we want to iterate over something that could be a single item or a list
 # of items we can use listify and just continue as if it's always a list
 def listify(maybe_list):
-    return [maybe_list] if not isinstance(maybe_list, sequence) else maybe_list
+    return [maybe_list] if not isinstance(maybe_list, (list, ImmutableList)) else maybe_list
 
 
 def _test_kv_store():


### PR DESCRIPTION
### Background

With conversion of resources to immutable-types, the `listify()` check will fail (list is not an immutablelist).  This updates this check to compare for both list and ImmutableList types

### Changes

* extract listify as global
* update listify to check for additional list type

### Testing

* `make test`
