### PR TITLE
Update Snowflake Pack queries to use p_occurs* macros w/ custom times…

### DIFF
--- a/snowflake_queries/snowflake_account_admin_assigned_query.yml
+++ b/snowflake_queries/snowflake_account_admin_assigned_query.yml
@@ -4,22 +4,22 @@ Enabled: false
 Description: >
   Monitor and detect granting account admin role.
 AthenaQuery: >
-  /* athena query not supported */ 
+  /* athena query not supported */
   SELECT count(1)
 SnowflakeQuery: >
   --return instances where account admin role is granted
 
   --this was adapted from a Security Feature Checklist query
 
-  SELECT 
+  SELECT
     user_name,
     role_name,
     query_text
   FROM snowflake.account_usage.query_history
-    WHERE 
-      DATEDIFF(HOUR,  start_time, CURRENT_TIMESTAMP) < 1
-      AND execution_status = 'SUCCESS' 
-      AND query_type = 'GRANT' 
+    WHERE
+      p_occurs_since('1 h',, start_time)
+      AND execution_status = 'SUCCESS'
+      AND query_type = 'GRANT'
       AND query_text ILIKE '%grant%accountadmin%to%'
   ORDER BY end_time desc
 Schedule:

--- a/snowflake_queries/snowflake_brute_force_ip_query.yml
+++ b/snowflake_queries/snowflake_brute_force_ip_query.yml
@@ -4,14 +4,14 @@ Enabled: false
 Description: >
   Detect brute force attempts by monitoring for failed logins to snowflake.
 AthenaQuery: >
-  /* athena query not supported */ 
+  /* athena query not supported */
   SELECT count(1)
 SnowflakeQuery: >
   --return IPs with more than 5 failed logins in the previous 24 hours
 
   --this was adapted from a SnowAlert query
 
-  SELECT 
+  SELECT
     client_ip,
     reported_client_type,
     ARRAY_AGG(DISTINCT error_code) as error_codes,
@@ -19,7 +19,7 @@ SnowflakeQuery: >
     COUNT(event_id) AS counts
   FROM snowflake.account_usage.login_history
   WHERE 1=1
-    AND DATEDIFF(HOUR,  event_timestamp, CURRENT_TIMESTAMP) < 24
+    AND p_occurs_since('24 h',, event_timestamp)
     AND error_code is NOT NULL
   GROUP BY client_ip, reported_client_type
   HAVING counts >= 5

--- a/snowflake_queries/snowflake_brute_force_username_query.yml
+++ b/snowflake_queries/snowflake_brute_force_username_query.yml
@@ -2,16 +2,16 @@ AnalysisType: scheduled_query
 QueryName: Query.Snowflake.BruteForceByUsername
 Enabled: false
 Description: >
-  Detect brute force attempts by monitoring for failed logins to snowflake. 
+  Detect brute force attempts by monitoring for failed logins to snowflake.
 AthenaQuery: >
-  /* athena query not supported */ 
+  /* athena query not supported */
   SELECT count(1)
 SnowflakeQuery: >
   --return users with more than 5 failed logins in the previous 24 hours
 
   --this was adapted from a SnowAlert query
 
-  SELECT 
+  SELECT
     user_name,
     reported_client_type,
     ARRAY_AGG(DISTINCT error_code) as error_codes,
@@ -19,7 +19,7 @@ SnowflakeQuery: >
     COUNT(event_id) AS counts
   FROM snowflake.account_usage.login_history
   WHERE 1=1
-    AND DATEDIFF(HOUR, event_timestamp, CURRENT_TIMESTAMP) < 24
+    AND p_occurs_since('24 h',, event_timestamp)
     AND error_code IS NOT NULL
   GROUP BY reported_client_type, user_name
   HAVING counts >=5;

--- a/snowflake_queries/snowflake_login_without_mfa_query.yml
+++ b/snowflake_queries/snowflake_login_without_mfa_query.yml
@@ -21,7 +21,7 @@ SnowflakeQuery: >
     second_authentication_factor
   FROM snowflake.account_usage.login_history
     WHERE
-      AND p_occurs_since('1 h',, event_timestamp)
+      p_occurs_since('1 h',, event_timestamp)
       AND first_authentication_factor = 'PASSWORD'
       AND second_authentication_factor IS null
   ORDER BY event_timestamp desc

--- a/snowflake_queries/snowflake_login_without_mfa_query.yml
+++ b/snowflake_queries/snowflake_login_without_mfa_query.yml
@@ -4,14 +4,14 @@ Enabled: false
 Description: >
   Monitor logins that are not using MFA.
 AthenaQuery: >
-  /* athena query not supported */ 
+  /* athena query not supported */
   SELECT count(1)
 SnowflakeQuery: >
   --return instances where a user logs in without MFA
 
   --this was adapted from a Security Feature Checklist query
 
-  SELECT 
+  SELECT
     event_timestamp,
     user_name,
     client_ip,
@@ -21,8 +21,8 @@ SnowflakeQuery: >
     second_authentication_factor
   FROM snowflake.account_usage.login_history
     WHERE
-      DATEDIFF(HOUR,  event_timestamp, CURRENT_TIMESTAMP) < 1
-      AND first_authentication_factor = 'PASSWORD' 
+      AND p_occurs_since('1 h',, event_timestamp)
+      AND first_authentication_factor = 'PASSWORD'
       AND second_authentication_factor IS null
   ORDER BY event_timestamp desc
 Schedule:

--- a/snowflake_queries/snowflake_network_policy_modified_query.yml
+++ b/snowflake_queries/snowflake_network_policy_modified_query.yml
@@ -7,7 +7,7 @@ AthenaQuery: >
   /* athena query not supported */
   SELECT count(1)
 SnowflakeQuery: >
-  --return create, aleter, or drop of network policies
+  --return create, alter, or drop of network policies
 
   --this was adapted from a Security Feature Checklist query
 

--- a/snowflake_queries/snowflake_network_policy_modified_query.yml
+++ b/snowflake_queries/snowflake_network_policy_modified_query.yml
@@ -4,23 +4,23 @@ Enabled: false
 Description: >
   Monitor and detect alterations to network policies.
 AthenaQuery: >
-  /* athena query not supported */ 
+  /* athena query not supported */
   SELECT count(1)
 SnowflakeQuery: >
   --return create, aleter, or drop of network policies
 
   --this was adapted from a Security Feature Checklist query
 
-  SELECT 
+  SELECT
     end_time,
     query_type,
     query_text,
     user_name,
     role_name
   FROM snowflake.account_usage.query_history
-    WHERE 
-      DATEDIFF(HOUR,  start_time, CURRENT_TIMESTAMP) < 24
-      AND execution_status = 'SUCCESS' 
+    WHERE
+      p_occurs_since('24 h',, start_time)
+      AND execution_status = 'SUCCESS'
       AND user_name != 'PANTHER_READONLY'
       AND (
           query_type in ('CREATE_NETWORK_POLICY', 'ALTER_NETWORK_POLICY', 'DROP_NETWORK_POLICY')

--- a/snowflake_queries/snowflake_privileged_object_changes_query.yml
+++ b/snowflake_queries/snowflake_privileged_object_changes_query.yml
@@ -20,6 +20,7 @@ SnowflakeQuery: >
     WHERE
       p_occurs_since('24 h',, start_time)
       AND execution_status = 'SUCCESS'
+      AND query_type NOT in ('SELECT')
       AND (
           query_text ILIKE '%create role%'
           OR query_text ILIKE '%manage grants%'

--- a/snowflake_queries/snowflake_privileged_object_changes_query.yml
+++ b/snowflake_queries/snowflake_privileged_object_changes_query.yml
@@ -4,22 +4,22 @@ Enabled: false
 Description: >
   Monitor for users that are being re-enabled.
 AthenaQuery: >
-  /* athena query not supported */ 
+  /* athena query not supported */
   SELECT count(1)
 SnowflakeQuery: >
   --return enable user events
 
   --this was adapted from a Security Feature Checklist query
 
-  SELECT 
+  SELECT
     query_text,
     user_name,
     role_name,
     end_time
   FROM snowflake.account_usage.query_history
-    WHERE 
-      DATEDIFF(HOUR,  start_time, CURRENT_TIMESTAMP) < 24
-      AND execution_status = 'SUCCESS' 
+    WHERE
+      p_occurs_since('24 h',, start_time)
+      AND execution_status = 'SUCCESS'
       AND (
           query_text ILIKE '%create role%'
           OR query_text ILIKE '%manage grants%'

--- a/snowflake_queries/snowflake_public_role_grant_query.yml
+++ b/snowflake_queries/snowflake_public_role_grant_query.yml
@@ -7,7 +7,7 @@ AthenaQuery: >
   /* athena query not supported */
   SELECT count(1)
 SnowflakeQuery: >
-  --return instances grants to the public role
+  --return instances of grants to the public role
 
   --this was adapted from a Security Feature Checklist query
 

--- a/snowflake_queries/snowflake_public_role_grant_query.yml
+++ b/snowflake_queries/snowflake_public_role_grant_query.yml
@@ -4,23 +4,23 @@ Enabled: false
 Description: >
   Monitor and detect alterations or grants to public role, which should be kept at a minimum.
 AthenaQuery: >
-  /* athena query not supported */ 
+  /* athena query not supported */
   SELECT count(1)
 SnowflakeQuery: >
   --return instances grants to the public role
 
   --this was adapted from a Security Feature Checklist query
 
-  SELECT 
+  SELECT
     user_name,
     role_name,
     query_text,
     end_time
   FROM snowflake.account_usage.query_history
-    WHERE 
-      DATEDIFF(HOUR,  start_time, CURRENT_TIMESTAMP) < 1
-      AND execution_status = 'SUCCESS' 
-      AND query_type = 'GRANT' 
+    WHERE
+      p_occurs_since('1 h',, start_time)
+      AND execution_status = 'SUCCESS'
+      AND query_type = 'GRANT'
       AND query_text ILIKE '%to%public%'
   ORDER BY end_time desc
 Schedule:

--- a/snowflake_queries/snowflake_user_created_query.yml
+++ b/snowflake_queries/snowflake_user_created_query.yml
@@ -4,23 +4,23 @@ Enabled: false
 Description: >
   Monitor for new users.
 AthenaQuery: >
-  /* athena query not supported */ 
+  /* athena query not supported */
   SELECT count(1)
 SnowflakeQuery: >
   --return create user events
 
   --this was adapted from a Security Feature Checklist query
 
-  SELECT 
+  SELECT
     end_time,
     query_type,
     query_text,
     user_name,
     role_name
   FROM snowflake.account_usage.query_history
-    WHERE 
-      DATEDIFF(HOUR,  start_time, CURRENT_TIMESTAMP) < 24
-      AND execution_status = 'SUCCESS' 
+    WHERE
+      p_occurs_since('24 h',, start_time)
+      AND execution_status = 'SUCCESS'
       AND query_type = 'CREATE_USER'
       AND query_text ILIKE '%create%user%'
   ORDER BY end_time desc

--- a/snowflake_queries/snowflake_user_enabled_query.yml
+++ b/snowflake_queries/snowflake_user_enabled_query.yml
@@ -4,25 +4,25 @@ Enabled: false
 Description: >
   Monitor for users that are being re-enabled.
 AthenaQuery: >
-  /* athena query not supported */ 
+  /* athena query not supported */
   SELECT count(1)
 SnowflakeQuery: >
   --return enable user events
 
   --this was adapted from a Security Feature Checklist query
 
-  SELECT 
+  SELECT
     end_time,
     query_type,
     query_text,
     user_name,
     role_name
   FROM snowflake.account_usage.query_history
-    WHERE 
-      DATEDIFF(HOUR,  start_time, CURRENT_TIMESTAMP) < 24
-      AND execution_status = 'SUCCESS' 
+    WHERE
+      p_occurs_since('24 h',, start_time)
+      AND execution_status = 'SUCCESS'
       AND query_type = 'ALTER_USER'
-      AND (query_text ILIKE '%alter user%set disabled = false%' 
+      AND (query_text ILIKE '%alter user%set disabled = false%'
           OR query_text ILIKE '%alter user%set disabled= false%'
           OR query_text ILIKE '%alter user%set disabled =false%'
           OR query_text ILIKE '%alter user%set disabled=false%')


### PR DESCRIPTION
## References

Relates to https://app.asana.com/0/1200964985136582/1200958080618566

## Background

We should leverage the new custom timestamp functionality in our pack queries as they are more portable and also provide useful examples for customers.

## Changes

- Update the Snowflake Pack queries which do timestamp diffs to use the `p_occurs*` macros with custom timestamp fields.

## Testing
I tested all of the queries in the UI by creating events which I confirmed did appear in the results. Also, I fixed the privileged object changes query to exclude "select" query types thereby excluding itself from the results. All of the other queries already had adequate filters in place to ensure that they were not included in the search results.

![image](https://user-images.githubusercontent.com/1292655/135161179-ed9c5e5a-f5f9-4fc1-88e0-ca62a4bff21f.png)


