### PR TITLE
Add OSS helpers to standard ruleset

### DIFF
--- a/packs/standard_ruleset.yml
+++ b/packs/standard_ruleset.yml
@@ -18,3 +18,4 @@ PackDefinition:
     - Standard.MFADisabled
     - panther_event_type_helpers
     - panther_base_helpers
+    - panther_oss_helpers


### PR DESCRIPTION
### Background
Add Panther OSS helpers to standard ruleset pack. This is to unblock https://app.asana.com/0/1200821831799747/1201079363635197/f

### Changes
Added OSS helpers to standard_ruleset.yml

### Testing

* CI + Unit tests
