### PR TITLE
`deep_get` helper enhancements & unit tests for global helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ dist/
 
 # Vim
 *.swp
+
+# Jetbrains
+.idea

--- a/.tests/test_global_helpers.py
+++ b/.tests/test_global_helpers.py
@@ -1,0 +1,91 @@
+import os
+import sys
+import unittest
+
+GLOBAL_HELPERS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'global_helpers'))
+
+if GLOBAL_HELPERS_PATH not in sys.path:
+    sys.path.append(GLOBAL_HELPERS_PATH)
+
+import panther_base_helpers
+
+
+class TestDeepGetLegacy(unittest.TestCase):
+    def test_key_path_exists(self):
+        self.assertEqual(
+            panther_base_helpers.deep_get_legacy({"session": {"key": 1}}, "session", "key"),
+            1
+        )
+
+    def test_no_keys(self):
+        self.assertDictEqual(
+            panther_base_helpers.deep_get_legacy({"session": {"key": 1}}),
+            {"session": {"key": 1}}
+        )
+
+    def test_no_keys_not_a_mapping(self):
+        self.assertListEqual(
+            panther_base_helpers.deep_get_legacy([1]),
+            [1]
+        )
+
+    def test_key_path_does_not_exist(self):
+        self.assertIsNone(
+            panther_base_helpers.deep_get_legacy({"session": {"key": 1}}, "session", "different_key")
+        )
+
+    def test_default(self):
+        self.assertEqual(
+            panther_base_helpers.deep_get_legacy({"session": {"key": 1}}, "session", "different_key", default=8),
+            8
+        )
+        self.assertEqual(
+            panther_base_helpers.deep_get_legacy({"session": {"key": 1}}, "session", "key", default=8),
+            1
+        )
+
+    def test_non_mapping_type(self):
+        self.assertEqual(
+            panther_base_helpers.deep_get_legacy([1], "session", "different_key", default=8),
+            8
+        )
+
+
+class TestDeepGet(unittest.TestCase):
+    def test_key_path_exists(self):
+        self.assertEqual(
+            panther_base_helpers.deep_get({"session": {"key": 1}}, "session", "key"),
+            1
+        )
+
+    def test_no_keys(self):
+        self.assertIsNone(
+            panther_base_helpers.deep_get({"session": {"key": 1}})
+        )
+
+    def test_no_keys_not_a_mapping(self):
+        self.assertIsNone(
+            panther_base_helpers.deep_get([1])
+        )
+
+    def test_key_path_does_not_exist(self):
+        self.assertIsNone(
+            panther_base_helpers.deep_get({"session": {"key": 1}}, "session", "different_key")
+        )
+
+    def test_default(self):
+        self.assertEqual(
+            panther_base_helpers.deep_get({"session": {"key": 1}}, "session", "different_key", default=8),
+            8
+        )
+        self.assertEqual(
+            panther_base_helpers.deep_get({"session": {"key": 1}}, "session", "key", default=8),
+            1
+        )
+
+    def test_non_mapping_type(self):
+        default_value = object()
+        self.assertIs(
+            panther_base_helpers.deep_get([1], "session", "different_key", default=default_value),
+            default_value
+        )

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ install:
 
 test:
 	pipenv run panther_analysis_tool test
+	python -m unittest discover -p '*.py' -s .tests -v
 
 managed-schemas:
 	mkdir -p dist/managed-schemas; \

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -207,7 +207,7 @@ def okta_alert_context(event: dict):
     }
 
 
-def deep_get(dictionary: dict, *keys, default=None):
+def deep_get_legacy(dictionary: dict, *keys, default=None):
     """Safely return the value of an arbitrarily nested map
 
     Inspired by https://bit.ly/3a0hq9E
@@ -215,6 +215,30 @@ def deep_get(dictionary: dict, *keys, default=None):
     return reduce(
         lambda d, key: d.get(key, default) if isinstance(d, Mapping) else default, keys, dictionary
     )
+
+
+# Used to identify whether a key exists in a mapping
+DEEP_GET_SENTINEL_VALUE = object()
+
+
+def deep_get(dictionary: dict, *keys, default=None):
+    """Safely return the value of an arbitrarily nested map."""
+
+    # Testing for identity is very fast, we optimize for the case where None is passed
+    if dictionary is None:
+        return default
+
+    value = default
+    element = dictionary
+    for key in keys:
+        if not isinstance(element, Mapping):
+            return default
+        element = element.get(key, DEEP_GET_SENTINEL_VALUE)
+        # If the sentinel object is returned the key does not exist in the mapping
+        if element is DEEP_GET_SENTINEL_VALUE:
+            return default
+        value = element
+    return value
 
 
 def aws_strip_role_session_id(user_identity_arn):


### PR DESCRIPTION
### Background

The new version is about 10% faster in successful lookups, and approximately 2.5x faster for the case where the first key is absent. Benchmarks were performed on a dictionary with 3 keys as input.

Since we are changing the behavior compared to the previous implementation, we still maintain the legacy version, in case a detection relies on it and a patch is required.

We are also introducing unit tests for global helpers as part of the CI process.

### Changes

* Rename existing `deep_get` function to `deep_get_legacy` to allow potential patches.
* Implement a new version of `deep_get` that can be slightly more performant and potentially easier to comprehend.
* Introduce unit tests for global helpers. We treat `global_helpers/*.py` as Python modules and allow them to be importable by appending their path to the import paths list (`sys.path`). Note that the import names are not the global helper names as defined in the accompanying YAML metadata files, but the filename itself.

### Testing

* Added unit tests in CI
