### PR TITLE
Backport account age helper changes from internal

### DIFF
--- a/aws_cloudtrail_rules/aws_console_login_without_mfa.py
+++ b/aws_cloudtrail_rules/aws_console_login_without_mfa.py
@@ -1,5 +1,9 @@
+import ast
+import logging
+
 from panther import lookup_aws_account_name
 from panther_base_helpers import deep_get
+from panther_oss_helpers import check_account_age
 
 
 def rule(event):
@@ -9,6 +13,28 @@ def rule(event):
     additional_event_data = event.get("additionalEventData", {})
     session_context = deep_get(event, "userIdentity", "sessionContext", default={})
     response_elements = event.get("responseElements", {})
+
+    # If Account is less than 3 days old do not alert
+    # This functionality is not enabled by default, in order to start logging new user creations
+    # Enable indicator_creation_rules/new_account_logging to start logging new users
+    new_user_string = (
+        deep_get(event, "userIdentity", "userName", default="<MISSING_USER_NAME>")
+        + "-"
+        + deep_get(event, "userIdentity", "principalId", default="<MISSING_ID>")
+    )
+    is_new_user = check_account_age(new_user_string)
+    if isinstance(is_new_user, str):
+        logging.debug("check_account_age is a mocked string for unit testing")
+        is_new_user = ast.literal_eval(is_new_user)
+    if is_new_user:
+        return False
+
+    is_new_account = check_account_age(event.get("recipientAccountId"))
+    if isinstance(is_new_account, str):
+        logging.debug("check_account_age is a mocked string for unit testing")
+        is_new_account = ast.literal_eval(is_new_account)
+    if is_new_account:
+        return False
 
     return (
         # Only alert on successful logins

--- a/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
+++ b/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
@@ -25,6 +25,9 @@ Tests:
   -
     Name: No MFA Login - IAM User
     ExpectedResult: true
+    Mocks:
+      - objectName: check_account_age
+        returnValue: "False"
     Log:
       {
         "eventVersion": "1.05",
@@ -57,6 +60,9 @@ Tests:
   -
     Name: No MFA Login - IAM User Unknown Account
     ExpectedResult: true
+    Mocks:
+      - objectName: check_account_age
+        returnValue: "False"
     Log:
       {
         "eventVersion": "1.05",
@@ -89,6 +95,9 @@ Tests:
   -
     Name: No MFA Login - Root User
     ExpectedResult: true
+    Mocks:
+      - objectName: check_account_age
+        returnValue: "False"
     Log:
       {
         "eventVersion": "1.05",
@@ -121,6 +130,9 @@ Tests:
   -
     Name: MFA Login - SAML
     ExpectedResult: false
+    Mocks:
+      - objectName: check_account_age
+        returnValue: "False"
     Log:
       {
         "additionalEventData": {
@@ -154,6 +166,9 @@ Tests:
   -
     Name: MFA Login
     ExpectedResult: false
+    Mocks:
+      - objectName: check_account_age
+        returnValue: "False"
     Log:
       {
           "eventVersion": "1.05",
@@ -186,6 +201,9 @@ Tests:
   -
     Name: No MFA - Login Failed
     ExpectedResult: false
+    Mocks:
+      - objectName: check_account_age
+        returnValue: "False"
     Log:
       {
           "eventVersion": "1.05",
@@ -218,6 +236,9 @@ Tests:
   -
     Name: No MFA - authenticated from session with MFA
     ExpectedResult: false
+    Mocks:
+      - objectName: check_account_age
+        returnValue: "False"
     Log:
       {
         "p_event_time": "2019-01-01 00:20:04.000Z",
@@ -243,5 +264,41 @@ Tests:
           },
           "type": "AssumedRole"
         }
+      }
+
+  -
+    Name: No MFA Login - New User
+    ExpectedResult: false
+    Mocks:
+      - objectName: check_account_age
+        returnValue: "True"
+    Log:
+      {
+        "eventVersion": "1.05",
+        "userIdentity": {
+          "type": "IAMUser",
+          "principalId": "1111",
+          "arn": "arn:aws:iam::123456789012:user/tester",
+          "accountId": "123456789012",
+          "userName": "tester"
+        },
+        "eventTime": "2019-01-01T00:00:00Z",
+        "eventSource": "signin.amazonaws.com",
+        "eventName": "ConsoleLogin",
+        "awsRegion": "us-east-1",
+        "sourceIPAddress": "111.111.111.111",
+        "userAgent": "Mozilla",
+        "requestParameters": null,
+        "responseElements": {
+          "ConsoleLogin": "Success"
+        },
+        "additionalEventData": {
+          "LoginTo": "https://console.aws.amazon.com/console/",
+          "MobileVersion": "No",
+          "MFAUsed": "No"
+        },
+        "eventID": "1",
+        "eventType": "AwsConsoleSignIn",
+        "recipientAccountId": "123456789012"
       }
 

--- a/data_models/aws_cloudtrail_data_model.py
+++ b/data_models/aws_cloudtrail_data_model.py
@@ -15,7 +15,7 @@ def get_event_type(event):
         if deep_get(event, "responseElements", "ConsoleLogin") == "Success":
             return event_type.SUCCESSFUL_LOGIN
     if event.get("eventName") == "CreateUser":
-        return event_type.ACCOUNT_CREATED
+        return event_type.USER_ACCOUNT_CREATED
     return None
 
 

--- a/data_models/aws_cloudtrail_data_model.yml
+++ b/data_models/aws_cloudtrail_data_model.yml
@@ -16,3 +16,5 @@ Mappings:
     Path: userAgent
   - Name: user
     Path: $.responseElements.user.userName
+  - Name: user_account_id
+    Path: $.responseElements.user.userId

--- a/data_models/onelogin_data_model.py
+++ b/data_models/onelogin_data_model.py
@@ -10,5 +10,5 @@ def get_event_type(event):
     if event.get("event_type_id") == 5:
         return event_type.SUCCESSFUL_LOGIN
     if event.get("event_type_id") == 13:
-        return event_type.ACCOUNT_CREATED
+        return event_type.USER_ACCOUNT_CREATED
     return None

--- a/data_models/onelogin_data_model.yml
+++ b/data_models/onelogin_data_model.yml
@@ -16,5 +16,7 @@ Mappings:
     Path: ipaddr
   - Name: user
     Path: user_name
+  - Name: user_account_id
+    Path: user_id
   - Name: user_agent
     Path: user_agent

--- a/global_helpers/panther_event_type_helpers.py
+++ b/global_helpers/panther_event_type_helpers.py
@@ -1,6 +1,6 @@
 # a place to hold event type constants used among many data models, rules, or policies
-ACCOUNT_CREATED = "account_created"
 ADMIN_ROLE_ASSIGNED = "admin_role_assigned"
 FAILED_LOGIN = "failed_login"
 MFA_DISABLED = "mfa_disabled"
 SUCCESSFUL_LOGIN = "successful_login"
+USER_ACCOUNT_CREATED = "user_account_created"

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -412,10 +412,14 @@ def add_parse_delay(event, context: dict) -> dict:
     return context
 
 
-# check for presence of user id in KV store for the purpose of modifying severity or suppressing
-# alerts based on expected actions for a new user
-def check_new_user(user_id):
-    return bool(get_string_set(user_id))
+def check_account_age(key):
+    """
+    Searches DynamoDB for stored user_id or account_id string stored by indicator creation
+    rules for new user / account creation
+    """
+    if isinstance(key, str) and key != "":
+        return bool(get_string_set(key))
+    return False
 
 
 # When a single item is loaded from json, it is loaded as a single item

--- a/indicator_creation_rules/new_user_account_logging.py
+++ b/indicator_creation_rules/new_user_account_logging.py
@@ -8,16 +8,19 @@ TTL = timedelta(days=3)
 
 
 def rule(event):
-    if event.udm("event_type") != event_type.ACCOUNT_CREATED:
+    if event.udm("event_type") != event_type.USER_ACCOUNT_CREATED:
         return False
 
-    event_id = f'new_user_{event.get("p_row_id")}'
+    user_event_id = f"new_user_{event.get('p_row_id')}"
     new_user = event.udm("user")
+    new_account = event.udm("user_account_id")
     event_time = resolve_timestamp_string(event.get("p_event_time"))
     expiry_time = event_time + TTL
 
-    put_string_set(new_user, [event_id], expiry_time.strftime("%s"))
-
+    if new_user:
+        put_string_set(
+            new_user + "-" + str(new_account), [user_event_id], expiry_time.strftime("%s")
+        )
     return True
 
 

--- a/indicator_creation_rules/new_user_account_logging.yml
+++ b/indicator_creation_rules/new_user_account_logging.yml
@@ -1,12 +1,14 @@
-# Monitors for account creation and adds an entry to the KVStore for the user. This depends on the
-# event_type of ACCOUNT_CREATED to be in the data model for the log source and will work in tandem
+# Monitors for useraccount creation and adds an entry to the KVStore for the user. This depends on the
+# event_type of USER_ACCOUNT_CREATED to be in the data model for the log source and will work in tandem
 # with a helper function that checks for the userid in the KV store.
+# This is rule is explicitly looking for accounts associated with a userid, not automation accounts that
+# May have no user associated
 
 AnalysisType: rule
-Filename: new_account_logging.py
-RuleID: Standard.NewAccountCreated
+Filename: new_user_account_logging.py
+RuleID: Standard.NewUserAccountCreated
 DisplayName: New User Account Created
-Enabled: true
+Enabled: false
 LogTypes:
   - OneLogin.Events
   - AWS.CloudTrail
@@ -33,8 +35,8 @@ Tests:
       {
         'event_type_id': 13,
         'actor_user_id': 123456,
+        'user_id': 12345,
         'actor_user_name': 'Bob Cat',
-        'user_id': 123456,
         'user_name': 'Bob Cat',
         'p_event_time': '2021-06-27 00:08:28.792Z',
         'p_log_type': 'OneLogin.Events',
@@ -48,8 +50,8 @@ Tests:
         'event_type_id': 5,
         'actor_user_id': 123456,
         'actor_user_name': 'Bob Cat',
-        'user_id': 123456,
         'user_name': 'Bob Cat',
+        'user_id': 12345,
         'ipaddr': '192.168.1.1',
         'p_event_time': '2021-06-27 00:08:28.792Z',
         'p_log_type': 'OneLogin.Events',
@@ -66,7 +68,8 @@ Tests:
         eventName: 'CreateUser',
         responseElements: {
                 user: {
-                  userName: 'Bob Cat'
+                  userName: 'Bob Cat',
+                  userId: '12345'
                 },
           },
         'p_event_time': '2021-08-31 15:46:02.000000000',


### PR DESCRIPTION
### Background
This ports in a large change from the internal repo, full context is here https://github.com/panther-labs/panther-analysis-dogfood/pull/197

The only appreciable change is a comment and this functionality will be disabled by default so that people are intentional about turning it on

### Changes
Backport Account age helper and related changes from internal repos

### Testing

CI and unit testing

