### PR TITLE
update the pack definition

### DIFF
--- a/packs/standard_ruleset.yml
+++ b/packs/standard_ruleset.yml
@@ -14,6 +14,7 @@ PackDefinition:
     - Standard.GSuite.Reports
     - Standard.Okta.SystemLog
     - Standard.OneLogin.Events
+    - Standard.Zendesk.AuditLog
     - Standard.AdminRoleAssigned
     - Standard.BruteForceByIP
     - Standard.MFADisabled


### PR DESCRIPTION
### Background

We are missing the github and zendesk data models in the standard pack definition. 

### Changes

* Updated the pack definition

### Testing

* `make test`
