### PR TITLE
Remove outdated IPs and disable IP check

### DIFF
--- a/global_helpers/panther_iocs.py
+++ b/global_helpers/panther_iocs.py
@@ -1,6 +1,7 @@
 # pylint: disable=line-too-long
-# SUNBURST IOCs: https://github.com/fireeye/sunburst_countermeasures/blob/main/indicator_release/Indicator_Release_NBIs.csv
-# Last accessed: 12-5-2020
+# SUNBURST IOCs:
+# https://github.com/fireeye/sunburst_countermeasures/blob/main/indicator_release/Indicator_Release_NBIs.csv
+# Last accessed: 2021-11-17
 SUNBURST_FQDN_IOCS = {
     "databasegalore.com",
     "deftsecurity.com",
@@ -19,25 +20,16 @@ SUNBURST_FQDN_IOCS = {
     "mhdosoksaccf9sni9icp.appsync-api.eu-west-1.avsvmcloud.com",
 }
 
-SUNBURST_IP_IOCS = {
-    "5.252.177.21",
-    "5.252.177.25",
-    "13.59.205.66",
-    "34.203.203.23",
-    "51.89.125.18",
-    "54.193.127.66",
-    "54.215.192.52",
-    "139.99.115.204",
-    "167.114.213.199",
-    "204.188.205.176",
-}
+SUNBURST_IP_IOCS = {"0.0.0.1"}
 
+# https://github.com/mandiant/sunburst_countermeasures/blob/main/indicator_release/Indicator_Release_Hashes.csv
+# Last accessed: 2021-11-17
 SUNBURST_SHA256_IOCS = {
     "019085a76ba7126fff22770d71bd901c325fc68ac55aa743327984e89f4b0134",
     "292327e5c94afa352cc5a02ca273df543f2020d0e76368ff96c84f4e90778712",
     "32519b85c0b422e4656de6e6c41878e95fd95026267daab4215ee59c107d6c77",
     "53f8dfc65169ccda021b72a62e0c22a4db7c4077f002fa742717d41b3c40f2c7",
-    "c15abaf51e78ca56c0376522d699c978217bf041a3bd3c71d09193efa5717c71",
+    "abe22cf0d78836c3ea072daeaf4c5eeaf9c29b6feb597741651979fc8fbd2417",
     "ce77d116a074dab7a22a0fd4f2c1ab475f16eec42e1ded3c0b0aa8211fe858d6",
     "d0d626deb3f9484e649294a8dfa814c5568f846d5aa02d4cdad5d041a29d5600",
 }

--- a/panther_ioc_rules/sunburst_ip_iocs.yml
+++ b/panther_ioc_rules/sunburst_ip_iocs.yml
@@ -2,7 +2,7 @@ AnalysisType: rule
 Filename: sunburst_ip_iocs.py
 RuleID: IOC.SunburstIPIOCs
 DisplayName: Sunburst Indicators of Compromise (IP)
-Enabled: true
+Enabled: false
 LogTypes:
   - AWS.ALB
   - AWS.CloudTrail
@@ -52,7 +52,7 @@ Tests:
     ExpectedResult: true
     Log:
       {
-        "srcaddr": "13.59.205.66",
+        "srcaddr": "0.0.0.1",
         "dstaddr": "10.0.0.1",
-        "p_any_ip_addresses": ["13.59.205.66"],
+        "p_any_ip_addresses": ["0.0.0.1"],
       }


### PR DESCRIPTION
### Background

The [SUNBURST breach](https://www.mandiant.com/solarwinds-break-resource-center) in 2020 was initially associated with certain Amazon-managed IP addresses. These IP addresses were quickly recycled and now no longer indicate association with SUNBURST.

### Changes

* Outdated source IP addresses removed from global helper
* IP check rule disabled by default
* Updated hashes of malicious files

### Testing

* n/a
