### PR TITLE
Set CODEOWNERS path to schemas/* for alxarch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,5 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @nhakmiller @lindsey-w @wey-chiang @jacknagz @alxarch @kostaspap @glerb @bseb
+*       @nhakmiller @lindsey-w @wey-chiang @jacknagz @kostaspap @glerb @bseb
+schemas/* @alxarch


### PR DESCRIPTION
### Background

Trying to limit the amount of email I am getting

### Changes

* use `schemas/*` prefix for myself in `CODEOWNERS` so that I am only notified for PRs that modify schemas

### Testing

* <Testing steps>
