### PR TITLE
Create Low Byte/Packet Count rule for VPC Flow

### DIFF
--- a/aws_vpc_flow_rules/aws_vpc_low_count.py
+++ b/aws_vpc_flow_rules/aws_vpc_low_count.py
@@ -1,0 +1,16 @@
+def rule(event):
+    """
+    Returns True for traffic seen smaller than 40 bytes and 2 or less packets
+    This activity is a possible indicator of a Log4J RCE exploit attempt"
+    Environments differ based upon usage, these parameters should be tuned to
+    your use case
+    """
+    if event.get("action") == "ACCEPT":
+        low_bytes = 40
+        low_packets = 2
+        return any((event.get("bytes") < low_bytes, event.get("packets") <= low_packets))
+    return False
+
+
+def title(event):
+    return f"Unusually low byte or packet count from IP: {event.get('srcAddr')}"

--- a/aws_vpc_flow_rules/aws_vpc_low_count.yml
+++ b/aws_vpc_flow_rules/aws_vpc_low_count.yml
@@ -1,0 +1,56 @@
+AnalysisType: rule
+Filename: aws_vpc_low_count.py
+RuleID: AWS.VPC.LowBytePacketCount
+DisplayName: AWS VPC Low Byte / Packet Count Traffic
+Enabled: false
+Threshold: 10
+DedupPeriodMinutes: 60
+LogTypes:
+  - AWS.VPCFlow
+Tags:
+  - AWS
+  - VPC
+  - Log4j
+
+Severity: Medium
+Description: >
+  Alerts on low packet count or low byte count traffic, a possible indicator of Log4j exploit attempt
+Runbook: >
+  Investigate traffic from listed IP to determine if malicious activity is underway.
+Tests:
+  -
+    Name: Normal Traffic
+    ExpectedResult: false
+    Log: {
+      "srcAddr": "10.0.0.72",
+      "packets": 15,
+      "bytes": 1186,
+      "action": "ACCEPT",
+      }
+  -
+    Name: Low Packet Count Traffic
+    ExpectedResult: true
+    Log: {
+      "srcAddr": "10.0.0.72",
+      "packets": 1,
+      "bytes": 1186,
+      "action": "ACCEPT",
+      }
+  -
+    Name: Low Byte Count Traffic
+    ExpectedResult: true
+    Log: {
+      "srcAddr": "10.0.0.72",
+      "packets": 2,
+      "bytes": 10,
+      "action": "ACCEPT",
+      }
+  -
+    Name: Low Packet Count Traffic but Rejected
+    ExpectedResult: false
+    Log: {
+      "srcAddr": "10.0.0.72",
+      "packets": 1,
+      "bytes": 1186,
+      "action": "REJECTED",
+      }


### PR DESCRIPTION
### Background
Wireshark analysis shows that an unusually low byte or packet count may be an indicator of an attempted log4j exploit


### Changes
Create Rule and tests for specified traffic pattern

### Testing
Unit tests
