### PR TITLE
Update Exploit detection to use flattened event string

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,5 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @nhakmiller @lindsey-w @wey-chiang @jacknagz @alxarch @kostaspap @glerb @bseb
+*       @nhakmiller @lindsey-w @wey-chiang @jacknagz @kostaspap @glerb @bseb
+schemas/* @alxarch

--- a/panther_ioc_rules/log4j_exploit_iocs.py
+++ b/panther_ioc_rules/log4j_exploit_iocs.py
@@ -1,8 +1,9 @@
 from panther_iocs import LOG4J_EXPLOIT_IOCS
 
 def rule(event):
+    event_string = str(event).lower()
     for exploit in LOG4J_EXPLOIT_IOCS:
-        if exploit.lower() in str(event).lower():
+        if exploit.lower() in event_string:
             return True
     return False
 

--- a/panther_ioc_rules/log4j_exploit_iocs.py
+++ b/panther_ioc_rules/log4j_exploit_iocs.py
@@ -1,13 +1,10 @@
-import re
-
 from panther_iocs import LOG4J_EXPLOIT_IOCS
 
-# defining at as a constant to save on compiliation time
-IOC_SEARCH = re.compile(".*" + "|".join(map(lambda x: re.escape(x), LOG4J_EXPLOIT_IOCS)), re.I)
-
-
 def rule(event):
-    return IOC_SEARCH.match(str(event))
+    for exploit in LOG4J_EXPLOIT_IOCS:
+        if exploit.lower() in str(event).lower:
+            return True
+    return False
 
 
 def title(event):

--- a/panther_ioc_rules/log4j_exploit_iocs.py
+++ b/panther_ioc_rules/log4j_exploit_iocs.py
@@ -1,24 +1,13 @@
+import re
+
 from panther_iocs import LOG4J_EXPLOIT_IOCS
 
-
-def nested_value_search(data, search_value):
-    if not hasattr(data, "__iter__"):
-        return False
-    if isinstance(data, list):
-        return any(nested_value_search(item, search_value) for item in data)
-
-    if isinstance(data, dict):
-        return any(nested_value_search(v, search_value) for v in data.values())
-
-    return search_value in data
+# defining at as a constant to save on compiliation time
+IOC_SEARCH = re.compile(".*" + "|".join(map(lambda x: re.escape(x), LOG4J_EXPLOIT_IOCS)), re.I)
 
 
 def rule(event):
-    event_dict = event.to_dict()
-    for ioc in LOG4J_EXPLOIT_IOCS:
-        if nested_value_search(event_dict, ioc):
-            return True
-    return False
+    return IOC_SEARCH.match(str(event))
 
 
 def title(event):

--- a/panther_ioc_rules/log4j_exploit_iocs.yml
+++ b/panther_ioc_rules/log4j_exploit_iocs.yml
@@ -34,6 +34,8 @@ Runbook: >
 SummaryAttributes:
   - p_any_domain_names
   - p_any_ipaddresses
+  - p_log_type
+  - p_source_label
 Tests:
   -
     Name: Exploit Detected in Event (String)

--- a/panther_ioc_rules/log4j_exploit_iocs.yml
+++ b/panther_ioc_rules/log4j_exploit_iocs.yml
@@ -7,7 +7,6 @@ LogTypes:
   - AWS.ALB
   - AWS.CloudTrail
   - AWS.S3ServerAccess
-  - AWS.VPCFlow
   - Apache.AccessCombined
   - Apache.AccessCommon
   - Cloudflare.Firewall


### PR DESCRIPTION
### Background
Updated, more efficient version of this rule

### Changes
- compile IOC search with re
- search event converted to string for compiled re

### Testing
Unit tests
