### PR TITLE
Add Team Detections as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @nhakmiller @lindsey-w @wey-chiang @jacknagz @kostaspap @glerb @bseb
+*       @nhakmiller @lindsey-w @wey-chiang @jacknagz @kostaspap @glerb @bseb @panther-labs/detections
 schemas/* @alxarch


### PR DESCRIPTION
### Background
Add the team to Codeowners

### Changes
Add @panther-labs/detections to CODEOWNERS

### Testing
Testing isnt really a thing here, but I'm explicity not removing individual names until we know this works as expected.

TRUST NOTHING!
