### PR TITLE
Update Policy to have safer dict searches and a dedup string

### DIFF
--- a/aws_kms_policies/aws_cmk_key_rotation.py
+++ b/aws_kms_policies/aws_cmk_key_rotation.py
@@ -1,8 +1,10 @@
 def policy(resource):
-    return (
-        # Ignore AWS managed keys
-        resource["KeyManager"] != "CUSTOMER"
-        # Check that the KeyRotation exists
-        # Explicit True check to avoid returning NoneType
-        or (resource["KeyRotationEnabled"] is True and resource["KeyState"] == "Enabled")
-    )
+    return (  # Ignore AWS managed keys
+            resource.get("KeyManager") != "CUSTOMER" # Check that the KeyRotation exists
+            # Explicit True check to avoid returning NoneType
+            or (resource.get("KeyRotationEnabled") is True and resource.get(
+                "KeyState") == "Enabled"))
+
+
+def dedup(resource):
+    return f"AWS KMS CMK Key Rotation - Account {resource.get('AccountId')}"


### PR DESCRIPTION
### Background
Every instance of this policy in King of Spades is returning a value error for its dedup string

### Changes
This should make the dict searches safer, and be explicit about the dedup
`Explicit is better than implicit`

### Testing
Unit tests / CI checks
