### PR TITLE
Only enforce policy on AWS managed keys

### DIFF
--- a/aws_kms_policies/aws_cmk_key_rotation.py
+++ b/aws_kms_policies/aws_cmk_key_rotation.py
@@ -1,9 +1,13 @@
 def policy(resource):
+    # per AWS Docs automatic rotation is only supported on managed symmetric keys
+    # These are of Origin AWS_KMS
+    if resource.get("Origin") != "AWS_KMS":
+        return True
     return (  # Ignore AWS managed keys
-            resource.get("KeyManager") != "CUSTOMER" # Check that the KeyRotation exists
-            # Explicit True check to avoid returning NoneType
-            or (resource.get("KeyRotationEnabled") is True and resource.get(
-                "KeyState") == "Enabled"))
+        resource.get("KeyManager") != "CUSTOMER"  # Check that the KeyRotation exists
+        # Explicit True check to avoid returning NoneType
+        or (resource.get("KeyRotationEnabled") is True and resource.get("KeyState") == "Enabled")
+    )
 
 
 def dedup(resource):

--- a/aws_kms_policies/aws_cmk_key_rotation.yml
+++ b/aws_kms_policies/aws_cmk_key_rotation.yml
@@ -114,11 +114,11 @@ Tests:
         "Policy": "{JSON policy document see https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html for details}"
       }
   -
-    Name: Key Not Eligible for Roration
+    Name: Key Not Eligible for Rotation
     ExpectedResult: true
     Resource:
       {
-        "KeyRotationEnabled": true,
+        "KeyRotationEnabled": null,
         "AWSAccountId": "1122334455",
         "Arn": "arn:aws:kms:us-west-2:11223344:key/1122233-asdf-adsf-111222333",
         "CloudHsmClusterId": null,

--- a/aws_kms_policies/aws_cmk_key_rotation.yml
+++ b/aws_kms_policies/aws_cmk_key_rotation.yml
@@ -113,3 +113,26 @@ Tests:
         "ValidTo": null,
         "Policy": "{JSON policy document see https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html for details}"
       }
+  -
+    Name: Key Not Eligible for Roration
+    ExpectedResult: true
+    Resource:
+      {
+        "KeyRotationEnabled": true,
+        "AWSAccountId": "1122334455",
+        "Arn": "arn:aws:kms:us-west-2:11223344:key/1122233-asdf-adsf-111222333",
+        "CloudHsmClusterId": null,
+        "CreationDate": "2019-01-01T00:00:00Z",
+        "CustomKeyStoreId": null,
+        "DeletionDate": null,
+        "Description": "Default master key that protects my Secrets Manager data when no other key is defined",
+        "Enabled": false,
+        "ExpirationModel": null,
+        "KeyId": "1122233-asdf-adsf-111222333",
+        "KeyManager": "AWS",
+        "KeyState": "Enabled",
+        "KeyUsage": "ENCRYPT_DECRYPT",
+        "Origin": "External",
+        "ValidTo": null,
+        "Policy": "{JSON policy document see https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html for details}"
+      }


### PR DESCRIPTION
### Background
As mentioned [here](https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html) any non AWS managed keys are not eligible for automatic rotation, we should not try to enforce a rotation policy on those

### Changes
Short circut if the Origin is not `AWS_KMS`

### Testing
Unit and CI pipeline
