### PR TITLE
POC for DataModel Test

### DIFF
--- a/data_model_test_rules/okta_data_model_test.py
+++ b/data_model_test_rules/okta_data_model_test.py
@@ -1,0 +1,17 @@
+from panther_base_helpers import deep_get
+
+
+def rule(event):
+    if event.get("eventType") == "user.session.start":
+        if deep_get(event, "outcome", "result") == "SUCCESS" and \
+                event.udm("event_type") != "successful_login":
+            return False
+        if deep_get(event, "outcome", "result") == "FAILURE" and \
+                event.udm("event_type") != "failed_login":
+            return False
+
+    return (
+        event.udm("actor_user") == deep_get(event, "actor", "displayName") and
+        event.udm("source_ip") == deep_get(event, "client", "ipAddress") and
+        event.udm("user_agent") == deep_get(event, "client", "userAgent", "rawUserAgent")
+     )

--- a/data_model_test_rules/okta_data_model_test.yml
+++ b/data_model_test_rules/okta_data_model_test.yml
@@ -1,0 +1,237 @@
+AnalysisType: rule
+LogTypes:
+  - Okta.SystemLog
+RuleID: Okta.Datamodel.Test
+DisplayName: Okta DataModel Extraction Test
+Severity: Low
+Description: This rule alerts if Okta DataModel fields are not being extracted properly
+DedupPeriodMinutes: 1440
+Enabled: false
+Filename: okta_data_model_test.py
+
+Tests:
+  -
+    Name: Test Event Type "SUCCESSFUL_LOGIN"
+    ExpectedResult: true
+    Log:
+      {
+        "uuid": "1234",
+        "published": "2021-11-01 21:22:28.54",
+        "eventType": "user.session.start",
+        "version": "0",
+        "severity": "INFO",
+        "legacyEventType": "app.auth.sso",
+        "displayMessage": "User single sign on to app",
+        "actor": {
+          "alternateId": "homer.simpson@springfield.gov",
+          "displayName": "Homer Simpson",
+          "id": "1111111111111111",
+          "type": "User"
+        },
+        "client": {
+          "device": "Computer",
+          "geographicalContext": {
+            "city": "Springfield",
+            "country": "United States",
+            "geolocation": {
+              "lat": 39.9242,
+              "lon": 83.8088
+            },
+            "postalCode": "11111",
+            "state": "Ohio"
+          },
+          "ipAddress": "1.1.1.1",
+          "userAgent": {
+            "browser": "NetscapeNavigator",
+            "os": "Mac OS X",
+            "rawUserAgent": "NetScape Navigator 7, BeOS"
+          },
+          "zone": "null"
+        },
+        "request": {
+          "ipChain": [
+            {
+              "geographicalContext": {
+                "city": "Springfield",
+                "country": "United States",
+                "geolocation": {
+                  "lat": 39.9242,
+                  "lon": 83.8088
+                },
+                "postalCode": "111111",
+                "state": "Ohio"
+              },
+              "ip": "1.1.1.1",
+              "version": "V4"
+            }
+          ]
+        },
+        "outcome": {
+          "result": "SUCCESS"
+        },
+        "target": [
+          {
+            "alternateId": "Panther (Release Testing)",
+            "detailEntry": {
+              "signOnModeType": "SAML_2_0"
+            },
+            "displayName": "DonutFactory",
+            "id": "1111111",
+            "type": "AppInstance"
+          },
+          {
+            "alternateId": "homer.simpson@springfield.gov",
+            "displayName": "Homer Simpson",
+            "id": "0ua4rmx4qsZRWjEZK696",
+            "type": "AppUser"
+          }
+        ],
+        "transaction": {
+          "detail": { },
+          "id": "222222222",
+          "type": "WEB"
+        },
+        "debugContext": {
+          "debugData": {
+            "audience": "Live Studio",
+            "authTime": "2021-11-01T21:17:35.764Z",
+            "authenticationClassRef": "Santas:Little:Helper",
+            "authnRequestId": "1111111",
+            "expiryTime": "2021-11-01T21:27:28.532Z",
+            "initiationType": "Fancy",
+            "issuedAt": "2021-11-01T21:22:28.532Z",
+            "issuer": "http://www.okta.com/shelbyville",
+            "jti": "1111111111",
+            "requestId": "1111111",
+            "requestUri": "/donut/sprinkes",
+            "signOnMode": "SAML 2077",
+            "subject": "homer.simpson@springfield.gov",
+            "url": "/duff/lite"
+          }
+        },
+        "authenticationContext": {
+          "authenticationStep": 0,
+          "externalSessionId": "1111111"
+        },
+        "securityContext": {
+          "asNumber": 1,
+          "asOrg": "foo.",
+          "domain": ".",
+          "isProxy": false,
+          "isp": "Starlink"
+        },
+        "p_log_type": "Okta.SystemLog",
+      }
+  -
+    Name: Test Event Type "FAILED_LOGIN"
+    ExpectedResult: true
+    Log:
+      {
+        "uuid": "1234",
+        "published": "2021-11-01 21:22:28.54",
+        "eventType": "user.session.start",
+        "version": "0",
+        "severity": "INFO",
+        "legacyEventType": "app.auth.sso",
+        "displayMessage": "User single sign on to app",
+        "actor": {
+          "alternateId": "homer.simpson@springfield.gov",
+          "displayName": "Homer Simpson",
+          "id": "1111111111111111",
+          "type": "User"
+        },
+        "client": {
+          "device": "Computer",
+          "geographicalContext": {
+            "city": "Springfield",
+            "country": "United States",
+            "geolocation": {
+              "lat": 39.9242,
+              "lon": 83.8088
+            },
+            "postalCode": "11111",
+            "state": "Ohio"
+          },
+          "ipAddress": "1.1.1.1",
+          "userAgent": {
+            "browser": "NetscapeNavigator",
+            "os": "Mac OS X",
+            "rawUserAgent": "NetScape Navigator 7, BeOS"
+          },
+          "zone": "null"
+        },
+        "request": {
+          "ipChain": [
+            {
+              "geographicalContext": {
+                "city": "Springfield",
+                "country": "United States",
+                "geolocation": {
+                  "lat": 39.9242,
+                  "lon": 83.8088
+                },
+                "postalCode": "111111",
+                "state": "Ohio"
+              },
+              "ip": "1.1.1.1",
+              "version": "V4"
+            }
+          ]
+        },
+        "outcome": {
+          "reason": "INVALID_CREDENTIALS",
+          "result": "FAILURE"
+        },
+        "target": [
+          {
+            "alternateId": "Panther (Release Testing)",
+            "detailEntry": {
+              "signOnModeType": "SAML_2_0"
+            },
+            "displayName": "DonutFactory",
+            "id": "1111111",
+            "type": "AppInstance"
+          },
+          {
+            "alternateId": "homer.simpson@springfield.gov",
+            "displayName": "Homer Simpson",
+            "id": "0ua4rmx4qsZRWjEZK696",
+            "type": "AppUser"
+          }
+        ],
+        "transaction": {
+          "detail": { },
+          "id": "222222222",
+          "type": "WEB"
+        },
+        "debugContext": {
+          "debugData": {
+            "audience": "Live Studio",
+            "authTime": "2021-11-01T21:17:35.764Z",
+            "authenticationClassRef": "Santas:Little:Helper",
+            "authnRequestId": "1111111",
+            "expiryTime": "2021-11-01T21:27:28.532Z",
+            "initiationType": "Fancy",
+            "issuedAt": "2021-11-01T21:22:28.532Z",
+            "issuer": "http://www.okta.com/shelbyville",
+            "jti": "111111111",
+            "requestId": "1111111",
+            "requestUri": "/donut/sprinkes",
+            "signOnMode": "SAML 2077",
+            "subject": "homer.simpson@springfield.gov",
+            "url": "/duff/lite"
+          }
+        },
+        "authenticationContext": {
+          "authenticationStep": 0,
+          "externalSessionId": "1111111"
+        },
+        "securityContext": {
+          "asNumber": 1,
+          "asOrg": "foo.",
+          "domain": ".",
+          "isProxy": false,
+          "isp": "Starlink"
+        },
+        "p_log_type": "Okta.SystemLog",
+      }


### PR DESCRIPTION
### Background
I was kicking around how we might design a test for our data model functionality with our current framework. 
This is only intended as a POC, but if we wanted a quick, internal use only method of validating data model extractions  are working this would do the job.  

I mainly opened this for discussion, Its not in any way polished but it seems interesting.

You'll probably notice the logs for tests are exceptionally long. I wanted to capture the entire event, less p_ fields (except log type) so we could validate that the extractions are working with the data in the same structure as it has when ingested.