### PR TITLE
Change S3 Detection Threshold

### DIFF
--- a/aws_s3_rules/aws_s3_access_error.yml
+++ b/aws_s3_rules/aws_s3_access_error.yml
@@ -2,7 +2,8 @@ AnalysisType: rule
 Filename: aws_s3_access_error.py
 RuleID: AWS.S3.ServerAccess.Error
 DisplayName: AWS S3 Access Error
-DedupPeriodMinutes: 720 # 12 hours
+DedupPeriodMinutes: 180
+Threshold: 5
 Enabled: true
 LogTypes:
   - AWS.S3ServerAccess


### PR DESCRIPTION
### Background
This rule has proven to be pretty noisey in situations like automated deployments where bucket policies might not be in place before the first atttempt to access that bucket.
The goal of this change is to only alert on likely broken processes or malicious attacks

### Changes
Take the dedup hours down to 3, but up the threshold to 5

### Testing

unit testing, and this rule triggers a lot in our internal environments
