### PR TITLE
Tune False Postives by eliminating incomplete Geolocation info

### DIFF
--- a/okta_rules/okta_geo_improbable_access.py
+++ b/okta_rules/okta_geo_improbable_access.py
@@ -17,6 +17,15 @@ def rule(event):
     ):
         return False
 
+    new_login_stats = {
+        "city": deep_get(event, "client", "geographicalContext", "city"),
+        "lon": deep_get(event, "client", "geographicalContext", "geolocation", "lon"),
+        "lat": deep_get(event, "client", "geographicalContext", "geolocation", "lat"),
+    }
+    # Bail out if we have a None value in set as it causes false positives
+    if None in new_login_stats.values():
+        return False
+
     # Generate a unique cache key for each user
     login_key = gen_key(event)
     # Retrieve the prior login info from the cache, if any
@@ -25,14 +34,6 @@ def rule(event):
     if not last_login:
         store_login_info(login_key, event)
         return False
-
-    # Load the last login from the cache into an object we can compare
-    old_login_stats = loads(last_login.pop())
-    new_login_stats = {
-        "city": deep_get(event, "client", "geographicalContext", "city"),
-        "lon": deep_get(event, "client", "geographicalContext", "geolocation", "lon"),
-        "lat": deep_get(event, "client", "geographicalContext", "geolocation", "lat"),
-    }
 
     distance = haversine_distance(old_login_stats, new_login_stats)
     old_time = datetime.strptime(old_login_stats["time"][:26], PANTHER_TIME_FORMAT)

--- a/okta_rules/okta_geo_improbable_access.py
+++ b/okta_rules/okta_geo_improbable_access.py
@@ -34,6 +34,8 @@ def rule(event):
     if not last_login:
         store_login_info(login_key, event)
         return False
+    # Load the last login from the cache into an object we can compare
+    old_login_stats = loads(last_login.pop())
 
     distance = haversine_distance(old_login_stats, new_login_stats)
     old_time = datetime.strptime(old_login_stats["time"][:26], PANTHER_TIME_FORMAT)

--- a/okta_rules/okta_geo_improbable_access.yml
+++ b/okta_rules/okta_geo_improbable_access.yml
@@ -122,6 +122,102 @@ Tests:
           "version": "0"
       }
 
+  -
+    Name: Incomplete GeoLocation info
+    ExpectedResult: false
+    Log:
+      {
+          "actor": {
+              "alternateId": "admin",
+              "displayName": "unknown",
+              "id": "unknown",
+              "type": "User"
+          },
+          "authenticationContext": {
+              "authenticationStep": 0,
+              "externalSessionId": "unknown"
+          },
+          "client": {
+              "device": "Computer",
+              "geographicalContext": {
+                  "country": "Brazil",
+                  "geolocation": {
+                      "lat": -29.6116,
+                      "lon": -51.0933
+                  },
+                  "postalCode": "93950",
+                  "state": "Rio Grande do Sul"
+              },
+              "ipAddress": "redacted",
+              "userAgent": {
+                  "browser": "CHROME",
+                  "os": "Linux",
+                  "rawUserAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.135 Safari/537.36"
+              },
+              "zone": "null"
+          },
+          "debugContext": {
+              "debugData": {
+                  "loginResult": "VERIFICATION_ERROR",
+                  "requestId": "redacted",
+                  "requestUri": "redacted",
+                  "threatSuspected": "false",
+                  "url": "redacted"
+              }
+          },
+          "displayMessage": "User login to Okta",
+          "eventType": "user.session.start",
+          "legacyEventType": "core.user_auth.login_failed",
+          "outcome": {
+              "result": "SUCCESS",
+          },
+          "p_any_domain_names": [
+              "rnvtelecom.com.br"
+          ],
+          "p_any_ip_addresses": [
+              "redacted"
+          ],
+          "p_event_time": "redacted",
+          "p_log_type": "Okta.SystemLog",
+          "p_parse_time": "redacted",
+          "p_row_id": "redacted",
+          "p_source_id": "redacted",
+          "p_source_label": "Okta",
+          "published": "redacted",
+          "request": {
+              "ipChain": [
+                  {
+                      "geographicalContext": {
+                          "country": "Brazil",
+                          "geolocation": {
+                              "lat": -29.6116,
+                              "lon": -51.0933
+                          },
+                          "postalCode": "93950",
+                          "state": "Rio Grande do Sul"
+                      },
+                      "ip": "redacted",
+                      "version": "V4"
+                  }
+              ]
+          },
+          "securityContext": {
+              "asNumber": 263297,
+              "asOrg": "renovare telecom",
+              "domain": "rnvtelecom.com.br",
+              "isProxy": false,
+              "isp": "renovare telecom"
+          },
+          "severity": "INFO",
+          "transaction": {
+              "detail": {},
+              "id": "redacted",
+              "type": "WEB"
+          },
+          "uuid": "redacted",
+          "version": "0"
+      }
+
 
 # These tests can be enabled if testing is done through the UI or from the CLI with valid AWS
 # credentials loaded to talk to the panther-kv table.


### PR DESCRIPTION
### Background
At times the geolocation info on these events is incomplete, resulting in false positives, i.e. Distance calculation between None and None. Commonly a problem with mobile carriers. This prevents incomplete data from being stored

### Changes
Move the creation of the login information dict higher, return False if it has a None value

### Testing

 New Unit Test
