### PR TITLE
Create Crowdstrike detection that looks for known DirtyPipe Exploits

### DIFF
--- a/global_helpers/panther_iocs.py
+++ b/global_helpers/panther_iocs.py
@@ -73,8 +73,8 @@ DIRTYPIPE_POC_HASHES = {
     "b52350c819dfd5c14359fca92dfcfcafd7c2a36b273546b1c94f6804cdd6b9d3",
     "0e40d0944ac44647ab51cf928914456a92606da6ebea5a47d44ee07783c78ec4",
     "3946337d1edc09f71394716b18b1bbc77fc8beb2cd23fa430b922c357172b93b",
-    "092691d88c6dde0d8ad9a93f819657fec016e427e48a872faa6984af2202b529"
-    }
+    "092691d88c6dde0d8ad9a93f819657fec016e427e48a872faa6984af2202b529",
+}
 
 # IOC Helper functions:
 def ioc_match(indicators: list, known_iocs: set) -> list:

--- a/global_helpers/panther_iocs.py
+++ b/global_helpers/panther_iocs.py
@@ -69,6 +69,13 @@ LOG4J_EXPLOIT_IOCS = {
     "${::-j",  # example: ${${::-j}${::-n}di:${::-l}d${::-a}p://example.com:1234/callback}
 }
 
+DIRTYPIPE_POC_HASHES = {
+    "b52350c819dfd5c14359fca92dfcfcafd7c2a36b273546b1c94f6804cdd6b9d3",
+    "0e40d0944ac44647ab51cf928914456a92606da6ebea5a47d44ee07783c78ec4",
+    "3946337d1edc09f71394716b18b1bbc77fc8beb2cd23fa430b922c357172b93b",
+    "092691d88c6dde0d8ad9a93f819657fec016e427e48a872faa6984af2202b529"
+    }
+
 # IOC Helper functions:
 def ioc_match(indicators: list, known_iocs: set) -> list:
     """Matches a set of indicators against known Indicators of Compromise

--- a/panther_ioc_rules/crowdstrike_dirtypipe_exploit_poc_rule.py
+++ b/panther_ioc_rules/crowdstrike_dirtypipe_exploit_poc_rule.py
@@ -1,0 +1,23 @@
+from panther_iocs import DIRTYPIPE_POC_HASHES
+
+# Detects known POC code that could be used to "off the shelf" exploit CVE-2022-0847 aka DirtyPipe
+
+
+def rule(event):
+    return (event.get("sha256hashdata") in DIRTYPIPE_POC_HASHES)
+
+
+def title(event):
+    return f"A file with a SHA256 hash matching CVE-2022-0847 was seen running with filename { event.get('imagefilename') }"
+
+def alert_context(event):
+    context = {
+        "hash": event.get("sha256hashdata"),
+        "filename": event.get("imagefilename"),
+        "crowdstrike_aid": event.get("aid"),
+        "ip_address": event.get("aip"),
+            }
+
+    return context
+
+

--- a/panther_ioc_rules/crowdstrike_dirtypipe_exploit_poc_rule.py
+++ b/panther_ioc_rules/crowdstrike_dirtypipe_exploit_poc_rule.py
@@ -4,11 +4,15 @@ from panther_iocs import DIRTYPIPE_POC_HASHES
 
 
 def rule(event):
-    return (event.get("sha256hashdata") in DIRTYPIPE_POC_HASHES)
+    return event.get("sha256hashdata") in DIRTYPIPE_POC_HASHES
 
 
 def title(event):
-    return f"A file with a SHA256 hash matching CVE-2022-0847 was seen running with filename { event.get('imagefilename') }"
+    return (
+        "A file with a SHA256 hash matching CVE-2022-0847 was seen running with filename"
+        f"{ event.get('imagefilename') }"
+    )
+
 
 def alert_context(event):
     context = {
@@ -16,8 +20,6 @@ def alert_context(event):
         "filename": event.get("imagefilename"),
         "crowdstrike_aid": event.get("aid"),
         "ip_address": event.get("aip"),
-            }
+    }
 
     return context
-
-

--- a/panther_ioc_rules/crowdstrike_dirtypipe_exploit_poc_rule.yml
+++ b/panther_ioc_rules/crowdstrike_dirtypipe_exploit_poc_rule.yml
@@ -1,0 +1,90 @@
+AnalysisType: rule
+Filename: crowdstrike_dirtypipe_exploit_poc_rule.py
+RuleID: IOC.Crowdstrike.DirtyPipe.Hashes
+DisplayName: DirtyPipe POC Hash Detection
+Enabled: True
+LogTypes:
+  - Crowdstrike.ProcessRollup2
+Tags:
+  - Crowdstrike
+  - DirtyPipe
+Severity: Critical
+Description: >
+  Detects Hashes that contain DirtyPipe Exploit POC code. These could be used as an "off the shelf" exploitation
+Reference: >
+  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0847
+Runbook: >
+  Investigate affected system, specifically filename matching hash. Patch to non vulnerable Kernel version if possible
+SummaryAttributes:
+  - p_any_ip_addresses
+  - p_any_sha256_hashes
+
+Tests:
+  -
+    Name: DirtyPipe Exploit Hash Detected
+    ExpectedResult: true
+    Log:
+      {
+      "event_simplename": "ProcessRollup2",
+       "name": "ProcessRollup2LinuxV5",
+       "aid": "9aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+       "aip": "1.1.1.1",
+       "cid": "7bbbbbbbbbbbbb",
+       "id": "b73a9d5d-aaf7-11eb-9009-06282f216951",
+       "event_platform": "Linux",
+       "timestamp": "2021-05-02 03:37:27.264",
+       "configbuild": "1007.4.0013403.11",
+       "configstatehash": "2559498804",
+       "entitlements": "15",
+       "imagefilename": "/bin/ps",
+       "commandline": "/bin/ps aux",
+       "rawprocessid": 42438,
+       "processstarttime": "2021-05-02 03:37:22.597",
+       "sha256hashdata": "092691d88c6dde0d8ad9a93f819657fec016e427e48a872faa6984af2202b529",
+       "tags": "139, 12094627905582, 12094627906234, 211106232533130",
+       "parentbasefilename": "somefile",
+       "processgroupid": 352587198232266560,
+       "uid": 0,
+       "ruid": 501,
+       "svuid": 501,
+       "gid": 20,
+       "rgid": 501,
+       "svgid": 20,
+       "sessionprocessid": 352461603267229250,
+       "machosubtype": "1",
+    }
+
+  -
+    Name: Non Vulnerable hash
+    ExpectedResult: false
+    Log:
+      {
+      "event_simplename": "ProcessRollup2",
+       "name": "ProcessRollup2LinuxV5",
+       "aid": "9aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+       "aip": "1.1.1.1",
+       "cid": "7bbbbbbbbbbbbb",
+       "id": "b73a9d5d-aaf7-11eb-9009-06282f216951",
+       "event_platform": "Linux",
+       "timestamp": "2021-05-02 03:37:27.264",
+       "configbuild": "1007.4.0013403.11",
+       "configstatehash": "2559498804",
+       "entitlements": "15",
+       "imagefilename": "/bin/ps",
+       "commandline": "/bin/ps aux",
+       "rawprocessid": 42438,
+       "processstarttime": "2021-05-02 03:37:22.597",
+       "sha256hashdata": "0D92691d88c6dde0dasdasdasdasdas57fec0dfgdfge48a872faa6984af2202b529",
+       "tags": "139, 12094627905582, 12094627906234, 211106232533130",
+       "parentbasefilename": "somefile",
+       "processgroupid": 352587198232266560,
+       "uid": 0,
+       "ruid": 501,
+       "svuid": 501,
+       "gid": 20,
+       "rgid": 501,
+       "svgid": 20,
+       "sessionprocessid": 352461603267229250,
+       "machosubtype": "1",
+    }
+


### PR DESCRIPTION
### Background
Detects hashes of known DirtyPipe exploit POC code in Crowdstrike. These specific POCs seem to be getting the most attention. These are all hashes compiled for X86-64 as I didn't have an ARM machine available

https://github.com/antx-code/CVE-2022-0847
https://github.com/Al1ex/LinuxEelvation
https://github.com/imfiver/CVE-2022-0847
https://github.com/bbaranoff/CVE-2022-0847

### Changes
Created Hash IOC helper and rule

### Testing
Unit tests
