### PR TITLE
Tune Amazon SSOv2 False Postives)

### DIFF
--- a/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
+++ b/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
@@ -301,4 +301,52 @@ Tests:
         "eventType": "AwsConsoleSignIn",
         "recipientAccountId": "123456789012"
       }
+  -
+    Name: AWS SSOv2 Login
+    ExpectedResult: false
+    Mocks:
+      - objectName: check_account_age
+        returnValue: "False"
+    Log:
+      {
+      "additionalEventData": {
+        "MFAUsed": "No",
+        "MobileVersion": "No"
+      },
+      "awsRegion": "us-east-2",
+      "eventID": "1111111111",
+      "eventName": "ConsoleLogin",
+      "eventSource": "signin.amazonaws.com",
+      "eventTime": "2022-03-16 19:17:41",
+      "eventType": "AwsConsoleSignIn",
+      "eventVersion": "1.08",
+      "managementEvent": true,
 
+      "readOnly": false,
+      "recipientAccountId": "xxx",
+      "responseElements": {
+        "ConsoleLogin": "Success"
+      },
+      "sourceIPAddress": "1.2.3.4",
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36",
+      "userIdentity": {
+        "accountId": "xxx",
+        "arn": "arn:aws:sts::xxx:assumed-role/AWSReservedSSO_developer_admin_asdf/foo@bar.com",
+        "principalId": "xxx:foo@bar.com",
+        "sessionContext": {
+          "attributes": {
+            "creationDate": "2022-03-16T19:17:41Z",
+            "mfaAuthenticated": "false"
+          },
+          "sessionIssuer": {
+            "accountId": "xxx",
+            "arn": "arn:aws:iam::xxx:role/aws-reserved/sso.amazonaws.com/us-east-2/AWSReservedSSO_developer_admin_asdf",
+            "principalId": "xxx",
+            "type": "Role",
+            "userName": "AWSReservedSSO_developer_admin_asdf"
+          },
+          "webIdFederationData": {}
+        },
+        "type": "AssumedRole"
+      }
+    }


### PR DESCRIPTION
### Background
AWS SSOv2 causes false positives in this rule, need to adjust logic accordingly


### Changes
Add filter for SS0v2 in logic. Move some stuff around to reduce dynamo queries that arent needed

Code changes to exclude SS0v2 contributed by @derricksong

### Testing

New Unit Tests 
