### PR TITLE
Okta Rule updates and investigative queries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @nhakmiller @lindsey-w @wey-chiang @kostaspap @bseb @panther-labs/detections
+*       @nhakmiller @lindsey-w @wey-chiang @kostaspap @bseb @k-bailey @panther-labs/detections
 schemas/* @alxarch

--- a/data_models/okta_data_model.py
+++ b/data_models/okta_data_model.py
@@ -12,10 +12,7 @@ def get_event_type(event):
         and event.get("outcome", {}).get("result") == "SUCCESS"
     ):
         return event_type.SUCCESSFUL_LOGIN
-    if (
-        event.get("eventType") in ["user.mfa.factor.deactivate", "user.mfa.factor.suspend"]
-    ):
+    if event.get("eventType") in ["user.mfa.factor.deactivate", "user.mfa.factor.suspend"]:
         return event_type.MFA_DISABLED
-    
-    
+
     return None

--- a/data_models/okta_data_model.py
+++ b/data_models/okta_data_model.py
@@ -21,4 +21,7 @@ def get_event_type(event):
         "user.mfa.factor.update ",
     ]:
         return event_type.MFA_ENABLED
+
+    if event.get("eventType") == "system.mfa.factor.deactivate":
+        return event_type.ADMIN_MFA_DISABLED
     return None

--- a/data_models/okta_data_model.py
+++ b/data_models/okta_data_model.py
@@ -15,4 +15,10 @@ def get_event_type(event):
     if event.get("eventType") in ["user.mfa.factor.deactivate", "user.mfa.factor.suspend"]:
         return event_type.MFA_DISABLED
 
+    if event.get("eventType") in [
+        "user.mfa.factor.activate",
+        "user.mfa.factor.unsuspend",
+        "user.mfa.factor.update ",
+    ]:
+        return event_type.MFA_ENABLED
     return None

--- a/data_models/okta_data_model.py
+++ b/data_models/okta_data_model.py
@@ -12,4 +12,10 @@ def get_event_type(event):
         and event.get("outcome", {}).get("result") == "SUCCESS"
     ):
         return event_type.SUCCESSFUL_LOGIN
+    if (
+        event.get("eventType") in ["user.mfa.factor.deactivate", "user.mfa.factor.suspend"]
+    ):
+        return event_type.MFA_DISABLED
+    
+    
     return None

--- a/global_helpers/panther_event_type_helpers.py
+++ b/global_helpers/panther_event_type_helpers.py
@@ -2,6 +2,7 @@
 ADMIN_ROLE_ASSIGNED = "admin_role_assigned"
 FAILED_LOGIN = "failed_login"
 MFA_DISABLED = "mfa_disabled"
+MFA_ENABLED = "mfa_enabled"
 SUCCESSFUL_LOGIN = "successful_login"
 SUCCESSFUL_LOGOUT = "successful_logout"
 USER_ACCOUNT_CREATED = "user_account_created"

--- a/global_helpers/panther_event_type_helpers.py
+++ b/global_helpers/panther_event_type_helpers.py
@@ -18,3 +18,5 @@ USER_GROUP_DELETED = "user_group_deleted"
 USER_ROLE_CREATED = "user_role_created"
 USER_ROLE_MODIFIED = "user_role_modified"
 USER_ROLE_DELETED = "user_role_deleted"
+# ADMIN_MFA_DISABLED refers to MFA being disabled for an entire org, account, or similar
+ADMIN_MFA_DISABLED = "admin_mfa_disabled"

--- a/okta_queries/okta_activity_audit.yml
+++ b/okta_queries/okta_activity_audit.yml
@@ -1,0 +1,28 @@
+AnalysisType: scheduled_query
+QueryName: Okta Investigate User Activity
+Enabled: true
+Description: >
+  Audit user activity across your environment. Customize to filter on specfic users, time ranges, etc
+AthenaQuery: >
+  SELECT actor.displayName AS actor_name, actor.alternateId AS actor_email, eventType, COUNT(*) AS activity_count
+  FROM panther_logs.okta_systemlog
+  WHERE p_occurs_since('7 days')
+  AND actor.type = 'User'
+  -- Uncomment lines below to filter by user email and/or eventType
+  -- and actor_email = 'email'
+  -- and eventType = 'eventType'
+  GROUP BY actor.displayName, actor.alternateId, eventType
+  ORDER BY  actor_name, activity_count DESC
+SnowflakeQuery: >
+  SELECT actor:displayName AS actor_name, actor:alternateId AS actor_email, eventType, COUNT(*) AS activity_count
+  FROM panther_logs.public.okta_systemlog
+  WHERE p_occurs_since('7 days')
+  AND actor:type = 'User'
+  -- Uncomment lines below to filter by user email and/or eventType
+  -- and actor_email = 'email'
+  -- and eventType = 'eventType'
+  GROUP BY actor:displayName, actor:alternateId, eventType
+  ORDER BY  actor_name, activity_count DESC
+Schedule:
+  RateMinutes: 43200
+  TimeoutMinutes: 1

--- a/okta_queries/okta_admin_access_granted.yml
+++ b/okta_queries/okta_admin_access_granted.yml
@@ -3,7 +3,30 @@ QueryName: Okta Admin Access Granted
 Enabled: true
 Description: >
   Audit instances of admin access granted in your okta tenant
-Query: >
+AthenaQuery: >
+  SELECT 
+  p_event_time as event_time,
+  actor.alternateid as actor_email,
+  actor.displayName as actor_name,
+  displayMessage,
+  eventType,
+  json_extract(debugcontext.debugdata, '$.privilegeGranted') as priv_granted,
+  target as target_name,
+  client.ipAddress as src_ip,
+  client.geographicalContext.city as city,
+  client.geographicalContext.country as country,
+  client.useragent.rawUserAgent as user_agent
+  FROM okta_systemlog
+  WHERE 
+  (
+  eventType = 'user.account.privilege.grant' OR 
+  eventType = 'group.privilege.grant' AND
+  cast(json_extract(debugcontext.debugdata, '$.privilegeGranted') as varchar) LIKE '%Admin%'
+  ) AND
+  p_occurs_between('2022-01-14','2022-03-22')
+  ORDER BY
+  event_time desc
+SnowflakeQuery: >
   SELECT 
   p_event_time as event_time,
   actor:alternateId as actor_email,

--- a/okta_queries/okta_admin_access_granted.yml
+++ b/okta_queries/okta_admin_access_granted.yml
@@ -16,7 +16,7 @@ AthenaQuery: >
   client.geographicalContext.city as city,
   client.geographicalContext.country as country,
   client.useragent.rawUserAgent as user_agent
-  FROM okta_systemlog
+  FROM panther_logs.okta_systemlog
   WHERE 
   (
   eventType = 'user.account.privilege.grant' OR 

--- a/okta_queries/okta_admin_access_granted.yml
+++ b/okta_queries/okta_admin_access_granted.yml
@@ -1,0 +1,34 @@
+AnalysisType: scheduled_query
+QueryName: Okta Admin Access Granted
+Enabled: true
+Description: >
+  Audit instances of admin access granted in your okta tenant
+Query: >
+  SELECT 
+  p_event_time as event_time,
+  actor:alternateId as actor_email,
+  actor:displayName as actor_name,
+  displayMessage,
+  eventType,
+  debugContext:debugData:privilegeGranted as priv_granted,
+  target as target_name,
+  client:ipAddress as src_ip,
+  client:geographicalContext:city as city,
+  client:geographicalContext:country as country,
+  client:userAgent:rawUserAgent as user_agent
+  FROM 
+    panther_logs.public.okta_systemlog
+  WHERE 
+  ( eventType = 'user.account.privilege.grant' 
+   OR 
+    eventType = 'group.privilege.grant'
+   AND
+     debugContext:debugData:privilegeGranted like '%Admin%'
+  )
+    AND  
+    p_occurs_between('2022-01-14','2022-03-22')
+  ORDER BY
+  event_time desc
+Schedule:
+  RateMinutes: 43200
+  TimeoutMinutes: 1

--- a/okta_queries/okta_mfa_password_reset_audit.yml
+++ b/okta_queries/okta_mfa_password_reset_audit.yml
@@ -12,7 +12,7 @@ AthenaQuery: >
 SnowflakeQuery: >
   SELECT p_event_time,actor:alternateId as actor_user,target[0]:alternateId as target_user, eventType,client:ipAddress as ip_address
   FROM panther_logs.public.okta_systemlog
-  WHERE eventType IN ('user.mfa.factor.reset_all', 'user.mfa.factor.deactivate', 'user.mfa.factor.suspend', 'user.account.reset_password', 'user.account.update_password')
+  WHERE eventType IN ('user.mfa.factor.reset_all', 'user.mfa.factor.deactivate', 'user.mfa.factor.suspend', 'user.account.reset_password', 'user.account.update_password','user.mfa.factor.update')
   and p_occurs_since('7days')
   -- Uncomment line below and replace email with email you wish to investigate
   -- and actor:alternateId = 'email'

--- a/okta_queries/okta_mfa_password_reset_audit.yml
+++ b/okta_queries/okta_mfa_password_reset_audit.yml
@@ -7,13 +7,13 @@ AthenaQuery: >
   SELECT p_event_time,actor.alternateId as actor_user,target[1].alternateId as target_user, eventType,client.ipAddress as ip_address
   FROM panther_logs.okta_systemlog
   WHERE eventType IN ('user.mfa.factor.reset_all', 'user.mfa.factor.deactivate', 'user.mfa.factor.suspend', 'user.account.reset_password', 'user.account.update_password')
-  and p_occurs_since('7days')
+  and p_occurs_since('7 days')
   ORDER by p_event_time DESC
 SnowflakeQuery: >
   SELECT p_event_time,actor:alternateId as actor_user,target[0]:alternateId as target_user, eventType,client:ipAddress as ip_address
   FROM panther_logs.public.okta_systemlog
   WHERE eventType IN ('user.mfa.factor.reset_all', 'user.mfa.factor.deactivate', 'user.mfa.factor.suspend', 'user.account.reset_password', 'user.account.update_password','user.mfa.factor.update')
-  and p_occurs_since('7days')
+  and p_occurs_since('7 days')
   -- Uncomment line below and replace email with email you wish to investigate
   -- and actor:alternateId = 'email'
   ORDER by p_event_time DESC

--- a/okta_queries/okta_session_id_audit.yml
+++ b/okta_queries/okta_session_id_audit.yml
@@ -1,0 +1,41 @@
+AnalysisType: scheduled_query
+QueryName: Okta Investigate Session ID Activity
+Enabled: true
+Description: >
+ Search for activity releated to a specific SessionID in Okta panther_logs.okta_systemlog
+AthenaQuery: >
+  SELECT  
+    p_event_time as event_time,
+    actor.alternateId as actor_email,
+    actor.displayName as actor_name,
+    authenticationContext.externalSessionId as sessionId,
+    displayMessage,
+    eventType,
+    client.ipAddress as src_ip,
+    client.geographicalContext.city as city,
+    client.geographicalContext.country as country,
+    client.userAgent.rawUserAgent as user_agent
+  FROM panther_logs.okta_systemlog
+  WHERE p_event_time >= current_timestamp - interval '604800' second
+      and if(partition_time is NULL, true, partition_time >= to_unixtime(date_trunc('HOUR', current_timestamp - interval '604800' second)))
+  -- Uncomment the line below and replace 'sessionId' with the sessionId you are investigating
+  -- and authenticationContext:externalSessionId = 'sessionId'
+  SnowflakeQuery: >
+    SELECT  
+      p_event_time as event_time,
+      actor:alternateId as actor_email,
+      actor:displayName as actor_name,
+      authenticationContext:externalSessionId as sessionId,
+      displayMessage,
+      eventType,
+      client:ipAddress as src_ip,
+      client:geographicalContext:city as city,
+      client:geographicalContext:country as country,
+      client:userAgent:rawUserAgent as user_agent
+    FROM panther_logs.public.okta_systemlog
+    WHERE p_occurs_since('7 days')
+    -- Uncomment the line below and replace 'sessionId' with the sessionId you are investigating
+    -- and authenticationContext:externalSessionId = 'sessionId'
+Schedule:
+  RateMinutes: 43200
+  TimeoutMinutes: 1

--- a/okta_queries/okta_session_id_audit.yml
+++ b/okta_queries/okta_session_id_audit.yml
@@ -16,8 +16,7 @@ AthenaQuery: >
     client.geographicalContext.country as country,
     client.userAgent.rawUserAgent as user_agent
   FROM panther_logs.okta_systemlog
-  WHERE p_event_time >= current_timestamp - interval '604800' second
-      and if(partition_time is NULL, true, partition_time >= to_unixtime(date_trunc('HOUR', current_timestamp - interval '604800' second)))
+  WHERE p_occurs_since('7 days')
   -- Uncomment the line below and replace 'sessionId' with the sessionId you are investigating
   -- and authenticationContext:externalSessionId = 'sessionId'
   SnowflakeQuery: >

--- a/okta_queries/okta_support_access.yml
+++ b/okta_queries/okta_support_access.yml
@@ -10,13 +10,11 @@ AthenaQuery: >
   actor.displayName as actor_name,
   displayMessage,
   eventType,
-  json_extract(debugcontext.debugdata, '$.privilegeGranted') as priv_granted,
-  target as target_name,
   client.ipAddress as src_ip,
   client.geographicalContext.city as city,
   client.geographicalContext.country as country,
   client.useragent.rawUserAgent as user_agent
-  FROM okta_systemlog
+  FROM panther_logs.okta_systemlog
   WHERE 
   (
   eventType = 'user.session.impersonation.grant' OR 

--- a/okta_queries/okta_support_access.yml
+++ b/okta_queries/okta_support_access.yml
@@ -1,0 +1,29 @@
+AnalysisType: scheduled_query
+QueryName: Okta Support Access
+Enabled: true
+Description: >
+  Show instances that Okta support was granted to your account
+Query: >
+  SELECT 
+  p_event_time as event_time,
+  actor:alternateId as actor_email,
+  actor:displayName as actor_name,
+  client:ipAddress as src_ip,
+  client:geographicalContext:city as city,
+  client:geographicalContext:country as country,
+  client:userAgent:rawUserAgent as user_agent,
+  displayMessage,
+  eventType
+  FROM 
+  panther_logs.public.okta_systemlog
+  WHERE 
+    eventType = 'user.session.impersonation.grant' 
+    OR 
+    eventType = 'user.session.impersonation.initiate'
+   AND  
+      p_occurs_between('2021-01-14','2021-03-22')
+  ORDER BY
+    event_time desc
+Schedule:
+  RateMinutes: 43200
+  TimeoutMinutes: 1

--- a/okta_queries/okta_support_access.yml
+++ b/okta_queries/okta_support_access.yml
@@ -3,7 +3,29 @@ QueryName: Okta Support Access
 Enabled: true
 Description: >
   Show instances that Okta support was granted to your account
-Query: >
+AthenaQuery: > 
+  SELECT 
+  p_event_time as event_time,
+  actor.alternateid as actor_email,
+  actor.displayName as actor_name,
+  displayMessage,
+  eventType,
+  json_extract(debugcontext.debugdata, '$.privilegeGranted') as priv_granted,
+  target as target_name,
+  client.ipAddress as src_ip,
+  client.geographicalContext.city as city,
+  client.geographicalContext.country as country,
+  client.useragent.rawUserAgent as user_agent
+  FROM okta_systemlog
+  WHERE 
+  (
+  eventType = 'user.session.impersonation.grant' OR 
+  eventType = 'user.session.impersonation.initiate'
+  ) and
+  p_occurs_between('2022-01-14','2022-03-22')
+  ORDER BY
+    event_time desc
+SnowflakeQuery: >
   SELECT 
   p_event_time as event_time,
   actor:alternateId as actor_email,
@@ -21,7 +43,7 @@ Query: >
     OR 
     eventType = 'user.session.impersonation.initiate'
    AND  
-      p_occurs_between('2021-01-14','2021-03-22')
+      p_occurs_between('2022-01-14','2022-03-22')
   ORDER BY
     event_time desc
 Schedule:

--- a/okta_rules/okta_account_support_access.py
+++ b/okta_rules/okta_account_support_access.py
@@ -1,0 +1,21 @@
+OKTA_SUPPORT_ACCESS_EVENTS = [
+    "user.session.impersonation.grant",
+    "user.session.impersonation.initiate",
+]
+
+
+def rule(event):
+    return event.get("eventType") in OKTA_SUPPORT_ACCESS_EVENTS
+
+
+def title(event):
+    return f"Okta Support Access Granted by {event.udm('actor_user')}"
+
+
+def alert_context(event):
+    context = {
+        "user": event.udm("actor_user"),
+        "ip": event.udm("source_ip"),
+        "event": event.get("eventType"),
+    }
+    return context

--- a/okta_rules/okta_account_support_access.yml
+++ b/okta_rules/okta_account_support_access.yml
@@ -1,0 +1,76 @@
+AnalysisType: rule
+Filename: okta_account_support_access.py
+RuleID: Okta.Support.Access
+DisplayName: Okta Support Access Granted
+Enabled: true
+LogTypes:
+  - Okta.SystemLog
+Tags:
+  - Identity & Access Management
+Severity: Medium
+Description: An admin user has granted accesss to Okta Support to your account
+Reference: https://help.okta.com/en/prod/Content/Topics/Settings/settings-support-access.htm
+Runbook: Contact Admin to ensure this was sanctioned activity
+DedupPeriodMinutes: 15
+SummaryAttributes:
+  - eventType
+  - severity
+  - displayMessage
+  - p_any_ip_addresses
+Tests:
+  -
+    Name: Support Access Granted
+    ExpectedResult: true
+    Log:
+      {
+      "published": "2022-03-22 14:21:53.225",
+      "eventType": "user.session.impersonation.grant",
+      "version": "0",
+      "severity": "INFO",
+      "legacyEventType": "core.user.impersonation.grant.enabled",
+      "displayMessage": "Enable impersonation grant",
+      "actor": {
+        "alternateId": "homer@springfield.gov",
+        "displayName": "Homer Simpson",
+        "id": "111111",
+        "type": "User"
+	    },
+        "client": {
+          "device": "Computer",
+          "ipAddress": "75.166.10.81",
+          "userAgent": {
+            "browser": "CHROME",
+            "os": "Mac OS X",
+            "rawUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.83 Safari/537.36"
+            },
+            "zone": "null"
+          },
+        "p_log_type": "Okta.SystemLog"
+        }
+  -
+    Name: Login Event
+    ExpectedResult: False
+    Log:
+      {
+      "published": "2022-03-22 14:21:53.225",
+      "eventType": "user.session.start",
+      "version": "0",
+      "severity": "INFO",
+      "actor": {
+        "alternateId": "homer@springfield.gov",
+        "displayName": "Homer Simpson",
+        "id": "111111",
+        "type": "User"
+	    },
+        "client": {
+          "device": "Computer",
+          "ipAddress": "75.166.10.81",
+          "userAgent": {
+            "browser": "CHROME",
+            "os": "Mac OS X",
+            "rawUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.83 Safari/537.36"
+            },
+            "zone": "null"
+          },
+        "p_log_type": "Okta.SystemLog"
+        }

--- a/okta_rules/okta_account_support_access.yml
+++ b/okta_rules/okta_account_support_access.yml
@@ -38,7 +38,7 @@ Tests:
         },
         "client": {
           "device": "Computer",
-          "ipAddress": "75.166.10.81",
+          "ipAddress": "1.1.1.1",
           "userAgent": {
             "browser": "CHROME",
             "os": "Mac OS X",
@@ -65,7 +65,7 @@ Tests:
         },
         "client": {
           "device": "Computer",
-          "ipAddress": "75.166.10.81",
+          "ipAddress": "1.1.1.1",
           "userAgent": {
             "browser": "CHROME",
             "os": "Mac OS X",

--- a/okta_rules/okta_account_support_access.yml
+++ b/okta_rules/okta_account_support_access.yml
@@ -7,6 +7,7 @@ LogTypes:
   - Okta.SystemLog
 Tags:
   - Identity & Access Management
+  - DataModel
 Severity: Medium
 Description: An admin user has granted accesss to Okta Support to your account
 Reference: https://help.okta.com/en/prod/Content/Topics/Settings/settings-support-access.htm
@@ -34,7 +35,7 @@ Tests:
         "displayName": "Homer Simpson",
         "id": "111111",
         "type": "User"
-	    },
+        },
         "client": {
           "device": "Computer",
           "ipAddress": "75.166.10.81",
@@ -61,7 +62,7 @@ Tests:
         "displayName": "Homer Simpson",
         "id": "111111",
         "type": "User"
-	    },
+        },
         "client": {
           "device": "Computer",
           "ipAddress": "75.166.10.81",

--- a/okta_rules/okta_admin_disabled_mfa.py
+++ b/okta_rules/okta_admin_disabled_mfa.py
@@ -1,0 +1,18 @@
+import panther_event_type_helpers as event_type
+
+
+def rule(event):
+    return event.udm("event_type") == event_type.ADMIN_MFA_DISABLED
+
+
+def title(event):
+    return f"Okta System-wide MFA Disabled by Admin User {event.udm('actor_user')}"
+
+
+def alert_context(event):
+    context = {
+        "user": event.udm("actor_user"),
+        "ip": event.udm("source_ip"),
+        "event": event.get("eventType"),
+    }
+    return context

--- a/okta_rules/okta_admin_disabled_mfa.yml
+++ b/okta_rules/okta_admin_disabled_mfa.yml
@@ -1,0 +1,75 @@
+AnalysisType: rule
+Filename: okta_admin_disabled_mfa.py
+RuleID: Okta.Global.MFA.Disabled
+DisplayName: Okta MFA Globally Disabled 
+Enabled: true
+LogTypes:
+  - Okta.SystemLog
+Tags:
+  - Identity & Access Management
+  - DataModel
+Severity: High
+Description: An admin user has disabled the MFA requirement for your Okta account 
+Reference: https://developer.okta.com/docs/reference/api/event-types/?q=system.mfa.factor.deactivate
+Runbook: Contact Admin to ensure this was sanctioned activity
+DedupPeriodMinutes: 15
+SummaryAttributes:
+  - eventType
+  - severity
+  - displayMessage
+  - p_any_ip_addresses
+Tests:
+  -
+    Name: MFA Disabled
+    ExpectedResult: true
+    Log:
+      {
+      "published": "2022-03-22 14:21:53.225",
+      "eventType": "system.mfa.factor.deactivate",
+      "version": "0",
+      "severity": "HIGH",
+      "actor": {
+        "alternateId": "homer@springfield.gov",
+        "displayName": "Homer Simpson",
+        "id": "111111",
+        "type": "User"
+        },
+        "client": {
+          "device": "Computer",
+          "ipAddress": "1.1.1.1",
+          "userAgent": {
+            "browser": "CHROME",
+            "os": "Mac OS X",
+            "rawUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.83 Safari/537.36"
+            },
+            "zone": "null"
+          },
+        "p_log_type": "Okta.SystemLog"
+        }
+  -
+    Name: Login Event
+    ExpectedResult: False
+    Log:
+      {
+      "published": "2022-03-22 14:21:53.225",
+      "eventType": "user.session.start",
+      "version": "0",
+      "severity": "INFO",
+      "actor": {
+        "alternateId": "homer@springfield.gov",
+        "displayName": "Homer Simpson",
+        "id": "111111",
+        "type": "User"
+        },
+        "client": {
+          "device": "Computer",
+          "ipAddress": "1.1.1.1",
+          "userAgent": {
+            "browser": "CHROME",
+            "os": "Mac OS X",
+            "rawUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.83 Safari/537.36"
+            },
+            "zone": "null"
+          },
+        "p_log_type": "Okta.SystemLog"
+        }

--- a/okta_rules/okta_admin_role_assigned.py
+++ b/okta_rules/okta_admin_role_assigned.py
@@ -42,6 +42,7 @@ def title(event):
 def alert_context(event):
     return okta_alert_context(event)
 
+
 def severity(event):
     if deep_get(event, "debugContext", "debugData", "privilegeGranted") == "Super administrator":
         return "HIGH"

--- a/okta_rules/okta_admin_role_assigned.py
+++ b/okta_rules/okta_admin_role_assigned.py
@@ -41,3 +41,8 @@ def title(event):
 
 def alert_context(event):
     return okta_alert_context(event)
+
+def severity(event):
+    if deep_get(event, "debugContext", "debugData", "privilegeGranted") == "Super administrator":
+        return "HIGH"
+    return "INFO"

--- a/okta_rules/okta_mfa_password_reset_audit.yml
+++ b/okta_rules/okta_mfa_password_reset_audit.yml
@@ -1,0 +1,19 @@
+AnalysisType: scheduled_query
+QueryName: Okta Investigate MFA and Password resets
+Enabled: true
+Description: >
+  Investigate Password and MFA resets for the last 7 days 
+AthenaQuery: > 
+  SELECT p_event_time,actor.alternateId as actor_user,target[1].alternateId as target_user, eventType,client.ipAddress as ip_address
+  FROM panther_logs.okta_systemlog
+  WHERE eventType IN ('user.mfa.factor.reset_all', 'user.mfa.factor.deactivate', 'user.mfa.factor.suspend', 'user.account.reset_password', 'user.account.update_password')
+  and p_occurs_since('7days')
+  ORDER by p_event_time DESC
+SnowflakeQuery: >
+  SELECT p_event_time,actor:alternateId as actor_user,target[0]:alternateId as target_user, eventType,client:ipAddress as ip_address
+  FROM panther_logs.public.okta_systemlog
+  WHERE eventType IN ('user.mfa.factor.reset_all', 'user.mfa.factor.deactivate', 'user.mfa.factor.suspend', 'user.account.reset_password', 'user.account.update_password')
+  and p_occurs_since('7days')
+  -- Uncomment line below and replace email with email you wish to investigate
+  -- and actor:alternateId = 'email'
+  ORDER by p_event_time DESC

--- a/okta_rules/okta_mfa_password_reset_audit.yml
+++ b/okta_rules/okta_mfa_password_reset_audit.yml
@@ -17,3 +17,6 @@ SnowflakeQuery: >
   -- Uncomment line below and replace email with email you wish to investigate
   -- and actor:alternateId = 'email'
   ORDER by p_event_time DESC
+Schedule:
+  RateMinutes: 43200
+  TimeoutMinutes: 1

--- a/packs/okta.yml
+++ b/packs/okta.yml
@@ -9,6 +9,7 @@ PackDefinition:
     - Okta.BruteForceLogins
     - Okta.GeographicallyImprobableAccess
     - Okta.Support.Access
+    - Okta.Global.MFA.Disabled
     # Globals used in these detections
     - panther_base_helpers
     - panther_oss_helpers

--- a/packs/okta.yml
+++ b/packs/okta.yml
@@ -8,6 +8,7 @@ PackDefinition:
     - Okta.APIKeyRevoked
     - Okta.BruteForceLogins
     - Okta.GeographicallyImprobableAccess
+    - Okta.Support.Access
     # Globals used in these detections
     - panther_base_helpers
     - panther_oss_helpers

--- a/packs/okta.yml
+++ b/packs/okta.yml
@@ -12,4 +12,6 @@ PackDefinition:
     # Globals used in these detections
     - panther_base_helpers
     - panther_oss_helpers
+    # Data Model
+    - Standard.Okta.SystemLog
 DisplayName: Panther Okta Pack

--- a/standard_rules/mfa_disabled.yml
+++ b/standard_rules/mfa_disabled.yml
@@ -8,6 +8,7 @@ LogTypes:
   - Atlassian.Audit
   - GitHub.Audit
   - Zendesk.Audit
+  - Okta.SystemLog
 Severity: High
 Description: Detects when Multi-Factor Authentication (MFA) is disabled
 SummaryAttributes:
@@ -91,3 +92,90 @@ Tests:
         "created_at": "2021-05-28T18:39:50Z",
         "p_log_type": "Zendesk.Audit"
     }
+  -
+    Name: Okta - MFA Disabled
+    ExpectedResult: true
+    Log:
+      {
+        "eventtype": "user.mfa.factor.deactivate",
+        "version": "0",
+        "severity": "INFO",
+        "displaymessage": "Reset factor for user",
+        "actor": {
+          "alternateId": "homer@springfield.gov",
+          "displayName": "Homer Simpson",
+          "id": "11111111111",
+          "type": "User"
+        },
+        "client": {
+          "device": "Computer",
+          "ipAddress": "1.1.1.1",
+          "userAgent": {
+            "browser": "CHROME",
+            "os": "Mac OS X",
+            "rawUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.55 Safari/537.36"
+          },
+          "zone": "null"
+        },
+        "outcome": {
+          "reason": "User reset FIDO_WEBAUTHN factor",
+          "result": "SUCCESS"
+        },
+        "target": [
+          {
+            "alternateId": "homer@springfield.gov",
+            "displayName": "Homer Simpson",
+            "id": "1111111",
+            "type": "User"
+          }
+        ],
+        "authenticationcontext": {
+          "authenticationStep": 0,
+          "externalSessionId": "1111111"
+        },
+        "p_log_type": "Okta.SystemLog",
+      }
+  -
+    Name: Okta - MFA Enabled
+    ExpectedResult: false
+    Log:
+      {
+        "eventtype": "user.mfa.factor.update",
+        "version": "0",
+        "severity": "INFO",
+        "displaymessage": "Update factor for user",
+        "actor": {
+          "alternateId": "homer@springfield.gov",
+          "displayName": "Homer Simpson",
+          "id": "11111111111",
+          "type": "User"
+        },
+        "client": {
+          "device": "Computer",
+          "ipAddress": "1.1.1.1",
+          "userAgent": {
+            "browser": "CHROME",
+            "os": "Mac OS X",
+            "rawUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.55 Safari/537.36"
+          },
+          "zone": "null"
+        },
+        "outcome": {
+          "reason": "User reset FIDO_WEBAUTHN factor",
+          "result": "SUCCESS"
+        },
+        "target": [
+          {
+            "alternateId": "homer@springfield.gov",
+            "displayName": "Homer Simpson",
+            "id": "1111111",
+            "type": "User"
+          }
+        ],
+        "authenticationcontext": {
+          "authenticationStep": 0,
+          "externalSessionId": "1111111"
+        },
+        "p_log_type": "Okta.SystemLog",
+      }
+


### PR DESCRIPTION
### Background
Responding to some activity with Okta, improve our detection and investigative posture with Okta

### Changes
- Add  several Saved queries for investigation of Okta Activity
- Update Okta DataModel to support MFA disabled standard rule
- Add Okta Detection for access being granted to Okta Support 
- Add dynamic severity to Okta Admin Access rule
- Updated Okta Pack with new rules
- Add MFA enabled event type to event type helpers
- Add Admin MFA disable to event type helpers
- Add Okta rule for an admin disabling MFA globally
### Testing

* Unit Tests / CICD
