### PR TITLE
New Rule for Support Resets and some cleanup

### DIFF
--- a/okta_rules/okta_admin_role_assigned.py
+++ b/okta_rules/okta_admin_role_assigned.py
@@ -18,10 +18,9 @@ def rule(event):
 
 
 def dedup(event):
-    request_id = deep_get(
+    return deep_get(
         event, "debugContext", "debugData", "requestId", default="<UNKNOWN_REQUEST_ID>"
     )
-    return f"{request_id}"
 
 
 def title(event):
@@ -34,7 +33,7 @@ def title(event):
 
     return (
         f"{deep_get(event, 'actor', 'displayName')} "
-        f"<{deep_get(event, 'actor', 'alternateId')}> was granted "
+        f"<{deep_get(event, 'actor', 'alternateId')}> granted "
         f"[{privilege}] privileges to {display_name} <{alternate_id}>"
     )
 

--- a/okta_rules/okta_api_key_created.py
+++ b/okta_rules/okta_api_key_created.py
@@ -9,18 +9,13 @@ def rule(event):
 
 
 def title(event):
-    title_str = "{} <{}> created a new API key [{}]"
 
     target = event.get("target", [{}])
-    display_name = (
+    key_name = (
         target[0].get("displayName", "MISSING DISPLAY NAME") if target else "MISSING TARGET"
     )
 
-    return title_str.format(
-        deep_get(event, "actor", "displayName"),
-        deep_get(event, "actor", "alternateId"),
-        display_name,
-    )
+    return f"{deep_get(event, 'actor', 'displayName')} <{deep_get(event, 'actor', 'alternateId')}> created a new API key - <{key_name}>"
 
 
 def alert_context(event):

--- a/okta_rules/okta_api_key_revoked.py
+++ b/okta_rules/okta_api_key_revoked.py
@@ -9,19 +9,12 @@ def rule(event):
 
 
 def title(event):
-    title_str = "{} <{}> revoked the API key [{}]"
-
     target = event.get("target", [{}])
-    display_name = (
+    key_name = (
         target[0].get("displayName", "MISSING DISPLAY NAME") if target else "MISSING TARGET"
     )
 
-    return title_str.format(
-        deep_get(event, "actor", "displayName"),
-        deep_get(event, "actor", "alternateId"),
-        display_name,
-    )
-
+    return f"{deep_get(event, 'actor', 'displayName')} <{deep_get(event, 'actor', 'alternateId')}> created a new API key - <{key_name}>"
 
 def alert_context(event):
     return okta_alert_context(event)

--- a/okta_rules/okta_support_reset.py
+++ b/okta_rules/okta_support_reset.py
@@ -1,0 +1,24 @@
+from panther_base_helpers import deep_get, okta_alert_context
+
+OKTA_SUPPORT_RESET_EVENTS = [
+    "user.account.reset_password",
+    "user.mfa.factor.update",
+    "system.mfa.factor.deactivate",
+    "user.mfa.attempt_bypass",
+    ]
+
+def rule(event):
+    if event.get('eventType') not in OKTA_SUPPORT_RESET_EVENTS:
+        return False
+    return(
+        deep_get(event, "actor", "alternateId") == "system@okta.com"
+        and deep_get(event, "userAgent", "rawUserAgent") is None
+        and deep_get(event, "client", "geographicalContext", "country") is None
+    )
+
+def title(event):
+    return f"Okta Support Reset Password or MFA for user {event.udm('actor_user')}"
+
+
+def alert_context(event):
+    return okta_alert_context(event)

--- a/okta_rules/okta_support_reset.yml
+++ b/okta_rules/okta_support_reset.yml
@@ -1,0 +1,110 @@
+AnalysisType: rule
+Filename: okta_support_reset.py
+RuleID: Okta.Support.Reset
+DisplayName: Okta Support Reset Credential
+Enabled: true
+LogTypes:
+  - Okta.SystemLog
+Tags:
+  - Identity & Access Management
+  - DataModel
+Severity: High
+Description: A Password or MFA factor was reset by Okta Support
+Reference: https://help.okta.com/en/prod/Content/Topics/Directory/get-support.htm#:~:text=Visit%20the%20Okta%20Help%20Center,1%2D800%2D219%2D0964
+Runbook: Contact Admin to ensure this was sanctioned activity
+DedupPeriodMinutes: 15
+SummaryAttributes:
+  - eventType
+  - severity
+  - p_any_ip_addresses
+Tests:
+  -
+    Name: Support Reset Credential
+    ExpectedResult: true
+    Log:
+      {
+        "uuid": "12345",
+        "published": "2021-11-29 18:56:40.014",
+        "eventType": "user.account.reset_password",
+        "version": "0",
+        "severity": "INFO",
+        "legacyEventType": "core.user.config.user_status.password_reset",
+        "displayMessage": "Fired when the user's Okta password is reset",
+        "actor": {
+          "alternateId": "system@okta.com",
+          "displayName": "system@okta.com",
+          "id": "1111111",
+          "type": "User"
+        },
+        "client": {
+          "device": "Computer",
+          "ipAddress": "1.1.1.1",
+          "userAgent": {
+            "browser": "CHROME",
+            "os": "Mac OS X",
+          },
+          "zone": "null"
+        },
+        "outcome": {
+          "result": "SUCCESS"
+        },
+        "target": [
+          {
+            "alternateId": "homer@springfield.gov",
+            "displayName": "Homer Simpson",
+            "id": "1111111",
+            "type": "User"
+          }
+        ],
+        "p_log_type": "Okta.SystemLog",
+    }
+  - 
+    Name: Reset by Company Admin
+    ExpectedResult: false
+    Log:
+      {
+      "eventType": "user.account.reset_password",
+      "version": "0",
+      "severity": "INFO",
+      "legacyEventType": "core.user.config.user_status.password_reset",
+      "displayMessage": "Fired when the user's Okta password is reset",
+      "actor": {
+        "alternateId": "marge@springfield.gov",
+        "displayName": "Marge Simpson",
+        "id": "1111",
+        "type": "User"
+      },
+      "client": {
+        "device": "Computer",
+        "geographicalContext": {
+          "city": "Springfield",
+          "country": "United States",
+          "postalCode": "80014",
+          "state": "Debated"
+        },
+        "ipAddress": "1.1.1.1",
+        "userAgent": {
+          "browser": "CHROME",
+          "os": "Mac OS X",
+          "rawUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.55 Safari/537.36"
+        },
+        "zone": "null"
+      },
+      "outcome": {
+        "result": "SUCCESS"
+      },
+      "target": [
+        {
+          "alternateId": "homer@springfield.gov",
+          "displayName": "Homer Simpson",
+          "id": "1.1.1.1",
+          "type": "User"
+        }
+      ],
+      "transaction": {
+        "detail": {},
+        "id": "1111",
+        "type": "WEB"
+      },
+      "p_log_type": "Okta.SystemLog",
+    }


### PR DESCRIPTION
### Background
Adding a new rule to detect when Okta support resets a password or MFA factor. Based on this [post](https://www.linkedin.com/posts/amram-englander-a23a6a89_after-reviewing-okta-audit-logs-for-the-last-activity-6912526919825534976-nhCE) 

### Changes
Created new rule mentioned above
Some random formatting changes to make things more consistent

### Testing
Unit Tests
