### PR TITLE
Add a default to deep_get to avoid NoneType

### DIFF
--- a/aws_cloudtrail_rules/aws_console_login_without_mfa.py
+++ b/aws_cloudtrail_rules/aws_console_login_without_mfa.py
@@ -16,7 +16,7 @@ def rule(event):
 
     # If using AWS SSOv2 or other SAML provider return False
     if (
-        "AWSReservedSSO" in deep_get(event, "userIdentity", "arn")
+        "AWSReservedSSO" in deep_get(event, "userIdentity", "arn", default=" ")
         or additional_event_data.get("SamlProviderArn") is not None
     ):
         return False


### PR DESCRIPTION
### Background
This was returning None in some cases which throws an error on a check for the string. Adding a default to avoid this

### Changes
Add default to Deep get Function

### Testing
Unit Testing
