### PR TITLE
Default to the Conduit Prod resources

### DIFF
--- a/lookup_tables/greynoise/advanced/noise_advanced.yml
+++ b/lookup_tables/greynoise/advanced/noise_advanced.yml
@@ -2,8 +2,8 @@ AnalysisType: lookup_table
 LookupName: greynoise_noise_advanced
 Schema: GreyNoise.Noise
 Refresh:
-  RoleARN: arn:aws:iam::347758056897:role/panther-greynoise-full-access-role
-  ObjectPath: s3://panther-greynoise-1rwdj37boou9s9tqp8gs19jp9ju9nusw2a-s3alias/luts/data/greynoise/noise_full.jsonl.gz
+  RoleARN: arn:aws:iam::893421435052:role/panther-greynoise-full-access-role
+  ObjectPath: s3://panther-greynoise-m5qt4p8qa7nnu5ij6orgsgpd4w58yusw2a-s3alias/luts/data/greynoise/noise_full.jsonl.gz
   PeriodMinutes: 60
 Description: GreyNoise NOISE Advanced classifies the intent of IPs seen scanning the internet, including tags, CVEs, geo-data and detailed context. This version of NOISE requires an additional license - please contact your Panther or GreyNoise representative for more information.
 Reference: https://docs.panther.com/enrichment-beta/threat-intelligence/greynoise

--- a/lookup_tables/greynoise/advanced/riot_advanced.yml
+++ b/lookup_tables/greynoise/advanced/riot_advanced.yml
@@ -2,8 +2,8 @@ AnalysisType: lookup_table
 LookupName: greynoise_riot_advanced
 Schema: GreyNoise.RIOT
 Refresh:
-  RoleARN: arn:aws:iam::347758056897:role/panther-greynoise-full-access-role
-  ObjectPath: s3://panther-greynoise-1rwdj37boou9s9tqp8gs19jp9ju9nusw2a-s3alias/luts/data/greynoise/riot_full.jsonl.gz
+  RoleARN: arn:aws:iam::893421435052:role/panther-greynoise-full-access-role
+  ObjectPath: s3://panther-greynoise-m5qt4p8qa7nnu5ij6orgsgpd4w58yusw2a-s3alias/luts/data/greynoise/riot_full.jsonl.gz
   PeriodMinutes: 240
 Description: GreyNoise RIOT Advanced identifies unpublished or dynamic IPs of common business services that are difficult for security teams to track, with detailed context. This version of RIOT requires an additional license - please contact your Panther or GreyNoise representative for more information.
 Reference: https://docs.panther.com/enrichment-beta/threat-intelligence/greynoise

--- a/lookup_tables/greynoise/basic/noise_basic.yml
+++ b/lookup_tables/greynoise/basic/noise_basic.yml
@@ -2,8 +2,8 @@ AnalysisType: lookup_table
 LookupName: greynoise_noise_basic
 Schema: GreyNoise.Noise
 Refresh:
-  RoleARN: arn:aws:iam::347758056897:role/panther-greynoise-basic-access-role
-  ObjectPath: s3://panther-greynoise-1rwdj37boou9s9tqp8gs19jp9ju9nusw2a-s3alias/luts/data/greynoise/noise_basic.jsonl.gz
+  RoleARN: arn:aws:iam::893421435052:role/panther-greynoise-basic-access-role
+  ObjectPath: s3://panther-greynoise-m5qt4p8qa7nnu5ij6orgsgpd4w58yusw2a-s3alias/luts/data/greynoise/noise_basic.jsonl.gz
   PeriodMinutes: 60
 Description: GreyNoise NOISE Basic classifies IPs seen scanning the internet based on intent - benign, malicious, and unknown. This version of NOISE is free with Panther.
 Reference: https://docs.panther.com/enrichment-beta/threat-intelligence/greynoise

--- a/lookup_tables/greynoise/basic/riot_basic.yml
+++ b/lookup_tables/greynoise/basic/riot_basic.yml
@@ -2,8 +2,8 @@ AnalysisType: lookup_table
 LookupName: greynoise_riot_basic
 Schema: GreyNoise.RIOT
 Refresh:
-  RoleARN: arn:aws:iam::347758056897:role/panther-greynoise-basic-access-role
-  ObjectPath: s3://panther-greynoise-1rwdj37boou9s9tqp8gs19jp9ju9nusw2a-s3alias/luts/data/greynoise/riot_basic.jsonl.gz
+  RoleARN: arn:aws:iam::893421435052:role/panther-greynoise-basic-access-role
+  ObjectPath: s3://panther-greynoise-m5qt4p8qa7nnu5ij6orgsgpd4w58yusw2a-s3alias/luts/data/greynoise/riot_basic.jsonl.gz
   PeriodMinutes: 240
 Description: GreyNoise RIOT Basic identifies unpublished or dynamic IPs of common business services that are difficult for security teams to track. This basic version of RIOT is free with Panther.
 Reference: https://docs.panther.com/enrichment-beta/threat-intelligence/greynoise


### PR DESCRIPTION
### Background

We need to reference the Conduit Production resources in the GreyNoise Pack files by default.

### Changes

* Updated from the staging to the prod resources

### Testing

* Manual deployment to `gremlins`
