### PR TITLE
Remove deprecated rules from packs

### DIFF
--- a/packs/box.yml
+++ b/packs/box.yml
@@ -5,7 +5,6 @@ PackDefinition:
   IDs:
     - Box.Access.Granted
     - Box.Shield.Anomalous.Download
-    - Box.Brute.Force.Login
     - Box.Event.Triggered.Externally
     - Box.Item.Shared.Externally
     - Box.Malicious.Content

--- a/packs/gcp_audit.yml
+++ b/packs/gcp_audit.yml
@@ -5,7 +5,6 @@ PackDefinition:
   IDs:
     - GCP.GCS.IAMChanges
     - GCP.GCS.Public
-    - GCP.IAM.AdminRoleAssigned
     - GCP.IAM.CorporateEmail
     - GCP.IAM.CustomRoleChanges
     - GCP.SQL.ConfigChanges

--- a/packs/gsuite_reports.yml
+++ b/packs/gsuite_reports.yml
@@ -4,7 +4,6 @@ Description: Group of all GSuite Reports detections
 PackDefinition:
   IDs:
     - GSuite.AdvancedProtection
-    - GSuite.BruteForceLogin
     - GSuite.DocOwnershipTransfer
     - GSuite.Drive.ExternalFileShare
     - GSuite.DriveOverlyVisible
@@ -21,7 +20,6 @@ PackDefinition:
     - GSuite.DeviceCompromise
     - GSuite.DeviceUnlockFailure
     - GSuite.DeviceSuspiciousActivity
-    - GSuite.PermisssionsDelegated
     - GSuite.SuspiciousLogins
     - GSuite.TwoStepVerification
     - GSuite.UserSuspended

--- a/packs/log4j.yml
+++ b/packs/log4j.yml
@@ -4,7 +4,6 @@ Description: Detect Log4J IOCs and known scanning IPs
 PackDefinition:
   IDs:
     - IOC.Log4jExploit
-    - IOC.Log4JIPs
     # Globals
     - panther_iocs
 DisplayName: Panther Log4J Detection Pack

--- a/packs/okta.yml
+++ b/packs/okta.yml
@@ -6,7 +6,6 @@ PackDefinition:
     - Okta.AdminRoleAssigned
     - Okta.APIKeyCreated
     - Okta.APIKeyRevoked
-    - Okta.BruteForceLogins
     - Okta.GeographicallyImprobableAccess
     - Okta.Support.Access
     - Okta.Global.MFA.Disabled

--- a/packs/onelogin.yml
+++ b/packs/onelogin.yml
@@ -4,9 +4,6 @@ Description: Group of all OneLogin detections
 PackDefinition:
   IDs:
     - OneLogin.ActiveLoginActivity
-    - OneLogin.AdminRoleAssigned
-    - OneLogin.BruteForceByIP
-    - OneLogin.BruteForceByUsername
     - OneLogin.HighRiskFailedLogin
     - OneLogin.HighRiskLogin
     - OneLogin.PasswordAccess
@@ -15,7 +12,6 @@ PackDefinition:
     - OneLogin.ThresholdAccountsDeleted
     - OneLogin.ThresholdAccountsModified
     - OneLogin.UnauthorizedAccess
-    - OneLogin.UnusualLogin
     - OneLogin.UserAccountLocked
     - OneLogin.UserAssumption
     # Globals used in these detections


### PR DESCRIPTION
### Background
Rules were deprecated at some point, but not removed from Packs
All deprecated rules are disabled

Going to consider the best way to boneyard old rules rather than letting them stay in the main folder
### Changes
Remove from Packs

### Testing

Unit
