### PR TITLE
Add Res-2020-10 to the TLSv1.2 list

### DIFF
--- a/aws_load_balancer_policies/aws_alb_ssl_policy.py
+++ b/aws_load_balancer_policies/aws_alb_ssl_policy.py
@@ -5,6 +5,7 @@ TLS_1_2_POLICIES = {
     "ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
     "ELBSecurityPolicy-FS-1-2-Res-2019-08",
     "ELBSecurityPolicy-FS-1-2-2019-08",
+    "ELBSecurityPolicy-FS-1-2-Res-2020-10",
 }
 
 


### PR DESCRIPTION
### Background

`ELBSecurityPolicy-FS-1-2-Res-2020-10` is missing from the list.

### Changes

* Added `ELBSecurityPolicy-FS-1-2-Res-2020-10` to the list.

WIth `ELBSecurityPolicy-FS-1-2-Res-2020-10` added, the list now matches present-day output of the commented AWS CLI command to generate the list.

### Testing

* ELBs that were failing because `ELBSecurityPolicy-FS-1-2-Res-2020-10` was the utilize SecurityPolicy now no longer fail.
