### PR TITLE
Adds get_actor_user method to Okta data model

### DIFF
--- a/data_models/okta_data_model.py
+++ b/data_models/okta_data_model.py
@@ -1,4 +1,5 @@
 import panther_event_type_helpers as event_type
+from panther_base_helpers import deep_get
 
 
 def get_event_type(event):
@@ -25,3 +26,10 @@ def get_event_type(event):
     if event.get("eventType") == "system.mfa.factor.deactivate":
         return event_type.ADMIN_MFA_DISABLED
     return None
+
+
+def get_actor_user(event):
+    actor = deep_get(event, "actor", "displayName")
+    if actor == "unknown":
+        actor = deep_get(event, "actor", "alternateId")
+    return actor

--- a/data_models/okta_data_model.yml
+++ b/data_models/okta_data_model.yml
@@ -7,7 +7,7 @@ Filename: okta_data_model.py
 Enabled: true
 Mappings:
   - Name: actor_user
-    Path: $.actor.displayName
+    Path: get_actor_user
   - Name: event_type
     Method: get_event_type
   - Name: source_ip


### PR DESCRIPTION
### Background

Fixes issue #417 

### Changes

Changes Okta's `actor_user` udm mapping from `$.actor.displayName` to `get_actor_user()`.

### Testing

`title()` in Standard.BruteForceByIP now returns a user's alternate ID when their display name = `"unknown"`.
