### PR TITLE
gcp_base_helpers

### DIFF
--- a/global_helpers/z_gcp_base_helpers.py
+++ b/global_helpers/z_gcp_base_helpers.py
@@ -1,0 +1,40 @@
+import panther_base_helpers
+
+def get_info(event):
+    fields = {
+        'principal': 'protoPayload.authenticationInfo.principalEmail',
+        'project_id': 'protoPayload.resource.labels.project_id',
+        'caller_ip': 'protoPayload.requestMetadata.callerIP',
+        'user_agent': 'protoPayload.requestMetadata.callerSuppliedUserAgent',
+        'method_name': 'protoPayload.methodName',
+    }
+    return {
+        name: panther_base_helpers.deep_get(event, *(path.split('.')))
+        for name, path in fields.items()
+    }
+
+def get_k8s_info(event):
+    '''
+    Get GCP K8s info such as pod, authorized user etc.
+    return a tuple of strings
+    '''
+    pod_slug = panther_base_helpers.deep_get(event, 'protoPayload', 'resourceName')
+    # core/v1/namespaces/<namespace>/pods/<pod-id>/<action>
+    _, _, _, namespace, _, pod, _ = pod_slug.split('/')
+    return get_info(event) | {'namespace': namespace, 'pod': pod}
+
+def get_flow_log_info(event):
+    fields = {
+        'src_ip': 'jsonPayload.connection.src_ip',
+        'dest_ip': 'jsonPayload.connection.dest_ip',
+        'src_port': 'jsonPayload.connection.src_port',
+        'dest_port': 'jsonPayload.connection.dest_port',
+        'protocol': 'jsonPayload.connection.protocol',
+        'bytes_sent': 'jsonPayload.bytes_sent',
+        'reporter': 'jsonPayload.reporter'
+    }
+    return {
+        name: panther_base_helpers.deep_get(event, *(path.split('.')))
+        for name, path in fields.items()
+    }
+    

--- a/global_helpers/z_gcp_base_helpers.yml
+++ b/global_helpers/z_gcp_base_helpers.yml
@@ -1,0 +1,5 @@
+AnalysisType: global
+Filename: z_gcp_base_helpers.py
+GlobalID: z_gcp_base_helpers
+Description: >
+  get_info, get_k8s_info, get_flow_logs_info etc return dicts of the most commonly used fields.


### PR DESCRIPTION

### Background

These functions will be useful for many gcp detections.
adds get_info, get_k8s_info and get_flow_log_info

We have several detections that rely on these helpers. Will follow up with other PRs once this is merged.

### Changes
The gcp_base_helpers.py relies on the deep_get base helper and there is a load order issue on local development that required us to prefix with z_.  This can be removed once the load order bug is fixed.

global_helpers/z_gcp_base_helpers.py
global_helpers/z_gcp_base_helpers.yml

### Testing
Tested in our deployment in gcp_k8s_rules detections.

