### PR TITLE
Optimize resolve_timestamp_resolver

### DIFF
--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -19,6 +19,7 @@ FIPS_SUFFIX = "-fips." + os.getenv("AWS_REGION", "") + ".amazonaws.com"
 # Auto Time Resolution Parameters
 EPOCH_REGEX = r"([0-9]{9,12}(\.\d+)?)"
 TIME_FORMATS = [
+    "%Y-%m-%d %H:%M:%S",  # Panther p_event_time Timestamp
     "%Y-%m-%dT%H:%M:%SZ",  # AWS Timestamp
     "%Y-%m-%dT%H:%M:%S.%fZ",  # Panther Timestamp
     "%Y-%m-%dT%H:%M:%S*%f%z",


### PR DESCRIPTION
### Background

The timestamp format for `p_event_time` is not in the `TIME_FORMATS` list. This timestamp format eventually gets resolved with the `dateutil.parser` method, but only after attempting to resolve each format in the `TIME_FORMATS` list. Since `p_event_time` is a rather common timestamp format, this PR adds that format to be the best case.

### Changes

* Added Panther `p_event_timestamp` format to `TIME_FORMATS`

### Testing

* Manual performance testing for `resolve_timestamp_string`
