### PR TITLE
fix format for saml logins

### DIFF
--- a/gsuite_activityevent_rules/gsuite_login_type.py
+++ b/gsuite_activityevent_rules/gsuite_login_type.py
@@ -16,6 +16,12 @@ def rule(event):
 
     if (
         event.get("type") == "login"
+        and deep_get(event, "id", "applicationName") == "saml"
+    ):
+        return False
+
+    if (
+        event.get("type") == "login"
         and event.get("name") != "logout"
         and deep_get(event, "parameters", "login_type") not in APPROVED_LOGIN_TYPES
     ):

--- a/gsuite_activityevent_rules/gsuite_login_type.yml
+++ b/gsuite_activityevent_rules/gsuite_login_type.yml
@@ -72,3 +72,26 @@ Tests:
           "login_type": "saml"
         },
       }
+  -
+    Name: Saml Login Event
+    ExpectedResult: false
+    Log:
+      {
+        "actor": {
+          "email": "some.user@somedomain.com",
+        },
+        "id": {
+          "applicationName": "saml",
+          "time": "2022-05-26 15:26:09.421000000",
+        },
+        "ipAddress": "10.10.10.10",
+        "kind": "admin#reports#activity",
+        "name": "login_success",
+        "parameters": {
+          "application_name": "Some SAML Application",
+          "initiated_by": "sp",
+          "orgunit_path": "/SomeOrgUnit",
+          "saml_status_code": "SUCCESS_URI"
+        },
+        "type": "login"
+      }


### PR DESCRIPTION
### Background

The "unauthorized login type" detection doesn't handle the format for SAML_LOGIN correctly, so I fixed it.

### Changes

- Added special-case handling to saml login type events
- Added new test case w/ data

### Testing
```
$ pipenv run panther_analysis_tool test --filter RuleID=GSuite.LoginType
[INFO]: Testing analysis items in .

GSuite.LoginType
        [PASS] Login With Approved Type
                [PASS] [rule] false
        [PASS] Login With Unapproved Type
                [PASS] [rule] true
                [PASS] [title] A login attempt of a non-approved type was detected for user [some.user@somedomain.com]
                [PASS] [dedup] A login attempt of a non-approved type was detected for user [some.user@somedomain.com]
        [PASS] Non-Login event
                [PASS] [rule] false
        [PASS] Saml Login Event
                [PASS] [rule] false

--------------------------
Panther CLI Test Summary
        Path: .
        Passed: 1
        Failed: 0
        Invalid: 0
```
