### PR TITLE
remove panther_core, update imports

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,6 @@ decorator = "~=5.1"
 
 [packages]
 panther-analysis-tool = "*"
-panther-core = "*"
 policyuniverse = "==1.4.0.20220110"
 requests = "~=2.27"
 

--- a/data_models/gcp_data_model.py
+++ b/data_models/gcp_data_model.py
@@ -3,7 +3,7 @@ from fnmatch import fnmatch
 
 import panther_event_type_helpers as event_type
 from panther_base_helpers import get_binding_deltas
-from panther_core.enriched_event import PantherEvent
+from panther_analysis_tool.enriched_event import PantherEvent
 
 ADMIN_ROLES = {
     # Primitive Rolesx

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional, Sequence, Set, Union
 import boto3
 import requests
 from dateutil import parser
-from panther_core.immutable import ImmutableList
+from panther_analysis_tool.immutable import ImmutableList
 
 _RESOURCE_TABLE = None  # boto3.Table resource, lazily constructed
 FIPS_ENABLED = os.getenv("ENABLE_FIPS", "").lower() == "true"


### PR DESCRIPTION
After consideration, we do not want panther-analysis depending on panther_core. This is the invert of https://github.com/panther-labs/panther-analysis/pull/430/files