### PR TITLE
Confluence 0-Day IOCs

### DIFF
--- a/global_helpers/panther_iocs.py
+++ b/global_helpers/panther_iocs.py
@@ -1,4 +1,25 @@
 # pylint: disable=line-too-long
+
+# 2022-06-02 Confluence 0-Day IOCs:
+# https://github.com/volexity/threat-intel/blob/main/2022/2022-06-02%20Active%20Exploitation%20Of%20Confluence%200-day/indicators/indicators.csv
+VOLEXITY_CONFLUENCE_IP_IOCS = {
+    "156.146.34.46",
+    "156.146.34.9",
+    "156.146.56.136",
+    "198.147.22.148",
+    "45.43.19.91",
+    "66.115.182.102",
+    "66.115.182.111",
+    "67.149.61.16",
+    "154.16.105.147",
+    "64.64.228.239",
+    "156.146.34.52",
+    "154.146.34.145",
+    "221.178.126.244",
+    "59.163.248.170",
+    "98.32.230.38",
+}
+
 # SUNBURST IOCs:
 # https://github.com/fireeye/sunburst_countermeasures/blob/main/indicator_release/Indicator_Release_NBIs.csv
 # Last accessed: 2021-11-17

--- a/panther_ioc_rules/atlassian_confluence_ip_iocs.py
+++ b/panther_ioc_rules/atlassian_confluence_ip_iocs.py
@@ -7,4 +7,4 @@ def rule(event):
 
 def title(event):
     ips = ",".join(ioc_match(event.get("p_any_ip_addresses"), VOLEXITY_CONFLUENCE_IP_IOCS))
-    return f"IP seen in May 2022 exploiting Confluence 0-Day: {ips}"
+    return f"IP seen from May 2022 exploitation of Confluence 0-Day: {ips}"

--- a/panther_ioc_rules/atlassian_confluence_ip_iocs.py
+++ b/panther_ioc_rules/atlassian_confluence_ip_iocs.py
@@ -1,0 +1,10 @@
+from panther_iocs import VOLEXITY_CONFLUENCE_IP_IOCS, ioc_match
+
+
+def rule(event):
+    return any(ioc_match(event.get("p_any_ip_addresses"), VOLEXITY_CONFLUENCE_IP_IOCS))
+
+
+def title(event):
+    ips = ",".join(ioc_match(event.get("p_any_ip_addresses"), VOLEXITY_CONFLUENCE_IP_IOCS))
+    return f"IP seen in May 2022 exploiting Confluence 0-Day: {ips}"

--- a/panther_ioc_rules/atlassian_confluence_ip_iocs.yml
+++ b/panther_ioc_rules/atlassian_confluence_ip_iocs.yml
@@ -1,0 +1,57 @@
+AnalysisType: rule
+Filename: atlassian_confluence_ip_iocs.py
+RuleID: Confluence.0DayIPs
+DisplayName: Confluence 0-Day Indicators of Compromise (IOCs)
+Enabled: True
+LogTypes:
+  - AWS.ALB
+  - AWS.CloudTrail
+  - AWS.GuardDuty
+  - AWS.S3ServerAccess
+  - AWS.VPCFlow
+  - GCP.AuditLog
+  - Apache.AccessCombined
+  - Apache.AccessCommon
+  - Cloudflare.Firewall
+  - Cloudflare.HttpRequest
+  - Juniper.Access
+  - Nginx.Access
+Tags:
+  - AWS
+  - DNS
+  - GCP
+  - Apache
+  - Cloudflare
+  - Nginx
+  - Juniper
+Severity: High
+Description: >
+   Detects IP addresses observed exploiting the 0-Day CVE-2022-26134
+Reference: >
+    https://confluence.atlassian.com/doc/confluence-security-advisory-2022-06-02-1130377146.html
+    https://www.volexity.com/blog/2022/06/02/zero-day-exploitation-of-atlassian-confluence/
+Runbook: >
+    Investigate traffic from these IP addresses and look for other IOCs associated with the 0-Day exploit CVE-2022-26134
+SummaryAttributes:
+  - p_any_domain_names
+  - p_any_ip_addresses
+Tests:
+  -
+    Name: Non-matching traffic
+    ExpectedResult: false
+    Log:
+      {
+        "dstport": 53,
+        "dstaddr": "1.1.1.1",
+        "srcaddr": "10.0.0.1",
+        "p_any_ip_addresses": ["1.1.1.1"],
+      }
+  -
+    Name: Log4j Indicator of Compromise (IP) Detected
+    ExpectedResult: true
+    Log:
+      {
+        "srcaddr": "59.163.248.170",
+        "dstaddr": "0.0.0.1",
+        "p_any_ip_addresses": ["59.163.248.170"],
+      }

--- a/panther_ioc_rules/atlassian_confluence_ip_iocs.yml
+++ b/panther_ioc_rules/atlassian_confluence_ip_iocs.yml
@@ -47,7 +47,7 @@ Tests:
         "p_any_ip_addresses": ["1.1.1.1"],
       }
   -
-    Name: Log4j Indicator of Compromise (IP) Detected
+    Name: Indicator of Compromise (IP) Detected
     ExpectedResult: true
     Log:
       {


### PR DESCRIPTION
### Background

Adds IP IOCs for the recent Atlassian Confluence on-prem 0-Day

### Changes

* Added IOCs published by Volexity
* Added a new rule that checks for these IOCs

### Testing

* `make test`
