### PR TITLE
Rename ATTACK to ATT&CK

### DIFF
--- a/aws_account_policies/aws_password_policy_complexity_guidelines.yml
+++ b/aws_account_policies/aws_password_policy_complexity_guidelines.yml
@@ -18,7 +18,7 @@ Reports:
     - 1.9
   PCI:
     - 8.2.3
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1110
 Severity: High
 Description: >

--- a/aws_account_policies/aws_password_policy_password_age_limit.yml
+++ b/aws_account_policies/aws_password_policy_password_age_limit.yml
@@ -14,7 +14,7 @@ Reports:
     - 1.11
   PCI:
     - 8.2.4
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1110
 Severity: Medium
 Description: >

--- a/aws_account_policies/aws_password_policy_password_reuse.yml
+++ b/aws_account_policies/aws_password_policy_password_reuse.yml
@@ -14,7 +14,7 @@ Reports:
     - 1.10
   PCI:
     - 8.2.5
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1110
 Severity: Medium
 Description: >

--- a/aws_acm_policies/aws_acm_certificate_expiration.yml
+++ b/aws_acm_policies/aws_acm_certificate_expiration.yml
@@ -6,7 +6,7 @@ Enabled: true
 ResourceTypes:
   - AWS.ACM.Certificate
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0042:T1588
 Tags:
   - AWS

--- a/aws_acm_policies/aws_acm_certificate_has_secure_algorithms.yml
+++ b/aws_acm_policies/aws_acm_certificate_has_secure_algorithms.yml
@@ -13,7 +13,7 @@ Tags:
 Reports:
   PCI:
     - 2.2.3
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: High
 Description: >

--- a/aws_acm_policies/aws_acm_certificate_valid.yml
+++ b/aws_acm_policies/aws_acm_certificate_valid.yml
@@ -6,7 +6,7 @@ Enabled: true
 ResourceTypes:
   - AWS.ACM.Certificate
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0042:T1588
 Tags:
   - AWS

--- a/aws_cloudformation_policies/aws_cloudformation_stack_drifted.yml
+++ b/aws_cloudformation_policies/aws_cloudformation_stack_drifted.yml
@@ -6,7 +6,7 @@ Enabled: true
 ResourceTypes:
   - AWS.CloudFormation.Stack
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0040:T1496
 Tags:
   - AWS

--- a/aws_cloudformation_policies/aws_cloudformation_termination_protection.yml
+++ b/aws_cloudformation_policies/aws_cloudformation_termination_protection.yml
@@ -6,7 +6,7 @@ Enabled: true
 ResourceTypes:
   - AWS.CloudFormation.Stack
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0040:T1496
 Tags:
   - AWS

--- a/aws_cloudtrail_policies/aws_cloudtrail_cloudwatch_logs.yml
+++ b/aws_cloudtrail_policies/aws_cloudtrail_cloudwatch_logs.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   CIS:
     - 2.4
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: Low
 Description: >

--- a/aws_cloudtrail_policies/aws_cloudtrail_enabled.yml
+++ b/aws_cloudtrail_policies/aws_cloudtrail_enabled.yml
@@ -14,7 +14,7 @@ Reports:
     - 2.1
   PCI:
     - 10.5.4
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: High
 Description: >

--- a/aws_cloudtrail_policies/aws_cloudtrail_log_encryption.yml
+++ b/aws_cloudtrail_policies/aws_cloudtrail_log_encryption.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   CIS:
     - 2.7
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0007:T1526
 Severity: Medium
 Description: >

--- a/aws_cloudtrail_policies/aws_cloudtrail_log_validation.yml
+++ b/aws_cloudtrail_policies/aws_cloudtrail_log_validation.yml
@@ -14,7 +14,7 @@ Reports:
     - 2.2
   PCI:
     - 10.5.5
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: Medium
 Description: >

--- a/aws_cloudtrail_policies/aws_cloudtrail_s3_bucket_access_logging.yml
+++ b/aws_cloudtrail_policies/aws_cloudtrail_s3_bucket_access_logging.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   CIS:
     - 2.6
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: Medium
 Description: >

--- a/aws_cloudtrail_policies/aws_cloudtrail_s3_bucket_public.yml
+++ b/aws_cloudtrail_policies/aws_cloudtrail_s3_bucket_public.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   CIS:
     - 2.3
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: High
 Description: >

--- a/aws_cloudtrail_rules/aws_ami_modified_for_public_access.yml
+++ b/aws_cloudtrail_rules/aws_ami_modified_for_public_access.yml
@@ -10,7 +10,7 @@ Tags:
   - Exfiltration:Transfer Data to Cloud Account
 Severity: Medium
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1537
 Description: >
   An Amazon Machine Image (AMI) was modified to allow it to be launched by anyone.

--- a/aws_cloudtrail_rules/aws_cloudtrail_created.yml
+++ b/aws_cloudtrail_rules/aws_cloudtrail_created.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   CIS:
     - 3.5
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0007:T1538
 Severity: Info
 Description: >

--- a/aws_cloudtrail_rules/aws_cloudtrail_stopped.yml
+++ b/aws_cloudtrail_rules/aws_cloudtrail_stopped.yml
@@ -13,7 +13,7 @@ Tags:
 Reports:
   CIS:
     - 3.5
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: Medium
 Description: >

--- a/aws_cloudtrail_rules/aws_codebuild_made_public.yml
+++ b/aws_cloudtrail_rules/aws_codebuild_made_public.yml
@@ -6,7 +6,7 @@ Enabled: true
 LogTypes:
   - AWS.CloudTrail
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1567
 Tags:
   - AWS

--- a/aws_cloudtrail_rules/aws_config_service_created.yml
+++ b/aws_cloudtrail_rules/aws_config_service_created.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   CIS:
     - 3.9
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0007:T1526
 Severity: Info
 Description: >

--- a/aws_cloudtrail_rules/aws_config_service_disabled_deleted.yml
+++ b/aws_cloudtrail_rules/aws_config_service_disabled_deleted.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   CIS:
     - 3.9
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: Medium
 Description: >

--- a/aws_cloudtrail_rules/aws_console_login_failed.yml
+++ b/aws_cloudtrail_rules/aws_console_login_failed.yml
@@ -15,7 +15,7 @@ Threshold: 5
 Reports:
   CIS:
     - 3.6
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1110
 Severity: Low
 Description: >

--- a/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
+++ b/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
@@ -13,7 +13,7 @@ Tags:
 Reports:
   CIS:
     - 3.2
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1078
 Severity: High
 Description: A console login was made without multi-factor authentication.

--- a/aws_cloudtrail_rules/aws_console_login_without_saml.yml
+++ b/aws_cloudtrail_rules/aws_console_login_without_saml.yml
@@ -7,7 +7,7 @@ Enabled: false
 LogTypes:
   - AWS.CloudTrail
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1078
 Tags:
   - AWS

--- a/aws_cloudtrail_rules/aws_console_root_login.yml
+++ b/aws_cloudtrail_rules/aws_console_root_login.yml
@@ -15,7 +15,7 @@ Tags:
 Reports:
   CIS:
     - 3.6
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Severity: High
 Description: The root account has been logged into.

--- a/aws_cloudtrail_rules/aws_console_root_login_failed.yml
+++ b/aws_cloudtrail_rules/aws_console_root_login_failed.yml
@@ -16,7 +16,7 @@ Threshold: 5
 Reports:
   CIS:
     - 3.6 
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1110
 Severity: High
 Description: A Root console login failed.

--- a/aws_cloudtrail_rules/aws_ec2_gateway_modified.yml
+++ b/aws_cloudtrail_rules/aws_ec2_gateway_modified.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   CIS:
     - 3.12
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: Info
 Description: An EC2 Network Gateway was modified.

--- a/aws_cloudtrail_rules/aws_ec2_manual_security_group_changes.yml
+++ b/aws_cloudtrail_rules/aws_ec2_manual_security_group_changes.yml
@@ -6,7 +6,7 @@ Enabled: false
 LogTypes:
   - AWS.CloudTrail
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Tags:
   - AWS

--- a/aws_cloudtrail_rules/aws_ec2_network_acl_modified.yml
+++ b/aws_cloudtrail_rules/aws_ec2_network_acl_modified.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   CIS:
     - 3.11
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: Info
 Description: An EC2 Network ACL was modified.

--- a/aws_cloudtrail_rules/aws_ec2_route_table_modified.yml
+++ b/aws_cloudtrail_rules/aws_ec2_route_table_modified.yml
@@ -11,7 +11,7 @@ Tags:
 Reports:
   CIS:
     - 3.13
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1048
 Severity: Info
 Description: An EC2 Route Table was modified.

--- a/aws_cloudtrail_rules/aws_ec2_security_group_modified.yml
+++ b/aws_cloudtrail_rules/aws_ec2_security_group_modified.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   CIS:
     - 3.10
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: Info
 DedupPeriodMinutes: 720 # 12 hours

--- a/aws_cloudtrail_rules/aws_ec2_vpc_modified.yml
+++ b/aws_cloudtrail_rules/aws_ec2_vpc_modified.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   CIS:
     - 3.14
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: Info
 DedupPeriodMinutes: 720 # 12 hours

--- a/aws_cloudtrail_rules/aws_iam_assume_role_blocklist_ignored.yml
+++ b/aws_cloudtrail_rules/aws_iam_assume_role_blocklist_ignored.yml
@@ -11,7 +11,7 @@ Tags:
   - Identity and Access Management
   - Privilege Escalation:Abuse Elevation Control Mechanism
 Reports:
-    MITRE ATTACK:
+    MITRE ATT&CK:
       - TA0004:T1548
 Severity: High
 Description: >

--- a/aws_cloudtrail_rules/aws_iam_entity_created_without_cloudformation.yml
+++ b/aws_cloudtrail_rules/aws_iam_entity_created_without_cloudformation.yml
@@ -6,7 +6,7 @@ Enabled: false
 LogTypes:
   - AWS.CloudTrail
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1136
 Tags:
   - AWS

--- a/aws_cloudtrail_rules/aws_iam_policy_modified.yml
+++ b/aws_cloudtrail_rules/aws_iam_policy_modified.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   CIS:
     - 3.4
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1548
 Severity: Info
 DedupPeriodMinutes: 720 # 12 hours

--- a/aws_cloudtrail_rules/aws_iam_user_recon_denied.yml
+++ b/aws_cloudtrail_rules/aws_iam_user_recon_denied.yml
@@ -9,7 +9,7 @@ Tags:
   - AWS
   - Discovery:Cloud Service Discovery
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0007:T1526
 Severity: Medium
 Threshold: 15

--- a/aws_cloudtrail_rules/aws_key_compromised.yml
+++ b/aws_cloudtrail_rules/aws_key_compromised.yml
@@ -6,7 +6,7 @@ Enabled: true
 LogTypes:
   - AWS.CloudTrail
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1552
 Tags:
   - AWS

--- a/aws_cloudtrail_rules/aws_kms_cmk_loss.yml
+++ b/aws_cloudtrail_rules/aws_kms_cmk_loss.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   CIS:
     - 3.7
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0040:T1485
 Severity: Info
 Description: >

--- a/aws_cloudtrail_rules/aws_network_acl_permissive_entry.yml
+++ b/aws_cloudtrail_rules/aws_network_acl_permissive_entry.yml
@@ -10,7 +10,7 @@ Tags:
   - Persistence:Account Manipulation
 Severity: Medium
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1098
 Description: >
   A Network ACL entry that allows access from anywhere was added.

--- a/aws_cloudtrail_rules/aws_resource_made_public.yml
+++ b/aws_cloudtrail_rules/aws_resource_made_public.yml
@@ -10,7 +10,7 @@ Tags:
   - Exfiltration:Transfer Data to Cloud Account
 Severity: Medium
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1537
 Description: >
   Some AWS resource was made publicly accessible over the internet.

--- a/aws_cloudtrail_rules/aws_root_access_key_created.yml
+++ b/aws_cloudtrail_rules/aws_root_access_key_created.yml
@@ -10,7 +10,7 @@ Tags:
   - Identity and Access Management
   - Persistence:Account Manipulation
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1098
 Severity: Critical
 Description: An access key was created for the Root account

--- a/aws_cloudtrail_rules/aws_root_activity.yml
+++ b/aws_cloudtrail_rules/aws_root_activity.yml
@@ -14,7 +14,7 @@ Tags:
 Reports:
   CIS:
     - 3.3
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Severity: High
 Description: >

--- a/aws_cloudtrail_rules/aws_root_console_login.yml
+++ b/aws_cloudtrail_rules/aws_root_console_login.yml
@@ -11,7 +11,7 @@ Tags:
   - Initial Access:Valid Accounts
 Severity: High
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1078
 Description: Deprecated. Please see AWS.Console.RootLogin instead.
 Runbook: >

--- a/aws_cloudtrail_rules/aws_root_failed_console_login.yml
+++ b/aws_cloudtrail_rules/aws_root_failed_console_login.yml
@@ -11,7 +11,7 @@ Tags:
   - Initial Access:Valid Accounts
 Severity: High
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1078
 Description: >
   Deprecated. Please see AWS.Console.RootLoginFailed instead.

--- a/aws_cloudtrail_rules/aws_root_password_changed.yml
+++ b/aws_cloudtrail_rules/aws_root_password_changed.yml
@@ -11,7 +11,7 @@ Tags:
   - Persistence:Account Manipulation
 Severity: High
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1098
 Description: >
   Someone manually changed the Root console login password.

--- a/aws_cloudtrail_rules/aws_s3_activity_greynoise.yml
+++ b/aws_cloudtrail_rules/aws_s3_activity_greynoise.yml
@@ -5,7 +5,7 @@ Enabled: true
 Filename: aws_s3_activity_greynoise.py
 Reference: https://attack.mitre.org/techniques/T1530/
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Runbook: Investigate all actions taken and validate that the ARN conducting the acitivty was not compromised
 Severity: High

--- a/aws_cloudtrail_rules/aws_s3_bucket_deleted.yml
+++ b/aws_cloudtrail_rules/aws_s3_bucket_deleted.yml
@@ -9,7 +9,7 @@ Tags:
   - AWS
   - Impact:Data Destruction
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0040:T1485
 Severity: Info
 Description: A S3 Bucket, Policy, or Website was deleted

--- a/aws_cloudtrail_rules/aws_s3_bucket_policy_modified.yml
+++ b/aws_cloudtrail_rules/aws_s3_bucket_policy_modified.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   CIS:
     - 3.8
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1567
 Severity: Info
 DedupPeriodMinutes: 720 # 12 hours

--- a/aws_cloudtrail_rules/aws_security_configuration_change.yml
+++ b/aws_cloudtrail_rules/aws_security_configuration_change.yml
@@ -10,7 +10,7 @@ Tags:
   - Defense Evasion:Impair Defenses
 Severity: Medium
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Description: An account wide security configuration was changed.
 Runbook: >

--- a/aws_cloudtrail_rules/aws_snapshot_made_public.yml
+++ b/aws_cloudtrail_rules/aws_snapshot_made_public.yml
@@ -9,7 +9,7 @@ Tags:
   - AWS
   - Exfiltration:Transfer Data to Cloud Account
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1537
 Severity: Medium
 Description: An AWS storage snapshot was made public.

--- a/aws_cloudtrail_rules/aws_unauthorized_api_call.yml
+++ b/aws_cloudtrail_rules/aws_unauthorized_api_call.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   CIS:
     - 3.1
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0007:T1526
 Severity: Info
 Description: An unauthorized AWS API call was made

--- a/aws_cloudtrail_rules/aws_update_credentials.yml
+++ b/aws_cloudtrail_rules/aws_update_credentials.yml
@@ -6,7 +6,7 @@ Enabled: true
 LogTypes:
   - AWS.CloudTrail
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1098
 Tags:
   - AWS

--- a/aws_dynamodb_policies/aws_dynamodb_table_encryption.yml
+++ b/aws_dynamodb_policies/aws_dynamodb_table_encryption.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   PCI:
     - 3.4
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: High
 Description: >

--- a/aws_dynamodb_policies/aws_dynamodb_table_ttl_enabled.yml
+++ b/aws_dynamodb_policies/aws_dynamodb_table_ttl_enabled.yml
@@ -13,7 +13,7 @@ Tags:
 Reports:
   PCI:
     - 3.1
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: Medium
 Description: >

--- a/aws_ec2_policies/aws_ami_private.yml
+++ b/aws_ec2_policies/aws_ami_private.yml
@@ -11,7 +11,7 @@ Tags:
   - Panther Enterprise
   - Exfiltration:Transfer Data to Cloud Account
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1537
 Severity: High
 Description: >

--- a/aws_ec2_policies/aws_ec2_cde_volume_encrypted.yml
+++ b/aws_ec2_policies/aws_ec2_cde_volume_encrypted.yml
@@ -13,7 +13,7 @@ Tags:
 Reports:
   PCI:
     - 3.4
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1005
 Severity: Critical
 Description: >

--- a/aws_ec2_policies/aws_ec2_instance_approved_ami.yml
+++ b/aws_ec2_policies/aws_ec2_instance_approved_ami.yml
@@ -10,7 +10,7 @@ Tags:
   - Configuration Required
   - Impact:Resource Hijacking
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0040:T1496
 Severity: High
 Description: >

--- a/aws_ec2_policies/aws_ec2_instance_detailed_monitoring.yml
+++ b/aws_ec2_policies/aws_ec2_instance_detailed_monitoring.yml
@@ -6,7 +6,7 @@ Enabled: true
 ResourceTypes:
   - AWS.EC2.Instance
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Tags:
   - AWS

--- a/aws_ec2_policies/aws_ec2_volume_encryption.yml
+++ b/aws_ec2_policies/aws_ec2_volume_encryption.yml
@@ -10,7 +10,7 @@ Tags:
   - Data Protection
   - Collection:Data From Local System
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1005
 Severity: High
 Description: >

--- a/aws_ec2_policies/aws_ec2_volume_snapshot_encrypted.yml
+++ b/aws_ec2_policies/aws_ec2_volume_snapshot_encrypted.yml
@@ -10,7 +10,7 @@ Tags:
   - Panther
   - Collection:Data From Cloud Storage Object
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: High
 Description: >

--- a/aws_elb_policies/aws_application_load_balancer_web_acl.yml
+++ b/aws_elb_policies/aws_application_load_balancer_web_acl.yml
@@ -11,7 +11,7 @@ Tags:
   - Security Control
   - Initial Access:Exploit Public-Facing Application
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1190
 Severity: High
 Description: >

--- a/aws_guardduty_policies/aws_guardduty_enabled.yml
+++ b/aws_guardduty_policies/aws_guardduty_enabled.yml
@@ -10,7 +10,7 @@ Tags:
   - Security Control
   - Defense Evasion:Impair Defenses
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: High
 Description: >

--- a/aws_guardduty_policies/aws_guardduty_master_account.yml
+++ b/aws_guardduty_policies/aws_guardduty_master_account.yml
@@ -11,7 +11,7 @@ Tags:
   - Security Control
   - Defense Evasion:Impair Defenses
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: High
 Description: >

--- a/aws_iam_policies/aws_access_key_rotation.yml
+++ b/aws_iam_policies/aws_access_key_rotation.yml
@@ -13,7 +13,7 @@ Tags:
 Reports:
   CIS:
     - 1.4
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1552
 Severity: Medium
 Description: >

--- a/aws_iam_policies/aws_cloudtrail_least_privilege.yml
+++ b/aws_iam_policies/aws_cloudtrail_least_privilege.yml
@@ -12,7 +12,7 @@ Tags:
   - Panther
   - Defense Evasion:Impair Defenses
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: Medium
 Description: >

--- a/aws_iam_policies/aws_iam_group_users.yml
+++ b/aws_iam_policies/aws_iam_group_users.yml
@@ -10,7 +10,7 @@ Tags:
   - Identity & Access Managment
   - Privilege Escalation:Valid Accounts
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Severity: Low
 Description: >

--- a/aws_iam_policies/aws_iam_inline_policy_does_not_grant_network_admin_access.yml
+++ b/aws_iam_policies/aws_iam_inline_policy_does_not_grant_network_admin_access.yml
@@ -16,7 +16,7 @@ Reports:
     - 1.1.5
     - 2.2.4
     - 7.1.2
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1078
 Severity: Medium
 Description: >

--- a/aws_iam_policies/aws_iam_policy_administrative_privileges.yml
+++ b/aws_iam_policies/aws_iam_policy_administrative_privileges.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   CIS:
     - 1.22
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Severity: High
 Description: >

--- a/aws_iam_policies/aws_iam_policy_assigned_to_user.yml
+++ b/aws_iam_policies/aws_iam_policy_assigned_to_user.yml
@@ -15,7 +15,7 @@ Reports:
   PCI:
     - 2.2.4
     - 7.1.1
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Severity: Low
 Description: >

--- a/aws_iam_policies/aws_iam_policy_blocklist.yml
+++ b/aws_iam_policies/aws_iam_policy_blocklist.yml
@@ -8,7 +8,7 @@ ResourceTypes:
   - AWS.IAM.Role
   - AWS.IAM.User
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Tags:
   - AWS

--- a/aws_iam_policies/aws_iam_policy_does_not_grant_admin_access.yml
+++ b/aws_iam_policies/aws_iam_policy_does_not_grant_admin_access.yml
@@ -14,7 +14,7 @@ Reports:
   PCI:
     - 2.2.4
     - 7.1.2
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Severity: Medium
 Description: >

--- a/aws_iam_policies/aws_iam_policy_does_not_grant_network_admin_access.yml
+++ b/aws_iam_policies/aws_iam_policy_does_not_grant_network_admin_access.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   PCI:
     - 1.1.5
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Severity: Medium
 Description: >

--- a/aws_iam_policies/aws_iam_resource_does_not_have_inline_policy.yml
+++ b/aws_iam_policies/aws_iam_resource_does_not_have_inline_policy.yml
@@ -14,7 +14,7 @@ Reports:
   PCI:
     - 2.2.4
     - 7.1.1
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1078
 Severity: Medium
 Description: >

--- a/aws_iam_policies/aws_iam_role_restricts_usage.yml
+++ b/aws_iam_policies/aws_iam_role_restricts_usage.yml
@@ -13,7 +13,7 @@ Tags:
 Reports:
   PCI:
     - 2.2.4
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Severity: Medium
 Description: >

--- a/aws_iam_policies/aws_iam_user_mfa.yml
+++ b/aws_iam_policies/aws_iam_user_mfa.yml
@@ -15,7 +15,7 @@ Reports:
   PCI:
     - 8.3.1
     - 8.3.2
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1110
 Severity: High
 Description: >

--- a/aws_iam_policies/aws_iam_user_not_in_conflicting_groups.yml
+++ b/aws_iam_policies/aws_iam_user_not_in_conflicting_groups.yml
@@ -14,7 +14,7 @@ Tags:
 Reports:
   PCI:
     - 7.2.2
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Severity: Medium
 Description: >

--- a/aws_iam_policies/aws_root_account_access_keys.yml
+++ b/aws_iam_policies/aws_root_account_access_keys.yml
@@ -15,7 +15,7 @@ Reports:
   PCI:
     - 7.1.2
     - 8.5
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1098
 Severity: Critical
 Description: >

--- a/aws_iam_policies/aws_root_account_hardware_mfa.yml
+++ b/aws_iam_policies/aws_root_account_hardware_mfa.yml
@@ -15,7 +15,7 @@ Reports:
     - 1.14
   PCI:
     - 7.1.2
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Severity: High
 Description: >

--- a/aws_iam_policies/aws_root_account_mfa.yml
+++ b/aws_iam_policies/aws_root_account_mfa.yml
@@ -15,7 +15,7 @@ Reports:
     - 1.14
   PCI:
     - 7.1.2
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Severity: Critical
 Description: >

--- a/aws_kms_policies/aws_cmk_key_rotation.yml
+++ b/aws_kms_policies/aws_cmk_key_rotation.yml
@@ -14,7 +14,7 @@ Reports:
     - 2.8
   PCI:
     - 3.5.2
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1552
 Severity: Low
 Description: >

--- a/aws_kms_policies/aws_kms_key_policy_restricts_usage.yml
+++ b/aws_kms_policies/aws_kms_key_policy_restricts_usage.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   PCI:
     - 3.5.2
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1552
 Severity: High
 Description: >

--- a/aws_load_balancer_policies/aws_alb_ssl_policy.yml
+++ b/aws_load_balancer_policies/aws_alb_ssl_policy.yml
@@ -13,7 +13,7 @@ Reports:
   PCI:
     - 2.2.3
     - 4.1
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1190
 Severity: Medium
 Description: Ensures that deprecated TLS versions are not supported in internet-facing load balancers

--- a/aws_load_balancer_policies/aws_elbv2_load_balancer_has_ssl_policy.yml
+++ b/aws_load_balancer_policies/aws_elbv2_load_balancer_has_ssl_policy.yml
@@ -13,7 +13,7 @@ Reports:
   PCI:
     - 2.2.3
     - 4.1
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1190
 Severity: High
 Description: This policy validates that ELBV2 load balancer listeners are using an SSL policy.

--- a/aws_queries/cloudtrail_password_spraying.yml
+++ b/aws_queries/cloudtrail_password_spraying.yml
@@ -3,7 +3,7 @@ Filename: scheduled_rule_default.py
 RuleID: CloudTrail.Password.Spraying
 DisplayName: CloudTrail Password Spraying
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1078
 Tags:
   - Initial Access:Valid Accounts

--- a/aws_queries/vpc_dns_tunneling.yml
+++ b/aws_queries/vpc_dns_tunneling.yml
@@ -5,7 +5,7 @@ DisplayName: VPC DNS Tunneling
 Description: >
   Detect dns tunneling traffic using a scheduled query
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1599
 Tags:
   - Defense Evasion:Network Boundary Bridging

--- a/aws_rds_policies/aws_rds_instance_encryption.yml
+++ b/aws_rds_policies/aws_rds_instance_encryption.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   PCI:
     - 3.4
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: High
 Description: >

--- a/aws_rds_policies/aws_rds_instance_public_access.yml
+++ b/aws_rds_policies/aws_rds_instance_public_access.yml
@@ -10,7 +10,7 @@ Tags:
   - Data Protection
   - Exfiltration:Exfiltration Over Web Service
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1567
 Severity: High
 Description: >

--- a/aws_rds_policies/aws_rds_instance_snapshot_public_access.yml
+++ b/aws_rds_policies/aws_rds_instance_snapshot_public_access.yml
@@ -10,7 +10,7 @@ Tags:
   - Data Protection
   - Exfiltration:Exfiltration Over Web Service
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1567
 Severity: Critical
 Description: >

--- a/aws_redshift_policies/aws_redshift_cluster_encryption.yml
+++ b/aws_redshift_policies/aws_redshift_cluster_encryption.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   PCI:
     - 3.4
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: High
 Description: >

--- a/aws_redshift_policies/aws_redshift_cluster_logging.yml
+++ b/aws_redshift_policies/aws_redshift_cluster_logging.yml
@@ -6,7 +6,7 @@ Enabled: true
 ResourceTypes:
   - AWS.Redshift.Cluster
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Tags:
   - AWS

--- a/aws_s3_policies/aws_s3_bucket_action_restrictions.yml
+++ b/aws_s3_policies/aws_s3_bucket_action_restrictions.yml
@@ -13,7 +13,7 @@ Reports:
   PCI:
     - 10.5.1
     - 10.5.2
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0040:T1485
 Severity: Medium
 Description: >

--- a/aws_s3_policies/aws_s3_bucket_encryption.yml
+++ b/aws_s3_policies/aws_s3_bucket_encryption.yml
@@ -13,7 +13,7 @@ Reports:
   PCI:
     - 2.2.3
     - 3.4
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: High
 Description: >

--- a/aws_s3_policies/aws_s3_bucket_logging.yml
+++ b/aws_s3_policies/aws_s3_bucket_logging.yml
@@ -11,7 +11,7 @@ Tags:
   - Security Control
   - Defense Evasion:Impair Defenses
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: Low
 Description: >

--- a/aws_s3_policies/aws_s3_bucket_mfa_delete.yml
+++ b/aws_s3_policies/aws_s3_bucket_mfa_delete.yml
@@ -10,7 +10,7 @@ Tags:
   - Data Protection
   - Impact:Data Destruction
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0040:T1485
 Severity: Low
 Description: >

--- a/aws_s3_policies/aws_s3_bucket_object_lock_configured.yml
+++ b/aws_s3_policies/aws_s3_bucket_object_lock_configured.yml
@@ -13,7 +13,7 @@ Tags:
 Reports:
   PCI:
     - 10.5.3
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0040:T1485
 Severity: Low
 Description: >

--- a/aws_s3_policies/aws_s3_bucket_policy_allow_with_not_principal.yml
+++ b/aws_s3_policies/aws_s3_bucket_policy_allow_with_not_principal.yml
@@ -10,7 +10,7 @@ Tags:
   - Identity & Access Management
   - Collection:Data From Cloud Storage Object
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: High
 Description: >

--- a/aws_s3_policies/aws_s3_bucket_principal_restrictions.yml
+++ b/aws_s3_policies/aws_s3_bucket_principal_restrictions.yml
@@ -13,7 +13,7 @@ Reports:
   PCI:
     - 10.5.1
     - 10.5.2
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: High
 Description: >

--- a/aws_s3_policies/aws_s3_bucket_public_access_block.yml
+++ b/aws_s3_policies/aws_s3_bucket_public_access_block.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   PCI:
     - 2.2.3
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: Medium
 Description: >

--- a/aws_s3_policies/aws_s3_bucket_public_read.yml
+++ b/aws_s3_policies/aws_s3_bucket_public_read.yml
@@ -13,7 +13,7 @@ Tags:
 Reports:
   PCI:
     - 10.5.1
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: High
 Description: >

--- a/aws_s3_policies/aws_s3_bucket_public_write.yml
+++ b/aws_s3_policies/aws_s3_bucket_public_write.yml
@@ -13,7 +13,7 @@ Tags:
 Reports:
   PCI:
     - 10.5.2
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0040:T1485
 Severity: Critical
 Description: Ensures that the S3 bucket is not publicly writeable.

--- a/aws_s3_policies/aws_s3_bucket_secure_access.yml
+++ b/aws_s3_policies/aws_s3_bucket_secure_access.yml
@@ -13,7 +13,7 @@ Reports:
   PCI:
     - 2.2.3
     - 4.1
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: Low
 Description: >

--- a/aws_s3_policies/aws_s3_bucket_versioning.yml
+++ b/aws_s3_policies/aws_s3_bucket_versioning.yml
@@ -13,7 +13,7 @@ Reports:
   PCI:
     - 10.5.3
     - 10.5.5
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0040:T1485
 Severity: Low
 Description: >

--- a/aws_s3_rules/aws_s3_access_error.yml
+++ b/aws_s3_rules/aws_s3_access_error.yml
@@ -12,7 +12,7 @@ Tags:
   - Security Control
   - Discovery:Cloud Storage Object Discovery
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0007:T1619
 Severity: Info
 Description: >

--- a/aws_s3_rules/aws_s3_access_ip_allowlist.yml
+++ b/aws_s3_rules/aws_s3_access_ip_allowlist.yml
@@ -12,7 +12,7 @@ Tags:
   - Identity & Access Management
   - Collection:Data From Cloud Storage Object
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: Medium
 Description: >

--- a/aws_s3_rules/aws_s3_insecure_access.yml
+++ b/aws_s3_rules/aws_s3_insecure_access.yml
@@ -12,7 +12,7 @@ Tags:
   - Security Control
   - Collection:Data From Cloud Storage Object
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: Low
 Description: >

--- a/aws_s3_rules/aws_s3_unauthenticated_access.yml
+++ b/aws_s3_rules/aws_s3_unauthenticated_access.yml
@@ -11,7 +11,7 @@ Tags:
   - Security Control
   - Collection:Data From Cloud Storage Object
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: Low
 Description: >

--- a/aws_s3_rules/aws_s3_unknown_requester_get_object.yml
+++ b/aws_s3_rules/aws_s3_unknown_requester_get_object.yml
@@ -14,7 +14,7 @@ Tags:
 Reports:
   Panther:
     - Data Access
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: Low
 Description: Validates that proper IAM entities are accessing sensitive data buckets.

--- a/aws_vpc_flow_rules/aws_vpc_inbound_traffic_port_allowlist.yml
+++ b/aws_vpc_flow_rules/aws_vpc_inbound_traffic_port_allowlist.yml
@@ -11,7 +11,7 @@ Tags:
   - Security Control
   - Command and Control:Non-Standard Port
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0011:T1571
 Severity: High
 Description: >

--- a/aws_vpc_flow_rules/aws_vpc_inbound_traffic_port_blocklist.yml
+++ b/aws_vpc_flow_rules/aws_vpc_inbound_traffic_port_blocklist.yml
@@ -11,7 +11,7 @@ Tags:
   - Security Control
   - Command and Control:Non-Standard Port
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0011:T1571
 Severity: High
 Description: >

--- a/aws_vpc_flow_rules/aws_vpc_unapproved_outbound_dns.yml
+++ b/aws_vpc_flow_rules/aws_vpc_unapproved_outbound_dns.yml
@@ -11,7 +11,7 @@ Tags:
   - Security Control
   - Command and Control:Application Layer Protocol
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0011:T1071
 Severity: Medium
 Description: >

--- a/aws_vpc_policies/aws_network_acl_restricted_ssh.yml
+++ b/aws_vpc_policies/aws_network_acl_restricted_ssh.yml
@@ -10,7 +10,7 @@ Tags:
   - Panther
   - Lateral Movement:Remote Services
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0008:T1021
 Severity: High
 Description: >

--- a/aws_vpc_policies/aws_network_acl_restricts_inbound_traffic.yml
+++ b/aws_vpc_policies/aws_network_acl_restricts_inbound_traffic.yml
@@ -14,7 +14,7 @@ Reports:
     - 1.3.5
     - 1.2.1
     - 1.1.4
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1190
 Severity: High
 Description: >

--- a/aws_vpc_policies/aws_network_acl_restricts_insecure_protocols.yml
+++ b/aws_vpc_policies/aws_network_acl_restricts_insecure_protocols.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   PCI:
     - 8.2.1
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0011:T1095
 Severity: Medium
 Description: >

--- a/aws_vpc_policies/aws_network_acl_restricts_outbound_traffic.yml
+++ b/aws_vpc_policies/aws_network_acl_restricts_outbound_traffic.yml
@@ -13,7 +13,7 @@ Reports:
   PCI:
     - 1.1.4
     - 1.3.2
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1567
 Severity: Medium
 Description: >

--- a/aws_vpc_policies/aws_only_dmz_security_groups_publicly_accessible.yml
+++ b/aws_vpc_policies/aws_only_dmz_security_groups_publicly_accessible.yml
@@ -13,7 +13,7 @@ Reports:
   PCI:
     - 1.3.1
     - 1.1.4
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1190
 Severity: High
 Description: >

--- a/aws_vpc_policies/aws_security_group_administrative_ingress.yml
+++ b/aws_vpc_policies/aws_security_group_administrative_ingress.yml
@@ -13,7 +13,7 @@ Reports:
   CIS:
     - 4.1
     - 4.2
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1190
 Severity: High
 Description: >

--- a/aws_vpc_policies/aws_security_group_restricts_access_to_cde.yml
+++ b/aws_vpc_policies/aws_security_group_restricts_access_to_cde.yml
@@ -13,7 +13,7 @@ Reports:
   PCI:
     - 1.3.2
     - 1.3.5
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1190
 Severity: Critical
 Description: >

--- a/aws_vpc_policies/aws_security_group_restricts_inbound_traffic.yml
+++ b/aws_vpc_policies/aws_security_group_restricts_inbound_traffic.yml
@@ -13,7 +13,7 @@ Reports:
   PCI:
     - 1.1.4
     - 1.3.5
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1190
 Severity: High
 Description: >

--- a/aws_vpc_policies/aws_security_group_restricts_inter_security_group_traffic.yml
+++ b/aws_vpc_policies/aws_security_group_restricts_inter_security_group_traffic.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   PCI:
     - 1.2.1
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0008:T1210
 Severity: Medium
 Description: >

--- a/aws_vpc_policies/aws_security_group_restricts_outbound_traffic.yml
+++ b/aws_vpc_policies/aws_security_group_restricts_outbound_traffic.yml
@@ -13,7 +13,7 @@ Reports:
   PCI:
     - 1.1.4
     - 1.3.2
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1567
 Severity: Medium
 Description: >

--- a/aws_vpc_policies/aws_security_group_restricts_traffic_leaving_cde.yml
+++ b/aws_vpc_policies/aws_security_group_restricts_traffic_leaving_cde.yml
@@ -10,7 +10,7 @@ Tags:
   - PCI
   - Exfiltration:Exfiltration Over Web Service
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1567
 Severity: High
 Description: >

--- a/aws_vpc_policies/aws_security_group_tightly_restricts_inbound_traffic.yml
+++ b/aws_vpc_policies/aws_security_group_tightly_restricts_inbound_traffic.yml
@@ -14,7 +14,7 @@ Reports:
     - 1.1.4
     - 1.2.1
     - 8.2.1
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1190
 Severity: Medium
 Description: >

--- a/aws_vpc_policies/aws_security_group_tightly_restricts_outbound_traffic.yml
+++ b/aws_vpc_policies/aws_security_group_tightly_restricts_outbound_traffic.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   PCI:
     - 1.1.4
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1567
 Severity: Medium
 Description: >

--- a/aws_vpc_policies/aws_vpc_default_network_acl_restricts_all_traffic.yml
+++ b/aws_vpc_policies/aws_vpc_default_network_acl_restricts_all_traffic.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   PCI:
     - 1.2.1
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1133
 Severity: Low
 Description: >

--- a/aws_vpc_policies/aws_vpc_default_security_restrictions.yml
+++ b/aws_vpc_policies/aws_vpc_default_security_restrictions.yml
@@ -14,7 +14,7 @@ Reports:
     - 4.3
   PCI:
     - 1.2.1
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1133
 Severity: Low
 Description: >

--- a/aws_vpc_policies/aws_vpc_flow_logs.yml
+++ b/aws_vpc_policies/aws_vpc_flow_logs.yml
@@ -12,7 +12,7 @@ Tags:
 Reports:
   CIS:
     - 2.9
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: Medium
 Description: >

--- a/aws_waf_policies/aws_waf_has_xss_predicate.yml
+++ b/aws_waf_policies/aws_waf_has_xss_predicate.yml
@@ -13,7 +13,7 @@ Tags:
 Reports:
   PCI:
     - 6.5.7
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1190
 Severity: High
 Description: >

--- a/box_rules/box_anomalous_download.yml
+++ b/box_rules/box_anomalous_download.yml
@@ -9,7 +9,7 @@ Tags:
   - Box
   - Exfiltration:Exfiltration Over Web Service
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1567
 Severity: High
 Description: >

--- a/box_rules/box_event_triggered_externally.yml
+++ b/box_rules/box_event_triggered_externally.yml
@@ -9,7 +9,7 @@ Tags:
   - Box
   - Exfiltration:Exfiltration Over Web Service
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1567
 Severity: Medium
 Description: >

--- a/box_rules/box_item_shared_externally.yml
+++ b/box_rules/box_item_shared_externally.yml
@@ -9,7 +9,7 @@ Tags:
   - Box
   - Exfiltration:Exfiltration Over Web Service
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1567
 Severity: Medium
 Description: >

--- a/box_rules/box_malicious_content.yml
+++ b/box_rules/box_malicious_content.yml
@@ -9,7 +9,7 @@ Tags:
   - Box
   - Execution:User Execution
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0002:T1204
 Severity: High
 Description: >

--- a/box_rules/box_new_login.yml
+++ b/box_rules/box_new_login.yml
@@ -9,7 +9,7 @@ Tags:
   - Box
   - Initial Access:Valid Accounts
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1078
 Severity: Info
 Description: >

--- a/box_rules/box_suspicious_login_or_session.yml
+++ b/box_rules/box_suspicious_login_or_session.yml
@@ -9,7 +9,7 @@ Tags:
   - Box
   - Initial Access:Valid Accounts
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1078
 Severity: High
 Description: >

--- a/box_rules/box_untrusted_device.yml
+++ b/box_rules/box_untrusted_device.yml
@@ -9,7 +9,7 @@ Tags:
   - Box
   - Initial Access:Valid Accounts
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1078
 Severity: Info
 Description: >

--- a/box_rules/box_user_downloads.yml
+++ b/box_rules/box_user_downloads.yml
@@ -9,7 +9,7 @@ Tags:
   - Box
   - Exfiltration:Exfiltration Over Web Service
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1567
 Severity: Low
 Description: >

--- a/box_rules/box_user_permission_updates.yml
+++ b/box_rules/box_user_permission_updates.yml
@@ -9,7 +9,7 @@ Tags:
   - Box
   - Privilege Escalation:Abuse Elevation Control Mechanism
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1548
 Severity: Low
 Description: >

--- a/crowdstrike_rules/crowdstrike_dns_request.yml
+++ b/crowdstrike_rules/crowdstrike_dns_request.yml
@@ -10,7 +10,7 @@ Tags:
   - Initial Access:Phishing
 Severity: Critical
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1566
 Description: A DNS request was made to a domain on an explicit denylist
 Reference: https://docs.runpanther.io/data-onboarding/supported-logs/crowdstrike#crowdstrike-dnsrequest

--- a/gcp_audit_rules/gcp_gcs_iam_changes.yml
+++ b/gcp_audit_rules/gcp_gcs_iam_changes.yml
@@ -13,7 +13,7 @@ Tags:
 Reports:
   CIS:
     - 2.10
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: Low
 Description: >

--- a/gcp_audit_rules/gcp_gcs_public.yml
+++ b/gcp_audit_rules/gcp_gcs_public.yml
@@ -11,7 +11,7 @@ Tags:
   - Google Cloud Storage
   - Collection:Data From Cloud Storage Object
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1530
 Severity: High
 Description: Adversaries may access data objects from improperly secured cloud storage.

--- a/gcp_audit_rules/gcp_iam_admin_role_assigned.yml
+++ b/gcp_audit_rules/gcp_iam_admin_role_assigned.yml
@@ -10,7 +10,7 @@ Tags:
   - Identity & Access Management
   - Privilege Escalation:Valid Accounts
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Severity: Medium
 Description: Attaching an audit role manually could be a sign of privilege escalation

--- a/gcp_audit_rules/gcp_iam_corp_email.yml
+++ b/gcp_audit_rules/gcp_iam_corp_email.yml
@@ -11,7 +11,7 @@ Tags:
   - Identity & Access Management
   - Persistence:Create Account
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1136
   CIS:
     - 1.1

--- a/gcp_audit_rules/gcp_iam_custom_role_changes.yml
+++ b/gcp_audit_rules/gcp_iam_custom_role_changes.yml
@@ -13,7 +13,7 @@ Tags:
 Reports:
   CIS:
     - 2.6
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Severity: Info
 Description: A custom role has been created, deleted, or updated.

--- a/gcp_audit_rules/gcp_unused_regions.yml
+++ b/gcp_audit_rules/gcp_unused_regions.yml
@@ -12,7 +12,7 @@ Tags:
   - Configuration Required
   - Defense Evasion:Unused/Unsupported Cloud Regions
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1535
 Severity: Medium
 Description: >

--- a/github_rules/github_branch_policy_override.yml
+++ b/github_rules/github_branch_policy_override.yml
@@ -9,7 +9,7 @@ Tags:
   - GitHub
   - Initial Access:Supply Chain Compromise
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1195
 Severity: High
 Description: Bypassing branch protection controls could indicate malicious use of admin credentials in an attempt to hide activity.

--- a/github_rules/github_branch_protection_disabled.yml
+++ b/github_rules/github_branch_protection_disabled.yml
@@ -9,7 +9,7 @@ Tags:
   - GitHub
   - Initial Access:Supply Chain Compromise
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1195
 Severity: High
 Description: Disabling branch protection controls could indicate malicious use of admin credentials in an attempt to hide activity.

--- a/github_rules/github_org_auth_modified.yml
+++ b/github_rules/github_org_auth_modified.yml
@@ -9,7 +9,7 @@ Tags:
   - GitHub
   - Persistence:Account Manipulation
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1098
 Severity: Critical
 SummaryAttributes:

--- a/github_rules/github_org_ip_allowlist.yml
+++ b/github_rules/github_org_ip_allowlist.yml
@@ -9,7 +9,7 @@ Tags:
   - GitHub
   - Persistence:Account Manipulation
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1098
 Severity: Medium
 SummaryAttributes:

--- a/github_rules/github_org_modified.yml
+++ b/github_rules/github_org_modified.yml
@@ -9,7 +9,7 @@ Tags:
   - GitHub
   - Initial Access:Supply Chain Compromise
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1195
 Severity: Info
 Description: Detects when a user is added or removed from a GitHub Org.

--- a/github_rules/github_repo_collaborator_change.yml
+++ b/github_rules/github_repo_collaborator_change.yml
@@ -9,7 +9,7 @@ Tags:
   - GitHub
   - Initial Access:Supply Chain Compromise
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1195
 Severity: Medium
 Description: Detects when a repository collaborator is added or removed.

--- a/github_rules/github_repo_hook_modified.yml
+++ b/github_rules/github_repo_hook_modified.yml
@@ -9,7 +9,7 @@ Tags:
   - GitHub
   - Exfiltration:Automated Exfiltration
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1020
 Severity: Info
 Description: Detects when a web hook is added, modified, or deleted in an org repository. 

--- a/github_rules/github_repo_visibility_change.yml
+++ b/github_rules/github_repo_visibility_change.yml
@@ -9,7 +9,7 @@ Tags:
   - GitHub
   - Exfiltration:Exfiltration Over Web Service
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0010:T1567
 Severity: High
 Description: Detects when an organization repository visibility changes.

--- a/github_rules/github_team_modified.yml
+++ b/github_rules/github_team_modified.yml
@@ -9,7 +9,7 @@ Tags:
   - GitHub
   - Initial Access:Supply Chain Compromise
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1195
 Severity: Info
 Description: Detects when a team is modified in some way, such as adding a new team, deleting a team, modifying members, or a change in repository control.

--- a/github_rules/github_user_access_key_created.yml
+++ b/github_rules/github_user_access_key_created.yml
@@ -9,7 +9,7 @@ Tags:
   - GitHub
   - Persistence:Valid Accounts
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1078
 Severity: Info
 Description: Detects when a GitHub user access key is created.

--- a/github_rules/github_user_role_updated.yml
+++ b/github_rules/github_user_role_updated.yml
@@ -9,7 +9,7 @@ Tags:
   - GitHub
   - Persistence:Account Manipulation
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1098
 Severity: High
 Description: Detects when a GitHub user role is upgraded to an admin or downgraded to a member

--- a/gravitational_teleport_rules/teleport_auth_errors.yml
+++ b/gravitational_teleport_rules/teleport_auth_errors.yml
@@ -10,7 +10,7 @@ Tags:
   - Credential Access:Brute Force
 Severity: Medium
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1110
 Description: A high volume of SSH errors could indicate a brute-force attack
 Threshold: 10

--- a/gravitational_teleport_rules/teleport_create_user_accounts.yml
+++ b/gravitational_teleport_rules/teleport_create_user_accounts.yml
@@ -9,7 +9,7 @@ Tags:
   - SSH
   - Persistence:Create Account
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1136
 Severity: High
 Description: A user has been manually created, modified, or delted

--- a/gravitational_teleport_rules/teleport_network_scanning.yml
+++ b/gravitational_teleport_rules/teleport_network_scanning.yml
@@ -12,7 +12,7 @@ Severity: Medium
 Description: A user has invoked a network scan that could potentially indicate enumeration of the network.
 DedupPeriodMinutes: 60
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0007:T1046
 Reference: https://gravitational.com/teleport/docs/admin-guide/
 Runbook: >

--- a/gravitational_teleport_rules/teleport_scheduled_jobs.yml
+++ b/gravitational_teleport_rules/teleport_scheduled_jobs.yml
@@ -10,7 +10,7 @@ Tags:
   - Execution:Scheduled Task/Job
 Severity: Medium
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0002:T1053
 Description: A user has manually edited the Linux crontab
 Threshold: 10

--- a/gravitational_teleport_rules/teleport_suspicious_commands.yml
+++ b/gravitational_teleport_rules/teleport_suspicious_commands.yml
@@ -12,7 +12,7 @@ Severity: Medium
 Description: A user has invoked a suspicious command that could lead to a host compromise
 DedupPeriodMinutes: 60
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0002:T1059
 Reference: https://gravitational.com/teleport/docs/admin-guide/
 Runbook: >

--- a/gsuite_activityevent_rules/gsuite_advanced_protection.yml
+++ b/gsuite_activityevent_rules/gsuite_advanced_protection.yml
@@ -9,7 +9,7 @@ Tags:
   - GSuite
   - Defense Evasion:Impair Defenses
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: Low
 Description: >

--- a/gsuite_activityevent_rules/gsuite_doc_ownership_transfer.yml
+++ b/gsuite_activityevent_rules/gsuite_doc_ownership_transfer.yml
@@ -10,7 +10,7 @@ Tags:
   - Configuration Required
   - Collection:Data from Information Repositories
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1213
 Severity: Low
 Description: >

--- a/gsuite_activityevent_rules/gsuite_external_forwarding.yml
+++ b/gsuite_activityevent_rules/gsuite_external_forwarding.yml
@@ -9,7 +9,7 @@ Tags:
   - GSuite
   - Collection:Email Collection
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1114
 Severity: High
 Description: >

--- a/gsuite_activityevent_rules/gsuite_leaked_password.yml
+++ b/gsuite_activityevent_rules/gsuite_leaked_password.yml
@@ -9,7 +9,7 @@ Tags:
   - GSuite
   - Credential Access:Unsecured Credentials
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1552
 Severity: High
 Description: >

--- a/gsuite_activityevent_rules/gsuite_login_type.yml
+++ b/gsuite_activityevent_rules/gsuite_login_type.yml
@@ -10,7 +10,7 @@ Tags:
   - Configuration Required
   - Initial Access:Valid Accounts
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1078
 Severity: Medium
 Description: >

--- a/gsuite_activityevent_rules/gsuite_mobile_device_screen_unlock_fail.yml
+++ b/gsuite_activityevent_rules/gsuite_mobile_device_screen_unlock_fail.yml
@@ -9,7 +9,7 @@ Tags:
   - GSuite
   - Credential Access:Brute Force
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1110
 Severity: Medium
 Description: >

--- a/gsuite_activityevent_rules/gsuite_two_step_verification.yml
+++ b/gsuite_activityevent_rules/gsuite_two_step_verification.yml
@@ -9,7 +9,7 @@ Tags:
   - GSuite
   - Defense Evasion:Modify Authentication Process
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1556
 Severity: Low
 Description: >

--- a/gsuite_reports_rules/gsuite_drive_external_share.yml
+++ b/gsuite_reports_rules/gsuite_drive_external_share.yml
@@ -11,7 +11,7 @@ Tags:
   - Configuration Required
   - Collection:Data from Information Repositories
 Reports:
-   MITRE ATTACK:
+   MITRE ATT&CK:
     - TA0009:T1213
 Severity: High
 Description: An employee shared a sensitive file externally with another organization

--- a/gsuite_reports_rules/gsuite_drive_overly_visible.yml
+++ b/gsuite_reports_rules/gsuite_drive_overly_visible.yml
@@ -9,7 +9,7 @@ Tags:
   - GSuite
   - Collection:Data from Information Repositories
 Reports:
-   MITRE ATTACK:
+   MITRE ATT&CK:
     - TA0009:T1213
 Severity: Info
 Description: >

--- a/gsuite_reports_rules/gsuite_drive_visibility_change.yml
+++ b/gsuite_reports_rules/gsuite_drive_visibility_change.yml
@@ -9,7 +9,7 @@ Tags:
   - GSuite
   - Collection:Data from Information Repositories
 Reports:
-   MITRE ATTACK:
+   MITRE ATT&CK:
     - TA0009:T1213
 Severity: Low
 Description: >

--- a/indicator_creation_rules/new_aws_account_logging.yml
+++ b/indicator_creation_rules/new_aws_account_logging.yml
@@ -11,7 +11,7 @@ Tags:
   - Persistence:Create Account
 Severity: Info
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1136
 Description: A new AWS account was created
 Runbook: A new AWS account was created, ensure it was created through standard practice and is for a valid purpose.

--- a/indicator_creation_rules/new_user_account_logging.yml
+++ b/indicator_creation_rules/new_user_account_logging.yml
@@ -20,7 +20,7 @@ Tags:
   - Persistence:Create Account
 Severity: Info
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1136
 Description: A new account was created
 Runbook: A new user account was created, ensure it was created through standard practice and is for a valid purpose.

--- a/okta_rules/okta_account_support_access.yml
+++ b/okta_rules/okta_account_support_access.yml
@@ -11,7 +11,7 @@ Tags:
   - Okta
   - Initial Access:Trusted Relationship
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1199
 Severity: Medium
 Description: An admin user has granted accesss to Okta Support to your account

--- a/okta_rules/okta_admin_disabled_mfa.yml
+++ b/okta_rules/okta_admin_disabled_mfa.yml
@@ -11,7 +11,7 @@ Tags:
   - Okta
   - Defense Evasion:Modify Authentication Process
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1556
 Severity: High
 Description: An admin user has disabled the MFA requirement for your Okta account

--- a/okta_rules/okta_admin_role_assigned.yml
+++ b/okta_rules/okta_admin_role_assigned.yml
@@ -10,7 +10,7 @@ Tags:
   - Okta
   - Privilege Escalation:Valid Accounts
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Severity: Info
 Description: A user has been granted administrative privileges in Okta

--- a/okta_rules/okta_api_key_created.yml
+++ b/okta_rules/okta_api_key_created.yml
@@ -10,7 +10,7 @@ Tags:
   - Okta
   - Credential Access:Steal Application Access Token
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1528
 Severity: Info
 Description: A user created an API Key in Okta

--- a/okta_rules/okta_geo_improbable_access.yml
+++ b/okta_rules/okta_geo_improbable_access.yml
@@ -10,7 +10,7 @@ Tags:
   - Okta
   - Initial Access:Valid Accounts
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1078
 Severity: High
 Description: A user has subsequent logins from two geographic locations that are very far apart

--- a/okta_rules/okta_support_reset.yml
+++ b/okta_rules/okta_support_reset.yml
@@ -11,7 +11,7 @@ Tags:
   - Okta
   - Initial Access:Trusted Relationship
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1199
 Severity: High
 Description: A Password or MFA factor was reset by Okta Support

--- a/onelogin_rules/onelogin_active_login_activity.yml
+++ b/onelogin_rules/onelogin_active_login_activity.yml
@@ -10,7 +10,7 @@ Tags:
   - Lateral Movement:Use Alternate Authentication Material
 Severity: Medium
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0008:T1550
 Description: Multiple user accounts logged in from the same ip address.
 Reference: https://developers.onelogin.com/api-docs/1/events/event-resource 

--- a/onelogin_rules/onelogin_brute_force_by_ip.yml
+++ b/onelogin_rules/onelogin_brute_force_by_ip.yml
@@ -10,7 +10,7 @@ Tags:
   - Credential Access:Brute Force
 Severity: Medium
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1110
 Description: A single ip address was denied access to OneLogin more times than the configured threshold.
 Threshold: 10

--- a/onelogin_rules/onelogin_brute_force_by_username.yml
+++ b/onelogin_rules/onelogin_brute_force_by_username.yml
@@ -10,7 +10,7 @@ Tags:
   - Credential Access:Brute Force
 Severity: Medium
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1110
 Description: A OneLogin user was denied access more times than the configured threshold.
 Threshold: 10

--- a/onelogin_rules/onelogin_password_accessed.yml
+++ b/onelogin_rules/onelogin_password_accessed.yml
@@ -9,7 +9,7 @@ Tags:
   - OneLogin
   - Credential Access:Unsecured Credentials
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1552
 Severity: Medium
 Description: >

--- a/onelogin_rules/onelogin_remove_authentication_factor.yml
+++ b/onelogin_rules/onelogin_remove_authentication_factor.yml
@@ -10,7 +10,7 @@ Tags:
   - Identity & Access Management
   - Defense Evasion:Modify Authentication Process
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1556
 Severity: Low
 Description: >

--- a/onelogin_rules/onelogin_threshold_accounts_deleted.yml
+++ b/onelogin_rules/onelogin_threshold_accounts_deleted.yml
@@ -10,7 +10,7 @@ Tags:
   - Impact:Account Access Removal
 Severity: Medium
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0040:T1531
 Description: >
   Possible Denial of Sevice detected. Threshold for user account deletions exceeded.

--- a/onelogin_rules/onelogin_threshold_accounts_modified.yml
+++ b/onelogin_rules/onelogin_threshold_accounts_modified.yml
@@ -10,7 +10,7 @@ Tags:
   - Impact:Account Access Removal
 Severity: Medium
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0040:T1531
 Description: >
   Possible Denial of Sevice detected. Threshold for user account password changes exceeded.

--- a/onelogin_rules/onelogin_unauthorized_access.yml
+++ b/onelogin_rules/onelogin_unauthorized_access.yml
@@ -9,7 +9,7 @@ Tags:
   - OneLogin
   - Lateral Movement:Use Alternate Authentication Material
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0008:T1550
 Severity: Medium
 Description: A OneLogin user was denied access to an app more times than the configured threshold.

--- a/onelogin_rules/onelogin_user_account_locked.yml
+++ b/onelogin_rules/onelogin_user_account_locked.yml
@@ -9,7 +9,7 @@ Tags:
   - OneLogin
   - Credential Access:Brute Force
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1110
 Severity: Low
 Description: >

--- a/onelogin_rules/onelogin_user_assumed.yml
+++ b/onelogin_rules/onelogin_user_assumed.yml
@@ -9,7 +9,7 @@ Tags:
   - OneLogin
   - Lateral Movement:Use Alternate Authentication Material
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0008:T1550
 Severity: Low
 Description: User assumed another user account

--- a/onepassword_rules/onepassword_lut_sensitive_item_access.yml
+++ b/onepassword_rules/onepassword_lut_sensitive_item_access.yml
@@ -18,7 +18,7 @@ Tags:
   - BETA
   - Credential Access:Unsecured Credentials
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1552
 Tests:
   -

--- a/onepassword_rules/onepassword_sensitive_item_access.yml
+++ b/onepassword_rules/onepassword_sensitive_item_access.yml
@@ -16,7 +16,7 @@ Tags:
   - 1Password
   - Credential Access:Unsecured Credentials
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1552
 Tests:
   -

--- a/onepassword_rules/onepassword_unusual_client.yml
+++ b/onepassword_rules/onepassword_unusual_client.yml
@@ -13,7 +13,7 @@ Tags:
   - 1Password
   - Credential Access:Forge Web Credentials
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1606
 SummaryAttributes:
   - p_any_ip_addresses

--- a/osquery_rules/osquery_linux_aws_commands.yml
+++ b/osquery_rules/osquery_linux_aws_commands.yml
@@ -10,7 +10,7 @@ Tags:
   - Linux
   - Execution:User Execution
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0002:T1204
 Severity: Medium
 Description: An AWS command was executed on a Linux instance

--- a/osquery_rules/osquery_linux_logins_non_office.yml
+++ b/osquery_rules/osquery_linux_logins_non_office.yml
@@ -11,7 +11,7 @@ Tags:
   - Linux
   - Initial Access:Valid Accounts
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1078
 Severity: High
 Description: A system has been logged into from a non approved IP space.

--- a/osquery_rules/osquery_mac_application_firewall.yml
+++ b/osquery_rules/osquery_mac_application_firewall.yml
@@ -14,7 +14,7 @@ Reports:
   CIS:
     - 2.6.3
     - 2.6.4
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: High
 Description: >

--- a/osquery_rules/osquery_mac_enable_auto_update.yml
+++ b/osquery_rules/osquery_mac_enable_auto_update.yml
@@ -13,7 +13,7 @@ Tags:
 Reports:
   CIS:
     - 1.2
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: Medium
 DedupPeriodMinutes: 1440

--- a/osquery_rules/osquery_mac_osx_attacks.yml
+++ b/osquery_rules/osquery_mac_osx_attacks.yml
@@ -11,7 +11,7 @@ Tags:
   - Malware
   - Resource Development:Develop Capabilites
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0042:T1588
 Severity: Medium
 Description: Malware has potentially been detected on a macOS system

--- a/osquery_rules/osquery_mac_osx_attacks_keyboard_events.yml
+++ b/osquery_rules/osquery_mac_osx_attacks_keyboard_events.yml
@@ -11,7 +11,7 @@ Tags:
   - Malware
   - Collection:Input Capture
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1056
 Severity: Medium
 Description: A Key Logger has potentially been detected on a macOS system

--- a/osquery_rules/osquery_mac_unwanted_chrome_extensions.yml
+++ b/osquery_rules/osquery_mac_unwanted_chrome_extensions.yml
@@ -11,7 +11,7 @@ Tags:
   - Malware
   - Persistence:Browser Extentions
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1176
 Severity: Medium
 Description: >

--- a/osquery_rules/osquery_ossec.yml
+++ b/osquery_rules/osquery_ossec.yml
@@ -10,7 +10,7 @@ Tags:
   - Malware
   - Defense Evasion:Rootkit
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1014
 Severity: Medium
 Description: >

--- a/osquery_rules/osquery_ssh_listener.yml
+++ b/osquery_rules/osquery_ssh_listener.yml
@@ -9,7 +9,7 @@ Tags:
   - Osquery
   - Lateral Movement:Remote Services
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0008:T1021
 Severity: Medium
 Description: >

--- a/osquery_rules/osquery_suspicious_cron.yml
+++ b/osquery_rules/osquery_suspicious_cron.yml
@@ -9,7 +9,7 @@ Tags:
   - Osquery
   - Execution:Scheduled Task/Job
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0002:T1053
 Severity: High
 Description: A suspicious cron has been added

--- a/panther_audit_rules/panther_detection_deleted.yml
+++ b/panther_audit_rules/panther_detection_deleted.yml
@@ -10,7 +10,7 @@ Tags:
   - DataModel
   - Defense Evasion:Impair Defenses
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Description: Detection content has been removed from Panther.
 Runbook: Ensure this change was approved and appropriate.

--- a/panther_audit_rules/panther_saml_modified.yml
+++ b/panther_audit_rules/panther_saml_modified.yml
@@ -10,7 +10,7 @@ Tags:
   - DataModel
   - Defense Evasion:Impair Defenses
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Description: An Admin has modified Panther's SAML configuration.
 Runbook: Ensure this change was approved and appropriate.

--- a/panther_audit_rules/panther_sensitive_role_created.yml
+++ b/panther_audit_rules/panther_sensitive_role_created.yml
@@ -10,7 +10,7 @@ Tags:
   - DataModel
   - Persistence:Account Manipulation
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1098
 Description: A Panther user role has been created that contains admin level permissions.
 Runbook: Contact the creator of this role to ensure its creation was appropriate.

--- a/panther_ioc_rules/log4j_exploit_iocs.yml
+++ b/panther_ioc_rules/log4j_exploit_iocs.yml
@@ -25,7 +25,7 @@ Tags:
   - Log4J
   - Execution:Exploitation for Client Execution
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0002:T1203
 Severity: Critical
 Description: >

--- a/panther_ioc_rules/sunburst_fqdn_iocs.yml
+++ b/panther_ioc_rules/sunburst_fqdn_iocs.yml
@@ -28,7 +28,7 @@ Tags:
   - Osquery
   - Initial Access:Trusted Relationship
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1199
 Severity: High
 Description: >

--- a/panther_ioc_rules/sunburst_sha256_iocs.yml
+++ b/panther_ioc_rules/sunburst_sha256_iocs.yml
@@ -26,7 +26,7 @@ Tags:
   - Osquery
   - Initial Access:Trusted Relationship
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1199
 Severity: High
 Description: >

--- a/snowflake_queries/snowflake_account_admin_assigned.yml
+++ b/snowflake_queries/snowflake_account_admin_assigned.yml
@@ -9,7 +9,7 @@ Tags:
   - Snowflake
   - Privilege Escalation:Valid Accounts
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 ScheduledQueries:
   - Query.Snowflake.AccountAdminGranted

--- a/snowflake_queries/snowflake_brute_force_ip.yml
+++ b/snowflake_queries/snowflake_brute_force_ip.yml
@@ -11,7 +11,7 @@ Tags:
   - Snowflake
   - Credential Access:Brute Force
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1110
 Severity: Medium
 Tests:

--- a/snowflake_queries/snowflake_brute_force_username.yml
+++ b/snowflake_queries/snowflake_brute_force_username.yml
@@ -11,7 +11,7 @@ Tags:
   - Snowflake
   - Credential Access:Brute Force
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1110
 Severity: Medium
 Tests:

--- a/snowflake_queries/snowflake_key_user_password_login.yml
+++ b/snowflake_queries/snowflake_key_user_password_login.yml
@@ -11,7 +11,7 @@ Tags:
   - Snowflake
   - Persistence:Account Manipulation
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1098
 Severity: Medium
 Tests:

--- a/snowflake_queries/snowflake_login_without_mfa.yml
+++ b/snowflake_queries/snowflake_login_without_mfa.yml
@@ -11,7 +11,7 @@ Tags:
   - Snowflake
   - Defense Evasion:Modify Authentication Process
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1556
 Severity: Medium
 Tests:

--- a/snowflake_queries/snowflake_network_policy_modified.yml
+++ b/snowflake_queries/snowflake_network_policy_modified.yml
@@ -11,7 +11,7 @@ Tags:
   - Snowflake
   - Defense Evasion:Impair Defenses
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1562
 Severity: Medium
 Tests:

--- a/snowflake_queries/snowflake_privileged_object_changes.yml
+++ b/snowflake_queries/snowflake_privileged_object_changes.yml
@@ -11,7 +11,7 @@ Tags:
   - Snowflake
   - Defense Evasion:File and Directory Permissions Modification
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1222
 Severity: Info
 Tests:

--- a/snowflake_queries/snowflake_scim_token_created.yml
+++ b/snowflake_queries/snowflake_scim_token_created.yml
@@ -10,7 +10,7 @@ Tags:
   - Snowflake
   - Persistence:Modify Authentication Process
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1556
 Severity: Info
 Tests:

--- a/snowflake_queries/snowflake_unusual_login_volume.yml
+++ b/snowflake_queries/snowflake_unusual_login_volume.yml
@@ -11,7 +11,7 @@ Tags:
   - Snowflake
   - Lateral Movement:Exploitation of Remote Services
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0008:T1210
 Severity: Low
 Tests:

--- a/snowflake_queries/snowflake_user_created.yml
+++ b/snowflake_queries/snowflake_user_created.yml
@@ -12,7 +12,7 @@ Tags:
   - Snowflake
   - Persistence:Create Account
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1136
 Tests:
   -

--- a/snowflake_queries/snowflake_user_enabled.yml
+++ b/snowflake_queries/snowflake_user_enabled.yml
@@ -12,7 +12,7 @@ Tags:
   - Snowflake
   - Persistence:Create Account
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1136
 Tests:
   -

--- a/standard_rules/admin_assigned.yml
+++ b/standard_rules/admin_assigned.yml
@@ -16,7 +16,7 @@ Tags:
   - Privilege Escalation:Valid Accounts
 Severity: Medium
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Description: Attaching an audit role manually could be a sign of privilege escalation
 Runbook: Verify with the user who attached the role or add to a allowlist

--- a/standard_rules/brute_force_by_ip.yml
+++ b/standard_rules/brute_force_by_ip.yml
@@ -19,7 +19,7 @@ Tags:
   - Credential Access:Brute Force
 Threshold: 5
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1110
 Description: An actor user was denied login access more times than the configured threshold.
 Runbook: Analyze the IP they came from, and other actions taken before/after. Check if a user from this ip eventually authenticated successfully.

--- a/standard_rules/mfa_disabled.yml
+++ b/standard_rules/mfa_disabled.yml
@@ -13,7 +13,7 @@ Tags:
   - DataModel
   - Defense Evasion:Modify Authentication Process
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0005:T1556
 Severity: High
 Description: Detects when Multi-Factor Authentication (MFA) is disabled

--- a/standard_rules/unusual_login.yml
+++ b/standard_rules/unusual_login.yml
@@ -21,7 +21,7 @@ Tags:
   - Identity & Access Management
   - Initial Access:Valid Accounts
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0001:T1078
 Severity: Medium
 Description: A user logged in from a new geolocation.

--- a/zendesk_rules/zendesk_mobile_app_access.yml
+++ b/zendesk_rules/zendesk_mobile_app_access.yml
@@ -10,7 +10,7 @@ Tags:
   - Zendesk
   - Persistence:Valid Accounts
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0003:T1078
 Severity: Medium
 Description: A user updated account setting that enabled or disabled mobile app access.

--- a/zendesk_rules/zendesk_new_api_token.yml
+++ b/zendesk_rules/zendesk_new_api_token.yml
@@ -11,7 +11,7 @@ Tags:
   - Zendesk
   - Credential Access:Steal Application Access Token
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0006:T1528
 Description: A user created a new API token to be used with Zendesk.
 Runbook: Validate the api token was created for valid use case, otherwise delete the token immediately.

--- a/zendesk_rules/zendesk_new_owner.yml
+++ b/zendesk_rules/zendesk_new_owner.yml
@@ -11,7 +11,7 @@ Tags:
   - Zendesk
   - Privilege Escalation:Valid Accounts
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Description: Only one admin user can be the account owner. Ensure the change in ownership is expected.
 SummaryAttributes:

--- a/zendesk_rules/zendesk_sensitive_data_redaction.yml
+++ b/zendesk_rules/zendesk_sensitive_data_redaction.yml
@@ -10,7 +10,7 @@ Tags:
   - Zendesk
   - Collection:Data from Information Repositories
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1213
 Severity: High
 Description: A user updated account setting that disabled credit card redaction.

--- a/zendesk_rules/zendesk_user_assumption.yml
+++ b/zendesk_rules/zendesk_user_assumption.yml
@@ -9,7 +9,7 @@ Tags:
   - Zendesk
   - Lateral Movement:Use Alternate Authentication Material
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0008:T1550
 Severity: Medium
 Description: User enabled or disabled zendesk support user assumption.

--- a/zendesk_rules/zendesk_user_suspension.yml
+++ b/zendesk_rules/zendesk_user_suspension.yml
@@ -10,7 +10,7 @@ Tags:
   - Zendesk
   - Impact:Account Access Removal
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0040:T1531
 Severity: High
 Description: A user's Zendesk suspension status was changed.

--- a/zoom_operation_rules/zoom_operation_passcode_disabled.yml
+++ b/zoom_operation_rules/zoom_operation_passcode_disabled.yml
@@ -12,7 +12,7 @@ Severity: Low
 Description: >
   Meeting passcode requirement has been disabled from usergroup
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0009:T1125
 Reference: https://support.zoom.us/hc/en-us/articles/360033559832-Zoom-Meeting-and-Webinar-passcodes
 Runbook: >

--- a/zoom_operation_rules/zoom_operation_user_granted_admin.yml
+++ b/zoom_operation_rules/zoom_operation_user_granted_admin.yml
@@ -12,7 +12,7 @@ Severity: Medium
 Description: >
   A Zoom user has been granted admin access
 Reports:
-  MITRE ATTACK:
+  MITRE ATT&CK:
     - TA0004:T1078
 Reference: https://support.zoom.us/hc/en-us/articles/115001078646-Using-role-management
 Runbook: >


### PR DESCRIPTION
### Background

Rename ATTACK to ATT&CK.

Because its the LAW.

### Changes

* Rename ATTACK to ATT&CK.

### Testing

* unit testing & linting
