### PR TITLE
fix: update greynoise reference links

### DIFF
--- a/lookup_tables/greynoise/advanced/riot_advanced.yml
+++ b/lookup_tables/greynoise/advanced/riot_advanced.yml
@@ -6,7 +6,7 @@ Refresh:
   ObjectPath: s3://panther-greynoise-m5qt4p8qa7nnu5ij6orgsgpd4w58yusw2a-s3alias/luts/data/greynoise/riot_full.jsonl.gz
   PeriodMinutes: 240
 Description: GreyNoise RIOT Advanced identifies unpublished or dynamic IPs of common business services that are difficult for security teams to track, with detailed context. This version of RIOT requires an additional license - please contact your Panther or GreyNoise representative for more information.
-Reference: https://docs.panther.com/enrichment-beta/threat-intelligence/greynoise
+Reference: https://docs.panther.com/enrichment/greynoise
 Enabled: false
 LogTypeMap:
   PrimaryKey: ip_cidr

--- a/lookup_tables/greynoise/basic/noise_basic.yml
+++ b/lookup_tables/greynoise/basic/noise_basic.yml
@@ -6,7 +6,7 @@ Refresh:
   ObjectPath: s3://panther-greynoise-m5qt4p8qa7nnu5ij6orgsgpd4w58yusw2a-s3alias/luts/data/greynoise/noise_basic.jsonl.gz
   PeriodMinutes: 60
 Description: GreyNoise NOISE Basic classifies IPs seen scanning the internet based on intent - benign, malicious, and unknown. This version of NOISE is free with Panther.
-Reference: https://docs.panther.com/enrichment-beta/threat-intelligence/greynoise
+Reference: https://docs.panther.com/enrichment/greynoise
 Enabled: true
 LogTypeMap:
   PrimaryKey: ip

--- a/lookup_tables/greynoise/basic/riot_basic.yml
+++ b/lookup_tables/greynoise/basic/riot_basic.yml
@@ -6,7 +6,7 @@ Refresh:
   ObjectPath: s3://panther-greynoise-m5qt4p8qa7nnu5ij6orgsgpd4w58yusw2a-s3alias/luts/data/greynoise/riot_basic.jsonl.gz
   PeriodMinutes: 240
 Description: GreyNoise RIOT Basic identifies unpublished or dynamic IPs of common business services that are difficult for security teams to track. This basic version of RIOT is free with Panther.
-Reference: https://docs.panther.com/enrichment-beta/threat-intelligence/greynoise
+Reference: https://docs.panther.com/enrichment/greynoise
 Enabled: true
 LogTypeMap:
   PrimaryKey: ip_cidr
@@ -220,4 +220,3 @@ LogTypeMap:
     - LogType: Zoom.Activity
       Selectors:
         - "ip_address"
-


### PR DESCRIPTION
### Background

Fixes some links for Greynoise Lookup Tables that no longer point to the correct locations in the docs.
