### PR TITLE
feat: allow users to define that they have an External IdP which enforces MFA for AWS RoleAssumption on ConsoleLogin events

### DIFF
--- a/aws_cloudtrail_rules/aws_console_login_without_mfa.py
+++ b/aws_cloudtrail_rules/aws_console_login_without_mfa.py
@@ -5,7 +5,12 @@ from panther import lookup_aws_account_name
 from panther_base_helpers import deep_get
 from panther_oss_helpers import check_account_age
 
+# if you have an external IdP ( like Okta )
+# that permits direct role assumption, then
+# set this variable to True.
+ROLES_VIA_EXTERNAL_IDP = False
 
+# pylint: disable=R0911
 def rule(event):
     if event.get("eventName") != "ConsoleLogin":
         return False
@@ -13,6 +18,19 @@ def rule(event):
     # Extract some nested JSON structure
     additional_event_data = event.get("additionalEventData", {})
     response_elements = event.get("responseElements", {})
+    user_identity_type = deep_get(event, "userIdentity", "type", default="")
+
+    # When there is an external IdP setup and users directly assume roles
+    # the additionalData.MFAUsed attribute will be set to "no"
+    #  AND the userIdentity.sessionContext.mfaAuthenticated attribute will be "false"
+    #
+    # This will create a lack of visibility into the condition where
+    #  users are allowed to directly AssumeRole outside of the IdP and without MFA
+    #
+    # To date we have not identified data inside the log events that clearly
+    #  delinates AssumeRole backed by an external IdP vs not backed by external IdP
+    if ROLES_VIA_EXTERNAL_IDP and user_identity_type == "AssumedRole":
+        return False
 
     # If using AWS SSOv2 or other SAML provider return False
     if (

--- a/aws_cloudtrail_rules/aws_console_login_without_mfa.py
+++ b/aws_cloudtrail_rules/aws_console_login_without_mfa.py
@@ -5,9 +5,7 @@ from panther import lookup_aws_account_name
 from panther_base_helpers import deep_get
 from panther_oss_helpers import check_account_age
 
-# if you have an external IdP ( like Okta )
-# that permits direct role assumption, then
-# set this variable to True.
+# Set to True for environments that permit direct role assumption via external IDP
 ROLES_VIA_EXTERNAL_IDP = False
 
 # pylint: disable=R0911

--- a/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
+++ b/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
@@ -398,3 +398,52 @@ Tests:
           "type": "AssumedRole"
         }
       }
+  - 
+    Name: No MFA - IAM Role and External IDP
+    ExpectedResult: false
+    Mocks:
+      - objectName: ROLES_VIA_EXTERNAL_IDP
+        returnValue: True
+    Log:
+      {
+        "eventVersion": "1.05",
+        "userIdentity": {
+          "accountId": "123456789012",
+          "arn": "arn:aws:sts::123456789012:assumed-role/SomeRole/1641313043312360000",
+          "principalId": "AROAXXXXXXXXXXXXXXXXX:1641313043312360000",
+          "sessionContext": {
+            "attributes": {
+              "creationDate": "2022-01-04T16:17:27Z",
+              "mfaAuthenticated": "false"
+            },
+            "sessionIssuer": {
+              "accountId": "123456789012",
+              "arn": "arn:aws:iam::123456789012:role/SomeRole",
+              "principalId": "AROAXXXXXXXXXXXXXXXXX",
+              "type": "Role",
+              "userName": "SomeRole"
+            }
+          },
+          "type": "AssumedRole"
+        },
+        "eventTime": "2019-01-01T00:00:00Z",
+        "eventSource": "signin.amazonaws.com",
+        "eventName": "ConsoleLogin",
+        "awsRegion": "us-east-1",
+        "sourceIPAddress": "111.111.111.111",
+        "userAgent": "Mozilla",
+        "requestParameters": null,
+        "responseElements": {
+          "ConsoleLogin": "Success"
+        },
+        "additionalEventData": {
+          "LoginTo": "https://console.aws.amazon.com/console/",
+          "MobileVersion": "No",
+          "MFAUsed": "No"
+        },
+        "eventID": "1",
+        "eventType": "AwsConsoleSignIn",
+        "recipientAccountId": "123456789013",
+        "p_row_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "p_log_type": "AWS.CloudTrail"
+      }


### PR DESCRIPTION
### Background

When using an external IdP that gives users direct role assumption on ConsoleLogin, the MFA bits are not set in the cloudtrail logs ( even when the external IdP requires MFA ). 

This changeset creates a user configurable flag to inform the ConsoleLogin without MFA detection that an external IdP is in use. When set, this detection will not fire an alert for ConsoleLogin cloudtrail events when the  `userIdentity.type: AssumedRole` is set. 

### Changes

* User configurable flag for external IdP that does direct role assumption

### Testing

* New test condition added to validate that this detection works as intended
* Existing test conditions confirm that historical behavior is unchanged
