### PR TITLE
[Fix] 1Password Unusual Client MITRE ATT&CK mapping

### DIFF
--- a/onepassword_rules/onepassword_unusual_client.yml
+++ b/onepassword_rules/onepassword_unusual_client.yml
@@ -11,10 +11,10 @@ Description: Detects when unusual or undesireable 1Password clients access your 
 Reference: https://1password.com/downloads/
 Tags:
   - 1Password
-  - Credential Access:Forge Web Credentials
+  - Credential Access:Credentials from Password Stores
 Reports:
   MITRE ATT&CK:
-    - TA0006:T1606
+    - TA0006:T1555
 SummaryAttributes:
   - p_any_ip_addresses
   - p_any_emails


### PR DESCRIPTION
### Background

This detection previously mapped to [Credential Access:Forge Web Credentials](https://attack.mitre.org/techniques/T1606/). 

From the technique description:

> This differs from Steal Web Session Cookie ... and other similar behaviors in that the credentials are new and forged by the adversary, rather than stolen or intercepted from legitimate users.

A more appropriate mapping would be to [Credential Access:Credentials from Password Stores](https://attack.mitre.org/techniques/T1555/), specifically sub-technique T1555.005 (Credentials from Password Stores: Password Managers). 

### Changes

* Changed MITRE ATT&CK Mapping

### Testing

* N/A
