### PR TITLE
fix: gsuite summary atribute

### DIFF
--- a/gsuite_activityevent_rules/gsuite_advanced_protection.yml
+++ b/gsuite_activityevent_rules/gsuite_advanced_protection.yml
@@ -18,7 +18,7 @@ Reference: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/
 Runbook: >
   Have the user re-enable Google Advanced Protection
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Advanced Protection Enabled

--- a/gsuite_activityevent_rules/gsuite_doc_ownership_transfer.yml
+++ b/gsuite_activityevent_rules/gsuite_doc_ownership_transfer.yml
@@ -19,7 +19,7 @@ Reference: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/
 Runbook: >
   Verify that this document did not contain sensitive or private company information.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Ownership Transferred Within Organization

--- a/gsuite_activityevent_rules/gsuite_google_access.yml
+++ b/gsuite_activityevent_rules/gsuite_google_access.yml
@@ -14,7 +14,7 @@ Reference: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/
 Runbook: >
   Your GSuite Super Admin can visit the Access Transparency report in the GSuite Admin Dashboard to see more details about the access.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Normal Login Event

--- a/gsuite_activityevent_rules/gsuite_gov_attack.yml
+++ b/gsuite_activityevent_rules/gsuite_gov_attack.yml
@@ -14,7 +14,7 @@ Reference: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/
 Runbook: >
   Followup with GSuite support for more details.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Normal Login Event

--- a/gsuite_activityevent_rules/gsuite_group_banned_user.yml
+++ b/gsuite_activityevent_rules/gsuite_group_banned_user.yml
@@ -14,7 +14,7 @@ Reference: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/
 Runbook: >
   Investigate the banned user to see if further disciplinary action needs to be taken.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: User Added

--- a/gsuite_activityevent_rules/gsuite_high_severity_rule.yml
+++ b/gsuite_activityevent_rules/gsuite_high_severity_rule.yml
@@ -14,7 +14,7 @@ Reference: https://support.google.com/a/answer/9420866
 Runbook: >
   Investigate what triggered the rule.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Non Triggered Rule

--- a/gsuite_activityevent_rules/gsuite_leaked_password.yml
+++ b/gsuite_activityevent_rules/gsuite_leaked_password.yml
@@ -18,7 +18,7 @@ Reference: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/
 Runbook: >
   GSuite has already disabled the compromised user's account. Consider investigating how the user's account was compromised, and reset their account and password. Advise the user to change any other passwords in use that are the sae as the compromised password.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Normal Login Event

--- a/gsuite_activityevent_rules/gsuite_login_type.yml
+++ b/gsuite_activityevent_rules/gsuite_login_type.yml
@@ -19,7 +19,7 @@ Reference: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/
 Runbook: >
   Correct the user account settings so that only logins of approved types are available.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Login With Approved Type

--- a/gsuite_activityevent_rules/gsuite_low_severity_rule.yml
+++ b/gsuite_activityevent_rules/gsuite_low_severity_rule.yml
@@ -14,7 +14,7 @@ Reference: https://support.google.com/a/answer/9420866
 Runbook: >
   Investigate what triggered the rule.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Non Triggered Rule

--- a/gsuite_activityevent_rules/gsuite_medium_severity_rule.yml
+++ b/gsuite_activityevent_rules/gsuite_medium_severity_rule.yml
@@ -14,7 +14,7 @@ Reference: https://support.google.com/a/answer/9420866
 Runbook: >
   Investigate what triggered the rule.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Non Triggered Rule

--- a/gsuite_activityevent_rules/gsuite_mobile_device_compromise.yml
+++ b/gsuite_activityevent_rules/gsuite_mobile_device_compromise.yml
@@ -14,7 +14,7 @@ Reference: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/
 Runbook: >
   Have the user change their passwords and reset the device.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Normal Mobile Event

--- a/gsuite_activityevent_rules/gsuite_mobile_device_screen_unlock_fail.yml
+++ b/gsuite_activityevent_rules/gsuite_mobile_device_screen_unlock_fail.yml
@@ -18,7 +18,7 @@ Reference: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/
 Runbook: >
   Verify that these unlock attempts came from the user, and not a malicious actor which has acquired the user's device.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Normal Mobile Event

--- a/gsuite_activityevent_rules/gsuite_mobile_device_suspicious_activity.yml
+++ b/gsuite_activityevent_rules/gsuite_mobile_device_suspicious_activity.yml
@@ -14,7 +14,7 @@ Reference: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/
 Runbook: >
   Validate that the suspicious activity was expected by the user.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Normal Mobile Event

--- a/gsuite_activityevent_rules/gsuite_permissions_delegated.yml
+++ b/gsuite_activityevent_rules/gsuite_permissions_delegated.yml
@@ -14,7 +14,7 @@ Reference: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/
 Runbook: >
   Valdiate that this users should have these permissions and they are not the result of a privilege escalation attack.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Other Admin Action

--- a/gsuite_activityevent_rules/gsuite_suspicious_logins.yml
+++ b/gsuite_activityevent_rules/gsuite_suspicious_logins.yml
@@ -14,7 +14,7 @@ Reference: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/
 Runbook: >
   Checkout the details of the login and verify this behavior with the user to ensure the account wasn't compromised.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Normal Login Event

--- a/gsuite_activityevent_rules/gsuite_two_step_verification.yml
+++ b/gsuite_activityevent_rules/gsuite_two_step_verification.yml
@@ -18,7 +18,7 @@ Reference: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/
 Runbook: >
   Depending on company policy, either suggest or require the user re-enable two step verification.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Two Step Verification Enabled

--- a/gsuite_activityevent_rules/gsuite_user_suspended.yml
+++ b/gsuite_activityevent_rules/gsuite_user_suspended.yml
@@ -14,7 +14,7 @@ Reference: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/
 Runbook: >
   Investigate the behavior that got the account suspended. Verify with the user that this intended behavior. If not, the account may have been compromised.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Normal Login Event

--- a/gsuite_reports_rules/gsuite_drive_overly_visible.yml
+++ b/gsuite_reports_rules/gsuite_drive_overly_visible.yml
@@ -18,7 +18,7 @@ Reference: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/
 Runbook: >
   Investigate whether the drive document is appropriate to be this visible.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Access Event

--- a/gsuite_reports_rules/gsuite_drive_visibility_change.yml
+++ b/gsuite_reports_rules/gsuite_drive_visibility_change.yml
@@ -18,7 +18,7 @@ Reference: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/
 Runbook: >
   Investigate whether the drive document is appropriate to be publicly accessible.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Access Event

--- a/gsuite_reports_rules/gsuite_drive_visibility_change_deprecated.yml
+++ b/gsuite_reports_rules/gsuite_drive_visibility_change_deprecated.yml
@@ -11,7 +11,7 @@ Severity: Low
 Description: >
   Deprecated - This will disable the old rule with typo in the RuleID. This rule can be deleted.
 SummaryAttributes:
-  - actor
+  - actor:email
 Tests:
   -
     Name: Any Event


### PR DESCRIPTION
### Background

The Gsuite summary attributes were referencing an object and not a field name. This resulted in the summary not displaying the correct data.

### Changes

* Updates SummaryAttributes for affected gsuite rules

### Testing

* make test/lint
