### PR TITLE
fix: S3 malicious access allow panther roles from AWS

### DIFF
--- a/aws_cloudtrail_rules/aws_s3_activity_greynoise.py
+++ b/aws_cloudtrail_rules/aws_s3_activity_greynoise.py
@@ -9,11 +9,12 @@ from panther_greynoise_helpers import GetGreyNoiseObject, GetGreyNoiseRiotObject
 # Monitor for GetObject events from S3.
 # Also check ListBucket to reveal object enumeration.
 _S3_EVENT_LIST = (
-    "ListBucket*", 
+    "ListBucket*",
     "GetObject*",
 )
 
-# Some AWS IP addresses listed as "malicious" are stale, this allows for allowing specific roles where this may occur
+# Some AWS IP addresses listed as "malicious" are stale
+# This enables allowing specific roles where this may occur
 _ALLOWED_ROLES = (
     "*PantherAuditRole-*",
     "*PantherLogProcessingRole-*",
@@ -33,7 +34,7 @@ def rule(event):
     # Filter: Non "Get" events
     if not pattern_match_list(event.get("eventName"), _S3_EVENT_LIST):
         return False
-    
+
     # Validate the IP is actually an IP (sometimes it's a string)
     try:
         ip_address(event.get("sourceIPAddress"))
@@ -62,7 +63,7 @@ def rule(event):
             else:
                 return False
         return True
-    
+
     return False
 
 

--- a/aws_cloudtrail_rules/aws_s3_activity_greynoise.py
+++ b/aws_cloudtrail_rules/aws_s3_activity_greynoise.py
@@ -3,11 +3,21 @@ from ipaddress import ip_address
 from panther_base_helpers import deep_get, pattern_match_list
 from panther_greynoise_helpers import GetGreyNoiseObject, GetGreyNoiseRiotObject
 
+
 # pylint: disable=too-many-return-statements,invalid-name,unused-argument,global-at-module-level,global-variable-undefined
 
 # Monitor for GetObject events from S3.
 # Also check ListBucket to reveal object enumeration.
-_S3_EVENT_LIST = ("ListBucket*", "GetObject*")
+_S3_EVENT_LIST = (
+    "ListBucket*", 
+    "GetObject*",
+)
+
+# Some AWS IP addresses listed as "malicious" are stale, this allows for allowing specific roles where this may occur
+_ALLOWED_ROLES = (
+    "*PantherAuditRole-*",
+    "*PantherLogProcessingRole-*",
+)
 
 
 def rule(event):
@@ -23,7 +33,7 @@ def rule(event):
     # Filter: Non "Get" events
     if not pattern_match_list(event.get("eventName"), _S3_EVENT_LIST):
         return False
-
+    
     # Validate the IP is actually an IP (sometimes it's a string)
     try:
         ip_address(event.get("sourceIPAddress"))
@@ -41,7 +51,18 @@ def rule(event):
 
     # Check that the IP is classified as 'malicious'
     if NOISE.classification("sourceIPAddress") == "malicious":
+
+        # Filter: Roles that generate FP's if used from AWS IP Space
+        if pattern_match_list(deep_get(event, "userIdentity", "arn"), _ALLOWED_ROLES):
+            # Only Greynoise advanced provides AS organization info
+            if NOISE.subscription_level() == 'advanced':
+                if NOISE.organization == 'Amazon.com, Inc.':
+                    return False
+            # return false if the role is seen and we are not able to valide the AS organization
+            else:
+                return False
         return True
+    
     return False
 
 

--- a/aws_cloudtrail_rules/aws_s3_activity_greynoise.yml
+++ b/aws_cloudtrail_rules/aws_s3_activity_greynoise.yml
@@ -208,3 +208,110 @@ Tests:
                 "arn:aws:s3:::panther"
             ]
         }
+  -
+    ExpectedResult: false
+    Name: Malicious GreyNoise finding that is allowed based on role and AS Org
+    Log:
+        {
+            "additionalEventData": {
+                "AuthenticationMethod": "AuthHeader",
+                "CipherSuite": "ECDHE-RSA-AES128-GCM-SHA256",
+                "SignatureVersion": "SigV4",
+                "bytesTransferredIn": 0,
+                "bytesTransferredOut": 2441
+            },
+            "awsRegion": "eu-central-1",
+            "eventID": "60858000-f093-465f-9d62-97655522ab1a",
+            "eventName": "GetObject",
+            "eventSource": "s3.amazonaws.com",
+            "eventTime": "2021-08-16 16:39:43",
+            "eventType": "AwsApiCall",
+            "eventVersion": "1.08",
+            "managementEvent": false,
+            "readOnly": true,
+            "recipientAccountId": "111122223333",
+            "requestID": "EFMWSVE492PYSCYN",
+            "requestParameters": {
+                "bucketName": "panther"
+            },
+            "resources": [],
+            "sourceIPAddress": "142.93.204.250",
+            "userAgent": "[aws-sdk-go/1.40.21 (go1.16.3; linux; amd64) exec-env/AWS_Lambda_go1.x S3Manager]",
+            "userIdentity": {
+                "accessKeyId": "AAAA22222XXXXXBBBBBBB",
+                "accountId": "111122223333",
+                "arn": "arn:aws:sts::111122223333:assumed-role/PantherAuditRole-us-west-2/1629131846392631241",
+                "principalId": "AAAA22222XXXXXBBBBBBB:1629131846392631241",
+                "sessionContext": {
+                    "attributes": {
+                        "creationDate": "2021-08-16T16:37:26Z",
+                        "mfaAuthenticated": "false"
+                    },
+                    "sessionIssuer": {
+                        "accountId": "111122223333",
+                        "arn": "arn:aws:iam::111122223333:role/Panther",
+                        "principalId": "AAAA22222XXXXXBBBBBBB",
+                        "type": "Role",
+                        "userName": "Panther"
+                    }
+                },
+                "type": "AssumedRole"
+            },
+            "p_event_time": "2021-08-16 16:39:43",
+            "p_parse_time": "2021-08-16 16:44:29.47",
+            "p_log_type": "AWS.CloudTrail",
+            "p_enrichment": {
+                "greynoise_noise_basic": {
+                    "sourceIPAddress": {
+                        "actor": "unknown",
+                        "bot": false,
+                        "classification": "malicious",
+                        "cve": [],
+                        "first_seen": "2022-03-19",
+                        "ip": "142.93.204.250",
+                        "last_seen": "2022-04-06",
+                        "metadata": {
+                            "asn": "AS14061",
+                            "category": "hosting",
+                            "city": "North Bergen",
+                            "country": "United States",
+                            "country_code": "US",
+                            "organization": "Amazon.com, Inc",
+                            "os": "Linux 2.2-3.x",
+                            "rdns": "",
+                            "region": "New Jersey",
+                            "tor": false
+                        },
+                        "raw_data": {
+                            "hassh": [],
+                            "ja3": [],
+                            "scan": [
+                                {
+                                    "port": 23,
+                                    "protocol": "TCP"
+                                }
+                            ],
+                            "web": {}
+                        },
+                        "seen": true,
+                        "spoofable": false,
+                        "tags": [
+                            "Mirai",
+                            "ZMap Client"
+                        ],
+                        "vpn": false,
+                        "vpn_service": "N/A"
+                    }
+                }
+            },
+            "p_any_ip_addresses": [
+                "142.93.204.250"
+            ],
+            "p_any_aws_account_ids": [
+                "111122223333"
+            ],
+            "p_any_aws_arns": [
+                "arn:aws:iam::111122223333:role/Panther",
+                "arn:aws:sts::111122223333:assumed-role/Panther/1629131846392631241"
+            ]
+        }


### PR DESCRIPTION
### Background

Greynoise data may be stale, specifically for AWS IP space. There are occurrences where Panther accesses a S3 bucket from an IP that has been labeled as previously malicious. This change addresses that case.

### Changes

* Create an allow list that include Panther roles known to trigger this alert
* add logic that excludes that access from generating an alert
* Add a test

### Testing

* make test/lint