### PR TITLE
chore: align casing on all github detections

### DIFF
--- a/github_rules/github_repo_visibility_change.yml
+++ b/github_rules/github_repo_visibility_change.yml
@@ -1,6 +1,6 @@
 AnalysisType: rule
 Filename: github_repo_visibility_change.py
-RuleID: Github.Repo.VisibilityChange
+RuleID: GitHub.Repo.VisibilityChange
 DisplayName: GitHub Repository Visibility Change
 Enabled: true
 LogTypes:

--- a/packs/github.yml
+++ b/packs/github.yml
@@ -10,7 +10,7 @@ PackDefinition:
     - Github.Repo.Created
     - GitHub.Repo.HookModified
     - GitHub.Repo.InitialAccess
-    - Github.Repo.VisibilityChange
+    - GitHub.Repo.VisibilityChange
     - GitHub.Team.Modified
     - GitHub.User.AccessKeyCreated
     - GitHub.User.RoleUpdated


### PR DESCRIPTION
### Background

When working through alert charts, I noticed that we had both `GitHub` and `Github`. Github had only one occurrence, and so noting, this PR moves us to be entirely `GitHub` 

### Changes


### Testing

* <Testing steps>
