### PR TITLE
fix: greynoise object function call not attribute

### DIFF
--- a/aws_cloudtrail_rules/aws_s3_activity_greynoise.py
+++ b/aws_cloudtrail_rules/aws_s3_activity_greynoise.py
@@ -58,7 +58,7 @@ def rule(event):
         if pattern_match_list(deep_get(event, "userIdentity", "arn"), _ALLOWED_ROLES):
             # Only Greynoise advanced provides AS organization info
             if NOISE.subscription_level() == 'advanced':
-                if NOISE.organization == 'Amazon.com, Inc.':
+                if NOISE.organization() == 'Amazon.com, Inc.':
                     return False
             # return false if the role is seen and we are not able to valide the AS organization
             else:


### PR DESCRIPTION
### Background

The greynoise object contains a function organization() not an attribute.

### Changes

* NOISE.organization --> NOISE.organization()

### Testing

* make lint/test
