### PR TITLE
fix: user and roles query in GCP data model

### DIFF
--- a/data_models/gcp_data_model.py
+++ b/data_models/gcp_data_model.py
@@ -40,10 +40,10 @@ def get_admin_map(event):
 def get_modified_users(event):
     roles_assigned = get_admin_map(event)
 
-    return json.dumps(list(roles_assigned.values()), default=PantherEvent.json_encoder)
+    return json.dumps(list(roles_assigned.keys()), default=PantherEvent.json_encoder)
 
 
 def get_iam_roles(event):
     roles_assigned = get_admin_map(event)
 
-    return json.dumps(list(roles_assigned.keys()), default=PantherEvent.json_encoder)
+    return json.dumps(list(roles_assigned.values()), default=PantherEvent.json_encoder)


### PR DESCRIPTION
### Background
Previously the GCP Data Model has an incorrect mapping for users and roles, which makes detection rules like [Standard.AdminRoleAssigned](https://github.com/panther-labs/panther-analysis/blob/master/standard_rules/admin_assigned.py) to throw an incorrect title when it comes to GCP Admin Assigned alerts.
For example, the tests in the Standard.AdminRoleAssigned rule will throw the following alert title:

```
GCP.AuditLog: [bob@example.com] assigned admin privileges [["cat@example.com"]] to [["roles/resourcemanager.organizationAdmin"]]
GCP.AuditLog: [bob@example.com] assigned admin privileges [["cat@example.com", "dog@example.com"]] to [["roles/resourcemanager.organizationAdmin", "roles/owner"]]
```

### Changes

The query in gcp_data_model.py for `get_modified_users` and `get_iam_roles` are reversed, swapping them fixed the issue.
Previously:
```
def get_modified_users(event):
    roles_assigned = get_admin_map(event)

    return json.dumps(list(roles_assigned.values()), default=PantherEvent.json_encoder)


def get_iam_roles(event):
    roles_assigned = get_admin_map(event)

    return json.dumps(list(roles_assigned.keys()), default=PantherEvent.json_encoder)
```

After changes:
```
def get_modified_users(event):
    roles_assigned = get_admin_map(event)

    return json.dumps(list(roles_assigned.keys()), default=PantherEvent.json_encoder)


def get_iam_roles(event):
    roles_assigned = get_admin_map(event)

    return json.dumps(list(roles_assigned.values()), default=PantherEvent.json_encoder)
```

### Testing

After the changes, the Standard.AdminRoleAssigned rule will now show the correct title for test GCP alerts:
```
GCP.AuditLog: [bob@example.com] assigned admin privileges [["roles/resourcemanager.organizationAdmin"]] to [["cat@example.com"]]
GCP.AuditLog: [bob@example.com] assigned admin privileges [["roles/resourcemanager.organizationAdmin", "roles/owner"]] to [["cat@example.com", "dog@example.com"]]
```
