### PR TITLE
chore: workflow tweak to allow sync to dogfood for both forks and branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
     types:


### PR DESCRIPTION
### Background

There is a internal-to-panther github action which wasn't functioning correctly when forks were merged to master. 

A slight tweak on the `on.` settings on this workflow should enable this action to work in all scenarios. [This github actions document](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) describes the scenario, and we already had the additional checks recommended there to ensure that the pull_request had been closed-via-merge. 

### Changes



### Testing


