### PR TITLE
Remove _timestamp from last_seen Advanced Greynoise Object function

### DIFF
--- a/global_helpers/panther_greynoise_helpers.py
+++ b/global_helpers/panther_greynoise_helpers.py
@@ -102,7 +102,7 @@ class GreyNoiseAdvanced:
         return parser.parse(deep_get(self.noise, match_field, "first_seen"))
 
     def last_seen(self, match_field) -> datetime.date:
-        return parser.parse(deep_get(self.noise, match_field, "last_seen_timestamp"))
+        return parser.parse(deep_get(self.noise, match_field, "last_seen"))
 
     def asn(self, match_field) -> str:
         return deep_get(self.noise, match_field, "metadata", "asn")


### PR DESCRIPTION
### Background

This field should just be `last_seen` instead of `last_seen_timestamp` according to the [docs](https://docs.panther.com/enrichment/greynoise/basic-vs.-advanced#noise-dataset-1)
As it is currently written, this function will always return None.

### Changes

* Changed L105 `last_seen_timestamp` -> `last_seen`
