### PR TITLE
Remove pat imports

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,13 +7,13 @@ verify_ssl = true
 bandit = "~=1.7"
 black = "~=22.8"
 click = "~=8.1"
+decorator = "~=5.1"
 isort = "~=5.10.0"
 mypy = "~=0.950"
+panther-analysis-tool = "*"
 pylint = "~=2.15.0"
-decorator = "~=5.1"
 
 [packages]
-panther-analysis-tool = "*"
 policyuniverse = "==1.4.0.20220110"
 requests = "~=2.27"
 

--- a/data_models/gcp_data_model.py
+++ b/data_models/gcp_data_model.py
@@ -2,7 +2,6 @@ import json
 from fnmatch import fnmatch
 
 import panther_event_type_helpers as event_type
-from panther_analysis_tool.enriched_event import PantherEvent
 from panther_base_helpers import get_binding_deltas
 
 ADMIN_ROLES = {
@@ -38,12 +37,14 @@ def get_admin_map(event):
 
 
 def get_modified_users(event):
-    roles_assigned = get_admin_map(event)
+    event_dict = event.to_dict()
+    roles_assigned = get_admin_map(event_dict)
 
-    return json.dumps(list(roles_assigned.keys()), default=PantherEvent.json_encoder)
+    return json.dumps(list(roles_assigned.keys()))
 
 
 def get_iam_roles(event):
-    roles_assigned = get_admin_map(event)
+    event_dict = event.to_dict()
+    roles_assigned = get_admin_map(event_dict)
 
-    return json.dumps(list(roles_assigned.values()), default=PantherEvent.json_encoder)
+    return json.dumps(list(roles_assigned.values()))

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, Optional, Sequence, Set, Union
 import boto3
 import requests
 from dateutil import parser
-from panther_analysis_tool.immutable import ImmutableList
 
 _RESOURCE_TABLE = None  # boto3.Table resource, lazily constructed
 FIPS_ENABLED = os.getenv("ENABLE_FIPS", "").lower() == "true"
@@ -429,7 +428,13 @@ def check_account_age(key):
 # When we want to iterate over something that could be a single item or a list
 # of items we can use listify and just continue as if it's always a list
 def listify(maybe_list):
-    return [maybe_list] if not isinstance(maybe_list, (list, ImmutableList)) else maybe_list
+    try:
+        iter(maybe_list)
+    except TypeError:
+        # not a list
+        return [maybe_list]
+    # either a list or string
+    return maybe_list if not isinstance(maybe_list, (str, bytes)) else [maybe_list]
 
 
 def _test_kv_store():


### PR DESCRIPTION
### Background

We want to remove all imports to panther_anlaysis_tool in detections.  This removes them with alternative solutions.

### Changes

* alternative option for listify 
* convert PantherEvent to dict before using it in the gcp data model helpers

### Testing

* `make test`
* upload
