### PR TITLE
fix: There was an un-exercised codepath for GreyNoise Advanced in aws_s3_activity_greynoise. this fixes the error and adds a test case to exercise the codepath

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_s3_activity_greynoise.py
+++ b/rules/aws_cloudtrail_rules/aws_s3_activity_greynoise.py
@@ -57,7 +57,7 @@ def rule(event):
         if pattern_match_list(deep_get(event, "userIdentity", "arn"), _ALLOWED_ROLES):
             # Only Greynoise advanced provides AS organization info
             if NOISE.subscription_level() == "advanced":
-                if NOISE.organization() == "Amazon.com, Inc.":
+                if NOISE.organization("sourceIPAddress") == "Amazon.com, Inc.":
                     return False
             # return false if the role is seen and we are not able to valide the AS organization
             else:

--- a/rules/aws_cloudtrail_rules/aws_s3_activity_greynoise.yml
+++ b/rules/aws_cloudtrail_rules/aws_s3_activity_greynoise.yml
@@ -240,7 +240,7 @@ Tests:
             "userIdentity": {
                 "accessKeyId": "AAAA22222XXXXXBBBBBBB",
                 "accountId": "111122223333",
-                "arn": "arn:aws:sts::111122223333:assumed-role/PantherAuditRole-us-west-2/1629131846392631241",
+                "arn": "arn:aws:sts::111122223333:assumed-role/PantherAuditRole-region/1629131846392631241",
                 "principalId": "AAAA22222XXXXXBBBBBBB:1629131846392631241",
                 "sessionContext": {
                     "attributes": {
@@ -314,4 +314,153 @@ Tests:
                 "arn:aws:iam::111122223333:role/Panther",
                 "arn:aws:sts::111122223333:assumed-role/Panther/1629131846392631241"
             ]
+        }
+  -
+    ExpectedResult: false
+    Name: Malicious GreyNoise finding that is allowed based on role and AS Org and GreyNoise Advanced
+    Log:
+        {
+            "additionalEventData": {
+                "AuthenticationMethod": "AuthHeader",
+                "CipherSuite": "ECDHE-RSA-AES128-GCM-SHA256",
+                "SignatureVersion": "SigV4",
+                "bytesTransferredIn": 0,
+                "bytesTransferredOut": 5441,
+                "x-amz-id-2": "1234"
+            },
+            "awsRegion": "eu-west-2",
+            "eventCategory": "Management",
+            "eventID": "aaaaaaaa-aaaa-4967-a2a6-d464e326891a",
+            "eventName": "ListBuckets",
+            "eventSource": "s3.amazonaws.com",
+            "eventTime": "2022-09-08 18:40:24.000000000",
+            "eventType": "AwsApiCall",
+            "eventVersion": "1.08",
+            "managementEvent": true,
+            "p_alert_creation_time": "2022-09-08 18:47:05.228700000",
+            "p_alert_id": "ffffffffffffffffffffffffffffffff",
+            "p_alert_severity": "HIGH",
+            "p_alert_update_time": "2022-09-08 18:47:05.228700000",
+            "p_any_aws_account_ids": [
+                "123456789012"
+            ],
+            "p_any_aws_arns": [
+                "arn:aws:iam::123456789012:role/PantherAuditRole-region",
+                "arn:aws:sts::123456789012:assumed-role/PantherAuditRole-region/1111111111111111111"
+            ],
+            "p_any_ip_addresses": [
+                "54.245.38.112"
+            ],
+            "p_enrichment": {
+                "greynoise_noise_advanced": {
+                    "p_any_ip_addresses": [
+                        {
+                            "actor": "unknown",
+                            "bot": false,
+                            "classification": "malicious",
+                            "first_seen": "2022-06-16 00:00:00.000000000",
+                            "ip": "54.245.38.112",
+                            "last_seen_timestamp": "2022-06-17 20:35:16.000000000",
+                            "metadata": {
+                                "asn": "AS16509",
+                                "category": "hosting",
+                                "city": "Boardman",
+                                "country": "United States",
+                                "country_code": "US",
+                                "organization": "Amazon.com, Inc.",
+                                "os": "Windows 7/8",
+                                "rdns": "ec2-54-245-38-112.us-west-2.compute.amazonaws.com",
+                                "region": "Oregon",
+                                "tor": false
+                            },
+                            "spoofable": false,
+                            "tags": [
+                                "PHPMyAdmin Worm",
+                                "Web Crawler"
+                            ],
+                            "vpn": false,
+                            "vpn_service": "N/A"
+                        }
+                    ],
+                    "sourceIPAddress": {
+                        "actor": "unknown",
+                        "bot": false,
+                        "classification": "malicious",
+                        "first_seen": "2022-06-16 00:00:00.000000000",
+                        "ip": "54.245.38.112",
+                        "last_seen_timestamp": "2022-06-17 20:35:16.000000000",
+                        "metadata": {
+                            "asn": "AS16509",
+                            "category": "hosting",
+                            "city": "Boardman",
+                            "country": "United States",
+                            "country_code": "US",
+                            "organization": "Amazon.com, Inc.",
+                            "os": "Windows 7/8",
+                            "rdns": "ec2-54-245-38-112.us-west-2.compute.amazonaws.com",
+                            "region": "Oregon",
+                            "tor": false
+                        },
+                        "spoofable": false,
+                        "tags": [
+                            "PHPMyAdmin Worm",
+                            "Web Crawler"
+                        ],
+                        "vpn": false,
+                        "vpn_service": "N/A"
+                    }
+                }
+            },
+            "p_event_time": "2022-09-08 18:40:24.000000000",
+            "p_log_type": "AWS.CloudTrail",
+            "p_parse_time": "2022-09-08 18:46:13.942177641",
+            "p_row_id": "abcdefabcdefabcdefabcdef13f4e402",
+            "p_rule_id": "AWS.S3.GreyNoiseActivity",
+            "p_rule_reports": {
+                "MITRE ATT&CK": [
+                    "TA0009:T1530"
+                ]
+            },
+            "p_rule_severity": "HIGH",
+            "p_rule_tags": [
+                "AWS",
+                "Collection:Data From Cloud Storage Object",
+                "GreyNoise"
+            ],
+            "p_source_id": "12345678-abcd-1234-abcd-1234abcd1234",
+            "p_source_label": "Some Human Friendly Source",
+            "readOnly": true,
+            "recipientAccountId": "0121234512345",
+            "requestID": "HJHJHJHJHJHJHJHJ",
+            "requestParameters": {
+                "Host": "s3.eu-west-2.amazonaws.com"
+            },
+            "sourceIPAddress": "54.245.38.112",
+            "tlsDetails": {
+                "cipherSuite": "ECDHE-RSA-AES128-GCM-SHA256",
+                "clientProvidedHostHeader": "s3.eu-west-2.amazonaws.com",
+                "tlsVersion": "TLSv1.2"
+            },
+            "userAgent": "[aws-sdk-go/1.44.77 (go1.19; linux; arm64)]",
+            "userIdentity": {
+                "accessKeyId": "ASIANNNNNNNNNNNNNNNN",
+                "accountId": "123456789012",
+                "arn": "arn:aws:sts::123456789012:assumed-role/PantherAuditRole-region/1111111111111111111",
+                "principalId": "AROANNNNNNNNNNNNNNNNN:1111111111111111111",
+                "sessionContext": {
+                    "attributes": {
+                        "creationDate": "2022-09-08T18:40:23Z",
+                        "mfaAuthenticated": "false"
+                    },
+                    "sessionIssuer": {
+                        "accountId": "123456789012",
+                        "arn": "arn:aws:iam::123456789012:role/PantherAuditRole-region",
+                        "principalId": "AROAWYT7IVYHE7N6ZVSGR",
+                        "type": "Role",
+                        "userName": "PantherAuditRole-region"
+                    },
+                    "webIdFederationData": {}
+                },
+                "type": "AssumedRole"
+            }
         }


### PR DESCRIPTION
### Background

the `NOISE.organization()` call inside aws_s3_activity_greynoise was raising a **TypeError** in at least one installation of the panther platform. 

### Changes


### Testing

* add test 📈 
* `make test`

