### PR TITLE
fix: detailed ec2 instance monitoring should only alert if an instance is Pending or Running

### DIFF
--- a/policies/aws_ec2_policies/aws_ec2_instance_detailed_monitoring.py
+++ b/policies/aws_ec2_policies/aws_ec2_instance_detailed_monitoring.py
@@ -2,4 +2,8 @@ from panther_base_helpers import deep_get
 
 
 def policy(resource):
+    # per https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instance-status.html
+    # > 16 Instance.State values indicate shutdown
+    if deep_get(resource, "State", "Code", default=0) > 16:
+        return True
     return deep_get(resource, "Monitoring", "State") != "disabled"

--- a/policies/aws_ec2_policies/aws_ec2_instance_detailed_monitoring.yml
+++ b/policies/aws_ec2_policies/aws_ec2_instance_detailed_monitoring.yml
@@ -12,6 +12,7 @@ Tags:
   - AWS
   - Security Control
   - Defense Evasion:Impair Defenses
+  - Debug
 Severity: Low
 Description: >
   This policy ensures that the AWS Instance has Detailed Monitoring Enabled
@@ -310,6 +311,1008 @@ Tests:
         "State": {
           "Code": 16,
           "Name": "running"
+        },
+        "StateReason": null,
+        "StateTransitionReason": null,
+        "SubnetId": "subnet-111222333",
+        "Tags": [
+          {
+            "Key": "TagOne",
+            "Value": "True"
+          }
+        ],
+        "VirtualizationType": "hvm",
+        "Volumes": [
+          {
+            "Attachments": [
+              {
+                "AttachTime": "2019-01-01T00:00:00Z",
+                "DeleteOnTermination": true,
+                "Device": "/dev/xvda",
+                "InstanceId": "i-111222333",
+                "State": "attached",
+                "VolumeId": "vol-111222333"
+              }
+            ],
+            "AvailabilityZone": "us-west-2b",
+            "CreateTime": "2019-01-01T00:00:00Z",
+            "Encrypted": false,
+            "Iops": 100,
+            "KmsKeyId": null,
+            "Size": 8,
+            "SnapshotId": "snap-111222333444",
+            "State": "in-use",
+            "Tags": [
+              {
+                "Key": "TagOne",
+                "Value": "True"
+              }
+            ],
+            "VolumeId": "vol-111222333444",
+            "VolumeType": "gp2"
+          }
+        ],
+        "VpcId": "vpc-111222333444"
+      }
+  -
+    Name: Instance Stopped
+    ExpectedResult: true
+    Resource:
+      {
+        "AmiLaunchIndex": 0,
+        "Architecture": "x86_64",
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/xvda",
+            "Ebs": {
+              "AttachTime": "2019-01-01T00:00:00Z",
+              "DeleteOnTermination": true,
+              "Status": "attached",
+              "VolumeId": "vol-0b111222333444"
+            }
+          }
+        ],
+        "CapacityReservationId": null,
+        "CapacityReservationSpecification": {
+          "CapacityReservationPreference": "open",
+          "CapacityReservationTarget": null
+        },
+        "ClientToken": null,
+        "CpuOptions": {
+          "CoreCount": 1,
+          "ThreadsPerCore": 1
+        },
+        "EbsOptimized": false,
+        "ElasticGpuAssociations": null,
+        "ElasticInferenceAcceleratorAssociations": null,
+        "EnaSupport": true,
+        "HibernationOptions": {
+          "Configured": false
+        },
+        "Hypervisor": "xen",
+        "IamInstanceProfile": null,
+        "ImageId": "ami-11122233344555",
+        "InstanceId": "i-111222333444555",
+        "InstanceLifecycle": null,
+        "InstanceType": "t2.micro",
+        "KernelId": null,
+        "KeyName": "key-1",
+        "LaunchTime": "2019-01-01T00:00:00Z",
+        "Licenses": null,
+        "Monitoring": {
+          "State": "disabled"
+        },
+        "NetworkInterfaces": [
+          {
+            "Association": {
+              "IpOwnerId": "amazon",
+              "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+              "PublicIp": "52.0.0.0"
+            },
+            "Attachment": {
+              "AttachTime": "2019-01-01T00:00:00Z",
+              "AttachmentId": "eni-attach-111222333444",
+              "DeleteOnTermination": true,
+              "DeviceIndex": 0,
+              "Status": "attached"
+            },
+            "Description": "Primary network interface",
+            "Groups": [
+              {
+                "GroupId": "sg-111222333444",
+                "GroupName": "base"
+              }
+            ],
+            "InterfaceType": "interface",
+            "Ipv6Addresses": null,
+            "MacAddress": "de:ad:be:ef:00:00",
+            "NetworkInterfaceId": "eni-111222333444",
+            "OwnerId": "123456789012",
+            "PrivateDnsName": "ip-10-0-0-0.us-west-2.compute.internal",
+            "PrivateIpAddress": "10.0.0.0",
+            "PrivateIpAddresses": [
+              {
+                "Association": {
+                  "IpOwnerId": "amazon",
+                  "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+                  "PublicIp": "52.0.0.0"
+                },
+                "Primary": true,
+                "PrivateDnsName": "ip-10-0-0-o.us-west-2.compute.internal",
+                "PrivateIpAddress": "10.0.0.0"
+              }
+            ],
+            "SourceDestCheck": true,
+            "Status": "in-use",
+            "SubnetId": "subnet-111222333444",
+            "VpcId": "vpc-111222333444"
+          }
+        ],
+        "Placement": {
+          "Affinity": null,
+          "AvailabilityZone": "us-west-2b",
+          "GroupName": null,
+          "HostId": null,
+          "PartitionNumber": null,
+          "SpreadDomain": null,
+          "Tenancy": "default"
+        },
+        "Platform": null,
+        "PrivateDnsName": "ip-10-0-0-0.us-west-2.compute.internal",
+        "PrivateIpAddress": "10.0.0.0",
+        "ProductCodes": null,
+        "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+        "PublicIpAddress": "52.0.0.0",
+        "RamdiskId": null,
+        "RootDeviceName": "/dev/xvda",
+        "RootDeviceType": "ebs",
+        "SecurityGroups": [
+          {
+            "GroupId": "sg-111222333444",
+            "GroupName": "base"
+          }
+        ],
+        "SourceDestCheck": true,
+        "SpotInstanceRequestId": null,
+        "SriovNetSupport": null,
+        "State": {
+          "Code": 80,
+          "Name": "stopped"
+        },
+        "StateReason": null,
+        "StateTransitionReason": null,
+        "SubnetId": "subnet-111222333",
+        "Tags": [
+          {
+            "Key": "TagOne",
+            "Value": "True"
+          }
+        ],
+        "VirtualizationType": "hvm",
+        "Volumes": [
+          {
+            "Attachments": [
+              {
+                "AttachTime": "2019-01-01T00:00:00Z",
+                "DeleteOnTermination": true,
+                "Device": "/dev/xvda",
+                "InstanceId": "i-111222333",
+                "State": "attached",
+                "VolumeId": "vol-111222333"
+              }
+            ],
+            "AvailabilityZone": "us-west-2b",
+            "CreateTime": "2019-01-01T00:00:00Z",
+            "Encrypted": false,
+            "Iops": 100,
+            "KmsKeyId": null,
+            "Size": 8,
+            "SnapshotId": "snap-111222333444",
+            "State": "in-use",
+            "Tags": [
+              {
+                "Key": "TagOne",
+                "Value": "True"
+              }
+            ],
+            "VolumeId": "vol-111222333444",
+            "VolumeType": "gp2"
+          }
+        ],
+        "VpcId": "vpc-111222333444"
+      }
+  -
+    Name: Instance Shutting Down
+    ExpectedResult: true
+    Resource:
+      {
+        "AmiLaunchIndex": 0,
+        "Architecture": "x86_64",
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/xvda",
+            "Ebs": {
+              "AttachTime": "2019-01-01T00:00:00Z",
+              "DeleteOnTermination": true,
+              "Status": "attached",
+              "VolumeId": "vol-0b111222333444"
+            }
+          }
+        ],
+        "CapacityReservationId": null,
+        "CapacityReservationSpecification": {
+          "CapacityReservationPreference": "open",
+          "CapacityReservationTarget": null
+        },
+        "ClientToken": null,
+        "CpuOptions": {
+          "CoreCount": 1,
+          "ThreadsPerCore": 1
+        },
+        "EbsOptimized": false,
+        "ElasticGpuAssociations": null,
+        "ElasticInferenceAcceleratorAssociations": null,
+        "EnaSupport": true,
+        "HibernationOptions": {
+          "Configured": false
+        },
+        "Hypervisor": "xen",
+        "IamInstanceProfile": null,
+        "ImageId": "ami-11122233344555",
+        "InstanceId": "i-111222333444555",
+        "InstanceLifecycle": null,
+        "InstanceType": "t2.micro",
+        "KernelId": null,
+        "KeyName": "key-1",
+        "LaunchTime": "2019-01-01T00:00:00Z",
+        "Licenses": null,
+        "Monitoring": {
+          "State": "disabled"
+        },
+        "NetworkInterfaces": [
+          {
+            "Association": {
+              "IpOwnerId": "amazon",
+              "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+              "PublicIp": "52.0.0.0"
+            },
+            "Attachment": {
+              "AttachTime": "2019-01-01T00:00:00Z",
+              "AttachmentId": "eni-attach-111222333444",
+              "DeleteOnTermination": true,
+              "DeviceIndex": 0,
+              "Status": "attached"
+            },
+            "Description": "Primary network interface",
+            "Groups": [
+              {
+                "GroupId": "sg-111222333444",
+                "GroupName": "base"
+              }
+            ],
+            "InterfaceType": "interface",
+            "Ipv6Addresses": null,
+            "MacAddress": "de:ad:be:ef:00:00",
+            "NetworkInterfaceId": "eni-111222333444",
+            "OwnerId": "123456789012",
+            "PrivateDnsName": "ip-10-0-0-0.us-west-2.compute.internal",
+            "PrivateIpAddress": "10.0.0.0",
+            "PrivateIpAddresses": [
+              {
+                "Association": {
+                  "IpOwnerId": "amazon",
+                  "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+                  "PublicIp": "52.0.0.0"
+                },
+                "Primary": true,
+                "PrivateDnsName": "ip-10-0-0-o.us-west-2.compute.internal",
+                "PrivateIpAddress": "10.0.0.0"
+              }
+            ],
+            "SourceDestCheck": true,
+            "Status": "in-use",
+            "SubnetId": "subnet-111222333444",
+            "VpcId": "vpc-111222333444"
+          }
+        ],
+        "Placement": {
+          "Affinity": null,
+          "AvailabilityZone": "us-west-2b",
+          "GroupName": null,
+          "HostId": null,
+          "PartitionNumber": null,
+          "SpreadDomain": null,
+          "Tenancy": "default"
+        },
+        "Platform": null,
+        "PrivateDnsName": "ip-10-0-0-0.us-west-2.compute.internal",
+        "PrivateIpAddress": "10.0.0.0",
+        "ProductCodes": null,
+        "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+        "PublicIpAddress": "52.0.0.0",
+        "RamdiskId": null,
+        "RootDeviceName": "/dev/xvda",
+        "RootDeviceType": "ebs",
+        "SecurityGroups": [
+          {
+            "GroupId": "sg-111222333444",
+            "GroupName": "base"
+          }
+        ],
+        "SourceDestCheck": true,
+        "SpotInstanceRequestId": null,
+        "SriovNetSupport": null,
+        "State": {
+          "Code": 32,
+          "Name": "shutting-down"
+        },
+        "StateReason": null,
+        "StateTransitionReason": null,
+        "SubnetId": "subnet-111222333",
+        "Tags": [
+          {
+            "Key": "TagOne",
+            "Value": "True"
+          }
+        ],
+        "VirtualizationType": "hvm",
+        "Volumes": [
+          {
+            "Attachments": [
+              {
+                "AttachTime": "2019-01-01T00:00:00Z",
+                "DeleteOnTermination": true,
+                "Device": "/dev/xvda",
+                "InstanceId": "i-111222333",
+                "State": "attached",
+                "VolumeId": "vol-111222333"
+              }
+            ],
+            "AvailabilityZone": "us-west-2b",
+            "CreateTime": "2019-01-01T00:00:00Z",
+            "Encrypted": false,
+            "Iops": 100,
+            "KmsKeyId": null,
+            "Size": 8,
+            "SnapshotId": "snap-111222333444",
+            "State": "in-use",
+            "Tags": [
+              {
+                "Key": "TagOne",
+                "Value": "True"
+              }
+            ],
+            "VolumeId": "vol-111222333444",
+            "VolumeType": "gp2"
+          }
+        ],
+        "VpcId": "vpc-111222333444"
+      }
+  -
+    Name: Instance Stopping Monitoring Disabled
+    ExpectedResult: true
+    Resource:
+      {
+        "AmiLaunchIndex": 0,
+        "Architecture": "x86_64",
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/xvda",
+            "Ebs": {
+              "AttachTime": "2019-01-01T00:00:00Z",
+              "DeleteOnTermination": true,
+              "Status": "attached",
+              "VolumeId": "vol-0b111222333444"
+            }
+          }
+        ],
+        "CapacityReservationId": null,
+        "CapacityReservationSpecification": {
+          "CapacityReservationPreference": "open",
+          "CapacityReservationTarget": null
+        },
+        "ClientToken": null,
+        "CpuOptions": {
+          "CoreCount": 1,
+          "ThreadsPerCore": 1
+        },
+        "EbsOptimized": false,
+        "ElasticGpuAssociations": null,
+        "ElasticInferenceAcceleratorAssociations": null,
+        "EnaSupport": true,
+        "HibernationOptions": {
+          "Configured": false
+        },
+        "Hypervisor": "xen",
+        "IamInstanceProfile": null,
+        "ImageId": "ami-11122233344555",
+        "InstanceId": "i-111222333444555",
+        "InstanceLifecycle": null,
+        "InstanceType": "t2.micro",
+        "KernelId": null,
+        "KeyName": "key-1",
+        "LaunchTime": "2019-01-01T00:00:00Z",
+        "Licenses": null,
+        "Monitoring": {
+          "State": "disabled"
+        },
+        "NetworkInterfaces": [
+          {
+            "Association": {
+              "IpOwnerId": "amazon",
+              "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+              "PublicIp": "52.0.0.0"
+            },
+            "Attachment": {
+              "AttachTime": "2019-01-01T00:00:00Z",
+              "AttachmentId": "eni-attach-111222333444",
+              "DeleteOnTermination": true,
+              "DeviceIndex": 0,
+              "Status": "attached"
+            },
+            "Description": "Primary network interface",
+            "Groups": [
+              {
+                "GroupId": "sg-111222333444",
+                "GroupName": "base"
+              }
+            ],
+            "InterfaceType": "interface",
+            "Ipv6Addresses": null,
+            "MacAddress": "de:ad:be:ef:00:00",
+            "NetworkInterfaceId": "eni-111222333444",
+            "OwnerId": "123456789012",
+            "PrivateDnsName": "ip-10-0-0-0.us-west-2.compute.internal",
+            "PrivateIpAddress": "10.0.0.0",
+            "PrivateIpAddresses": [
+              {
+                "Association": {
+                  "IpOwnerId": "amazon",
+                  "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+                  "PublicIp": "52.0.0.0"
+                },
+                "Primary": true,
+                "PrivateDnsName": "ip-10-0-0-o.us-west-2.compute.internal",
+                "PrivateIpAddress": "10.0.0.0"
+              }
+            ],
+            "SourceDestCheck": true,
+            "Status": "in-use",
+            "SubnetId": "subnet-111222333444",
+            "VpcId": "vpc-111222333444"
+          }
+        ],
+        "Placement": {
+          "Affinity": null,
+          "AvailabilityZone": "us-west-2b",
+          "GroupName": null,
+          "HostId": null,
+          "PartitionNumber": null,
+          "SpreadDomain": null,
+          "Tenancy": "default"
+        },
+        "Platform": null,
+        "PrivateDnsName": "ip-10-0-0-0.us-west-2.compute.internal",
+        "PrivateIpAddress": "10.0.0.0",
+        "ProductCodes": null,
+        "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+        "PublicIpAddress": "52.0.0.0",
+        "RamdiskId": null,
+        "RootDeviceName": "/dev/xvda",
+        "RootDeviceType": "ebs",
+        "SecurityGroups": [
+          {
+            "GroupId": "sg-111222333444",
+            "GroupName": "base"
+          }
+        ],
+        "SourceDestCheck": true,
+        "SpotInstanceRequestId": null,
+        "SriovNetSupport": null,
+        "State": {
+          "Code": 64,
+          "Name": "stopping"
+        },
+        "StateReason": null,
+        "StateTransitionReason": null,
+        "SubnetId": "subnet-111222333",
+        "Tags": [
+          {
+            "Key": "TagOne",
+            "Value": "True"
+          }
+        ],
+        "VirtualizationType": "hvm",
+        "Volumes": [
+          {
+            "Attachments": [
+              {
+                "AttachTime": "2019-01-01T00:00:00Z",
+                "DeleteOnTermination": true,
+                "Device": "/dev/xvda",
+                "InstanceId": "i-111222333",
+                "State": "attached",
+                "VolumeId": "vol-111222333"
+              }
+            ],
+            "AvailabilityZone": "us-west-2b",
+            "CreateTime": "2019-01-01T00:00:00Z",
+            "Encrypted": false,
+            "Iops": 100,
+            "KmsKeyId": null,
+            "Size": 8,
+            "SnapshotId": "snap-111222333444",
+            "State": "in-use",
+            "Tags": [
+              {
+                "Key": "TagOne",
+                "Value": "True"
+              }
+            ],
+            "VolumeId": "vol-111222333444",
+            "VolumeType": "gp2"
+          }
+        ],
+        "VpcId": "vpc-111222333444"
+      }
+  -
+    Name: Instance Terminated Monitoring Disabled
+    ExpectedResult: true
+    Resource:
+      {
+        "AmiLaunchIndex": 0,
+        "Architecture": "x86_64",
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/xvda",
+            "Ebs": {
+              "AttachTime": "2019-01-01T00:00:00Z",
+              "DeleteOnTermination": true,
+              "Status": "attached",
+              "VolumeId": "vol-0b111222333444"
+            }
+          }
+        ],
+        "CapacityReservationId": null,
+        "CapacityReservationSpecification": {
+          "CapacityReservationPreference": "open",
+          "CapacityReservationTarget": null
+        },
+        "ClientToken": null,
+        "CpuOptions": {
+          "CoreCount": 1,
+          "ThreadsPerCore": 1
+        },
+        "EbsOptimized": false,
+        "ElasticGpuAssociations": null,
+        "ElasticInferenceAcceleratorAssociations": null,
+        "EnaSupport": true,
+        "HibernationOptions": {
+          "Configured": false
+        },
+        "Hypervisor": "xen",
+        "IamInstanceProfile": null,
+        "ImageId": "ami-11122233344555",
+        "InstanceId": "i-111222333444555",
+        "InstanceLifecycle": null,
+        "InstanceType": "t2.micro",
+        "KernelId": null,
+        "KeyName": "key-1",
+        "LaunchTime": "2019-01-01T00:00:00Z",
+        "Licenses": null,
+        "Monitoring": {
+          "State": "disabled"
+        },
+        "NetworkInterfaces": [
+          {
+            "Association": {
+              "IpOwnerId": "amazon",
+              "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+              "PublicIp": "52.0.0.0"
+            },
+            "Attachment": {
+              "AttachTime": "2019-01-01T00:00:00Z",
+              "AttachmentId": "eni-attach-111222333444",
+              "DeleteOnTermination": true,
+              "DeviceIndex": 0,
+              "Status": "attached"
+            },
+            "Description": "Primary network interface",
+            "Groups": [
+              {
+                "GroupId": "sg-111222333444",
+                "GroupName": "base"
+              }
+            ],
+            "InterfaceType": "interface",
+            "Ipv6Addresses": null,
+            "MacAddress": "de:ad:be:ef:00:00",
+            "NetworkInterfaceId": "eni-111222333444",
+            "OwnerId": "123456789012",
+            "PrivateDnsName": "ip-10-0-0-0.us-west-2.compute.internal",
+            "PrivateIpAddress": "10.0.0.0",
+            "PrivateIpAddresses": [
+              {
+                "Association": {
+                  "IpOwnerId": "amazon",
+                  "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+                  "PublicIp": "52.0.0.0"
+                },
+                "Primary": true,
+                "PrivateDnsName": "ip-10-0-0-o.us-west-2.compute.internal",
+                "PrivateIpAddress": "10.0.0.0"
+              }
+            ],
+            "SourceDestCheck": true,
+            "Status": "in-use",
+            "SubnetId": "subnet-111222333444",
+            "VpcId": "vpc-111222333444"
+          }
+        ],
+        "Placement": {
+          "Affinity": null,
+          "AvailabilityZone": "us-west-2b",
+          "GroupName": null,
+          "HostId": null,
+          "PartitionNumber": null,
+          "SpreadDomain": null,
+          "Tenancy": "default"
+        },
+        "Platform": null,
+        "PrivateDnsName": "ip-10-0-0-0.us-west-2.compute.internal",
+        "PrivateIpAddress": "10.0.0.0",
+        "ProductCodes": null,
+        "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+        "PublicIpAddress": "52.0.0.0",
+        "RamdiskId": null,
+        "RootDeviceName": "/dev/xvda",
+        "RootDeviceType": "ebs",
+        "SecurityGroups": [
+          {
+            "GroupId": "sg-111222333444",
+            "GroupName": "base"
+          }
+        ],
+        "SourceDestCheck": true,
+        "SpotInstanceRequestId": null,
+        "SriovNetSupport": null,
+        "State": {
+          "Code": 48,
+          "Name": "terminated"
+        },
+        "StateReason": null,
+        "StateTransitionReason": null,
+        "SubnetId": "subnet-111222333",
+        "Tags": [
+          {
+            "Key": "TagOne",
+            "Value": "True"
+          }
+        ],
+        "VirtualizationType": "hvm",
+        "Volumes": [
+          {
+            "Attachments": [
+              {
+                "AttachTime": "2019-01-01T00:00:00Z",
+                "DeleteOnTermination": true,
+                "Device": "/dev/xvda",
+                "InstanceId": "i-111222333",
+                "State": "attached",
+                "VolumeId": "vol-111222333"
+              }
+            ],
+            "AvailabilityZone": "us-west-2b",
+            "CreateTime": "2019-01-01T00:00:00Z",
+            "Encrypted": false,
+            "Iops": 100,
+            "KmsKeyId": null,
+            "Size": 8,
+            "SnapshotId": "snap-111222333444",
+            "State": "in-use",
+            "Tags": [
+              {
+                "Key": "TagOne",
+                "Value": "True"
+              }
+            ],
+            "VolumeId": "vol-111222333444",
+            "VolumeType": "gp2"
+          }
+        ],
+        "VpcId": "vpc-111222333444"
+      }
+  -
+    Name: Instance Running Monitoring Disabled
+    ExpectedResult: false
+    Resource:
+      {
+        "AmiLaunchIndex": 0,
+        "Architecture": "x86_64",
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/xvda",
+            "Ebs": {
+              "AttachTime": "2019-01-01T00:00:00Z",
+              "DeleteOnTermination": true,
+              "Status": "attached",
+              "VolumeId": "vol-0b111222333444"
+            }
+          }
+        ],
+        "CapacityReservationId": null,
+        "CapacityReservationSpecification": {
+          "CapacityReservationPreference": "open",
+          "CapacityReservationTarget": null
+        },
+        "ClientToken": null,
+        "CpuOptions": {
+          "CoreCount": 1,
+          "ThreadsPerCore": 1
+        },
+        "EbsOptimized": false,
+        "ElasticGpuAssociations": null,
+        "ElasticInferenceAcceleratorAssociations": null,
+        "EnaSupport": true,
+        "HibernationOptions": {
+          "Configured": false
+        },
+        "Hypervisor": "xen",
+        "IamInstanceProfile": null,
+        "ImageId": "ami-11122233344555",
+        "InstanceId": "i-111222333444555",
+        "InstanceLifecycle": null,
+        "InstanceType": "t2.micro",
+        "KernelId": null,
+        "KeyName": "key-1",
+        "LaunchTime": "2019-01-01T00:00:00Z",
+        "Licenses": null,
+        "Monitoring": {
+          "State": "disabled"
+        },
+        "NetworkInterfaces": [
+          {
+            "Association": {
+              "IpOwnerId": "amazon",
+              "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+              "PublicIp": "52.0.0.0"
+            },
+            "Attachment": {
+              "AttachTime": "2019-01-01T00:00:00Z",
+              "AttachmentId": "eni-attach-111222333444",
+              "DeleteOnTermination": true,
+              "DeviceIndex": 0,
+              "Status": "attached"
+            },
+            "Description": "Primary network interface",
+            "Groups": [
+              {
+                "GroupId": "sg-111222333444",
+                "GroupName": "base"
+              }
+            ],
+            "InterfaceType": "interface",
+            "Ipv6Addresses": null,
+            "MacAddress": "de:ad:be:ef:00:00",
+            "NetworkInterfaceId": "eni-111222333444",
+            "OwnerId": "123456789012",
+            "PrivateDnsName": "ip-10-0-0-0.us-west-2.compute.internal",
+            "PrivateIpAddress": "10.0.0.0",
+            "PrivateIpAddresses": [
+              {
+                "Association": {
+                  "IpOwnerId": "amazon",
+                  "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+                  "PublicIp": "52.0.0.0"
+                },
+                "Primary": true,
+                "PrivateDnsName": "ip-10-0-0-o.us-west-2.compute.internal",
+                "PrivateIpAddress": "10.0.0.0"
+              }
+            ],
+            "SourceDestCheck": true,
+            "Status": "in-use",
+            "SubnetId": "subnet-111222333444",
+            "VpcId": "vpc-111222333444"
+          }
+        ],
+        "Placement": {
+          "Affinity": null,
+          "AvailabilityZone": "us-west-2b",
+          "GroupName": null,
+          "HostId": null,
+          "PartitionNumber": null,
+          "SpreadDomain": null,
+          "Tenancy": "default"
+        },
+        "Platform": null,
+        "PrivateDnsName": "ip-10-0-0-0.us-west-2.compute.internal",
+        "PrivateIpAddress": "10.0.0.0",
+        "ProductCodes": null,
+        "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+        "PublicIpAddress": "52.0.0.0",
+        "RamdiskId": null,
+        "RootDeviceName": "/dev/xvda",
+        "RootDeviceType": "ebs",
+        "SecurityGroups": [
+          {
+            "GroupId": "sg-111222333444",
+            "GroupName": "base"
+          }
+        ],
+        "SourceDestCheck": true,
+        "SpotInstanceRequestId": null,
+        "SriovNetSupport": null,
+        "State": {
+          "Code": 16,
+          "Name": "running"
+        },
+        "StateReason": null,
+        "StateTransitionReason": null,
+        "SubnetId": "subnet-111222333",
+        "Tags": [
+          {
+            "Key": "TagOne",
+            "Value": "True"
+          }
+        ],
+        "VirtualizationType": "hvm",
+        "Volumes": [
+          {
+            "Attachments": [
+              {
+                "AttachTime": "2019-01-01T00:00:00Z",
+                "DeleteOnTermination": true,
+                "Device": "/dev/xvda",
+                "InstanceId": "i-111222333",
+                "State": "attached",
+                "VolumeId": "vol-111222333"
+              }
+            ],
+            "AvailabilityZone": "us-west-2b",
+            "CreateTime": "2019-01-01T00:00:00Z",
+            "Encrypted": false,
+            "Iops": 100,
+            "KmsKeyId": null,
+            "Size": 8,
+            "SnapshotId": "snap-111222333444",
+            "State": "in-use",
+            "Tags": [
+              {
+                "Key": "TagOne",
+                "Value": "True"
+              }
+            ],
+            "VolumeId": "vol-111222333444",
+            "VolumeType": "gp2"
+          }
+        ],
+        "VpcId": "vpc-111222333444"
+      }
+  -
+    Name: Instance Pending Monitoring Disabled
+    ExpectedResult: false
+    Resource:
+      {
+        "AmiLaunchIndex": 0,
+        "Architecture": "x86_64",
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/xvda",
+            "Ebs": {
+              "AttachTime": "2019-01-01T00:00:00Z",
+              "DeleteOnTermination": true,
+              "Status": "attached",
+              "VolumeId": "vol-0b111222333444"
+            }
+          }
+        ],
+        "CapacityReservationId": null,
+        "CapacityReservationSpecification": {
+          "CapacityReservationPreference": "open",
+          "CapacityReservationTarget": null
+        },
+        "ClientToken": null,
+        "CpuOptions": {
+          "CoreCount": 1,
+          "ThreadsPerCore": 1
+        },
+        "EbsOptimized": false,
+        "ElasticGpuAssociations": null,
+        "ElasticInferenceAcceleratorAssociations": null,
+        "EnaSupport": true,
+        "HibernationOptions": {
+          "Configured": false
+        },
+        "Hypervisor": "xen",
+        "IamInstanceProfile": null,
+        "ImageId": "ami-11122233344555",
+        "InstanceId": "i-111222333444555",
+        "InstanceLifecycle": null,
+        "InstanceType": "t2.micro",
+        "KernelId": null,
+        "KeyName": "key-1",
+        "LaunchTime": "2019-01-01T00:00:00Z",
+        "Licenses": null,
+        "Monitoring": {
+          "State": "disabled"
+        },
+        "NetworkInterfaces": [
+          {
+            "Association": {
+              "IpOwnerId": "amazon",
+              "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+              "PublicIp": "52.0.0.0"
+            },
+            "Attachment": {
+              "AttachTime": "2019-01-01T00:00:00Z",
+              "AttachmentId": "eni-attach-111222333444",
+              "DeleteOnTermination": true,
+              "DeviceIndex": 0,
+              "Status": "attached"
+            },
+            "Description": "Primary network interface",
+            "Groups": [
+              {
+                "GroupId": "sg-111222333444",
+                "GroupName": "base"
+              }
+            ],
+            "InterfaceType": "interface",
+            "Ipv6Addresses": null,
+            "MacAddress": "de:ad:be:ef:00:00",
+            "NetworkInterfaceId": "eni-111222333444",
+            "OwnerId": "123456789012",
+            "PrivateDnsName": "ip-10-0-0-0.us-west-2.compute.internal",
+            "PrivateIpAddress": "10.0.0.0",
+            "PrivateIpAddresses": [
+              {
+                "Association": {
+                  "IpOwnerId": "amazon",
+                  "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+                  "PublicIp": "52.0.0.0"
+                },
+                "Primary": true,
+                "PrivateDnsName": "ip-10-0-0-o.us-west-2.compute.internal",
+                "PrivateIpAddress": "10.0.0.0"
+              }
+            ],
+            "SourceDestCheck": true,
+            "Status": "in-use",
+            "SubnetId": "subnet-111222333444",
+            "VpcId": "vpc-111222333444"
+          }
+        ],
+        "Placement": {
+          "Affinity": null,
+          "AvailabilityZone": "us-west-2b",
+          "GroupName": null,
+          "HostId": null,
+          "PartitionNumber": null,
+          "SpreadDomain": null,
+          "Tenancy": "default"
+        },
+        "Platform": null,
+        "PrivateDnsName": "ip-10-0-0-0.us-west-2.compute.internal",
+        "PrivateIpAddress": "10.0.0.0",
+        "ProductCodes": null,
+        "PublicDnsName": "ec2-52-0-0-0.us-west-2.compute.amazonaws.com",
+        "PublicIpAddress": "52.0.0.0",
+        "RamdiskId": null,
+        "RootDeviceName": "/dev/xvda",
+        "RootDeviceType": "ebs",
+        "SecurityGroups": [
+          {
+            "GroupId": "sg-111222333444",
+            "GroupName": "base"
+          }
+        ],
+        "SourceDestCheck": true,
+        "SpotInstanceRequestId": null,
+        "SriovNetSupport": null,
+        "State": {
+          "Code": 0,
+          "Name": "pending"
         },
         "StateReason": null,
         "StateTransitionReason": null,


### PR DESCRIPTION
### Background
A customer reported that EC2 Instance Detailed Monitoring detection had alerted for them on terminated instances. 

I added tests to cover the conditions, then modified the detection to accommodate.

### Changes


### Testing

* `make test`
**Before**
<img width="701" alt="Screen Shot 2022-09-12 at 15 23 15" src="https://user-images.githubusercontent.com/932424/189770269-fd7c886c-7aa9-4307-a616-55bd8c0573e7.png">

**After**
<img width="623" alt="Screen Shot 2022-09-12 at 15 27 35" src="https://user-images.githubusercontent.com/932424/189770273-428e47bb-09da-41f6-9e1b-45629f927c69.png">

