### PR TITLE
Revert "bug: GreyNoise last_seen attribute had been referenced by a non-extant field name. update to an extant field (#486)

### DIFF
--- a/global_helpers/panther_greynoise_helpers.py
+++ b/global_helpers/panther_greynoise_helpers.py
@@ -102,7 +102,7 @@ class GreyNoiseAdvanced:
         return parser.parse(deep_get(self.noise, match_field, "first_seen"))
 
     def last_seen(self, match_field) -> datetime.date:
-        return parser.parse(deep_get(self.noise, match_field, "last_seen"))
+        return parser.parse(deep_get(self.noise, match_field, "last_seen_timestamp"))
 
     def asn(self, match_field) -> str:
         return deep_get(self.noise, match_field, "metadata", "asn")


### PR DESCRIPTION
### Background

This reverts commit f86b06b429a8ca0c88fb5422cffa0f3081c8730c.


After deploying, we found evidence that this field is named with the underbar timestamp suffix. Reverting while we try to align documentation + reality. 

### Changes

* 

### Testing

* 
