### PR TITLE
fix: remove double comma 😱

### DIFF
--- a/queries/snowflake_queries/snowflake_brute_force_ip_query.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_ip_query.yml
@@ -19,7 +19,7 @@ SnowflakeQuery: >
     COUNT(event_id) AS counts
   FROM snowflake.account_usage.login_history
   WHERE 1=1
-    AND p_occurs_since('24 h',, event_timestamp)
+    AND p_occurs_since('24 h', event_timestamp)
     AND error_code is NOT NULL
   GROUP BY client_ip, reported_client_type
   HAVING counts >= 5

--- a/queries/snowflake_queries/snowflake_brute_force_username_query.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_username_query.yml
@@ -19,10 +19,10 @@ SnowflakeQuery: >
     COUNT(event_id) AS counts
   FROM snowflake.account_usage.login_history
   WHERE 1=1
-    AND p_occurs_since('24 h',, event_timestamp)
+    AND p_occurs_since('24 h', event_timestamp)
     AND error_code IS NOT NULL
   GROUP BY reported_client_type, user_name
   HAVING counts >=5;
 Schedule:
-  CronExpression: '0 6 * * *'
+  CronExpression: "0 6 * * *"
   TimeoutMinutes: 1

--- a/queries/snowflake_queries/snowflake_key_user_password_login_query.yml
+++ b/queries/snowflake_queries/snowflake_key_user_password_login_query.yml
@@ -19,10 +19,9 @@ SnowflakeQuery: >
   JOIN snowflake.account_usage.users u on l.user_name = u.name and has_rsa_public_key = 'true'
    WHERE is_success = 'YES'
    AND first_authentication_factor != 'RSA_KEYPAIR'
-   AND p_occurs_since('24 h',, event_timestamp)
+   AND p_occurs_since('24 h', event_timestamp)
    GROUP BY name, first_authentication_factor, second_authentication_factor
    ORDER BY count(*) desc
 Schedule:
   RateMinutes: 1440
   TimeoutMinutes: 2
-

--- a/queries/snowflake_queries/snowflake_login_without_mfa_query.yml
+++ b/queries/snowflake_queries/snowflake_login_without_mfa_query.yml
@@ -21,7 +21,7 @@ SnowflakeQuery: >
     second_authentication_factor
   FROM snowflake.account_usage.login_history
     WHERE
-      p_occurs_since('1 h',, event_timestamp)
+      p_occurs_since('1 h', event_timestamp)
       AND first_authentication_factor = 'PASSWORD'
       AND second_authentication_factor IS null
   ORDER BY event_timestamp desc

--- a/queries/snowflake_queries/snowflake_network_policy_modified_query.yml
+++ b/queries/snowflake_queries/snowflake_network_policy_modified_query.yml
@@ -19,7 +19,7 @@ SnowflakeQuery: >
     role_name
   FROM snowflake.account_usage.query_history
     WHERE
-      p_occurs_since('24 h',, start_time)
+      p_occurs_since('24 h', start_time)
       AND execution_status = 'SUCCESS'
       AND user_name != 'PANTHER_READONLY'
       AND (
@@ -29,5 +29,5 @@ SnowflakeQuery: >
         )
   ORDER BY end_time desc
 Schedule:
-  CronExpression: '0 6 * * *'
+  CronExpression: "0 6 * * *"
   TimeoutMinutes: 1

--- a/queries/snowflake_queries/snowflake_privileged_object_changes_query.yml
+++ b/queries/snowflake_queries/snowflake_privileged_object_changes_query.yml
@@ -18,7 +18,7 @@ SnowflakeQuery: >
     end_time
   FROM snowflake.account_usage.query_history
     WHERE
-      p_occurs_since('24 h',, start_time)
+      p_occurs_since('24 h', start_time)
       AND execution_status = 'SUCCESS'
       AND query_type NOT in ('SELECT')
       AND (
@@ -32,5 +32,5 @@ SnowflakeQuery: >
           )
   ORDER BY end_time desc
 Schedule:
-  CronExpression: '0 6 * * *'
+  CronExpression: "0 6 * * *"
   TimeoutMinutes: 1

--- a/queries/snowflake_queries/snowflake_public_role_grant_query.yml
+++ b/queries/snowflake_queries/snowflake_public_role_grant_query.yml
@@ -18,7 +18,7 @@ SnowflakeQuery: >
     end_time
   FROM snowflake.account_usage.query_history
     WHERE
-      p_occurs_since('1 h',, start_time)
+      p_occurs_since('1 h', start_time)
       AND execution_status = 'SUCCESS'
       AND query_type = 'GRANT'
       AND query_text ILIKE '%to%public%'

--- a/queries/snowflake_queries/snowflake_scim_token_created_query.yml
+++ b/queries/snowflake_queries/snowflake_scim_token_created_query.yml
@@ -13,7 +13,7 @@ SnowflakeQuery: >
     *
   FROM snowflake.account_usage.query_history
     WHERE
-    p_occurs_since('1 h',, start_time)
+    p_occurs_since('1 h', start_time)
     AND execution_status = 'SUCCESS'
     AND query_text ilike '%system$generate_scim_access_token%'
   ORDER BY end_time desc

--- a/queries/snowflake_queries/snowflake_unusual_login_volume_query.yml
+++ b/queries/snowflake_queries/snowflake_unusual_login_volume_query.yml
@@ -10,7 +10,7 @@ SnowflakeQuery: >
 
   SELECT DISTINCT user_name, count(user_name), first_authentication_factor
   FROM snowflake.account_usage.login_history
-  WHERE p_occurs_since('24 h' ,, event_timestamp)
+  WHERE p_occurs_since('24 h' , event_timestamp)
   AND is_success = 'YES'
   AND user_name NOT LIKE '%PANTHER%'
     GROUP BY user_name, first_authentication_factor

--- a/queries/snowflake_queries/snowflake_user_created_query.yml
+++ b/queries/snowflake_queries/snowflake_user_created_query.yml
@@ -19,11 +19,11 @@ SnowflakeQuery: >
     role_name
   FROM snowflake.account_usage.query_history
     WHERE
-      p_occurs_since('24 h',, start_time)
+      p_occurs_since('24 h', start_time)
       AND execution_status = 'SUCCESS'
       AND query_type = 'CREATE_USER'
       AND query_text ILIKE '%create%user%'
   ORDER BY end_time desc
 Schedule:
-  CronExpression: '0 6 * * *'
+  CronExpression: "0 6 * * *"
   TimeoutMinutes: 1

--- a/queries/snowflake_queries/snowflake_user_enabled_query.yml
+++ b/queries/snowflake_queries/snowflake_user_enabled_query.yml
@@ -19,7 +19,7 @@ SnowflakeQuery: >
     role_name
   FROM snowflake.account_usage.query_history
     WHERE
-      p_occurs_since('24 h',, start_time)
+      p_occurs_since('24 h', start_time)
       AND execution_status = 'SUCCESS'
       AND query_type = 'ALTER_USER'
       AND (query_text ILIKE '%alter user%set disabled = false%'
@@ -28,5 +28,5 @@ SnowflakeQuery: >
           OR query_text ILIKE '%alter user%set disabled=false%')
   ORDER BY end_time desc
 Schedule:
-  CronExpression: '0 6 * * *'
+  CronExpression: "0 6 * * *"
   TimeoutMinutes: 1


### PR DESCRIPTION
### Background

The double comma seems to be invalid syntax for our macro and keeps it from properly expanding. This causes issues when these queries are uploaded and the snowflake-admin api attempts to set things up


### Testing

* <Testing steps>
