### PR TITLE
fix: remove localdev cruft from github workflow

### DIFF
--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -13,11 +13,6 @@ jobs:
       false
     runs-on: ubuntu-latest
     steps:
-      - name: echo stuff
-        run: |
-          echo "${{ github }}"
-          echo and also
-          echo "${{ context }}"
       - uses: actions/github-script@v6
         id: set_upstream
         name: Check Upstream


### PR DESCRIPTION
### Background

I had been using https://github.com/nektos/act to validate this locally, and in so doing I left a step in here which errors out when run via github actions. 

### Changes

* 

### Testing

* 
