### PR TITLE
[cloudtrail rules] AWS Macie Evasion

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,12 @@ pipenv run panther_analysis_tool zip --filter Severity=Critical
 
 ### Upload detections to your Panther instance
 ```bash
+# Note: Set your AWS access keys and region env variables before running the `upload` command
+
+export AWS_REGION=us-east-1
 pipenv run panther_analysis_tool upload [-h] [--path PATH] [--out OUT]
                                   [--filter KEY=VALUE [KEY=VALUE ...]]
                                   [--debug]
-
-# Important: Make sure you have access keys and region settings set for the AWS account running Panther
 ```
 
 Global helper functions are defined in the `global_helpers` folder. This is a hard coded location and cannot change. However, you may create as many files as you'd like under this path. Simply import them into your detections by the specified `GlobalID`.

--- a/rules/aws_cloudtrail_rules/aws_macie_evasion.py
+++ b/rules/aws_cloudtrail_rules/aws_macie_evasion.py
@@ -1,0 +1,27 @@
+from panther_base_helpers import deep_get, pattern_match
+
+MACIE_EVENTS = {
+    "ArchiveFindings",
+    "CreateFindingsFilter",
+    "DeleteMember",
+    "DisassociateFromMasterAccount",
+    "DisassociateMember",
+    "DisableMacie",
+    "DisableOrganizationAdminAccount",
+    "UpdateFindingsFilter",
+    "UpdateMacieSession",
+    "UpdateMemberSession",
+    "UpdateClassificationJob",
+}
+
+
+def rule(event):
+    return event.get("eventName") in MACIE_EVENTS and pattern_match(
+        event.get("eventSource"), "macie?.amazonaws.com"
+    )
+
+
+def title(event):
+    account = event.get("recipientAccountId")
+    user_arn = deep_get(event, "userIdentity", "arn")
+    return f"AWS Macie in AWS Account [{account}] Disabled or Updated by [{user_arn}]"

--- a/rules/aws_cloudtrail_rules/aws_macie_evasion.py
+++ b/rules/aws_cloudtrail_rules/aws_macie_evasion.py
@@ -17,11 +17,11 @@ MACIE_EVENTS = {
 
 def rule(event):
     return event.get("eventName") in MACIE_EVENTS and pattern_match(
-        event.get("eventSource"), "macie?.amazonaws.com"
+        event.get("eventSource"), "macie*.amazonaws.com"
     )
 
 
 def title(event):
     account = event.get("recipientAccountId")
     user_arn = deep_get(event, "userIdentity", "arn")
-    return f"AWS Macie in AWS Account [{account}] Disabled or Updated by [{user_arn}]"
+    return f"AWS Macie in AWS Account [{account}] Disabled/Updated by [{user_arn}]"

--- a/rules/aws_cloudtrail_rules/aws_macie_evasion.yml
+++ b/rules/aws_cloudtrail_rules/aws_macie_evasion.yml
@@ -154,3 +154,66 @@ Tests:
           "type": "AssumedRole"
         }
       }
+  -
+    Name: UpdateSession (Macie v1 event) # The title of the test
+    ExpectedResult: true # If the sample event should generate an alert or not
+    Log:
+      {
+        "awsRegion": "us-east-2",
+        "eventCategory": "Management",
+        "eventID": "63033dfd-08c9-42f3-80ae-dca45e86ae84",
+        "eventName": "UpdateMacieSession",
+        "eventSource": "macie.amazonaws.com",
+        "eventTime": "2022-09-27 19:59:08",
+        "eventType": "AwsApiCall",
+        "eventVersion": "1.08",
+        "managementEvent": true,
+        "p_any_aws_account_ids": [
+          "123456789012"
+        ],
+        "p_any_aws_arns": [
+          "arn:aws:iam::123456789012:role/Admin",
+          "arn:aws:sts::123456789012:assumed-role/Admin/Jack"
+        ],
+        "p_any_ip_addresses": [
+          "46.91.25.204"
+        ],
+        "p_any_trace_ids": [
+          "ASIASWJRT64Z42HFV6QX"
+        ],
+        "p_event_time": "2022-09-27 19:59:08",
+        "p_log_type": "AWS.CloudTrail",
+        "p_parse_time": "2022-09-27 20:02:43.816",
+        "p_row_id": "665d45a409cad7d68ff7bbd4138123",
+        "p_source_id": "b00eb354-da7a-49dd-9cc6-32535e32096a",
+        "p_source_label": "CloudTrail Test",
+        "readOnly": false,
+        "recipientAccountId": "123456789012",
+        "requestID": "1b9981dc-21d2-4f77-92b0-69e23c8a40de",
+        "requestParameters": {
+          "findingPublishingFrequency": "SIX_HOURS"
+        },
+        "sourceIPAddress": "46.91.25.204",
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36",
+        "userIdentity": {
+          "accessKeyId": "ASIASWJRT64Z42HFV6QX",
+          "accountId": "123456789012",
+          "arn": "arn:aws:sts::123456789012:assumed-role/Admin/Jack",
+          "principalId": "AAAAA44444LE6DYFKKKKK:Jack",
+          "sessionContext": {
+            "attributes": {
+              "creationDate": "2022-09-27T17:56:01Z",
+              "mfaAuthenticated": "true"
+            },
+            "sessionIssuer": {
+              "accountId": "123456789012",
+              "arn": "arn:aws:iam::123456789012:role/Admin",
+              "principalId": "AAAAA44444LE6DYFKKKKK",
+              "type": "Role",
+              "userName": "Admin"
+            },
+            "webIdFederationData": {}
+          },
+          "type": "AssumedRole"
+        }
+      }

--- a/rules/aws_cloudtrail_rules/aws_macie_evasion.yml
+++ b/rules/aws_cloudtrail_rules/aws_macie_evasion.yml
@@ -1,0 +1,156 @@
+AnalysisType: rule
+Filename: aws_macie_evasion.py
+RuleID: AWS.Macie.Evasion
+DisplayName: AWS Macie Disabled/Updated
+Enabled: true
+LogTypes:
+  - AWS.CloudTrail
+Reports:
+  MITRE ATT&CK:
+    - 'TA0005:T1562' # Tactic ID:Technique ID (https://attack.mitre.org/tactics/enterprise/)
+Severity: Medium 
+Description: > 
+  Amazon Macie is a data security and data privacy service to discover and protect sensitive data.
+  Security teams use Macie to detect open S3 Buckets that could have potentially sensitive data in it along with 
+  policy violations, such as missing Encryption. If an attacker disables Macie, it could potentially hide data exfiltration.
+Reference: https://aws.amazon.com/macie/
+Runbook: >
+  Analyze the events to ensure it's not normal maintenance.
+  If it's abnormal, run the Indicator Search on the UserIdentity:Arn for the past hour and analyze other services accessed/changed.
+DedupPeriodMinutes: 60
+Threshold: 5
+SummaryAttributes:
+  - awsRegion
+  - eventName
+  - p_any_aws_arns
+  - p_any_ip_addresses
+  - userIdentity:type
+  - userIdentity:arn
+Tests:
+  - 
+    Name: ListMembers
+    ExpectedResult: false
+    Log:
+      {
+        "awsRegion": "us-west-1",
+        "eventCategory": "Management",
+        "eventID": "5b3e4cf6-c37d-4c8c-9016-b8444a37ceaa",
+        "eventName": "ListMembers",
+        "eventSource": "macie2.amazonaws.com",
+        "eventTime": "2022-09-27 18:11:33",
+        "eventType": "AwsApiCall",
+        "eventVersion": "1.08",
+        "managementEvent": true,
+        "p_any_aws_account_ids": [
+          "123456789012"
+        ],
+        "p_any_aws_arns": [
+          "arn:aws:iam::123456789012:role/Admin",
+          "arn:aws:sts::123456789012:assumed-role/Admin/Jack"
+        ],
+        "p_any_ip_addresses": [
+          "178.253.78.209"
+        ],
+        "p_any_trace_ids": [
+          "AAAASSSST64ZTHFY7777"
+        ],
+        "p_event_time": "2022-09-27 18:11:33",
+        "p_log_type": "AWS.CloudTrail",
+        "p_parse_time": "2022-09-27 18:16:43.428",
+        "p_row_id": "665d45a409cad7d68ff7bbd4138d02",
+        "p_source_id": "b00eb354-da7a-49dd-9cc6-32535e32096a",
+        "p_source_label": "CloudTrail Test",
+        "readOnly": true,
+        "recipientAccountId": "123456789012",
+        "requestID": "2164bbea-3eb0-444b-8e10-8ba53b3460b6",
+        "requestParameters": {
+          "maxResults": "1",
+          "onlyAssociated": "true"
+        },
+        "sourceIPAddress": "178.253.78.209",
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36",
+        "userIdentity": {
+          "accessKeyId": "AAAASSSST64ZTHFY7777",
+          "accountId": "123456789012",
+          "arn": "arn:aws:sts::123456789012:assumed-role/Admin/Jack",
+          "principalId": "AAAAA44444LE6DYFKKKKK:Jack",
+          "sessionContext": {
+            "attributes": {
+              "creationDate": "2022-09-27T17:56:01Z",
+              "mfaAuthenticated": "true"
+            },
+            "sessionIssuer": {
+              "accountId": "123456789012",
+              "arn": "arn:aws:iam::123456789012:role/Admin",
+              "principalId": "AAAAA44444LE6DYFKKKKK",
+              "type": "Role",
+              "userName": "Admin"
+            },
+            "webIdFederationData": {}
+          },
+          "type": "AssumedRole"
+        }
+      }
+  -
+    Name: UpdateSession # The title of the test
+    ExpectedResult: true # If the sample event should generate an alert or not
+    Log:
+      {
+        "awsRegion": "us-east-2",
+        "eventCategory": "Management",
+        "eventID": "63033dfd-08c9-42f3-80ae-dca45e86ae84",
+        "eventName": "UpdateMacieSession",
+        "eventSource": "macie2.amazonaws.com",
+        "eventTime": "2022-09-27 19:59:08",
+        "eventType": "AwsApiCall",
+        "eventVersion": "1.08",
+        "managementEvent": true,
+        "p_any_aws_account_ids": [
+          "123456789012"
+        ],
+        "p_any_aws_arns": [
+          "arn:aws:iam::123456789012:role/Admin",
+          "arn:aws:sts::123456789012:assumed-role/Admin/Jack"
+        ],
+        "p_any_ip_addresses": [
+          "46.91.25.204"
+        ],
+        "p_any_trace_ids": [
+          "ASIASWJRT64Z42HFV6QX"
+        ],
+        "p_event_time": "2022-09-27 19:59:08",
+        "p_log_type": "AWS.CloudTrail",
+        "p_parse_time": "2022-09-27 20:02:43.816",
+        "p_row_id": "665d45a409cad7d68ff7bbd4138123",
+        "p_source_id": "b00eb354-da7a-49dd-9cc6-32535e32096a",
+        "p_source_label": "CloudTrail Test",
+        "readOnly": false,
+        "recipientAccountId": "123456789012",
+        "requestID": "1b9981dc-21d2-4f77-92b0-69e23c8a40de",
+        "requestParameters": {
+          "findingPublishingFrequency": "SIX_HOURS"
+        },
+        "sourceIPAddress": "46.91.25.204",
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36",
+        "userIdentity": {
+          "accessKeyId": "ASIASWJRT64Z42HFV6QX",
+          "accountId": "123456789012",
+          "arn": "arn:aws:sts::123456789012:assumed-role/Admin/Jack",
+          "principalId": "AAAAA44444LE6DYFKKKKK:Jack",
+          "sessionContext": {
+            "attributes": {
+              "creationDate": "2022-09-27T17:56:01Z",
+              "mfaAuthenticated": "true"
+            },
+            "sessionIssuer": {
+              "accountId": "123456789012",
+              "arn": "arn:aws:iam::123456789012:role/Admin",
+              "principalId": "AAAAA44444LE6DYFKKKKK",
+              "type": "Role",
+              "userName": "Admin"
+            },
+            "webIdFederationData": {}
+          },
+          "type": "AssumedRole"
+        }
+      }

--- a/templates/example_rule.yml
+++ b/templates/example_rule.yml
@@ -5,7 +5,7 @@ DisplayName: Human Readable Detection Name
 Enabled: true
 LogTypes:
   - LogType.Name # https://docs.panther.com/data-onboarding/supported-logs
-Tags: 
+Tags: # (Optional)
   - Tag
 Reports: # (Optional)
   MITRE ATT&CK:


### PR DESCRIPTION
### Background

Inspired by the [Sigma rule](https://github.com/SigmaHQ/sigma/blob/master/rules/cloud/aws/aws_macic_evasion.yml) to detect if AWS Macie has been disabled or updated in a way to mask findings.

### Changes

* AWS Macie Rule and Tests

### Testing

* Locally and Unit Tests
