### PR TITLE
fix: aws waf disassociation detects mitre technique T1498

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_waf_disassociation.yml
+++ b/rules/aws_cloudtrail_rules/aws_waf_disassociation.yml
@@ -7,7 +7,7 @@ Reference: https://attack.mitre.org/techniques/T1078/
 Severity: Critical
 Reports:
   MITRE ATT&CK:
-    - TA0004:T1078
+    - TA0004:T1498
 Tests:
     - ExpectedResult: true
       Log:


### PR DESCRIPTION
### Background

I was looking at the MITRE coverage and noticed that network DoS was uncovered, though this detection provides some coverage for T1498 

### Changes

* 

### Testing

* 
