### PR TITLE
fix: Default behavior of our python environment should be to use the Pipfile.lock specified versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ci:
 	pipenv run $(MAKE) lint test
 
 deps:
-	pipenv install --dev
+	pipenv sync --dev
 
 deps-update:
 	pipenv update
@@ -26,7 +26,7 @@ lint-fmt:
 	pipenv run black --line-length=100 --check $(dirs)
 
 venv:
-	pipenv install --dev
+	pipenv sync --dev
 
 pat-update:
 	pipenv update panther-analysis-tool
@@ -36,7 +36,7 @@ fmt:
 	pipenv run black --line-length=100 $(dirs)
 
 install:
-	pipenv install --dev
+	pipenv sync --dev
 
 test: global-helpers-unit-test
 	pipenv run panther_analysis_tool test

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1715e6a6f19caee2af4f02c4e04ec9ef2a383b3c94dc39b72e2abec903f14893"
+            "sha256": "54fe61c59f3dacad02cefd22fc88dd3525b95253d548767a6ef57d3fce9fb3c8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -21,7 +21,7 @@
                 "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
                 "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2022.9.24"
         },
         "charset-normalizer": {
@@ -29,7 +29,7 @@
                 "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
                 "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2.1.1"
         },
         "idna": {
@@ -255,7 +255,7 @@
                 "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
                 "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2022.9.24"
         },
         "charset-normalizer": {
@@ -263,7 +263,7 @@
                 "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
                 "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2.1.1"
         },
         "click": {


### PR DESCRIPTION
### Background

CI runs and other workflows could install versions beyond what is specified in Pipfile.lock, because of the default behavior of `pipenv install` 

This change makes the default behavior of the tooling to be **install based on lockfile versions**
 
In order to bring upstream version updates, one will need to run `make deps-update` or `make pat-update` 


### Changes

* The default installation behavior for python dependencies could potentially lead to version differences between the content used to validate the primary branch and subsequent actions taken when the source material is the primary branch. 

### Testing

* make test
