### PR TITLE
feat: allow gsuite admins to provide an allow-list of applicationNames for when google is the IdP for a saml app

### DIFF
--- a/rules/gsuite_activityevent_rules/gsuite_login_type.py
+++ b/rules/gsuite_activityevent_rules/gsuite_login_type.py
@@ -1,6 +1,6 @@
 from panther_base_helpers import deep_get
 
-# Remove any unapproved login methods
+# allow-list of approved login types
 APPROVED_LOGIN_TYPES = {
     "exchange",
     "google_password",
@@ -9,19 +9,24 @@ APPROVED_LOGIN_TYPES = {
     "unknown",
 }
 
+# allow-list any application names here
+APPROVED_APPLICATION_NAMES = {"saml"}
+
 
 def rule(event):
     if event.get("type") != "login":
         return False
 
-    if (
-        event.get("type") == "login"
-        and event.get("name") != "logout"
-        and deep_get(event, "parameters", "login_type") not in APPROVED_LOGIN_TYPES
-    ):
-        return True
+    if event.get("name") == "logout":
+        return False
 
-    return False
+    if (
+        deep_get(event, "parameters", "login_type") in APPROVED_LOGIN_TYPES
+        or deep_get(event, "id", "applicationName") in APPROVED_APPLICATION_NAMES
+    ):
+        return False
+
+    return True
 
 
 def title(event):

--- a/rules/gsuite_activityevent_rules/gsuite_login_type.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_login_type.yml
@@ -72,3 +72,26 @@ Tests:
           "login_type": "saml"
         },
       }
+  -
+    Name: Saml Login Event
+    ExpectedResult: false
+    Log:
+      {
+        "actor": {
+          "email": "some.user@somedomain.com",
+        },
+        "id": {
+          "applicationName": "saml",
+          "time": "2022-05-26 15:26:09.421000000",
+        },
+        "ipAddress": "10.10.10.10",
+        "kind": "admin#reports#activity",
+        "name": "login_success",
+        "parameters": {
+          "application_name": "Some SAML Application",
+          "initiated_by": "sp",
+          "orgunit_path": "/SomeOrgUnit",
+          "saml_status_code": "SUCCESS_URI"
+        },
+        "type": "login"
+      }


### PR DESCRIPTION
### Background

I was reviewing old PRs and noticed #434. This branch implements the same logic as proposed in #434 

### Changes

* Manifests an allow-list for gsuite login events based on applicationName
* Additionally, I restructured the existing logic to make the allow-lists more comprehensible. 

### Testing

* make test
