### PR TITLE
Potential typo prevents tests from passing

### DIFF
--- a/rules/okta_rules/okta_password_accessed.py
+++ b/rules/okta_rules/okta_password_accessed.py
@@ -11,9 +11,9 @@ def rule(event):
         return False
 
     # event['target'] = [{...}, {...}, {...}]
-    TARGET_USERS = get_val_from_list(event.get("target", [{}]), "alternateId", "Type", "AppUser")
+    TARGET_USERS = get_val_from_list(event.get("target", [{}]), "alternateId", "type", "AppUser")
     TARGET_APP_NAMES = get_val_from_list(
-        event.get("target", [{}]), "alternateId", "Type", "AppInstance"
+        event.get("target", [{}]), "alternateId", "type", "AppInstance"
     )
 
     if deep_get(event, "actor", "alternateId") not in TARGET_USERS:


### PR DESCRIPTION
Logs show `type`, with low case `t`. I've encountered issues with the logic in this rule until I modified this.

### Background

Importing the rule as is threw a nondescript error: `None should be instance of 'dict'`

Local checks against our system logs for Okta showed that `type` was spelt in lower case. Changing this fixed the tests. 

### Changes

`T` -> `t` :)

### Testing

N/A
