### PR TITLE
fix: get_val_from_list would raise an error if the comparison key was not in the input item of the list

### DIFF
--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -14,6 +14,21 @@ import panther_base_helpers as p_b_h  # pylint: disable=C0413
 import panther_tor_helpers as p_tor_h  # pylint: disable=C0413
 
 
+class TestGetValFromList(unittest.TestCase):
+    def test_input_dict(self):
+        input = [{"actor": 1, "two": 2, "select": "me" }, {"actor": 3, "four": 4, "select": "notme"}]
+        response = p_b_h.get_val_from_list(input, "actor", "select", "me")
+        should_be = set()
+        should_be.add(1)
+        self.assertCountEqual(response, should_be)
+
+    # This test case validate that get_val_from_list will return the empty set when the comparison key is not found
+    def test_input_notdict(self):
+        input = [{"actor": 1, "two": 2, "select": "me" }, {"actor": 3, "four": 4, "select": "notme"}]
+        response = p_b_h.get_val_from_list(input, "actor", "doesnotexist", "noExceptionRaised")
+        should_be = set()
+        self.assertCountEqual(response, should_be)
+
 class TestBoxParseAdditionalDetails(unittest.TestCase):
     def setUp(self):
         self.initial_dict = {"t": 10, "a": [{"b": 1, "c": 2}], "d": {"e": {"f": True}}}

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -17,11 +17,10 @@ import panther_tor_helpers as p_tor_h  # pylint: disable=C0413
 class TestGetValFromList(unittest.TestCase):
     def setUp(self):
         self.input = [
-            {"actor": 1, "one": 1, "select": "me" },
+            {"actor": 1, "one": 1, "select": "me"},
             {"actor": 2, "two": 2, "select": "me"},
-            {"actor": 3, "three": 3, "select": "not_me"}
-            ]
- 
+            {"actor": 3, "three": 3, "select": "not_me"},
+        ]
 
     def test_input_key_exists(self):
         response = p_b_h.get_val_from_list(self.input, "actor", "select", "me")
@@ -30,11 +29,13 @@ class TestGetValFromList(unittest.TestCase):
         should_be.add(2)
         self.assertCountEqual(response, should_be)
 
-    # This test case validate that get_val_from_list will return the empty set when the comparison key is not found
+    # This test case validate that get_val_from_list will return the
+    # empty set when the comparison key is not found
     def test_input_notdict(self):
         response = p_b_h.get_val_from_list(self.input, "actor", "doesnotexist", "noExceptionRaised")
         should_be = set()
         self.assertCountEqual(response, should_be)
+
 
 class TestBoxParseAdditionalDetails(unittest.TestCase):
     def setUp(self):

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -15,17 +15,24 @@ import panther_tor_helpers as p_tor_h  # pylint: disable=C0413
 
 
 class TestGetValFromList(unittest.TestCase):
-    def test_input_dict(self):
-        input = [{"actor": 1, "two": 2, "select": "me" }, {"actor": 3, "four": 4, "select": "notme"}]
-        response = p_b_h.get_val_from_list(input, "actor", "select", "me")
+    def setUp(self):
+        self.input = [
+            {"actor": 1, "one": 1, "select": "me" },
+            {"actor": 2, "two": 2, "select": "me"},
+            {"actor": 3, "three": 3, "select": "not_me"}
+            ]
+ 
+
+    def test_input_key_exists(self):
+        response = p_b_h.get_val_from_list(self.input, "actor", "select", "me")
         should_be = set()
         should_be.add(1)
+        should_be.add(2)
         self.assertCountEqual(response, should_be)
 
     # This test case validate that get_val_from_list will return the empty set when the comparison key is not found
     def test_input_notdict(self):
-        input = [{"actor": 1, "two": 2, "select": "me" }, {"actor": 3, "four": 4, "select": "notme"}]
-        response = p_b_h.get_val_from_list(input, "actor", "doesnotexist", "noExceptionRaised")
+        response = p_b_h.get_val_from_list(self.input, "actor", "doesnotexist", "noExceptionRaised")
         should_be = set()
         self.assertCountEqual(response, should_be)
 

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -251,14 +251,13 @@ def deep_get(dictionary: dict, *keys, default=None):
     )
 
 
-def get_val_from_list(lst, field_name, field_type_key, field_type_val):
+def get_val_from_list(list_of_dicts, return_field_key, field_cmp_key, field_cmp_val):
     # pylint: disable=invalid-name
-    """Return a specific field in a list of Python dictionaries"""
+    """Return a specific field in a list of Python dictionaries. We return the empty set if the comparison key is not found"""
     rv = set()
-    for x in lst:
-        if field_name in x:
-            if x[field_type_key] == field_type_val:
-                rv.add(x[field_name])
+    for item in list_of_dicts:
+        if item.get(field_cmp_key) == field_cmp_val:
+            rv.add(item.get(return_field_key))
     return rv
 
 

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -252,13 +252,13 @@ def deep_get(dictionary: dict, *keys, default=None):
 
 
 def get_val_from_list(list_of_dicts, return_field_key, field_cmp_key, field_cmp_val):
-    # pylint: disable=invalid-name
-    """Return a specific field in a list of Python dictionaries. We return the empty set if the comparison key is not found"""
-    rv = set()
+    """Return a specific field in a list of Python dictionaries.
+    We return the empty set if the comparison key is not found"""
+    values_of_return_field = set()
     for item in list_of_dicts:
         if item.get(field_cmp_key) == field_cmp_val:
-            rv.add(item.get(return_field_key))
-    return rv
+            values_of_return_field.add(item.get(return_field_key))
+    return values_of_return_field
 
 
 def aws_strip_role_session_id(user_identity_arn):


### PR DESCRIPTION
### Background

#546 demonstrates that `get_val_from_list()` global helper was not robust to the condition where the key whose value is being compared was absent from the item being iterated. 

### Changes

* moves `get_val_from_list()` away from direct attribute assessment.

### Testing

* `make global-helpers-unit-test`
