### PR TITLE
fix: dedup aws_iam_user_key_created based on the userIdentity.arn to group by source identity

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_iam_user_key_created.py
+++ b/rules/aws_cloudtrail_rules/aws_iam_user_key_created.py
@@ -21,5 +21,9 @@ def title(event):
     )
 
 
+def dedup(event):
+    return f"{deep_get(event,'userIdentity','arn')}"
+
+
 def alert_context(event):
     return aws_rule_context(event)


### PR DESCRIPTION
### Background

I believe most operators would prefer to see the "this identity created IAM Keys for some other IAM User" grouped by the user doing the acting. 


### Changes

* adds dedup() function to rules/aws_cloudtrail_rules/aws_iam_user_key_created.py

### Testing

* make test
