### PR TITLE
fix: remove all references to ast.literal_eval

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_console_login_without_mfa.py
+++ b/rules/aws_cloudtrail_rules/aws_console_login_without_mfa.py
@@ -7,7 +7,7 @@ from panther_oss_helpers import check_account_age
 # Set to True for environments that permit direct role assumption via external IDP
 ROLES_VIA_EXTERNAL_IDP = False
 
-# pylint: disable=R0911
+# pylint: disable=R0911,R0912,R1260
 def rule(event):
     if event.get("eventName") != "ConsoleLogin":
         return False
@@ -57,10 +57,10 @@ def rule(event):
     is_new_account = check_account_age(event.get("recipientAccountId"))
     if isinstance(is_new_account, str):
         logging.debug("check_account_age is a mocked string for unit testing")
-        if is_new_user == "False":
-            is_new_user = False
-        if is_new_user == "True":
-            is_new_user = True
+        if is_new_account == "False":
+            is_new_account = False
+        if is_new_account == "True":
+            is_new_account = True
     if is_new_account:
         return False
 

--- a/rules/aws_cloudtrail_rules/aws_console_login_without_mfa.py
+++ b/rules/aws_cloudtrail_rules/aws_console_login_without_mfa.py
@@ -1,4 +1,3 @@
-import ast
 import logging
 
 from panther import lookup_aws_account_name
@@ -48,14 +47,20 @@ def rule(event):
     is_new_user = check_account_age(new_user_string)
     if isinstance(is_new_user, str):
         logging.debug("check_account_age is a mocked string for unit testing")
-        is_new_user = ast.literal_eval(is_new_user)
+        if is_new_user == "False":
+            is_new_user = False
+        if is_new_user == "True":
+            is_new_user = True
     if is_new_user:
         return False
 
     is_new_account = check_account_age(event.get("recipientAccountId"))
     if isinstance(is_new_account, str):
         logging.debug("check_account_age is a mocked string for unit testing")
-        is_new_account = ast.literal_eval(is_new_account)
+        if is_new_user == "False":
+            is_new_user = False
+        if is_new_user == "True":
+            is_new_user = True
     if is_new_account:
         return False
 

--- a/rules/standard_rules/unusual_login_deprecated.py
+++ b/rules/standard_rules/unusual_login_deprecated.py
@@ -2,7 +2,6 @@
 # service. At high rates of log processing, the third party service may throttle requests
 # unless you buy a subscription to it, which may cause this rule to no longer work.
 
-import ast
 import json
 import logging
 
@@ -57,7 +56,7 @@ def rule(event):
         logging.debug("previous_geo_logins is a mocked string:")
         logging.debug(previous_geo_logins)
         if previous_geo_logins:
-            previous_geo_logins = ast.literal_eval(previous_geo_logins)
+            previous_geo_logins = set([previous_geo_logins])
         else:
             previous_geo_logins = set()
         logging.debug("new type of previous_geo_logins should be 'set':")

--- a/rules/standard_rules/unusual_login_deprecated.yml
+++ b/rules/standard_rules/unusual_login_deprecated.yml
@@ -47,13 +47,13 @@ Tests:
                           }
       - objectName: get_string_set
         returnValue: >-
-                          {'{
+                          {
                           "UnitTestRegion:UnitTestCity1": "2021-06-04 09:59:53.650801",
                           "UnitTestRegion:UnitTestCity2": "2021-06-04 09:59:53.650802",
                           "UnitTestRegion:UnitTestCity3": "2021-06-04 09:59:53.650803",
                           "UnitTestRegion:UnitTestCity4": "2021-06-04 09:59:53.650804",
                           "UnitTestRegion:UnitTestCity5": "2021-06-04 09:59:53.650805"
-                          }'}
+                          }
       - objectName: put_string_set
         returnValue: >-
     Log:
@@ -84,7 +84,7 @@ Tests:
                           }
       - objectName: get_string_set
         returnValue: >-
-                       {'{"UnitTestRegion:UnitTestCity": "2021-06-04 09:59:53.650801"}'}
+                       {"UnitTestRegion:UnitTestCity": "2021-06-04 09:59:53.650801"}
       - objectName: put_string_set
         returnValue: >-
     Log:
@@ -145,7 +145,7 @@ Tests:
                           }
       - objectName: get_string_set
         returnValue: >-
-                         {'{"UnitTestRegion:UnitTestCity": "2021-06-04 09:59:53.650801"}'}
+                         {"UnitTestRegion:UnitTestCity": "2021-06-04 09:59:53.650801"}
       - objectName: put_string_set
         returnValue: >-
     Log:
@@ -180,13 +180,13 @@ Tests:
                           }
       - objectName: get_string_set
         returnValue: >-
-                          {'{
+                          {
                           "UnitTestRegion:UnitTestCity1": "2021-06-04 09:59:53.650801",
                           "UnitTestRegion:UnitTestCity2": "2021-06-04 09:59:53.650802",
                           "UnitTestRegion:UnitTestCity3": "2021-06-04 09:59:53.650803",
                           "UnitTestRegion:UnitTestCity4": "2021-06-04 09:59:53.650804",
                           "UnitTestRegion:UnitTestCity5": "2021-06-04 09:59:53.650805"
-                          }'}
+                          }
       - objectName: put_string_set
         returnValue: >-
     Log:
@@ -281,7 +281,7 @@ Tests:
                           }
       - objectName: get_string_set
         returnValue: >-
-                         {'{"UnitTestRegion:UnitTestCity": "2021-06-04 09:59:53.650801"}'}
+                         {"UnitTestRegion:UnitTestCity": "2021-06-04 09:59:53.650801"}
       - objectName: put_string_set
         returnValue: >-
     Log:
@@ -384,7 +384,7 @@ Tests:
                           }
       - objectName: get_string_set
         returnValue: >-
-                        {'{"UnitTestRegion:UnitTestCity": "2021-06-04 09:59:53.650801"}'}
+                        {"UnitTestRegion:UnitTestCity": "2021-06-04 09:59:53.650801"}
       - objectName: put_string_set
         returnValue: >-
     Log:
@@ -417,7 +417,7 @@ Tests:
                           }
       - objectName: get_string_set
         returnValue: >-
-                        {'{"UnitTestRegion:UnitTestCity": "2021-06-04 09:59:53.650801"}'}
+                        {"UnitTestRegion:UnitTestCity": "2021-06-04 09:59:53.650801"}
       - objectName: put_string_set
         returnValue: >-
     Log:
@@ -477,7 +477,7 @@ Tests:
                           }
       - objectName: get_string_set
         returnValue: >-
-                         {'{"UnitTestRegion:UnitTestCity": "2021-06-04 09:59:53.650801"}'}
+                         {"UnitTestRegion:UnitTestCity": "2021-06-04 09:59:53.650801"}
       - objectName: put_string_set
         returnValue: >-
     Log:
@@ -507,13 +507,13 @@ Tests:
                         }
       - objectName: get_string_set
         returnValue: >-
-                        {'{
+                        {
                         "UnitTestRegion:UnitTestCity1": "2021-06-04 09:59:53.650801",
                         "UnitTestRegion:UnitTestCity2": "2021-06-04 09:59:53.650802",
                         "UnitTestRegion:UnitTestCity3": "2021-06-04 09:59:53.650803",
                         "UnitTestRegion:UnitTestCity4": "2021-06-04 09:59:53.650804",
                         "UnitTestRegion:UnitTestCity5": "2021-06-04 09:59:53.650805"
-                        }'}
+                        }
       - objectName: put_string_set
         returnValue: >-
     Log:


### PR DESCRIPTION
### Background

This changeset removes the remaining references to `ast.literal_eval` in favor of implementations that are more predictable, were they to receive hostile inputs.

### Changes

* 

### Testing

* 
