### PR TITLE
Update gcp_unused_regions.py

### DIFF
--- a/rules/gcp_audit_rules/gcp_unused_regions.py
+++ b/rules/gcp_audit_rules/gcp_unused_regions.py
@@ -38,8 +38,8 @@ def _get_location_or_zone(event):
 
 
 def rule(event):
-    method_name = deep_get(event, "protoPayload", "methodName")
-    if not (method_name.endswith(".insert") or method_name.endswith(".create")):
+    method_name = deep_get(event, "protoPayload", "methodName", default='<UNKNOWN_METHOD>')
+    if not method_name.endswith(('insert', 'create')):
         return False
     return _resource_in_active_region(_get_location_or_zone(event))
 

--- a/rules/gcp_audit_rules/gcp_unused_regions.py
+++ b/rules/gcp_audit_rules/gcp_unused_regions.py
@@ -38,8 +38,8 @@ def _get_location_or_zone(event):
 
 
 def rule(event):
-    method_name = deep_get(event, "protoPayload", "methodName", default='<UNKNOWN_METHOD>')
-    if not method_name.endswith(('insert', 'create')):
+    method_name = deep_get(event, "protoPayload", "methodName", default="<UNKNOWN_METHOD>")
+    if not method_name.endswith(("insert", "create")):
         return False
     return _resource_in_active_region(_get_location_or_zone(event))
 


### PR DESCRIPTION


### Background
Alert would error if logline was missing methodName. We would see `AttributeError("'NoneType' object has no attribute 'endswith'")`


### Changes

* Added a default value so it has something instead of None
* Shortened the if not statement

### Testing

* Tested against the included function tests that came with the rule.
