### PR TITLE
fix: add some error handling to the sync action

### DIFF
--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -1,16 +1,18 @@
 name: sync-panther-analysis-from-upstream
+
 on:
   schedule:
-    # 15:00Z, every Monday
-    - cron: "00 15 * * 1"
+    # 15:00Z, every Tuesday
+    - cron: "00 15 * * 2"
   workflow_dispatch: # or on button click  
+
+env:
+  YOUR_REPO_PRIMARY_BRANCH_NAME: "master"
 
 jobs:
   check_upstream:
-    ## Change the false in this if statement to true in order to run this workflow
     if: | 
-      github.repository != 'panther-labs/panther-analysis' &&
-      false
+      github.repository != 'panther-labs/panther-analysis'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6
@@ -18,27 +20,28 @@ jobs:
         name: Check Upstream
         with:
           script: |
+            const fs = require('fs');
             const upstreamLatest = await github.rest.repos.getLatestRelease({
               owner: 'panther-labs',
               repo: 'panther-analysis'
             })
-            console.log("::set-output name=latest-release::" +  upstreamLatest.data.tag_name)
+            fs.appendFileSync(
+              process.env['GITHUB_OUTPUT'],
+              'latest-release=' +  upstreamLatest.data.tag_name + '\n');
       ## CREATE A BRANCH
-      - uses: peterjgrainger/action-create-branch@v2.2.0
+      - uses: peterjgrainger/action-create-branch@v2.3.0
         id: create_a_branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           branch: 'sync_upstream_${{steps.set_upstream.outputs.latest-release}}'
       # Checkout this repo into the branch
-      - name: Checkout your repo
+      - name: Checkout your local repo in PR branch
         uses: actions/checkout@v2
         with:
-        #  # optional: set the branch to checkout,
-        #  # sync action checks out your 'target_sync_branch' anyway
           ref: 'sync_upstream_${{steps.set_upstream.outputs.latest-release}}'
       # Sync this branch with upstream
-      - name: Sync upstream changes
+      - name: Sync upstream changes into PR branch
         id: sync
         uses: aormsby/Fork-Sync-With-Upstream-action@v3.2
         with:
@@ -52,35 +55,53 @@ jobs:
           upstream_sync_branch: ${{steps.set_upstream.outputs.latest-release}}
           upstream_sync_repo: panther-labs/panther-analysis
           #test_mode: true  
-      # Create a PR from this branch back to this fork's primary branch ( hardcoded to master ) 
+      # Create a PR from this branch back to this fork's primary branch
       - uses: actions/github-script@v6
         id: create_pr
-        name: Create a PR from this branch to the local primary
+        name: Create a PR to bring upstream changes into the local repo primary branch
         if: steps.sync.outputs.has_new_commits == 'true'
         with:
           result-encoding: string
           script: |
+            const fs = require('fs');
             try {
               const response = await github.rest.pulls.create({
                 owner: '${{github.repository_owner}}',
                 repo: '${{  github.event.repository.name }}',
                 title: 'sync this fork to panther-labs/panther-analysis ${{steps.set_upstream.outputs.latest-release}}',
                 head: 'sync_upstream_${{steps.set_upstream.outputs.latest-release}}',
-                base: 'master',
+                base: '${{env.YOUR_REPO_PRIMARY_BRANCH_NAME}}',
               });
             } catch(e) {
               if (e.response.data.errors[0].message.includes('No commits between')) {
-                return 'no-updates';
+                fs.appendFileSync(
+                  process.env['GITHUB_OUTPUT'],
+                  'pr_state=no-updates\n');
               } else if (e.response.data.errors[0].message.includes('A pull request already exists for')) {
-                return 'update-pr-already-exists';
+                fs.appendFileSync(
+                  process.env['GITHUB_OUTPUT'],
+                  'pr_state=update-pr-already-exists\n');
               } else {
+                fs.appendFileSync(
+                  process.env['GITHUB_OUTPUT'],
+                  'pr_state=error\n');
                 console.log(e);
-                return 'false';
               }
             }
-      - id: pr_outputs
-        name: Show create PR output
-        if: ${{ steps.run_test.outputs.result == 'false' }}
+      - id: pr_not_needed_already_exists
+        name: PR for latest release already exists
+        if: ${{ steps.create_pr.outputs.pr_state == 'update-pr-already-exists' }}
         run: |
-          echo "unhandled PR exception was raised. outputs is ${steps.run_tests.outputs.result}"
+          echo "PR for latest release was previously created and is not closed"
+      - id: pr_not_needed_in_sync
+        name: Local repo already synced to latest release
+        if: ${{ steps.create_pr.outputs.pr_state == 'no-updates' }}
+        run: |
+          echo "Local repo in sync with latest upstream release"  
+      - id: pr_create_error
+        name: Create PR step had an error
+        if: ${{ steps.create_pr.outputs.pr_state == 'error' }}
+        run: |
+          echo "unhandled exception in PR create step. Check output of that step."
+          exit 128
       

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -56,13 +56,31 @@ jobs:
       - uses: actions/github-script@v6
         id: create_pr
         name: Create a PR from this branch to the local primary
+        if: steps.sync.outputs.has_new_commits == 'true'
         with:
+          result-encoding: string
           script: |
-            const upstreamLatest = await github.rest.pulls.create({
-              owner: '${{github.repository_owner}}',
-              repo: '${{  github.event.repository.name }}',
-              title: 'sync this fork to panther-labs/panther-analysis ${{steps.set_upstream.outputs.latest-release}}',
-              head: 'sync_upstream_${{steps.set_upstream.outputs.latest-release}}',
-              base: 'master',
-            })
-            console.log("::set-output name=latest-release::" +  upstreamLatest.data.tag_name)
+            try {
+              const response = await github.rest.pulls.create({
+                owner: '${{github.repository_owner}}',
+                repo: '${{  github.event.repository.name }}',
+                title: 'sync this fork to panther-labs/panther-analysis ${{steps.set_upstream.outputs.latest-release}}',
+                head: 'sync_upstream_${{steps.set_upstream.outputs.latest-release}}',
+                base: 'master',
+              });
+            } catch(e) {
+              if (e.response.data.errors[0].message.includes('No commits between')) {
+                return 'no-updates';
+              } else if (e.response.data.errors[0].message.includes('A pull request already exists for')) {
+                return 'update-pr-already-exists';
+              } else {
+                console.log(e);
+                return 'false';
+              }
+            }
+      - id: pr_outputs
+        name: Show create PR output
+        if: ${{ steps.run_test.outputs.result == 'false' }}
+        run: |
+          echo "unhandled PR exception was raised. outputs is ${steps.run_tests.outputs.result}"
+      


### PR DESCRIPTION
### Background
Updates the Sync upstream GitHub action in the following ways:
1.  Sync GH Action is now **enabled by default**
2. Adds a user-configurable local primary branch name ( i.e. folks that are using `main` ) as an ENV var at top-of-file. **defaults to master**
3. Runs on Tuesdays ( in case of Monday release cutting )
4. Updates outputs to use the new `$GITHUB_OUTPUT` env var instead of using [the to-be-deprecated set-output method](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
5. Error handling for **PR Already Exists For Latest Upstream Release**
6. Error handling for **Local Repo Already in Sync with Latest Upstream**

Errors should raise if other fault modes are encountered in the PR creation process


### Testing

* test run in personal private copy of repo
<img width="1466" alt="Screen Shot 2022-11-25 at 11 17 50" src="https://user-images.githubusercontent.com/932424/204048576-a5cfba29-dfc6-4088-85cf-5c8bb98cf526.png">
<img width="1422" alt="Screen Shot 2022-11-25 at 11 22 12" src="https://user-images.githubusercontent.com/932424/204048577-aae7ee82-554b-4476-846c-c1cd77d17e97.png">
<img width="1185" alt="Screen Shot 2022-11-25 at 11 29 16" src="https://user-images.githubusercontent.com/932424/204048579-4dc9164b-3644-4cfe-afe7-ec351cfef7f2.png">

