### PR TITLE
Github: New Secret Scanning Rule & Update Pack

### DIFF
--- a/packs/github.yml
+++ b/packs/github.yml
@@ -3,9 +3,12 @@ PackID: PantherManaged.GitHub.Audit
 Description: Group of all GitHub Audit detections
 PackDefinition:
   IDs:
+    - GitHub.Advanced.Security.Change
     - GitHub.Branch.PolicyOverride
     - GitHub.Branch.ProtectionDisabled
+    - GitHub.Org.AuthChange
     - GitHub.Org.Modified
+    - GitHub.Org.IpAllowlist
     - Github.Repo.CollaboratorChange
     - Github.Repo.Created
     - GitHub.Repo.HookModified
@@ -14,6 +17,7 @@ PackDefinition:
     - GitHub.Team.Modified
     - GitHub.User.AccessKeyCreated
     - GitHub.User.RoleUpdated
+    - GitHub.Secret.Scanning.Alert.Created
     # Standard rules applicable
     - Standard.AdminRoleAssigned
     - Standard.MFADisabled

--- a/packs/github.yml
+++ b/packs/github.yml
@@ -7,17 +7,17 @@ PackDefinition:
     - GitHub.Branch.PolicyOverride
     - GitHub.Branch.ProtectionDisabled
     - GitHub.Org.AuthChange
-    - GitHub.Org.Modified
     - GitHub.Org.IpAllowlist
+    - GitHub.Org.Modified
     - Github.Repo.CollaboratorChange
     - Github.Repo.Created
     - GitHub.Repo.HookModified
     - GitHub.Repo.InitialAccess
     - Github.Repo.VisibilityChange
+    - GitHub.Secret.Scanning.Alert.Created
     - GitHub.Team.Modified
     - GitHub.User.AccessKeyCreated
     - GitHub.User.RoleUpdated
-    - GitHub.Secret.Scanning.Alert.Created
     # Standard rules applicable
     - Standard.AdminRoleAssigned
     - Standard.MFADisabled

--- a/rules/aws_eks_rules/system_namespace_public_ip.py
+++ b/rules/aws_eks_rules/system_namespace_public_ip.py
@@ -2,7 +2,6 @@ from ipaddress import ip_address
 
 from panther_base_helpers import deep_get, eks_panther_obj_ref
 
-
 # Explicitly ignore eks:node-manager and eks:addon-manager
 #  which are run as Lamdas and originate from public IPs
 AMZ_PUBLICS = {"eks:addon-manager", "eks:node-manager"}

--- a/rules/github_rules/github_secret_scanning_alert_created.py
+++ b/rules/github_rules/github_secret_scanning_alert_created.py
@@ -1,5 +1,3 @@
-from panther_base_helpers import github_alert_context
-
 def rule(event):
     return event.get('action') == 'secret_scanning_alert.create'
 

--- a/rules/github_rules/github_secret_scanning_alert_created.py
+++ b/rules/github_rules/github_secret_scanning_alert_created.py
@@ -10,5 +10,6 @@ def alert_context(event):
     return {
         'repo': event.get('repo'),
         'alert #': event.get('number'),
-        'url': f"https://github.com/{event.get('repo')}/security/secret-scanning/{event.get('number')}",
+        'url': f"https://github.com/{event.get('repo')}/security/secret-scanning/"
+               f"{event.get('number')}",
     }

--- a/rules/github_rules/github_secret_scanning_alert_created.py
+++ b/rules/github_rules/github_secret_scanning_alert_created.py
@@ -8,7 +8,7 @@ def title(event):
 
 def alert_context(event):
     return {
-        'repo': event.get("repo"),
-        'alert #': event.get("number"),
+        'repo': event.get('repo'),
+        'alert #': event.get('number'),
         'url': f"https://github.com/{event.get('repo')}/security/secret-scanning/{event.get('number')}",
     }

--- a/rules/github_rules/github_secret_scanning_alert_created.py
+++ b/rules/github_rules/github_secret_scanning_alert_created.py
@@ -1,5 +1,5 @@
 def rule(event):
-    return event.get('action') == 'secret_scanning_alert.create'
+    return event.get("action") == "secret_scanning_alert.create"
 
 
 def title(event):
@@ -8,8 +8,8 @@ def title(event):
 
 def alert_context(event):
     return {
-        'repo': event.get('repo'),
-        'alert #': event.get('number'),
-        'url': f"https://github.com/{event.get('repo')}/security/secret-scanning/"
-               f"{event.get('number')}",
+        "repo": event.get("repo"),
+        "alert #": event.get("number"),
+        "url": f"https://github.com/{event.get('repo')}/security/secret-scanning/"
+        f"{event.get('number')}",
     }

--- a/rules/github_rules/github_secret_scanning_alert_created.py
+++ b/rules/github_rules/github_secret_scanning_alert_created.py
@@ -1,0 +1,16 @@
+from panther_base_helpers import github_alert_context
+
+def rule(event):
+    return event.get('action') == 'secret_scanning_alert.create'
+
+
+def title(event):
+    return f"Github detected a secret in {event.get('repo')} (#{event.get('number')})"
+
+
+def alert_context(event):
+    return {
+        'repo': event.get("repo"),
+        'alert #': event.get("number"),
+        'url': f"https://github.com/{event.get('repo')}/security/secret-scanning/{event.get('number')}",
+    }

--- a/rules/github_rules/github_secret_scanning_alert_created.yml
+++ b/rules/github_rules/github_secret_scanning_alert_created.yml
@@ -1,0 +1,41 @@
+AnalysisType: rule
+Filename: github_secret_scanning_alert_created.py
+RuleID: GitHub.Secret.Scanning.Alert.Created
+DisplayName: GitHub Secret Scanning Alert Created
+Enabled: true
+LogTypes:
+  - GitHub.Audit
+Tags:
+  - GitHub
+Reports:
+  MITRE ATT&CK:
+    - TA0006:T1552
+Severity: Medium
+Description: GitHub detected a secret and created a secret scanning alert.
+Runbook: Review the secret to determine if it needs to be revoked or the alert suppressed. 
+Tests:
+  -
+    Name: GitHub detected a secret
+    ExpectedResult: True
+    Log:
+      {
+        "action": "secret_scanning_alert.create",
+        "actor": "github",
+        "at_sign_timestamp": "2022-09-08 19:34:43.468",
+        "created_at": "2022-09-08 19:34:43.468",
+        "number": 1792,
+        "org": "acme-co",
+        "repo": "acme-co/website"
+      }
+  -
+    Name: Unrelated
+    ExpectedResult: False
+    Log:
+      {
+        "action": "unrelated.create",
+        "actor": "github",
+        "at_sign_timestamp": "2022-09-08 19:34:43.468",
+        "created_at": "2022-09-08 19:34:43.468",
+        "org": "acme-co",
+        "repo": "acme-co/website"
+      }


### PR DESCRIPTION
### Changes

- New rule that detects when GitHub identifies a new secret
- Add this new rule to the pack
- Added existing Github rules that were missing from the pack

### Testing

```
pipenv run panther_analysis_tool test --path rules/github_rules
...
GitHub.Secret.Scanning.Alert.Created
	[PASS] GitHub detected a secret
		[PASS] [rule] true
		[PASS] [title] Github detected a secret in acme-co/website (#1792)
		[PASS] [dedup] Github detected a secret in acme-co/website (#1792)
		[PASS] [alertContext] {"repo": "acme-co/website", "alert #": 1792, "url": "https://github.com/acme-co/website/security/secret-scanning/1792"}
	[PASS] Unrelated
		[PASS] [rule] false
...
--------------------------
Panther CLI Test Summary
	Path: rules/github_rules
	Passed: 15
	Failed: 0
	Invalid: 0
```
