### PR TITLE
adding qa tested aws guardduty rules to aws pack

### DIFF
--- a/packs/aws.yml
+++ b/packs/aws.yml
@@ -80,6 +80,8 @@ PackDefinition:
     - AWS.IAM.Policy.AdministrativePrivileges
     - AWS.GuardDuty.Enabled
     - AWS.GuardDuty.HighSeverityFinding
+    - AWS.GuardDuty.MediumSeverityFinding
+    - AWS.GuardDuty.LowSeverityFinding
     - AWS.ELBV2.LoadBalancer.HasSSLPolicy
     - AWS.WAF.HasXSSPredicate
     - AWS.WAF.Disassociation


### PR DESCRIPTION
### Background

<High level overview here>

### Changes
added the following already existing rules to pack after qa: 

  - AWS.GuardDuty.MediumSeverityFinding
  - AWS.GuardDuty.LowSeverityFinding
### Testing

* <Testing steps>
