### PR TITLE
fix: AWS SAML provisioning should be permitted by the service role for AWSSSO

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_saml_activity.py
+++ b/rules/aws_cloudtrail_rules/aws_saml_activity.py
@@ -4,6 +4,11 @@ SAML_ACTIONS = ["UpdateSAMLProvider", "CreateSAMLProvider", "DeleteSAMLProvider"
 
 
 def rule(event):
+    # Allow AWSSSO to manage
+    if deep_get(event, "userIdentity", "arn", default="").endswith(
+        ":assumed-role/AWSServiceRoleForSSO/AWS-SSO"
+    ):
+        return False
     return (
         event.get("eventSource") == "iam.amazonaws.com" and event.get("eventName") in SAML_ACTIONS
     )

--- a/rules/aws_cloudtrail_rules/aws_saml_activity.yml
+++ b/rules/aws_cloudtrail_rules/aws_saml_activity.yml
@@ -133,6 +133,108 @@ Tests:
                 webIdFederationData: {}
             type: AssumedRole
       Name: UpdateSAMLProvider
+    - 
+      Name: Activity from AWSSSO Service Managed Role
+      ExpectedResult: false
+      Log:
+        {
+            "awsRegion": "us-east-1",
+            "eventCategory": "Management",
+            "eventName": "CreateSAMLProvider",
+            "eventSource": "iam.amazonaws.com",
+            "eventTime": "2022-12-12 21:46:17.000000000",
+            "eventType": "AwsApiCall",
+            "eventVersion": "1.08",
+            "managementEvent": true,
+            "p_alert_context": {
+                "awsRegion": "us-east-1",
+                "eventName": "CreateSAMLProvider",
+                "eventSource": "iam.amazonaws.com",
+                "recipientAccountId": "123412341234",
+                "sourceIPAddress": "sso.amazonaws.com",
+                "userAgent": "sso.amazonaws.com",
+                "userIdentity": {
+                    "accessKeyId": "ASIAXXXXNLMHSP3MFXX",
+                    "accountId": "123412341234",
+                    "arn": "arn:aws:sts::123412341234:assumed-role/AWSServiceRoleForSSO/AWS-SSO",
+                    "invokedBy": "sso.amazonaws.com",
+                    "principalId": "AROAT7BCMNLMONMOFFFFF:AWS-SSO",
+                    "sessionContext": {
+                        "attributes": {
+                            "creationDate": "2022-12-12T21:46:16Z",
+                            "mfaAuthenticated": "false"
+                        },
+                        "sessionIssuer": {
+                            "accountId": "123412341234",
+                            "arn": "arn:aws:iam::123412341234:role/aws-service-role/sso.amazonaws.com/AWSServiceRoleForSSO",
+                            "principalId": "AROAT7BCMNLMONMOFFFFF",
+                            "type": "Role",
+                            "userName": "AWSServiceRoleForSSO"
+                        },
+                        "webIdFederationData": {}
+                    },
+                    "type": "AssumedRole"
+                }
+            },
+            "p_alert_creation_time": "2022-12-12 21:51:37.115853000",
+            "p_alert_update_time": "2022-12-12 21:51:37.115853000",
+            "p_any_aws_account_ids": [
+                "123412341234"
+            ],
+            "p_any_aws_arns": [
+                "arn:aws:iam::123412341234:role/aws-service-role/sso.amazonaws.com/AWSServiceRoleForSSO",
+                "arn:aws:iam::123412341234:saml-provider/AWSSSO_abdf34fd171b4a7e_DO_NOT_DELETE",
+                "arn:aws:sts::123412341234:assumed-role/AWSServiceRoleForSSO/AWS-SSO"
+            ],
+            "p_any_domain_names": [
+                "sso.amazonaws.com"
+            ],
+            "p_any_trace_ids": [
+                "ASIAXXXXNLMHSP3MFXX"
+            ],
+            "p_any_usernames": [
+                "AWSServiceRoleForSSO"
+            ],
+            "p_event_time": "2022-12-12 21:46:17.000000000",
+            "p_log_type": "AWS.CloudTrail",
+            "p_parse_time": "2022-12-12 21:49:13.694384486",
+            "p_rule_id": "AWS.Suspicious.SAML.Activity",
+            "p_source_label": "YourOrg - Cloudtrail - Label",
+            "readOnly": false,
+            "recipientAccountId": "123412341234",
+            "requestID": "cb89df1f-6019-427f-9a69-00b8b904ce0d",
+            "requestParameters": {
+                "name": "AWSSSO_abdf34fd171b4a7e_DO_NOT_DELETE",
+                "sAMLMetadataDocument": "<?xml version=\"1.0\" encoding=\"UTF-8\"?></xml>"
+            },
+            "responseElements": {
+                "sAMLProviderArn": "arn:aws:iam::123412341234:saml-provider/AWSSSO_abdf34fd171b4a7e_DO_NOT_DELETE"
+            },
+            "sourceIPAddress": "sso.amazonaws.com",
+            "userAgent": "sso.amazonaws.com",
+            "userIdentity": {
+                "accessKeyId": "ASIAXXXXNLMHSP3MFXX",
+                "accountId": "123412341234",
+                "arn": "arn:aws:sts::123412341234:assumed-role/AWSServiceRoleForSSO/AWS-SSO",
+                "invokedBy": "sso.amazonaws.com",
+                "principalId": "AROAT7BCMNLMONMOFFFFF:AWS-SSO",
+                "sessionContext": {
+                    "attributes": {
+                        "creationDate": "2022-12-12T21:46:16Z",
+                        "mfaAuthenticated": "false"
+                    },
+                    "sessionIssuer": {
+                        "accountId": "123412341234",
+                        "arn": "arn:aws:iam::123412341234:role/aws-service-role/sso.amazonaws.com/AWSServiceRoleForSSO",
+                        "principalId": "AROAT7BCMNLMONMOFFFFF",
+                        "type": "Role",
+                        "userName": "AWSServiceRoleForSSO"
+                    },
+                    "webIdFederationData": {}
+                },
+                "type": "AssumedRole"
+            }
+        }
 DedupPeriodMinutes: 60
 LogTypes:
     - AWS.CloudTrail


### PR DESCRIPTION
### Background

We expect the service role for AWS SSO to be doing these SAML modification activities.

### Changes

* Adds a quick escape for AWS.Suspicious.SAML.Activity if the originating role is the service role assumed by AWS SSO

### Testing

* added additional test case for new logic. 
