### PR TITLE
New Rule: DUO: User marked action as fraudulent

### DIFF
--- a/rules/duo_rules/duo_user_action_fraudulent.py
+++ b/rules/duo_rules/duo_user_action_fraudulent.py
@@ -1,0 +1,20 @@
+from panther_base_helpers import deep_get
+
+
+def rule(event):
+    return event.get('result') == 'fraud'
+
+def title(event):
+    return 'A DUO action was marked as fraudulent.'
+
+
+def alert_context(event):
+    return {
+        "factor": event.get('factor'),
+        "reason": event.get('reason'),
+        "user": deep_get(event, "user", "name"),
+        "os": deep_get(event, "access_device", "os"),
+        "ip_access": deep_get(event, "access_device", "ip"),
+        "ip_auth": deep_get(event, "auth_device", "ip"),
+        "application": deep_get(event, "application", "name"),
+    }

--- a/rules/duo_rules/duo_user_action_fraudulent.py
+++ b/rules/duo_rules/duo_user_action_fraudulent.py
@@ -2,16 +2,17 @@ from panther_base_helpers import deep_get
 
 
 def rule(event):
-    return event.get('result') == 'fraud'
+    return event.get("result") == "fraud"
+
 
 def title(event):
-    return 'A DUO action was marked as fraudulent.'
+    return f"A DUO action was marked as fraudulent by {deep_get(event, 'user', 'name')}"
 
 
 def alert_context(event):
     return {
-        "factor": event.get('factor'),
-        "reason": event.get('reason'),
+        "factor": event.get("factor"),
+        "reason": event.get("reason"),
         "user": deep_get(event, "user", "name"),
         "os": deep_get(event, "access_device", "os"),
         "ip_access": deep_get(event, "access_device", "ip"),

--- a/rules/duo_rules/duo_user_action_fraudulent.yml
+++ b/rules/duo_rules/duo_user_action_fraudulent.yml
@@ -1,0 +1,39 @@
+AnalysisType: rule
+Filename: duo_user_action_fraudulent.py
+RuleID: DUO.User.Action.Fraudulent
+DisplayName: DUO User Action Reported as Fraudulent
+Enabled: true
+DedupPeriodMinutes: 15
+LogTypes:
+  - Duo.Authentication
+Tags:
+  - DUO
+Severity: Medium
+Description: >
+  Alert when a user reports a DUO action as fraudulent.
+Runbook: Follow up with the user to confirm.
+Tests:
+  -
+    Name: user_marked_fraud
+    ExpectedResult: true
+    Log:
+      {
+        "access_device": {
+          "ip": "12.12.112.25",
+          "os": "Mac OS X"
+        },
+        "auth_device": {
+          "ip": "12.12.12.12"
+        },
+        "application": {
+          "key": "D12345",
+          "name": "Slack"
+        },
+        "event_type": "authentication",
+        "factor": "duo_push",
+        "reason": "user_marked_fraud",
+        "result": "fraud",
+        "user": {
+          "name": "example@example.io"
+        }
+      }

--- a/rules/duo_rules/duo_user_action_fraudulent.yml
+++ b/rules/duo_rules/duo_user_action_fraudulent.yml
@@ -11,6 +11,7 @@ Tags:
 Severity: Medium
 Description: >
   Alert when a user reports a DUO action as fraudulent.
+Reference: https://duo.com/docs/adminapi#authentication-logs
 Runbook: Follow up with the user to confirm.
 Tests:
   -


### PR DESCRIPTION
### Background

New Rule: DUO: User marked action as fraudulent

### Changes

- New rule folder
- New rule and associated test
- `make fmt`

### Testing

```
% pipenv run panther_analysis_tool test --path rules/duo_rules
[INFO]: Testing analysis items in rules/duo_rules

DUO.User.Action.Fraudulent
	[PASS] user_marked_fraud
		[PASS] [rule] true
		[PASS] [title] A DUO action was marked as fraudulent by example@example.io
		[PASS] [dedup] A DUO action was marked as fraudulent by example@example.io
		[PASS] [alertContext] {"factor": "duo_push", "reason": "user_marked_fraud", "user": "example@example.io", "os": "Mac OS X", "ip_access": "12.12.112.25", "ip_auth": "12.12.12.12", "application": "Slack"}

--------------------------
Panther CLI Test Summary
	Path: rules/duo_rules
	Passed: 1
	Failed: 0
	Invalid: 0
```
