### PR TITLE
New Github Organization Application Installation Rule

### DIFF
--- a/packs/github.yml
+++ b/packs/github.yml
@@ -1,6 +1,7 @@
 AnalysisType: pack
 PackID: PantherManaged.GitHub.Audit
 Description: Group of all GitHub Audit detections
+DisplayName: Panther GitHub Audit Pack
 PackDefinition:
   IDs:
     - GitHub.Advanced.Security.Change
@@ -18,6 +19,7 @@ PackDefinition:
     - GitHub.Team.Modified
     - GitHub.User.AccessKeyCreated
     - GitHub.User.RoleUpdated
+    - Github.Organization.App.Integration.Installed
     # Standard rules applicable
     - Standard.AdminRoleAssigned
     - Standard.MFADisabled
@@ -25,4 +27,4 @@ PackDefinition:
     - Standard.Github.Audit
     # Globals
     - panther_event_type_helpers
-DisplayName: Panther GitHub Audit Pack
+    - panther_base_helpers

--- a/rules/github_rules/github_organization_app_integration_installed.py
+++ b/rules/github_rules/github_organization_app_integration_installed.py
@@ -9,7 +9,7 @@ def rule(event):
 
 def title(event):
     # (Optional) Return a string which will be shown as the alert title.
-    # If no 'dedup' function is defined, the return value of this method 
+    # If no 'dedup' function is defined, the return value of this method
     # will act as deduplication string.
     return (
         f" Github User {event.get('actor',{})} in {event.get('org')} "

--- a/rules/github_rules/github_organization_app_integration_installed.py
+++ b/rules/github_rules/github_organization_app_integration_installed.py
@@ -1,0 +1,28 @@
+from panther_base_helpers import github_alert_context
+
+
+def rule(event):
+    # Return True to match the log event and trigger an alert.
+    # Creates a new alert if the event's action was ""
+    return event.get("action") == "integration_installation.create"
+
+
+def title(event):
+    # (Optional) Return a string which will be shown as the alert title.
+    # If no 'dedup' function is defined, the return value of this method 
+    # will act as deduplication string.
+    return (
+        f" Github User {event.get('actor',{})} in {event.get('org')} "
+        f"installed the following integration: {event.get('name')}."
+    )
+
+
+# def dedup(event):
+#  (Optional) Return a string which will be used to deduplicate similar alerts.
+# return ''
+
+
+def alert_context(event):
+    #  (Optional) Return a dictionary with additional data to be included in the
+    #  alert sent to the SNS/SQS/Webhook destination
+    return github_alert_context(event)

--- a/rules/github_rules/github_organization_app_integration_installed.py
+++ b/rules/github_rules/github_organization_app_integration_installed.py
@@ -12,8 +12,8 @@ def title(event):
     # If no 'dedup' function is defined, the return value of this method
     # will act as deduplication string.
     return (
-        f" Github User '{event.get('actor',{})}' in '{event.get('org')}' "
-        f"installed the following integration: '{event.get('name')}'."
+        f" Github User [{event.get('actor',{})}] in [{event.get('org')}] "
+        f"installed the following integration: [{event.get('name')}]."
     )
 
 

--- a/rules/github_rules/github_organization_app_integration_installed.py
+++ b/rules/github_rules/github_organization_app_integration_installed.py
@@ -12,8 +12,8 @@ def title(event):
     # If no 'dedup' function is defined, the return value of this method
     # will act as deduplication string.
     return (
-        f" Github User {event.get('actor',{})} in {event.get('org')} "
-        f"installed the following integration: {event.get('name')}."
+        f" Github User '{event.get('actor',{})}' in '{event.get('org')}' "
+        f"installed the following integration: '{event.get('name')}'."
     )
 
 

--- a/rules/github_rules/github_organization_app_integration_installed.yml
+++ b/rules/github_rules/github_organization_app_integration_installed.yml
@@ -36,6 +36,15 @@ Tests:
         name: Datadog CI
         org: example-io
       Name: App Integration Installation-2
+    - ExpectedResult: false
+      Log:
+        action: repo.archived
+        actor: cat
+        created_at: 1.621305118553e+12
+        org: my-org
+        p_log_type: GitHub.Audit
+        repo: my-org/my-repo
+      Name: Repository Archived
 DedupPeriodMinutes: 60
 LogTypes:
     - GitHub.Audit

--- a/rules/github_rules/github_organization_app_integration_installed.yml
+++ b/rules/github_rules/github_organization_app_integration_installed.yml
@@ -1,0 +1,47 @@
+AnalysisType: rule
+Description: An application integration was installed to your organization's Github account by someone in your organization.
+DisplayName: Github Organization App Integration Installed
+Enabled: false
+Filename: github_organization_app_integration_installed.py
+Reference: https://docs.github.com/en/enterprise-server@3.4/developers/apps/managing-github-apps/installing-github-apps
+Runbook: Confirm that the app integration installation was a desired behavior.
+Severity: Low
+Tags:
+    - Application Installation
+    - Github
+Tests:
+    - ExpectedResult: true
+      Log:
+        _document_id: A-2345
+        action: integration_installation.create
+        actor: user_name
+        actor_location:
+            country_code: US
+        at_sign_timestamp: "2022-12-11 05:28:05.542"
+        created_at: "2022-12-11 05:28:05.542"
+        name: Microsoft Teams for GitHub
+        org: your-organization
+        p_any_usernames:
+            - user_name
+      Name: App Integration Installation
+    - ExpectedResult: true
+      Log:
+        _document_id: A-1234
+        action: integration_installation.create
+        actor: leetboy
+        actor_location:
+            country_code: US
+        at_sign_timestamp: "2022-12-02 17:40:08.671"
+        created_at: "2022-12-02 17:40:08.671"
+        name: Datadog CI
+        org: example-io
+      Name: App Integration Installation-2
+DedupPeriodMinutes: 60
+LogTypes:
+    - GitHub.Audit
+RuleID: Github.Organization.App.Integration.Installed
+SummaryAttributes:
+    - actor
+    - name
+    - org
+Threshold: 1


### PR DESCRIPTION
### Background

<High level overview here>

### Changes

Added newly written rule to monitor activity related to installing a github organization application, fixed key ordering in pack file, referenced the rule ID in the github pack, and added global helper to pack.

### Testing

* Test Cases Included in Yml file.
* results linked below: (updated to include bracketed interpolated values in results)
![Screen Shot 2022-12-13 at 1 14 40 PM](https://user-images.githubusercontent.com/117778222/207434879-7ff5ca4e-6770-4be6-8b8c-35cfbee8f6f7.png)


