### PR TITLE
New Github Public Repo Creation Rule

### DIFF
--- a/packs/github.yml
+++ b/packs/github.yml
@@ -20,6 +20,7 @@ PackDefinition:
     - GitHub.User.AccessKeyCreated
     - GitHub.User.RoleUpdated
     - Github.Organization.App.Integration.Installed
+    - Github.Public.Repository.Created
     # Standard rules applicable
     - Standard.AdminRoleAssigned
     - Standard.MFADisabled

--- a/rules/github_rules/github_public_repository_created.py
+++ b/rules/github_rules/github_public_repository_created.py
@@ -1,0 +1,27 @@
+from panther_base_helpers import github_alert_context
+
+
+def rule(event):
+    # Return True if a public repository was created
+    return event.get("action", "") == "repo.create" and event.get("visibility", "") == "public"
+
+
+def title(event):
+    # (Optional) Return a string which will be shown as the alert title.
+    # If no 'dedup' function is defined, the return value of this method
+    # will act as deduplication string.
+    return (
+        f"Repository [{event.get('repo', '<UNKNOWN_REPO>')}]"
+        f"created with public status by Github user [{event.get('actor')}]."
+    )
+
+
+# def dedup(event):
+#  (Optional) Return a string which will be used to deduplicate similar alerts.
+# return ''
+
+
+def alert_context(event):
+    #  (Optional) Return a dictionary with additional data to be included in the alert
+    # sent to the SNS/SQS/Webhook destination
+    return github_alert_context(event)

--- a/rules/github_rules/github_public_repository_created.py
+++ b/rules/github_rules/github_public_repository_created.py
@@ -11,7 +11,7 @@ def title(event):
     # If no 'dedup' function is defined, the return value of this method
     # will act as deduplication string.
     return (
-        f"Repository [{event.get('repo', '<UNKNOWN_REPO>')}]"
+        f"Repository [{event.get('repo', '<UNKNOWN_REPO>')}] "
         f"created with public status by Github user [{event.get('actor')}]."
     )
 

--- a/rules/github_rules/github_public_repository_created.yml
+++ b/rules/github_rules/github_public_repository_created.yml
@@ -1,0 +1,47 @@
+AnalysisType: rule
+Description: A public Github repository was created.
+DisplayName: Github Public Repository Created
+Enabled: true
+Filename: github_public_repository_created.py
+Runbook: Confirm this github repository was intended to be created as 'public' versus 'private'.
+Severity: Medium
+Tags:
+    - Github Repository
+    - Public
+    - Repository Created
+Tests:
+    - ExpectedResult: true
+      Log:
+        _document_id: abCD
+        action: repo.create
+        actor: example-actor
+        actor_location:
+            country_code: US
+        at_sign_timestamp: "2022-12-11 22:40:20.268"
+        created_at: "2022-12-11 22:40:20.268"
+        org: example-io
+        repo: example-io/oops
+        visibility: public
+      Name: Public Repo Created
+    - ExpectedResult: false
+      Log:
+        _document_id: abCD
+        action: repo.create
+        actor: example-actor
+        actor_location:
+            country_code: US
+        at_sign_timestamp: "2022-12-11 22:40:20.268"
+        created_at: "2022-12-11 22:40:20.268"
+        org: example-io
+        repo: example-io/oops
+        visibility: private
+      Name: Private Repo Created
+DedupPeriodMinutes: 60
+LogTypes:
+    - GitHub.Audit
+RuleID: Github.Public.Repository.Created
+SummaryAttributes:
+    - actor
+    - repo
+    - visibility
+Threshold: 1


### PR DESCRIPTION


### Background

<High level overview here>

### Changes

Added newly created rule to monitor and alert when a public github repo gets created inside of an organization

### Testing

* Results linked below:
* 
![Screen Shot 2022-12-13 at 1 50 59 PM](https://user-images.githubusercontent.com/117778222/207442115-155b5eff-e6e5-4b26-8efd-4b0edf3442d8.png)
