### PR TITLE
feat: Gsuite Gmail detections for when admins modify  DefaultRoutingRules and Disable Pre-Delivery Scanning

### DIFF
--- a/rules/gsuite_activityevent_rules/gsuite_external_forwarding.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_external_forwarding.yml
@@ -27,7 +27,7 @@ Tests:
       {
       "id": {
           "applicationName": "user_accounts",
-          "customerId": "C045p8dnk",
+          "customerId": "D12345",
         },
         "actor": {
           "email": "homer.simpson@.springfield.io",
@@ -46,7 +46,7 @@ Tests:
       {
       "id": {
           "applicationName": "user_accounts",
-          "customerId": "C045p8dnk",
+          "customerId": "D12345",
         },
         "actor": {
           "email": "homer.simpson@.springfield.io",
@@ -65,7 +65,7 @@ Tests:
       {
       "id": {
           "applicationName": "user_accounts",
-          "customerId": "C045p8dnk",
+          "customerId": "D12345",
         },
         "actor": {
           "email": "homer.simpson@.springfield.io",

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_default_routing_rule.py
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_default_routing_rule.py
@@ -1,0 +1,25 @@
+from panther_base_helpers import deep_get
+
+
+def rule(event):
+    if all(
+        [
+            (event.get("type", "") == "EMAIL_SETTINGS"),
+            (event.get("name", "").endswith("_GMAIL_SETTING")),
+            (deep_get(event, "parameters", "SETTING_NAME", default="") == "MESSAGE_SECURITY_RULE"),
+        ]
+    ):
+        return True
+    return False
+
+
+def title(event):
+    # Gmail records the event name as DELETE_GMAIL_SETTING/CREATE_GMAIL_SETTING
+    # We shouldn't be able to enter title() unless event[name] ends with
+    #  _GMAIL_SETTING, and as such change_type assumes the happy path.
+    change_type = f"{event.get('name', '').split('_')[0].lower()}d"
+    return (
+        f"GSuite Gmail Default Routing Rule Was "
+        f"[{change_type}] "
+        f"by [{deep_get(event, 'actor', 'email', default='<UNKNOWN_EMAIL>')}]"
+    )

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_default_routing_rule.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_default_routing_rule.yml
@@ -1,0 +1,103 @@
+AnalysisType: rule
+Filename: gsuite_workspace_gmail_default_routing_rule.py
+RuleID: GSuite.Workspace.GmailDefaultRoutingRuleModified
+DisplayName: GSuite Workspace Gmail Default Routing Rule Modified
+Enabled: true
+LogTypes:
+  - GSuite.ActivityEvent
+Tags:
+  - GSuite
+Reports:
+  MITRE ATT&CK:
+    - TA0003:T1098
+Severity: High
+Description: >
+  A Workspace Admin Has Modified A Default Routing Rule In Gmail
+Reference: https://support.google.com/a/answer/2368153?hl=en
+Runbook: >
+  Administrators use Default Routing to set up how inbound email is
+  delivered within an organization. The configuration of the default routing
+  rule needs to be inspected in order to verify the intent of the rule is benign.
+  
+  If this change was not planned, inspect the other actions taken by this actor.
+SummaryAttributes:
+  - actor:email
+Tests:
+  -
+    Name: Workspace Admin Creates Default Routing Rule
+    ExpectedResult: true
+    Log:
+      {
+        "actor": {
+          "callerType": "USER",
+          "email": "user@example.io",
+          "profileId": "110555555555555555555"
+        },
+        "id": {
+          "applicationName": "admin",
+          "customerId": "D12345",
+          "time": "2022-12-11 00:50:03.493000000",
+          "uniqueQualifier": "-6333333333333333333"
+        },
+        "ipAddress": "12.12.12.12",
+        "kind": "admin#reports#activity",
+        "name": "CREATE_GMAIL_SETTING",
+        "parameters": {
+          "SETTING_NAME": "MESSAGE_SECURITY_RULE",
+          "USER_DEFINED_SETTING_NAME": "44444"
+        },
+        "type": "EMAIL_SETTINGS"
+      }
+  -
+    Name: Workspace Admin Deletes Default Routing Rule
+    ExpectedResult: true
+    Log:
+      {
+        "actor": {
+          "callerType": "USER",
+          "email": "user@example.io",
+          "profileId": "110555555555555555555"
+        },
+        "id": {
+          "applicationName": "admin",
+          "customerId": "D12345",
+          "time": "2022-12-11 00:50:41.760000000",
+          "uniqueQualifier": "-5015136739334825037"
+        },
+        "ipAddress": "12.12.12.12",
+        "kind": "admin#reports#activity",
+        "name": "DELETE_GMAIL_SETTING",
+        "parameters": {
+          "SETTING_NAME": "MESSAGE_SECURITY_RULE",
+          "USER_DEFINED_SETTING_NAME": "44444"
+        },
+        "type": "EMAIL_SETTINGS"
+      }
+  -
+    Name: Admin Set Default Calendar SHARING_OUTSIDE_DOMAIN Setting to READ_ONLY_ACCESS
+    ExpectedResult: false
+    Log:
+      {
+        "actor": {
+          "callerType": "USER",
+          "email": "example@example.io",
+          "profileId": "12345"
+        },
+        "id": {
+          "applicationName": "admin",
+          "customerId": "D12345",
+          "time": "2022-12-11 01:06:26.303000000",
+          "uniqueQualifier": "-12345"
+        },
+        "ipAddress": "12.12.12.12",
+        "kind": "admin#reports#activity",
+        "name": "CHANGE_CALENDAR_SETTING",
+        "parameters": {
+          "DOMAIN_NAME": "example.io",
+          "NEW_VALUE": "READ_ONLY_ACCESS",
+          "OLD_VALUE": "DEFAULT",
+          "ORG_UNIT_NAME": "Example IO",
+          "SETTING_NAME": "SHARING_OUTSIDE_DOMAIN"
+        },
+        "type": "CALENDAR_SETTINGS"
+      }

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_enhanced_predelivery_scanning.py
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_enhanced_predelivery_scanning.py
@@ -1,0 +1,25 @@
+from panther_base_helpers import deep_get
+
+
+def rule(event):
+    if all(
+        [
+            (event.get("name", "") == "CHANGE_APPLICATION_SETTING"),
+            (deep_get(event, "parameters", "APPLICATION_NAME", default="").lower() == "gmail"),
+            (deep_get(event, "parameters", "NEW_VALUE", default="").lower() == "true"),
+            (
+                deep_get(event, "parameters", "SETTING_NAME", default="")
+                == "DelayedDeliverySettingsProto disable_delayed_delivery_for_suspicious_email"
+            ),
+        ]
+    ):
+        return True
+    return False
+
+
+def title(event):
+    return (
+        f"GSuite Gmail Enhanced Pre-Delivery Scanning was disabled "
+        f"for [{deep_get(event, 'parameters', 'ORG_UNIT_NAME', default='<NO_ORG_UNIT_NAME>')}] "
+        f"by [{deep_get(event, 'actor', 'email', default='<UNKNOWN_EMAIL>')}]"
+    )

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_enhanced_predelivery_scanning.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_enhanced_predelivery_scanning.yml
@@ -1,0 +1,80 @@
+AnalysisType: rule
+Filename: gsuite_workspace_gmail_enhanced_predelivery_scanning.py
+RuleID: GSuite.Workspace.GmailPredeliveryScanningDisabled
+DisplayName: GSuite Workspace Gmail Pre-Delivery Message Scanning Disabled
+Enabled: true
+LogTypes:
+  - GSuite.ActivityEvent
+Tags:
+  - GSuite
+Reports:
+  MITRE ATT&CK:
+    - TA0001:T1566
+Severity: Medium
+Description: >
+  A Workspace Admin Has Disabled Pre-Delivery Scanning For Gmail. 
+Reference: https://support.google.com/a/answer/7380368
+Runbook: >
+  Pre-delivery scanning is a feature in Gmail that subjects suspicious emails
+  to additional automated scrutiny by Google.
+
+  If this change was not intentional, inspect the other actions taken by this actor.
+SummaryAttributes:
+  - actor:email
+Tests:
+  -
+    Name: Workspace Admin Disables Enhanced Pre-Delivery Scanning
+    ExpectedResult: true
+    Log:
+      {
+        "actor": {
+          "callerType": "USER",
+          "email": "example@example.io",
+          "profileId": "12345"
+        },
+        "id": {
+          "applicationName": "admin",
+          "customerId": "D12345",
+          "time": "2022-12-11 03:42:54.859000000",
+          "uniqueQualifier": "-12345"
+        },
+        "ipAddress": "12.12.12.12",
+        "kind": "admin#reports#activity",
+        "name": "CHANGE_APPLICATION_SETTING",
+        "parameters": {
+          "APPLICATION_EDITION": "business_plus_2021",
+          "APPLICATION_NAME": "Gmail",
+          "NEW_VALUE": "true",
+          "ORG_UNIT_NAME": "Example IO",
+          "SETTING_NAME": "DelayedDeliverySettingsProto disable_delayed_delivery_for_suspicious_email"
+        },
+        "type": "APPLICATION_SETTINGS"
+      }
+  -
+    Name: Admin Set Default Calendar SHARING_OUTSIDE_DOMAIN Setting to READ_ONLY_ACCESS
+    ExpectedResult: false
+    Log:
+      {
+        "actor": {
+          "callerType": "USER",
+          "email": "example@example.io",
+          "profileId": "12345"
+        },
+        "id": {
+          "applicationName": "admin",
+          "customerId": "D12345",
+          "time": "2022-12-11 01:06:26.303000000",
+          "uniqueQualifier": "-12345"
+        },
+        "ipAddress": "12.12.12.12",
+        "kind": "admin#reports#activity",
+        "name": "CHANGE_CALENDAR_SETTING",
+        "parameters": {
+          "DOMAIN_NAME": "example.io",
+          "NEW_VALUE": "READ_ONLY_ACCESS",
+          "OLD_VALUE": "DEFAULT",
+          "ORG_UNIT_NAME": "Example IO",
+          "SETTING_NAME": "SHARING_OUTSIDE_DOMAIN"
+        },
+        "type": "CALENDAR_SETTINGS"
+      }

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_trusted_domains_allowlist.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_trusted_domains_allowlist.yml
@@ -32,7 +32,7 @@ Tests:
         },
         "id": {
           "applicationName": "admin",
-          "customerId": "C026x5eyw",
+          "customerId": "D12345",
           "time": "2022-12-11 00:01:34.643000000",
           "uniqueQualifier": "-2972206985263071668"
         },
@@ -56,7 +56,7 @@ Tests:
         },
         "id": {
           "applicationName": "admin",
-          "customerId": "C026x5eyw",
+          "customerId": "D12345",
           "time": "2022-12-10 23:59:24.470000000",
           "uniqueQualifier": "-334478670839567761"
         },


### PR DESCRIPTION
### Background

Some Gsuite detections for Gmail
1. on modification of Default Routing Rules
2. If pre-delivery scanning is disabled 

### Changes

* 

### Testing

```shell
user@computer:panther-analysis $ pipenv run panther_analysis_tool test --filter RuleID=GSuite.Workspace.GmailDefaultRoutingRuleModified
[INFO]: Testing analysis items in .

GSuite.Workspace.GmailDefaultRoutingRuleModified
        [PASS] Workspace Admin Creates Default Routing Rule
                [PASS] [rule] true
                [PASS] [title] GSuite Gmail Default Routing Rule Was [created] by [user@example.io]
                [PASS] [dedup] GSuite Gmail Default Routing Rule Was [created] by [user@example.io]
        [PASS] Workspace Admin Deletes Default Routing Rule
                [PASS] [rule] true
                [PASS] [title] GSuite Gmail Default Routing Rule Was [deleted] by [user@example.io]
                [PASS] [dedup] GSuite Gmail Default Routing Rule Was [deleted] by [user@example.io]
        [PASS] Admin Set Default Calendar SHARING_OUTSIDE_DOMAIN Setting to READ_ONLY_ACCESS
                [PASS] [rule] false

--------------------------
Panther CLI Test Summary
        Path: .
        Passed: 1
        Failed: 0
        Invalid: 0

user@computer:panther-analysis $ pipenv run panther_analysis_tool test --filter RuleID=GSuite.Workspace.GmailPredeliveryScanningDisabled
[INFO]: Testing analysis items in .

GSuite.Workspace.GmailPredeliveryScanningDisabled
        [PASS] Workspace Admin Disables Enhanced Pre-Delivery Scanning
                [PASS] [rule] true
                [PASS] [title] GSuite Gmail Enhanced Pre-Delivery Scanning was disabled for [Example IO] by [example@example.io]
                [PASS] [dedup] GSuite Gmail Enhanced Pre-Delivery Scanning was disabled for [Example IO] by [example@example.io]
        [PASS] Admin Set Default Calendar SHARING_OUTSIDE_DOMAIN Setting to READ_ONLY_ACCESS
                [PASS] [rule] false

--------------------------
Panther CLI Test Summary
        Path: .
        Passed: 1
        Failed: 0
        Invalid: 0

```
