### PR TITLE
Newly Created Github Rule to Monitor Repository Transfers

### DIFF
--- a/packs/github.yml
+++ b/packs/github.yml
@@ -21,6 +21,7 @@ PackDefinition:
     - GitHub.User.RoleUpdated
     - Github.Organization.App.Integration.Installed
     - Github.Public.Repository.Created
+    - Github.Repository.Transfer
     # Standard rules applicable
     - Standard.AdminRoleAssigned
     - Standard.MFADisabled

--- a/rules/github_rules/github_repository_transfer.py
+++ b/rules/github_rules/github_repository_transfer.py
@@ -3,10 +3,10 @@ from panther_base_helpers import github_alert_context
 
 def rule(event):
     # Return True to match the log event and trigger an alert.
-    return (
-        event.get("action", "") == "repo.transfer"
-        or event.get("action", "") == "repo.transfer_outgoing"
-        or event.get("action", "") == "repo.transfer_start"
+    return event.get("action", "") in (
+        "repo.transfer",
+        "repo.transfer_outgoing",
+        "repo.transfer_start",
     )
 
 

--- a/rules/github_rules/github_repository_transfer.py
+++ b/rules/github_rules/github_repository_transfer.py
@@ -1,0 +1,47 @@
+from panther_base_helpers import github_alert_context
+
+
+def rule(event):
+    # Return True to match the log event and trigger an alert.
+    return (
+        event.get("action", "") == "repo.transfer"
+        or event.get("action", "") == "repo.transfer_outgoing"
+        or event.get("action", "") == "repo.transfer_start"
+    )
+
+
+def title(event):
+    # (Optional) Return a string which will be shown as the alert title.
+    # If no 'dedup' function is defined, the return value of this method
+    # will act as deduplication string.
+    action = event.get("action", "")
+    if action == "repo.transfer":
+        # return something like: A user accepted a request to receive a transferred repository.
+        return (
+            f"Github User [{event.get('actor','NO_ACTOR_FOUND')}] accepted a request to "
+            f"receive repository [{event.get('repo','NO_REPO_NAME_FOUND')}] in "
+            f"[{event.get('org','NO_ORG_NAME_FOUND')}]."
+        )
+    if action == "repo.transfer_outgoing":
+        # return something like: A repository was transferred to another repository network.
+        return (
+            f"Github User [{event.get('actor','NO_ACTOR_FOUND')}] transferred repository "
+            f"[{event.get('repo','NO_REPO_NAME_FOUND')}] in "
+            f"[{event.get('org','NO_ORG_NAME_FOUND')}]."
+        )
+    if action == "repo.transfer_start":
+        # return something like: A user sent a request to transfer a
+        # repository to another user or organization.
+        return (
+            f"Github User [{event.get('actor','NO_ACTOR_FOUND')}] sent a request to "
+            f"transfer repository [{event.get('repo','NO_REPO_NAME_FOUND')}] "
+            f"to another user or organization."
+        )
+
+    return ""
+
+
+def alert_context(event):
+    #  (Optional) Return a dictionary with additional data to be included in the alert
+    # sent to the SNS/SQS/Webhook destination
+    return github_alert_context(event)

--- a/rules/github_rules/github_repository_transfer.yml
+++ b/rules/github_rules/github_repository_transfer.yml
@@ -1,7 +1,7 @@
 AnalysisType: rule
 Description: A user accepted a request to receive a transferred Github repository, a  Github repository was transferred to another repository network, or a user sent a request to transfer a repository to another user or organization.
 DisplayName: Github Repository Transfer
-Enabled: false
+Enabled: true
 Filename: github_repository_transfer.py
 Reference: |-
     https://docs.github.com/en/enterprise-server@3.3/repositories/creating-and-managing-repositories/transferring-a-repository

--- a/rules/github_rules/github_repository_transfer.yml
+++ b/rules/github_rules/github_repository_transfer.yml
@@ -1,0 +1,76 @@
+AnalysisType: rule
+Description: A user accepted a request to receive a transferred Github repository, a  Github repository was transferred to another repository network, or a user sent a request to transfer a repository to another user or organization.
+DisplayName: Github Repository Transfer
+Enabled: false
+Filename: github_repository_transfer.py
+Reference: |-
+    https://docs.github.com/en/enterprise-server@3.3/repositories/creating-and-managing-repositories/transferring-a-repository
+
+    https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/audit-log-events-for-your-enterprise#repo-category-actions
+Runbook: Please check with the referenced users or their supervisors to ensure the transferring of this repository is expected and allowed.
+Severity: Medium
+Tags:
+    - Github Repository
+    - Github Repository Transfer
+    - Repository
+    - Transfer
+Tests:
+    - ExpectedResult: false
+      Log:
+        _document_id: abCD
+        action: repo.create
+        actor: example-actor
+        actor_location:
+            country_code: US
+        at_sign_timestamp: "2022-12-11 22:40:20.268"
+        created_at: "2022-12-11 22:40:20.268"
+        org: example-io
+        repo: example-io/oops
+        visibility: public
+      Name: Public Repo Created
+    - ExpectedResult: true
+      Log:
+        _document_id: BodJtQIrT3kWMIQpm1ANew
+        action: repo.transfer_outgoing
+        actor: user-name
+        actor_location:
+            country_code: US
+        at_sign_timestamp: "2022-12-14 19:16:31.299"
+        created_at: "2022-12-14 19:16:31.299"
+        org: your-organization
+        repo: your-organizatoin/project_repo
+        visibility: private
+      Name: Repo Transfer Outgoing
+    - ExpectedResult: true
+      Log:
+        _document_id: BodJtQIrT3kWMIQpm1ANew
+        action: repo.transfer_start
+        actor: user-name
+        actor_location:
+            country_code: US
+        at_sign_timestamp: "2022-12-14 19:16:31.299"
+        created_at: "2022-12-14 19:16:31.299"
+        org: your-organization
+        repo: your-organizatoin/project_repo
+        visibility: private
+      Name: Repo Transfer Start
+    - ExpectedResult: true
+      Log:
+        _document_id: CFyS8UJsQjJfCgsmTLI6mQ
+        action: repo.transfer
+        actor: org-user
+        actor_location:
+            country_code: US
+        at_sign_timestamp: "2022-12-14 19:21:01.035"
+        created_at: "2022-12-14 19:21:01.035"
+        org: your-organization
+        repo: your-organization/project_repo
+        visibility: private
+      Name: Repository Transfer
+DedupPeriodMinutes: 60
+LogTypes:
+    - GitHub.Audit
+RuleID: Github.Repository.Transfer
+SummaryAttributes:
+    - action
+Threshold: 1


### PR DESCRIPTION


### Background

<High level overview here>

### Changes

* adding newly created rule to monitor and alert on github repository transfer events

### Testing

*
![Screen Shot 2022-12-15 at 11 42 05 AM](https://user-images.githubusercontent.com/117778222/207942206-ce1be8e6-8789-4f80-8662-ef53cc5f5067.png)

