### PR TITLE
Atlassian user logged in as user

### DIFF
--- a/packs/atlassian.yml
+++ b/packs/atlassian.yml
@@ -1,0 +1,9 @@
+AnalysisType: pack
+PackID: PantherManaged.Atlassian
+Description: Group of all Atlassian detections
+PackDefinition:
+  IDs:
+    - Atlassian.User.LoggedInAs.User
+    # Globals used in these detections
+    - panther_base_helpers
+DisplayName: Panther Atlassian Pack

--- a/packs/atlassian.yml
+++ b/packs/atlassian.yml
@@ -3,7 +3,7 @@ PackID: PantherManaged.Atlassian
 Description: Group of all Atlassian detections
 PackDefinition:
   IDs:
-    - Atlassian.User.LoggedInAs.User
+    - Atlassian.User.LoggedInAsUser
     # Globals used in these detections
     - panther_base_helpers
 DisplayName: Panther Atlassian Pack

--- a/rules/atlassian_rules/user_logged_in_as_user.py
+++ b/rules/atlassian_rules/user_logged_in_as_user.py
@@ -10,9 +10,9 @@ def rule(event):
 
 def title(event):
     actor = deep_get(event, "attributes", "actor", "email", default="<unknown-email>")
-    impersonated_user = deep_get(
-        event, "attributes", "context", default="<unknown-user-attributes>"
-    )[0]["attributes"].get("email")
+    context = deep_get(
+        event, "attributes", "context", default=[{}])
+    impersonated_user = context[0].get('attributes',{}).get('email', '<unknown-email>')
     return f"{actor} logged in as {impersonated_user}."
 
 

--- a/rules/atlassian_rules/user_logged_in_as_user.py
+++ b/rules/atlassian_rules/user_logged_in_as_user.py
@@ -2,20 +2,17 @@ from panther_base_helpers import deep_get
 
 
 def rule(event):
-    return deep_get(
-        event,
-        "attributes",
-        "action",
-        default="<unknown-action>") == "user_logged_in_as_user"
+    return (
+        deep_get(event, "attributes", "action", default="<unknown-action>")
+        == "user_logged_in_as_user"
+    )
 
 
 def title(event):
     actor = deep_get(event, "attributes", "actor", "email", default="<unknown-email>")
     impersonated_user = deep_get(
-        event,
-        "attributes",
-        "context",
-        default="<unknown-user-attributes>")[0]["attributes"].get("email")
+        event, "attributes", "context", default="<unknown-user-attributes>"
+    )[0]["attributes"].get("email")
     return f"{actor} logged in as {impersonated_user}."
 
 
@@ -24,9 +21,7 @@ def alert_context(event):
         "Timestamp": deep_get(event, "attributes", "time", default="<unknown-time>"),
         "Actor": deep_get(event, "attributes", "actor", "email", default="<unknown-actor-email>"),
         "Impersonated user": deep_get(
-            event,
-            "attributes",
-            "context",
-            default="<unknown-user-attributes>")[0]["attributes"].get("email"),
+            event, "attributes", "context", default="<unknown-user-attributes>"
+        )[0]["attributes"].get("email"),
         "Event ID": event.get("id"),
     }

--- a/rules/atlassian_rules/user_logged_in_as_user.py
+++ b/rules/atlassian_rules/user_logged_in_as_user.py
@@ -10,9 +10,8 @@ def rule(event):
 
 def title(event):
     actor = deep_get(event, "attributes", "actor", "email", default="<unknown-email>")
-    context = deep_get(
-        event, "attributes", "context", default=[{}])
-    impersonated_user = context[0].get('attributes',{}).get('email', '<unknown-email>')
+    context = deep_get(event, "attributes", "context", default=[{}])
+    impersonated_user = context[0].get("attributes", {}).get("email", "<unknown-email>")
     return f"{actor} logged in as {impersonated_user}."
 
 
@@ -20,7 +19,8 @@ def alert_context(event):
     return {
         "Timestamp": deep_get(event, "attributes", "time", default="<unknown-time>"),
         "Actor": deep_get(event, "attributes", "actor", "email", default="<unknown-actor-email>"),
-        "Impersonated user": deep_get(
-        event, "attributes", "context", default=[{}])[0].get('attributes',{}).get('email', '<unknown-email>'),
+        "Impersonated user": deep_get(event, "attributes", "context", default=[{}])[0]
+        .get("attributes", {})
+        .get("email", "<unknown-email>"),
         "Event ID": event.get("id"),
     }

--- a/rules/atlassian_rules/user_logged_in_as_user.py
+++ b/rules/atlassian_rules/user_logged_in_as_user.py
@@ -21,6 +21,6 @@ def alert_context(event):
         "Timestamp": deep_get(event, "attributes", "time", default="<unknown-time>"),
         "Actor": deep_get(event, "attributes", "actor", "email", default="<unknown-actor-email>"),
         "Impersonated user": deep_get(
-        event, "attributes", "context", default=[{}])[0].get('attributes',{}).get('email', '<unknown-email>')
+        event, "attributes", "context", default=[{}])[0].get('attributes',{}).get('email', '<unknown-email>'),
         "Event ID": event.get("id"),
     }

--- a/rules/atlassian_rules/user_logged_in_as_user.py
+++ b/rules/atlassian_rules/user_logged_in_as_user.py
@@ -2,7 +2,11 @@ from panther_base_helpers import deep_get
 
 
 def rule(event):
-    return deep_get(event, "attributes", "action", default="<unknown-action>") == "user_logged_in_as_user"
+    return deep_get(
+        event,
+        "attributes",
+        "action",
+        default="<unknown-action>") == "user_logged_in_as_user"
 
 
 def title(event):

--- a/rules/atlassian_rules/user_logged_in_as_user.py
+++ b/rules/atlassian_rules/user_logged_in_as_user.py
@@ -1,0 +1,28 @@
+from panther_base_helpers import deep_get
+
+
+def rule(event):
+    return deep_get(event, "attributes", "action", default="<unknown-action>") == "user_logged_in_as_user"
+
+
+def title(event):
+    actor = deep_get(event, "attributes", "actor", "email", default="<unknown-email>")
+    impersonated_user = deep_get(
+        event,
+        "attributes",
+        "context",
+        default="<unknown-user-attributes>")[0]["attributes"].get("email")
+    return f"{actor} logged in as {impersonated_user}."
+
+
+def alert_context(event):
+    return {
+        "Timestamp": deep_get(event, "attributes", "time", default="<unknown-time>"),
+        "Actor": deep_get(event, "attributes", "actor", "email", default="<unknown-actor-email>"),
+        "Impersonated user": deep_get(
+            event,
+            "attributes",
+            "context",
+            default="<unknown-user-attributes>")[0]["attributes"].get("email"),
+        "Event ID": event.get("id"),
+    }

--- a/rules/atlassian_rules/user_logged_in_as_user.py
+++ b/rules/atlassian_rules/user_logged_in_as_user.py
@@ -21,7 +21,6 @@ def alert_context(event):
         "Timestamp": deep_get(event, "attributes", "time", default="<unknown-time>"),
         "Actor": deep_get(event, "attributes", "actor", "email", default="<unknown-actor-email>"),
         "Impersonated user": deep_get(
-            event, "attributes", "context", default="<unknown-user-attributes>"
-        )[0]["attributes"].get("email"),
+        event, "attributes", "context", default=[{}])[0].get('attributes',{}).get('email', '<unknown-email>')
         "Event ID": event.get("id"),
     }

--- a/rules/atlassian_rules/user_logged_in_as_user.yml
+++ b/rules/atlassian_rules/user_logged_in_as_user.yml
@@ -3,18 +3,59 @@ DedupPeriodMinutes: 60 # 1 hour
 DisplayName: Atlassian user logged in as user
 Enabled: true
 Filename: user_logged_in_as_user.py
-RuleID: Atlassian.User.LoggedInAs.User
+RuleID: Atlassian.User.LoggedInAsUser
 Severity: High
 LogTypes:
   - Atlassian.Audit
-Reports:
-  ReportName (like CIS, MITRE ATT&CK):
-    - The specific report section relevant to this rule
 Tags:
   - Atlassian
   - User impersonation
 Description: >
-  This rule exists to validate the CLI workflows of the Panther CLI
+  Reports when an Atlassian user logs in (impersonates) another user.
 Runbook: >
-  First, find out who wrote this the spec format, then notify them with feedback.
-Reference: https://www.a-clickable-link-to-more-info.com
+  Validate that the Atlassian admin did log in (impersonate) as another user.
+Reference: https://support.atlassian.com/user-management/docs/log-in-as-another-user/
+Tests:
+  -
+    Name: Admin impersonated user successfully
+    ExpectedResult: true
+    Log:
+        {
+          "attributes": {
+            "action": "user_logged_in_as_user",
+            "actor": {
+              "email": "example.admin@example.com",
+              "id": "1234567890abcdefghijklmn",
+              "name": "Example Admin"
+            },
+            "container": [
+              {
+                "attributes": {
+                  "siteHostName": "https://example.atlassian.net",
+                  "siteName": "example"
+                },
+                "id": "12345678-abcd-9012-efgh-1234567890abcd",
+                "links": {
+                  "alt": "https://example.atlassian.net"
+                },
+                "type": "sites"
+              }
+            ],
+            "context": [
+              {
+                "attributes": {
+                  "accountType": "atlassian",
+                  "email": "example.user@example.io",
+                  "name": "example.user@example.io"
+                },
+                "type": "users"
+              }
+            ],
+            "time": "2022-12-15T00:35:15.890Z"
+          },
+          "id": "2508d209-3336-4763-89a0-aceaf1322fcf", #event ID
+          "message": {
+            "content": "Logged in as example.user@example.io",
+            "format": "simple"
+          },
+        }

--- a/rules/atlassian_rules/user_logged_in_as_user.yml
+++ b/rules/atlassian_rules/user_logged_in_as_user.yml
@@ -59,3 +59,47 @@ Tests:
             "format": "simple"
           },
         }
+  -
+    Name: user_logged_in_as_user not in log
+    ExpectedResult: false
+    Log:
+        {
+          "attributes": {
+            "action": "user_login",
+            "actor": {
+              "email": "example.admin@example.com",
+              "id": "1234567890abcdefghijklmn",
+              "name": "Example Admin"
+            },
+            "container": [
+              {
+                "attributes": {
+                  "siteHostName": "https://example.atlassian.net",
+                  "siteName": "example"
+                },
+                "id": "12345678-abcd-9012-efgh-1234567890abcd",
+                "links": {
+                  "alt": "https://example.atlassian.net"
+                },
+                "type": "sites"
+              }
+            ],
+            "context": [
+              {
+                "attributes": {
+                  "accountType": "atlassian",
+                  "email": "example.user@example.io",
+                  "name": "example.user@example.io"
+                },
+                "type": "users"
+              }
+            ],
+            "time": "2022-12-15T00:35:15.890Z"
+          },
+          "id": "2508d209-3336-4763-89a0-aceaf1322fcf", #event ID
+          "message": {
+            "content": "Logged in as example.user@example.io",
+            "format": "simple"
+          },
+        }
+

--- a/rules/atlassian_rules/user_logged_in_as_user.yml
+++ b/rules/atlassian_rules/user_logged_in_as_user.yml
@@ -1,0 +1,20 @@
+AnalysisType: rule
+DedupPeriodMinutes: 60 # 1 hour
+DisplayName: Atlassian user logged in as user
+Enabled: true
+Filename: user_logged_in_as_user.py
+RuleID: Atlassian.User.LoggedInAs.User
+Severity: High
+LogTypes:
+  - Atlassian.Audit
+Reports:
+  ReportName (like CIS, MITRE ATT&CK):
+    - The specific report section relevant to this rule
+Tags:
+  - Atlassian
+  - User impersonation
+Description: >
+  This rule exists to validate the CLI workflows of the Panther CLI
+Runbook: >
+  First, find out who wrote this the spec format, then notify them with feedback.
+Reference: https://www.a-clickable-link-to-more-info.com


### PR DESCRIPTION
### Background

Detects the `user_logged_in_as_user` event. Atlassian admins can impersonate another non-admin user account on a per-application (Jira, Confluence, etc.) basis. This detection runs at the Atlassian admin level but does not call out which application the admin looking at when impersonating another user.

Created a new Atlassian Pack, `packs/atlassian.yml` to support this new detection. 

[Atlassian docs](https://support.atlassian.com/user-management/docs/log-in-as-another-user/)

### Changes

* Adds an Atlassian rule to detect `logged_in_as_user.
* Adds a Pack for Atlassian. 

### Testing
```
[INFO]: Testing analysis items in rules/atlassian_rules

Atlassian.User.LoggedInAsUser
	[PASS] Admin impersonated user successfully
		[PASS] [rule] true
		[PASS] [title] example.admin@example.com logged in as example.user@example.io.
		[PASS] [dedup] example.admin@example.com logged in as example.user@example.io.
		[PASS] [alertContext] {"Timestamp": "2022-12-15T00:35:15.890Z", "Actor": "example.admin@example.com", "Impersonated user": "example.user@example.io", "Event ID": "2508d209-3336-4763-89a0-aceaf1322fcf"}
	[PASS] user_logged_in_as_user not in log
		[PASS] [rule] false

--------------------------
Panther CLI Test Summary
	Path: rules/atlassian_rules
	Passed: 1
	Failed: 0
	Invalid: 0
```
