### PR TITLE
fix: yaml lines are not allowed to have \t as the first character

### DIFF
--- a/rules/duo_rules/duo_admin_marked_push_fraudulent.yml
+++ b/rules/duo_rules/duo_admin_marked_push_fraudulent.yml
@@ -18,20 +18,20 @@ Tests:
     ExpectedResult: true
     Log:
       {
-      	"action": "admin_2fa_error",
-      	"description": "{\"ip_address\": \"12.12.12.12\", \"email\": \"example@example.io\", \"factor\": \"push\", \"error\": \"Login request reported as fraudulent.\"}",
-      	"isotimestamp": "2022-12-14 20:11:53",
-      	"timestamp": "2022-12-14 20:11:53",
-      	"username": "John P. Admin"
+      "action": "admin_2fa_error",
+      "description": "{\"ip_address\": \"12.12.12.12\", \"email\": \"example@example.io\", \"factor\": \"push\", \"error\": \"Login request reported as fraudulent.\"}",
+      "isotimestamp": "2022-12-14 20:11:53",
+      "timestamp": "2022-12-14 20:11:53",
+      "username": "John P. Admin"
       } 
   -
     Name: different_admin_action 
     ExpectedResult: false
     Log:
       {
-      	"action": "admin_update",
-      	"description": "{}",
-      	"isotimestamp": "2022-12-14 20:11:53",
-      	"timestamp": "2022-12-14 20:11:53",
-      	"username": "John P. Admin"
+      "action": "admin_update",
+      "description": "{}",
+      "isotimestamp": "2022-12-14 20:11:53",
+      "timestamp": "2022-12-14 20:11:53",
+      "username": "John P. Admin"
       } 


### PR DESCRIPTION
### Background
`\t` is verboten to begin a line per yaml spec, see [Section 5.1](https://yaml.org/spec/1.2.2/). The parsers, and/or the options that they are instantiated with in `panther_analysis_tool` permit it, though the spec does not and other downstream parsers complain about invalid yaml when encountering these.


### Changes

* 

### Testing

* 
![Screen Shot 2022-12-19 at 09 06 41](https://user-images.githubusercontent.com/932424/208480723-69e32487-86c4-455e-b7e1-c5a5618ecea7.png)
