### PR TITLE
fix: some of the keys subordinate to the parameters top level key in google workspace logs can mutate the shape of their values between string and list of strings

### DIFF
--- a/rules/gsuite_activityevent_rules/google_workspace_admin_custom_role.yml
+++ b/rules/gsuite_activityevent_rules/google_workspace_admin_custom_role.yml
@@ -49,6 +49,44 @@ Tests:
             ROLE_NAME: CustomAdminRoleName
         type: DELEGATED_ADMIN_SETTINGS
       Name: New Custom Role Created
+    - Name: ListObject Type
+      ExpectedResult: false
+      Log:
+        {
+            "actor": {
+            "email": "user@example.io",
+            "profileId": "118111111111111111111"
+            },
+            "id": {
+            "applicationName": "drive",
+            "customerId": "D12345",
+            "time": "2022-12-20 17:27:47.080000000",
+            "uniqueQualifier": "-7312729053723258069"
+            },
+            "ipAddress": "12.12.12.12",
+            "kind": "admin#reports#activity",
+            "name": "rename",
+            "parameters": {
+            "actor_is_collaborator_account": null,
+            "billable": true,
+            "doc_id": "1GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+            "doc_title": "Document Title- Found Here",
+            "doc_type": "presentation",
+            "is_encrypted": null,
+            "new_value": [
+                "Document Title- Found Here"
+            ],
+            "old_value": [
+                "Document Title- Old"
+            ],
+            "owner": "user@example.io",
+            "owner_is_shared_drive": null,
+            "owner_is_team_drive": null,
+            "primary_event": true,
+            "visibility": "private"
+            },
+            "type": "access"
+        }
 DedupPeriodMinutes: 60
 LogTypes:
     - GSuite.ActivityEvent

--- a/rules/gsuite_activityevent_rules/google_workspace_advanced_protection_program.yml
+++ b/rules/gsuite_activityevent_rules/google_workspace_advanced_protection_program.yml
@@ -69,6 +69,45 @@ Tests:
             ROLE_NAME: CustomAdminRoleName
         type: DELEGATED_ADMIN_SETTINGS
       Name: New Custom Role Created
+
+    - Name: ListObject Type
+      ExpectedResult: false
+      Log:
+        {
+            "actor": {
+            "email": "user@example.io",
+            "profileId": "118111111111111111111"
+            },
+            "id": {
+            "applicationName": "drive",
+            "customerId": "D12345",
+            "time": "2022-12-20 17:27:47.080000000",
+            "uniqueQualifier": "-7312729053723258069"
+            },
+            "ipAddress": "12.12.12.12",
+            "kind": "admin#reports#activity",
+            "name": "rename",
+            "parameters": {
+            "actor_is_collaborator_account": null,
+            "billable": true,
+            "doc_id": "1GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+            "doc_title": "Document Title- Found Here",
+            "doc_type": "presentation",
+            "is_encrypted": null,
+            "new_value": [
+                "Document Title- Found Here"
+            ],
+            "old_value": [
+                "Document Title- Old"
+            ],
+            "owner": "user@example.io",
+            "owner_is_shared_drive": null,
+            "owner_is_team_drive": null,
+            "primary_event": true,
+            "visibility": "private"
+            },
+            "type": "access"
+        }
 DedupPeriodMinutes: 60
 LogTypes:
     - GSuite.ActivityEvent

--- a/rules/gsuite_activityevent_rules/google_workspace_apps_marketplace_allowlist.yml
+++ b/rules/gsuite_activityevent_rules/google_workspace_apps_marketplace_allowlist.yml
@@ -67,6 +67,44 @@ Tests:
             ROLE_NAME: CustomAdminRoleName
         type: DELEGATED_ADMIN_SETTINGS
       Name: New Custom Role Created
+    - Name: ListObject Type
+      ExpectedResult: false
+      Log:
+        {
+            "actor": {
+            "email": "user@example.io",
+            "profileId": "118111111111111111111"
+            },
+            "id": {
+            "applicationName": "drive",
+            "customerId": "D12345",
+            "time": "2022-12-20 17:27:47.080000000",
+            "uniqueQualifier": "-7312729053723258069"
+            },
+            "ipAddress": "12.12.12.12",
+            "kind": "admin#reports#activity",
+            "name": "rename",
+            "parameters": {
+            "actor_is_collaborator_account": null,
+            "billable": true,
+            "doc_id": "1GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+            "doc_title": "Document Title- Found Here",
+            "doc_type": "presentation",
+            "is_encrypted": null,
+            "new_value": [
+                "Document Title- Found Here"
+            ],
+            "old_value": [
+                "Document Title- Old"
+            ],
+            "owner": "user@example.io",
+            "owner_is_shared_drive": null,
+            "owner_is_team_drive": null,
+            "primary_event": true,
+            "visibility": "private"
+            },
+            "type": "access"
+        }
 DedupPeriodMinutes: 60
 LogTypes:
     - GSuite.ActivityEvent

--- a/rules/gsuite_activityevent_rules/google_workspace_apps_marketplace_new_domain_application.yml
+++ b/rules/gsuite_activityevent_rules/google_workspace_apps_marketplace_new_domain_application.yml
@@ -65,6 +65,44 @@ Tests:
             APPLICATION_NAME: Microsoft Applications for Google
         type: DOMAIN_SETTINGS
       Name: Microsoft Apps for Google
+    - Name: ListObject Type
+      ExpectedResult: false
+      Log:
+        {
+            "actor": {
+            "email": "user@example.io",
+            "profileId": "118111111111111111111"
+            },
+            "id": {
+            "applicationName": "drive",
+            "customerId": "D12345",
+            "time": "2022-12-20 17:27:47.080000000",
+            "uniqueQualifier": "-7312729053723258069"
+            },
+            "ipAddress": "12.12.12.12",
+            "kind": "admin#reports#activity",
+            "name": "rename",
+            "parameters": {
+            "actor_is_collaborator_account": null,
+            "billable": true,
+            "doc_id": "1GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+            "doc_title": "Document Title- Found Here",
+            "doc_type": "presentation",
+            "is_encrypted": null,
+            "new_value": [
+                "Document Title- Found Here"
+            ],
+            "old_value": [
+                "Document Title- Old"
+            ],
+            "owner": "user@example.io",
+            "owner_is_shared_drive": null,
+            "owner_is_team_drive": null,
+            "primary_event": true,
+            "visibility": "private"
+            },
+            "type": "access"
+        }
 DedupPeriodMinutes: 60
 LogTypes:
     - GSuite.ActivityEvent

--- a/rules/gsuite_activityevent_rules/google_workspace_apps_new_mobile_app_installed.yml
+++ b/rules/gsuite_activityevent_rules/google_workspace_apps_new_mobile_app_installed.yml
@@ -49,6 +49,45 @@ Tests:
             SETTING_NAME: Advanced Protection Program Settings - Enable user enrollment
         type: APPLICATION_SETTINGS
       Name: Enable User Enrollement
+    - Name: ListObject Type
+      ExpectedResult: false
+      Log:
+        {
+            "actor": {
+            "email": "user@example.io",
+            "profileId": "118111111111111111111"
+            },
+            "id": {
+            "applicationName": "drive",
+            "customerId": "D12345",
+            "time": "2022-12-20 17:27:47.080000000",
+            "uniqueQualifier": "-7312729053723258069"
+            },
+            "ipAddress": "12.12.12.12",
+            "kind": "admin#reports#activity",
+            "name": "rename",
+            "parameters": {
+            "actor_is_collaborator_account": null,
+            "billable": true,
+            "doc_id": "1GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+            "doc_title": "Document Title- Found Here",
+            "doc_type": "presentation",
+            "is_encrypted": null,
+            "new_value": [
+                "Document Title- Found Here"
+            ],
+            "old_value": [
+                "Document Title- Old"
+            ],
+            "owner": "user@example.io",
+            "owner_is_shared_drive": null,
+            "owner_is_team_drive": null,
+            "primary_event": true,
+            "visibility": "private"
+            },
+            "type": "access"
+        }
+
 DedupPeriodMinutes: 60
 LogTypes:
     - GSuite.ActivityEvent

--- a/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.yml
@@ -75,3 +75,41 @@ Tests:
         },
         "type": "CALENDAR_SETTINGS"
       }
+  - Name: ListObject Type
+    ExpectedResult: false
+    Log:
+      {
+          "actor": {
+          "email": "user@example.io",
+          "profileId": "118111111111111111111"
+          },
+          "id": {
+          "applicationName": "drive",
+          "customerId": "D12345",
+          "time": "2022-12-20 17:27:47.080000000",
+          "uniqueQualifier": "-7312729053723258069"
+          },
+          "ipAddress": "12.12.12.12",
+          "kind": "admin#reports#activity",
+          "name": "rename",
+          "parameters": {
+          "actor_is_collaborator_account": null,
+          "billable": true,
+          "doc_id": "1GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+          "doc_title": "Document Title- Found Here",
+          "doc_type": "presentation",
+          "is_encrypted": null,
+          "new_value": [
+              "Document Title- Found Here"
+          ],
+          "old_value": [
+              "Document Title- Old"
+          ],
+          "owner": "user@example.io",
+          "owner_is_shared_drive": null,
+          "owner_is_team_drive": null,
+          "primary_event": true,
+          "visibility": "private"
+          },
+          "type": "access"
+      }

--- a/rules/gsuite_activityevent_rules/gsuite_external_forwarding.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_external_forwarding.yml
@@ -73,4 +73,42 @@ Tests:
         "type": "2sv_change",
         "name": "2sv_enroll",
       }
+  - Name: ListObject Type
+    ExpectedResult: false
+    Log:
+      {
+          "actor": {
+          "email": "user@example.io",
+          "profileId": "118111111111111111111"
+          },
+          "id": {
+          "applicationName": "drive",
+          "customerId": "D12345",
+          "time": "2022-12-20 17:27:47.080000000",
+          "uniqueQualifier": "-7312729053723258069"
+          },
+          "ipAddress": "12.12.12.12",
+          "kind": "admin#reports#activity",
+          "name": "rename",
+          "parameters": {
+          "actor_is_collaborator_account": null,
+          "billable": true,
+          "doc_id": "1GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+          "doc_title": "Document Title- Found Here",
+          "doc_type": "presentation",
+          "is_encrypted": null,
+          "new_value": [
+              "Document Title- Found Here"
+          ],
+          "old_value": [
+              "Document Title- Old"
+          ],
+          "owner": "user@example.io",
+          "owner_is_shared_drive": null,
+          "owner_is_team_drive": null,
+          "primary_event": true,
+          "visibility": "private"
+          },
+          "type": "access"
+      }
 

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_calendar_external_sharing.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_calendar_external_sharing.yml
@@ -127,3 +127,41 @@ Tests:
         },
         "type": "CUSTOMER_TAKEOUT"
       }
+  - Name: ListObject Type
+    ExpectedResult: false
+    Log:
+      {
+          "actor": {
+          "email": "user@example.io",
+          "profileId": "118111111111111111111"
+          },
+          "id": {
+          "applicationName": "drive",
+          "customerId": "D12345",
+          "time": "2022-12-20 17:27:47.080000000",
+          "uniqueQualifier": "-7312729053723258069"
+          },
+          "ipAddress": "12.12.12.12",
+          "kind": "admin#reports#activity",
+          "name": "rename",
+          "parameters": {
+          "actor_is_collaborator_account": null,
+          "billable": true,
+          "doc_id": "1GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+          "doc_title": "Document Title- Found Here",
+          "doc_type": "presentation",
+          "is_encrypted": null,
+          "new_value": [
+              "Document Title- Found Here"
+          ],
+          "old_value": [
+              "Document Title- Old"
+          ],
+          "owner": "user@example.io",
+          "owner_is_shared_drive": null,
+          "owner_is_team_drive": null,
+          "primary_event": true,
+          "visibility": "private"
+          },
+          "type": "access"
+      }

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_data_export_created.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_data_export_created.yml
@@ -91,4 +91,42 @@ Tests:
         },
         "type": "CALENDAR_SETTINGS"
       }
- 
+  - Name: ListObject Type
+    ExpectedResult: false
+    Log:
+      {
+          "actor": {
+          "email": "user@example.io",
+          "profileId": "118111111111111111111"
+          },
+          "id": {
+          "applicationName": "drive",
+          "customerId": "D12345",
+          "time": "2022-12-20 17:27:47.080000000",
+          "uniqueQualifier": "-7312729053723258069"
+          },
+          "ipAddress": "12.12.12.12",
+          "kind": "admin#reports#activity",
+          "name": "rename",
+          "parameters": {
+          "actor_is_collaborator_account": null,
+          "billable": true,
+          "doc_id": "1GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+          "doc_title": "Document Title- Found Here",
+          "doc_type": "presentation",
+          "is_encrypted": null,
+          "new_value": [
+              "Document Title- Found Here"
+          ],
+          "old_value": [
+              "Document Title- Old"
+          ],
+          "owner": "user@example.io",
+          "owner_is_shared_drive": null,
+          "owner_is_team_drive": null,
+          "primary_event": true,
+          "visibility": "private"
+          },
+          "type": "access"
+      }
+

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_default_routing_rule.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_default_routing_rule.yml
@@ -101,3 +101,41 @@ Tests:
         },
         "type": "CALENDAR_SETTINGS"
       }
+  - Name: ListObject Type
+    ExpectedResult: false
+    Log:
+      {
+          "actor": {
+          "email": "user@example.io",
+          "profileId": "118111111111111111111"
+          },
+          "id": {
+          "applicationName": "drive",
+          "customerId": "D12345",
+          "time": "2022-12-20 17:27:47.080000000",
+          "uniqueQualifier": "-7312729053723258069"
+          },
+          "ipAddress": "12.12.12.12",
+          "kind": "admin#reports#activity",
+          "name": "rename",
+          "parameters": {
+          "actor_is_collaborator_account": null,
+          "billable": true,
+          "doc_id": "1GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+          "doc_title": "Document Title- Found Here",
+          "doc_type": "presentation",
+          "is_encrypted": null,
+          "new_value": [
+              "Document Title- Found Here"
+          ],
+          "old_value": [
+              "Document Title- Old"
+          ],
+          "owner": "user@example.io",
+          "owner_is_shared_drive": null,
+          "owner_is_team_drive": null,
+          "primary_event": true,
+          "visibility": "private"
+          },
+          "type": "access"
+      }

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_enhanced_predelivery_scanning.py
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_enhanced_predelivery_scanning.py
@@ -2,6 +2,10 @@ from panther_base_helpers import deep_get
 
 
 def rule(event):
+    # the shape of the items in parameters can change a bit ( like NEW_VALUE can be an array )
+    #  when the applicationName is something other than admin
+    if not deep_get(event, "id", "applicationName", default="").lower() == "admin":
+        return False
     if all(
         [
             (event.get("name", "") == "CHANGE_APPLICATION_SETTING"),

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_enhanced_predelivery_scanning.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_enhanced_predelivery_scanning.yml
@@ -78,3 +78,41 @@ Tests:
         },
         "type": "CALENDAR_SETTINGS"
       }
+  - Name: ListObject Type
+    ExpectedResult: false
+    Log:
+      {
+        "actor": {
+          "email": "user@example.io",
+          "profileId": "118111111111111111111"
+        },
+        "id": {
+          "applicationName": "drive",
+          "customerId": "D12345",
+          "time": "2022-12-20 17:27:47.080000000",
+          "uniqueQualifier": "-7312729053723258069"
+        },
+        "ipAddress": "12.12.12.12",
+        "kind": "admin#reports#activity",
+        "name": "rename",
+        "parameters": {
+          "actor_is_collaborator_account": null,
+          "billable": true,
+          "doc_id": "1GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+          "doc_title": "Document Title- Found Here",
+          "doc_type": "presentation",
+          "is_encrypted": null,
+          "new_value": [
+            "Document Title- Found Here"
+          ],
+          "old_value": [
+            "Document Title- Old"
+          ],
+          "owner": "user@example.io",
+          "owner_is_shared_drive": null,
+          "owner_is_team_drive": null,
+          "primary_event": true,
+          "visibility": "private"
+        },
+        "type": "access"
+      }

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_security_sandbox_disabled.py
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_security_sandbox_disabled.py
@@ -2,6 +2,8 @@ from panther_base_helpers import deep_get
 
 
 def rule(event):
+    if not deep_get(event, "id", "applicationName", default="").lower() == "admin":
+        return False
     if all(
         [
             (event.get("name", "") == "CHANGE_APPLICATION_SETTING"),

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_security_sandbox_disabled.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_security_sandbox_disabled.yml
@@ -77,3 +77,41 @@ Tests:
         },
         "type": "CALENDAR_SETTINGS"
       }
+  - Name: ListObject Type
+    ExpectedResult: false
+    Log:
+      {
+          "actor": {
+          "email": "user@example.io",
+          "profileId": "118111111111111111111"
+          },
+          "id": {
+          "applicationName": "drive",
+          "customerId": "D12345",
+          "time": "2022-12-20 17:27:47.080000000",
+          "uniqueQualifier": "-7312729053723258069"
+          },
+          "ipAddress": "12.12.12.12",
+          "kind": "admin#reports#activity",
+          "name": "rename",
+          "parameters": {
+          "actor_is_collaborator_account": null,
+          "billable": true,
+          "doc_id": "1GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+          "doc_title": "Document Title- Found Here",
+          "doc_type": "presentation",
+          "is_encrypted": null,
+          "new_value": [
+              "Document Title- Found Here"
+          ],
+          "old_value": [
+              "Document Title- Old"
+          ],
+          "owner": "user@example.io",
+          "owner_is_shared_drive": null,
+          "owner_is_team_drive": null,
+          "primary_event": true,
+          "visibility": "private"
+          },
+          "type": "access"
+      }

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_password_enforce_strong_disabled.py
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_password_enforce_strong_disabled.py
@@ -2,6 +2,8 @@ from panther_base_helpers import deep_get
 
 
 def rule(event):
+    if not deep_get(event, "id", "applicationName", default="").lower() == "admin":
+        return False
     if all(
         [
             (event.get("name", "") == "CHANGE_APPLICATION_SETTING"),

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_password_enforce_strong_disabled.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_password_enforce_strong_disabled.yml
@@ -77,3 +77,41 @@ Tests:
         },
         "type": "CALENDAR_SETTINGS"
       }
+  - Name: ListObject Type
+    ExpectedResult: false
+    Log:
+      {
+          "actor": {
+          "email": "user@example.io",
+          "profileId": "118111111111111111111"
+          },
+          "id": {
+          "applicationName": "drive",
+          "customerId": "D12345",
+          "time": "2022-12-20 17:27:47.080000000",
+          "uniqueQualifier": "-7312729053723258069"
+          },
+          "ipAddress": "12.12.12.12",
+          "kind": "admin#reports#activity",
+          "name": "rename",
+          "parameters": {
+          "actor_is_collaborator_account": null,
+          "billable": true,
+          "doc_id": "1GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+          "doc_title": "Document Title- Found Here",
+          "doc_type": "presentation",
+          "is_encrypted": null,
+          "new_value": [
+              "Document Title- Found Here"
+          ],
+          "old_value": [
+              "Document Title- Old"
+          ],
+          "owner": "user@example.io",
+          "owner_is_shared_drive": null,
+          "owner_is_team_drive": null,
+          "primary_event": true,
+          "visibility": "private"
+          },
+          "type": "access"
+      }

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_password_reuse_enabled.py
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_password_reuse_enabled.py
@@ -2,6 +2,8 @@ from panther_base_helpers import deep_get
 
 
 def rule(event):
+    if not deep_get(event, "id", "applicationName", default="").lower() == "admin":
+        return False
     if all(
         [
             (event.get("name", "") == "CHANGE_APPLICATION_SETTING"),

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_password_reuse_enabled.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_password_reuse_enabled.yml
@@ -77,3 +77,41 @@ Tests:
         },
         "type": "CALENDAR_SETTINGS"
       }
+  - Name: ListObject Type
+    ExpectedResult: false
+    Log:
+      {
+          "actor": {
+          "email": "user@example.io",
+          "profileId": "118111111111111111111"
+          },
+          "id": {
+          "applicationName": "drive",
+          "customerId": "D12345",
+          "time": "2022-12-20 17:27:47.080000000",
+          "uniqueQualifier": "-7312729053723258069"
+          },
+          "ipAddress": "12.12.12.12",
+          "kind": "admin#reports#activity",
+          "name": "rename",
+          "parameters": {
+          "actor_is_collaborator_account": null,
+          "billable": true,
+          "doc_id": "1GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+          "doc_title": "Document Title- Found Here",
+          "doc_type": "presentation",
+          "is_encrypted": null,
+          "new_value": [
+              "Document Title- Found Here"
+          ],
+          "old_value": [
+              "Document Title- Old"
+          ],
+          "owner": "user@example.io",
+          "owner_is_shared_drive": null,
+          "owner_is_team_drive": null,
+          "primary_event": true,
+          "visibility": "private"
+          },
+          "type": "access"
+      }

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_trusted_domains_allowlist.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_trusted_domains_allowlist.yml
@@ -95,3 +95,41 @@ Tests:
         },
         "type": "CALENDAR_SETTINGS"
       }
+  - Name: ListObject Type
+    ExpectedResult: false
+    Log:
+      {
+          "actor": {
+          "email": "user@example.io",
+          "profileId": "118111111111111111111"
+          },
+          "id": {
+          "applicationName": "drive",
+          "customerId": "D12345",
+          "time": "2022-12-20 17:27:47.080000000",
+          "uniqueQualifier": "-7312729053723258069"
+          },
+          "ipAddress": "12.12.12.12",
+          "kind": "admin#reports#activity",
+          "name": "rename",
+          "parameters": {
+          "actor_is_collaborator_account": null,
+          "billable": true,
+          "doc_id": "1GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+          "doc_title": "Document Title- Found Here",
+          "doc_type": "presentation",
+          "is_encrypted": null,
+          "new_value": [
+              "Document Title- Found Here"
+          ],
+          "old_value": [
+              "Document Title- Old"
+          ],
+          "owner": "user@example.io",
+          "owner_is_shared_drive": null,
+          "owner_is_team_drive": null,
+          "primary_event": true,
+          "visibility": "private"
+          },
+          "type": "access"
+      }


### PR DESCRIPTION
### Background

Exceptions were getting raised by some gsuite google workspace detections when the shape of `parameters.new_value` and `parameters.old_value` was changing from string to list. We've added a new test case for this condition on all of the fresh gsuite detections

### Changes

* 

### Testing

*
