### PR TITLE
fix: msft365 spells INFO severity as informational

### DIFF
--- a/rules/microsoft_rules/microsoft_graph_passthrough.py
+++ b/rules/microsoft_rules/microsoft_graph_passthrough.py
@@ -14,7 +14,7 @@ def dedup(event):
 
 
 def severity(event):
-    if event.get("severity") == "informational":
+    if event.get("severity", "").lower() == "informational":
         return "INFO"
     return event.get("severity")
 

--- a/rules/microsoft_rules/microsoft_graph_passthrough.py
+++ b/rules/microsoft_rules/microsoft_graph_passthrough.py
@@ -14,6 +14,8 @@ def dedup(event):
 
 
 def severity(event):
+    if event.get("severity") == "informational":
+        return "INFO"
     return event.get("severity")
 
 


### PR DESCRIPTION
### Background

We received reports that the INFO severity passthrough was not functional due to a spelling mismatch.  cc/ @hbenac10 

### Changes

* 

### Testing

* 
