### PR TITLE
fix: we should ignore iam:CreateAccessKey when errorCode is present

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_iam_user_key_created.py
+++ b/rules/aws_cloudtrail_rules/aws_iam_user_key_created.py
@@ -3,7 +3,8 @@ from panther_base_helpers import aws_rule_context, deep_get
 
 def rule(event):
     return (
-        event.get("eventSource") == "iam.amazonaws.com"
+        "errorCode" not in event
+        and event.get("eventSource") == "iam.amazonaws.com"
         and event.get("eventName") == "CreateAccessKey"
         and (
             not deep_get(event, "userIdentity", "arn", default="").endswith(

--- a/rules/aws_cloudtrail_rules/aws_iam_user_key_created.yml
+++ b/rules/aws_cloudtrail_rules/aws_iam_user_key_created.yml
@@ -163,6 +163,48 @@ Tests:
             type: IAMUser
             userName: user1
       Name: jack create keys for jackson
+    - ExpectedResult: false
+      Name: CreateKey returns error code
+      Log:
+        {
+            "awsRegion": "us-east-1",
+            "errorCode": "LimitExceededException",
+            "errorMessage": "Cannot exceed quota for AccessKeysPerUser: 2",
+            "eventCategory": "Management",
+            "eventID": "efffffff-bbbb-4444-bbbb-ffffffffffff",
+            "eventName": "CreateAccessKey",
+            "eventSource": "iam.amazonaws.com",
+            "eventTime": "2023-01-03 01:52:07.000000000",
+            "eventType": "AwsApiCall",
+            "eventVersion": "1.08",
+            "managementEvent": true,
+            "readOnly": false,
+            "recipientAccountId": "123456789012",
+            "requestID": "84eeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+            "sourceIPAddress": "12.12.12.12",
+            "tlsDetails": {
+                "cipherSuite": "ECDHE-RSA-AES128-GCM-SHA256",
+                "clientProvidedHostHeader": "iam.amazonaws.com",
+                "tlsVersion": "TLSv1.2"
+            },
+            "userAgent": "aws-sdk-go-v2/1.14.0 os/macos lang/go/1.17.6 md/GOOS/darwin md/GOARCH/arm64 api/iam/1.17.0",
+            "userIdentity": {
+                "accessKeyId": "ASIA5ZXAKGI33TI7QQGW",
+                "accountId": "123456789012",
+                "arn": "arn:aws:iam::123456789012:user/some_iam_user",
+                "principalId": "AIDA55555555555555555",
+                "sessionContext": {
+                    "attributes": {
+                        "creationDate": "2023-01-03T01:52:07Z",
+                        "mfaAuthenticated": "true"
+                    },
+                    "sessionIssuer": {},
+                    "webIdFederationData": {}
+                },
+                "type": "IAMUser",
+                "userName": "some_iam_user"
+            }
+        }
       
 DedupPeriodMinutes: 60
 LogTypes:


### PR DESCRIPTION
### Background

This alert triggered and the destination user was empty. Investigation yields that this situation can happen if errorCode is present in a cloudtrail iam:CreateAccessKey event. 

### Changes

* 

### Testing

* add test case
* tweak detection

```shell
(panther-analysis) user@computer:~/Sources/PAN/panther-analysis $  panther_analysis_tool test --filter
 RuleID=AWS.IAM.Backdoor.User.Keys 
[INFO]: Testing analysis items in .

AWS.IAM.Backdoor.User.Keys
        [PASS] user1 create keys for user1
                [PASS] [rule] false
        [PASS] user1 create keys for user2
                [PASS] [rule] true
                [PASS] [title] [arn:aws:iam::123456789:user/user1] created API keys for [user2]
                [PASS] [dedup] arn:aws:iam::123456789:user/user1
                [PASS] [alertContext] {"eventName": "CreateAccessKey", "eventSource": "iam.amazonaws.com", "awsRegion": "us-east-1", "recipientAccountId": "123456789", "sourceIPAddress": "cloudformation.amazonaws.com", "userAgent": "cloudformation.amazonaws.com", "userIdentity": {"accessKeyId": "ABCDEFGH", "accountId": "123456789", "arn": "arn:aws:iam::123456789:user/user1", "invokedBy": "cloudformation.amazonaws.com", "principalId": "ABCDEFGH", "sessionContext": {"attributes": {"creationDate": "2022-09-27T17:08:35Z", "mfaAuthenticated": "false"}, "sessionIssuer": {}, "webIdFederationData": {}}, "type": "IAMUser", "userName": "user1"}}
        [PASS] jackson create keys for jack
                [PASS] [rule] true
                [PASS] [title] [arn:aws:iam::123456789:user/jackson] created API keys for [jack]
                [PASS] [dedup] arn:aws:iam::123456789:user/jackson
                [PASS] [alertContext] {"eventName": "CreateAccessKey", "eventSource": "iam.amazonaws.com", "awsRegion": "us-east-1", "recipientAccountId": "123456789", "sourceIPAddress": "cloudformation.amazonaws.com", "userAgent": "cloudformation.amazonaws.com", "userIdentity": {"accessKeyId": "ABCDEFGH", "accountId": "123456789", "arn": "arn:aws:iam::123456789:user/jackson", "invokedBy": "cloudformation.amazonaws.com", "principalId": "ABCDEFGH", "sessionContext": {"attributes": {"creationDate": "2022-09-27T17:08:35Z", "mfaAuthenticated": "false"}, "sessionIssuer": {}, "webIdFederationData": {}}, "type": "IAMUser", "userName": "user1"}}
        [PASS] jack create keys for jackson
                [PASS] [rule] true
                [PASS] [title] [arn:aws:iam::123456789:user/jack] created API keys for [jackson]
                [PASS] [dedup] arn:aws:iam::123456789:user/jack
                [PASS] [alertContext] {"eventName": "CreateAccessKey", "eventSource": "iam.amazonaws.com", "awsRegion": "us-east-1", "recipientAccountId": "123456789", "sourceIPAddress": "cloudformation.amazonaws.com", "userAgent": "cloudformation.amazonaws.com", "userIdentity": {"accessKeyId": "ABCDEFGH", "accountId": "123456789", "arn": "arn:aws:iam::123456789:user/jack", "invokedBy": "cloudformation.amazonaws.com", "principalId": "ABCDEFGH", "sessionContext": {"attributes": {"creationDate": "2022-09-27T17:08:35Z", "mfaAuthenticated": "false"}, "sessionIssuer": {}, "webIdFederationData": {}}, "type": "IAMUser", "userName": "user1"}}
        [PASS] CreateKey returns error code
                [PASS] [rule] false

--------------------------
Panther CLI Test Summary
        Path: .
        Passed: 1
        Failed: 0
        Invalid: 0

```
