### PR TITLE
chore: restructure the S3 bucket defacement rule to pass cylcocomplexity checks and restructure tests to logical boundaries

### DIFF
--- a/rules/aws_s3_rules/aws_s3_bucket_defacement_attempt.py
+++ b/rules/aws_s3_rules/aws_s3_bucket_defacement_attempt.py
@@ -1,61 +1,49 @@
+import json
 from fnmatch import fnmatch
-import ast
+from unittest.mock import MagicMock
 
 # Ignore certain operations, users, user agents and specifc iam roles
-EXCLUDED_OPERATIONS = ["REST.GET.*", "REST.HEAD.*", "S3.EXPIRE.OBJECT"]
-EXCLUDED_REQUESTERS = ["svc:*", "AmazonS3", "*:assumed-role/AWSServiceRole*", ""]
-EXCLUDED_USERAGENTS = ["*aws-internal*"]
-EXCLUDED_ASSUMED_ROLES = ["*assumed-role/pan*"]
+ALWAYS_IGNORE_SETTINGS = {
+    "operation": ["REST.GET.*", "REST.HEAD.*", "S3.EXPIRE.OBJECT"],
+    # requestor can also hold assumed-roles
+    "requester": ["svc:*", "AmazonS3", "*:assumed-role/AWSServiceRole*"],
+    # NOTE: S3 web console uses a userAgent that starts with S3Console and contains
+    #  "aws-internal" inside the userAgent string. it's important that we glob _after_
+    "userAgent": ["aws-internal*"],
+    # Set any buckets that you want to ignore in the bucket list
+    "bucket": [],
+}
 
-# Optionally, explicitly monitor specific buckets and/or files
-# Defined as functions so that we may mock our testing
-def get_included_bucket_names():
-    included_bucket_names = []
-    return included_bucket_names
-
-
-def get_included_s3_bucket_keys():
-    included_s3_bucket_keys = []
-    return included_s3_bucket_keys
+# Any items put in ALERT_SETTINGS will cause an alert to raise, provided
+# that they do not match the ignore conditions in ALWAYS_IGNORE_SETTINGS
+ALERT_SETTINGS = {
+    # If there are high-pri buckets, put their names here
+    "bucket": [],
+    # If there are high-pri bucket keys, put their names here
+    "keys": [],
+}
 
 
 def rule(event):
+    global ALWAYS_IGNORE_SETTINGS  # pylint: disable=global-statement
+    global ALERT_SETTINGS  # pylint: disable=global-statement
+    # First we exclude ignored items
+    if isinstance(ALWAYS_IGNORE_SETTINGS, MagicMock):
+        # pylint: disable=redefined-outer-name,not-callable
+        ALWAYS_IGNORE_SETTINGS = json.loads(ALWAYS_IGNORE_SETTINGS())
+    for event_key, ignore_values in ALWAYS_IGNORE_SETTINGS.items():
+        for ignore_value in ignore_values:
+            if fnmatch(event.get(event_key, ""), ignore_value):
+                return False
 
-    # Exit if event contains ignored value
-    for item in EXCLUDED_OPERATIONS:
-        if fnmatch(event.get("operation"), item):
-            return False
-
-    for item in EXCLUDED_REQUESTERS:
-        if fnmatch(event.get("requester"), item):
-            return False
-
-    for item in EXCLUDED_USERAGENTS:
-        if fnmatch(event.get("useragent"), item):
-            return False
-
-    for item in EXCLUDED_ASSUMED_ROLES:
-        if fnmatch(event.get("requester"), item):
-            return False
-
-    # Exit if event contains watched values
-    # with logic added to support mock tests
-    included_bucket_names = get_included_bucket_names()
-    included_s3_bucket_keys = get_included_s3_bucket_keys()
-
-    if isinstance(included_bucket_names, str):
-        included_bucket_names = ast.literal_eval(included_bucket_names)
-
-    if isinstance(included_s3_bucket_keys, str):
-        included_s3_bucket_keys = ast.literal_eval(included_s3_bucket_keys)
-
-    for item in included_bucket_names:
-        if fnmatch(event.get("bucket"), item):
-            return True
-
-    for item in included_s3_bucket_keys:
-        if fnmatch(event.get("key"), item):
-            return True
+    # Check for explicitly marked ALWAYS_ALERT_SETTINGS
+    if isinstance(ALERT_SETTINGS, MagicMock):
+        # pylint: disable=redefined-outer-name,not-callable
+        ALERT_SETTINGS = json.loads(ALERT_SETTINGS())
+    for event_key, alert_values in ALERT_SETTINGS.items():
+        for alert_value in alert_values:
+            if fnmatch(event.get(event_key, ""), alert_value):
+                return True
 
     return False
 

--- a/rules/aws_s3_rules/aws_s3_bucket_defacement_attempt.yml
+++ b/rules/aws_s3_rules/aws_s3_bucket_defacement_attempt.yml
@@ -7,6 +7,8 @@ Reference: https://attack.mitre.org/techniques/T1491/
 Reports:
     MITRE ATT&CK:
         - TA0040:T1491
+Tags:
+  - Configuration Required
 Severity: Low
 Tests:
     - ExpectedResult: false
@@ -20,19 +22,9 @@ Tests:
         httpstatus: 200
         key: layers/sample-file.zip
         objectsize: 6.022694e+06
-        operation: REST.GET.ACL
-        p_any_aws_arns:
-            - arn:aws:sts::12345678910:assumed-role/sample-role
-        p_any_ip_addresses:
-            - 10.0.18.38
-        p_event_time: "2022-11-01 18:45:45"
-        p_log_type: AWS.S3ServerAccess
-        p_parse_time: "2022-11-01 19:17:50.353"
-        p_row_id: ea9400dbc7b99c88a9b6ccac14d39201
-        p_source_id: 4a42e408-9e2d-4a55-9830-708b8286bc32
-        p_source_label: s3-sensitive-data
+        operation: REST.PUT.OBJECT
         remoteip: 10.0.18.38
-        requester: arn:aws:sts::732337452730:assumed-role/PantherLogProcessingRole
+        requester: arn:aws:sts::732337452730:assumed-role/AWSServiceRoleForSomething
         requestid: 6NBZJ3SRYX5MPDX8
         requesturi: PUT /layers/sample-file.zip HTTP/1.1
         signatureversion: SigV4
@@ -54,16 +46,6 @@ Tests:
         key: layers/sample-file.zip
         objectsize: 6.022694e+06
         operation: S3.EXPIRE.OBJECT
-        p_any_aws_arns:
-            - arn:aws:sts::12345678910:assumed-role/sample-role
-        p_any_ip_addresses:
-            - 10.0.18.38
-        p_event_time: "2022-11-01 18:45:45"
-        p_log_type: AWS.S3ServerAccess
-        p_parse_time: "2022-11-01 19:17:50.353"
-        p_row_id: ea9400dbc7b99c88a9b6ccac14d39201
-        p_source_id: 4a42e408-9e2d-4a55-9830-708b8286bc32
-        p_source_label: s3-sensitive-data
         remoteip: 10.0.18.38
         requester: arn:aws:sts::12345678910:assumed-role/test-role
         requestid: 6NBZJ3SRYX5MPDX8
@@ -86,17 +68,7 @@ Tests:
         httpstatus: 200
         key: layers/sample-file.zip
         objectsize: 6.022694e+06
-        operation: REST.GET.ACL
-        p_any_aws_arns:
-            - arn:aws:sts::12345678910:assumed-role/sample-role
-        p_any_ip_addresses:
-            - 10.0.18.38
-        p_event_time: "2022-11-01 18:45:45"
-        p_log_type: AWS.S3ServerAccess
-        p_parse_time: "2022-11-01 19:17:50.353"
-        p_row_id: ea9400dbc7b99c88a9b6ccac14d39201
-        p_source_id: 4a42e408-9e2d-4a55-9830-708b8286bc32
-        p_source_label: s3-sensitive-data
+        operation: REST.PUT.OBJECT
         remoteip: 10.0.18.38
         requester: AmazonS3
         requestid: 6NBZJ3SRYX5MPDX8
@@ -119,19 +91,9 @@ Tests:
         httpstatus: 200
         key: layers/sample-file.zip
         objectsize: 6.022694e+06
-        operation: REST.GET.ACL
-        p_any_aws_arns:
-            - arn:aws:sts::12345678910:assumed-role/sample-role
-        p_any_ip_addresses:
-            - 10.0.18.38
-        p_event_time: "2022-11-01 18:45:45"
-        p_log_type: AWS.S3ServerAccess
-        p_parse_time: "2022-11-01 19:17:50.353"
-        p_row_id: ea9400dbc7b99c88a9b6ccac14d39201
-        p_source_id: 4a42e408-9e2d-4a55-9830-708b8286bc32
-        p_source_label: s3-sensitive-data
+        operation: REST.PUT.OBJECT
         remoteip: 10.0.18.38
-        requester: svc:s3.amazonaws.com
+        requester: arn:aws:sts::123456789012:assumed-role/SomeRole/some_role_assumer
         requestid: 6NBZJ3SRYX5MPDX8
         requesturi: PUT /layers/sample-file.zip HTTP/1.1
         signatureversion: SigV4
@@ -139,9 +101,9 @@ Tests:
         tlsVersion: TLSv1.2
         totaltime: 197
         turnaroundtime: 96
-        useragent: aws-cli/1.20.58 Python/3.9.5 Linux/4.14.248-189.473.amzn2.aarch64 exec-env/AWS_ECS_EC2 botocore/1.21.58
+        useragent: aws-internal/3 aws-sdk-java/1.12.302 Linux/4.14.294-150.533.amzn1.x86_64 OpenJDK_64-Bit_Server_VM/25.342-b07 java/1.8.0_342 scala/2.12.7 kotlin/1.3.72 vendor/Oracle_Corporation cfg/retry-mode/standard
       Name: EXCLUDED USERAGENTS - False
-    - ExpectedResult: false
+    - ExpectedResult: true
       Log:
         authenticationtype: AuthHeader
         bucket: sample-bucket-name
@@ -152,19 +114,9 @@ Tests:
         httpstatus: 200
         key: layers/sample-file.zip
         objectsize: 6.022694e+06
-        operation: REST.GET.ACL
-        p_any_aws_arns:
-            - arn:aws:sts::12345678910:assumed-role/sample-role
-        p_any_ip_addresses:
-            - 10.0.18.38
-        p_event_time: "2022-11-01 18:45:45"
-        p_log_type: AWS.S3ServerAccess
-        p_parse_time: "2022-11-01 19:17:50.353"
-        p_row_id: ea9400dbc7b99c88a9b6ccac14d39201
-        p_source_id: 4a42e408-9e2d-4a55-9830-708b8286bc32
-        p_source_label: s3-sensitive-data
+        operation: REST.PUT.OBJECT
         remoteip: 10.0.18.38
-        requester: arn:aws:sts::12345678910:assumed-role/test-role
+        requester: arn:aws:sts::123456789012:assumed-role/SomeRole/some_role_assumer
         requestid: 6NBZJ3SRYX5MPDX8
         requesturi: PUT /layers/sample-file.zip HTTP/1.1
         signatureversion: SigV4
@@ -172,12 +124,18 @@ Tests:
         tlsVersion: TLSv1.2
         totaltime: 197
         turnaroundtime: 96
-        useragent: aws-cli/1.20.58 Python/3.9.5 Linux/4.14.248-189.473.amzn2.aarch64 exec-env/AWS_ECS_EC2 botocore/1.21.58
-      Name: S3 GET - False
+        useragent: S3Console/0.4, aws-internal/3 aws-sdk-java/1.11.1030 Linux/5.10.157-122.673.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/25.352-b08 java/1.8.0_352 vendor/Oracle_Corporation cfg/retry-mode/standard
+      Mocks:
+        - objectName: ALERT_SETTINGS
+          returnValue: >-
+                  {
+                    "bucket": ["sample-bucket-name"]
+                  }
+      Name: aws-internal UserAgent for S3 Console - True
     - ExpectedResult: true
       Log:
         authenticationtype: AuthHeader
-        bucket: sample
+        bucket: sample-bucket-name
         bucketowner: a5ebe8d8c26923db177773b444efba8fc3c87ee7416a2a7453c42b49eb66dcee
         ciphersuite: ECDHE-RSA-AES128-GCM-SHA256
         hostheader: sample-bucket-name.s3.us-east-2.amazonaws.com
@@ -186,16 +144,6 @@ Tests:
         key: layers/sample-file.zip
         objectsize: 6.022694e+06
         operation: REST.PUT.OBJECT
-        p_any_aws_arns:
-            - arn:aws:sts::12345678910:assumed-role/sample-role
-        p_any_ip_addresses:
-            - 10.0.18.38
-        p_event_time: "2022-11-01 18:45:45"
-        p_log_type: AWS.S3ServerAccess
-        p_parse_time: "2022-11-01 19:17:50.353"
-        p_row_id: ea9400dbc7b99c88a9b6ccac14d39201
-        p_source_id: 4a42e408-9e2d-4a55-9830-708b8286bc32
-        p_source_label: s3-sensitive-data
         remoteip: 10.0.18.38
         requester: arn:aws:sts::12345678910:assumed-role/test-role
         requestid: 6NBZJ3SRYX5MPDX8
@@ -207,8 +155,8 @@ Tests:
         turnaroundtime: 96
         useragent: aws-cli/1.20.58 Python/3.9.5 Linux/4.14.248-189.473.amzn2.aarch64 exec-env/AWS_ECS_EC2 botocore/1.21.58
       Mocks:
-        - objectName: get_included_bucket_names
-          returnValue: '[''sample'', ''test'', ''bucket''] '
+        - objectName: ALERT_SETTINGS
+          returnValue: '{"bucket": ["sample-bucket-name"]}'
       Name: S3 PUT - Included Bucket Names
     - ExpectedResult: true
       Log:
@@ -222,16 +170,6 @@ Tests:
         key: layers/sample-file.zip
         objectsize: 6.022694e+06
         operation: REST.PUT.OBJECT
-        p_any_aws_arns:
-            - arn:aws:sts::12345678910:assumed-role/sample-role
-        p_any_ip_addresses:
-            - 10.0.18.38
-        p_event_time: "2022-11-01 18:45:45"
-        p_log_type: AWS.S3ServerAccess
-        p_parse_time: "2022-11-01 19:17:50.353"
-        p_row_id: ea9400dbc7b99c88a9b6ccac14d39201
-        p_source_id: 4a42e408-9e2d-4a55-9830-708b8286bc32
-        p_source_label: s3-sensitive-data
         remoteip: 10.0.18.38
         requester: arn:aws:sts::12345678910:assumed-role/test-role
         requestid: 6NBZJ3SRYX5MPDX8
@@ -243,8 +181,8 @@ Tests:
         turnaroundtime: 96
         useragent: aws-cli/1.20.58 Python/3.9.5 Linux/4.14.248-189.473.amzn2.aarch64 exec-env/AWS_ECS_EC2 botocore/1.21.58
       Mocks:
-        - objectName: get_included_s3_bucket_keys
-          returnValue: '[''layers/sample-file.zip'', ''sample/file.zip''] '
+        - objectName: ALERT_SETTINGS
+          returnValue: '{"key": ["layers/sample-file.zip"]}'
       Name: S3 PUT - Included S3 Bucket Key
 DedupPeriodMinutes: 60
 LogTypes:


### PR DESCRIPTION
note: this PR is back to the originating branch for this detection 

### Background

modifies detection for sensitive S3 operations. 

This detection first compares the `event` to an exclude list. If the event passes the exclude list filter, then the event is compared to an include list. 

### Changes

*

### Testing

* 

```shell
(panther-analysis) user@computer:~/Sources/PAN/panther-analysis $ pipenv run panther_analysis_tool test --filter RuleID=AWS.S3.Defacement.Attempt 
Courtesy Notice: Pipenv found itself running within a virtual environment, so it will automatically use that environment, instead of creating its own for any project. You can set PIPENV_IGNORE_VIRTUALENVS=1 to force pipenv to ignore that environment and create its own instead. You can set PIPENV_VERBOSITY=-1 to suppress this warning.
[INFO]: Testing analysis items in .

AWS.S3.Defacement.Attempt
        [PASS] EXCLUDED ASSUMED_ROLES - False
                [PASS] [rule] false
        [PASS] EXCLUDED OPERATIONS - False
                [PASS] [rule] false
        [PASS] EXCLUDED REQUESTER - False
                [PASS] [rule] false
        [PASS] EXCLUDED USERAGENTS - False
                [PASS] [rule] false
        [PASS] aws-internal UserAgent for S3 Console - True
                [PASS] [rule] true
                [PASS] [title] Unexpected requester put [layers/sample-file.zip] in [sample-bucket-name]
                [PASS] [dedup] Unexpected requester put [layers/sample-file.zip] in [sample-bucket-name]
                [PASS] [alertContext] {"requester": "arn:aws:sts::123456789012:assumed-role/SomeRole/some_role_assumer", "bucket": "sample-bucket-name", "remoteip": "10.0.18.38", "key": "layers/sample-file.zip", "useragent": "S3Console/0.4, aws-internal/3 aws-sdk-java/1.11.1030 Linux/5.10.157-122.673.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/25.352-b08 java/1.8.0_352 vendor/Oracle_Corporation cfg/retry-mode/standard"}
        [PASS] S3 PUT - Included Bucket Names
                [PASS] [rule] true
                [PASS] [title] Unexpected requester put [layers/sample-file.zip] in [sample-bucket-name]
                [PASS] [dedup] Unexpected requester put [layers/sample-file.zip] in [sample-bucket-name]
                [PASS] [alertContext] {"requester": "arn:aws:sts::12345678910:assumed-role/test-role", "bucket": "sample-bucket-name", "remoteip": "10.0.18.38", "key": "layers/sample-file.zip", "useragent": "aws-cli/1.20.58 Python/3.9.5 Linux/4.14.248-189.473.amzn2.aarch64 exec-env/AWS_ECS_EC2 botocore/1.21.58"}
        [PASS] S3 PUT - Included S3 Bucket Key
                [PASS] [rule] true
                [PASS] [title] Unexpected requester put [layers/sample-file.zip] in [sample-bucket-name]
                [PASS] [dedup] Unexpected requester put [layers/sample-file.zip] in [sample-bucket-name]
                [PASS] [alertContext] {"requester": "arn:aws:sts::12345678910:assumed-role/test-role", "bucket": "sample-bucket-name", "remoteip": "10.0.18.38", "key": "layers/sample-file.zip", "useragent": "aws-cli/1.20.58 Python/3.9.5 Linux/4.14.248-189.473.amzn2.aarch64 exec-env/AWS_ECS_EC2 botocore/1.21.58"}

--------------------------
Panther CLI Test Summary
        Path: .
        Passed: 1
        Failed: 0
        Invalid: 0
```