### PR TITLE
duo admin rules

### DIFF
--- a/global_helpers/panther_duo_helpers.py
+++ b/global_helpers/panther_duo_helpers.py
@@ -23,3 +23,12 @@ def deserialize_administrator_log_event_description(event: dict) -> dict:
             pass
 
     return {"value": desc_string}
+
+
+def duo_alert_context(event):
+    return {
+        "action": event.get("action", "<action_not_found>"),
+        "description": event.get("description", "<description_not_found>"),
+        "username": event.get("username", "<username_not_found>"),
+        "timestamp": event.get("timestamp", "<timestamp_not_found>"),
+    }

--- a/rules/duo_rules/duo_admin_mfa_restrictions_updated.py
+++ b/rules/duo_rules/duo_admin_mfa_restrictions_updated.py
@@ -1,0 +1,13 @@
+from panther_duo_helpers import duo_alert_context
+
+
+def rule(event):
+    return event.get("action") == "update_admin_factor_restrictions"
+
+
+def title(event):
+    return "Duo Admin MFA Restrictions Updated " f"by [{event.get('username','<user_not_found>')}]"
+
+
+def alert_context(event):
+    return duo_alert_context(event)

--- a/rules/duo_rules/duo_admin_mfa_restrictions_updated.yml
+++ b/rules/duo_rules/duo_admin_mfa_restrictions_updated.yml
@@ -1,0 +1,28 @@
+AnalysisType: rule
+Description: Detects changes to allowed MFA factors administrators can use to log into the admin panel.
+DisplayName: Duo Admin MFA Restrictions Updated
+Enabled: true
+Filename: duo_admin_mfa_restrictions_updated.py
+Severity: Medium
+Tests:
+    - ExpectedResult: true
+      Log:
+        action: update_admin_factor_restrictions
+        description: '{"allowed_factors": "Duo mobile passcodes, Hardware tokens, Duo push, Yubikey aes"}'
+        isotimestamp: "2022-02-21 21:48:06"
+        timestamp: "2022-02-21 21:48:06"
+        username: Homer Simpson
+      Name: Admin MFA Update Event
+    - ExpectedResult: false
+      Log:
+        action: admin_login
+        description: '{"ip_address": "1.2.3.4", "device": "123-456-789", "factor": "sms", "saml_idp": "OneLogin", "primary_auth_method": "Single Sign-On"}'
+        isotimestamp: "2021-06-30 19:45:37"
+        timestamp: "2021-06-30 19:45:37"
+        username: Homer Simpson
+      Name: Login Event
+DedupPeriodMinutes: 60
+LogTypes:
+    - Duo.Administrator
+RuleID: Duo.Admin.MFA.Restrictions.Updated
+Threshold: 1

--- a/rules/duo_rules/duo_admin_sso_saml_requirement_disabled.py
+++ b/rules/duo_rules/duo_admin_sso_saml_requirement_disabled.py
@@ -1,0 +1,25 @@
+from panther_duo_helpers import (
+    deserialize_administrator_log_event_description,
+    duo_alert_context,
+)
+
+
+def rule(event):
+    if event.get("action") == "admin_single_sign_on_update":
+        description = deserialize_administrator_log_event_description(event)
+        enforcement_status = description.get("enforcement_status", "required")
+        return enforcement_status != "required"
+    return False
+
+
+def title(event):
+    description = deserialize_administrator_log_event_description(event)
+    return (
+        f"Duo: [{event.get('username', '<username_not_found>')}] "
+        "changed SAML authentication requirements for Administrators "
+        f"to [{description.get('enforcement_status', '<enforcement_status_not_found>')}]"
+    )
+
+
+def alert_context(event):
+    return duo_alert_context(event)

--- a/rules/duo_rules/duo_admin_sso_saml_requirement_disabled.yml
+++ b/rules/duo_rules/duo_admin_sso_saml_requirement_disabled.yml
@@ -1,0 +1,44 @@
+AnalysisType: rule
+Description: Detects when SAML Authentication for Administrators is marked as Disabled or Optional.
+DisplayName: Duo Admin SSO SAML Requirement Disabled
+Enabled: true
+Filename: duo_admin_sso_saml_requirement_disabled.py
+Severity: Medium
+Tests:
+    - ExpectedResult: true
+      Log:
+        action: admin_single_sign_on_update
+        description: '{"enforcement_status": "disabled"}'
+        isotimestamp: "2021-10-12 21:29:22"
+        timestamp: "2021-10-12 21:29:22"
+        username: Homer Simpson
+      Name: Enforcement Disabled
+    - ExpectedResult: true
+      Log:
+        action: admin_single_sign_on_update
+        description: '{"enforcement_status": "optional"}'
+        isotimestamp: "2021-10-12 21:29:22"
+        timestamp: "2021-10-12 21:29:22"
+        username: Homer Simpson
+      Name: Enforcement Optional
+    - ExpectedResult: false
+      Log:
+        action: admin_single_sign_on_update
+        description: '{"enforcement_status": "required"}'
+        isotimestamp: "2021-10-12 21:29:22"
+        timestamp: "2021-10-12 21:29:22"
+        username: Homer Simpson
+      Name: Enforcement Required
+    - ExpectedResult: false
+      Log:
+        action: admin_single_sign_on_update
+        description: '{"sso_url": "https://duff.okta.com/app/duoadminpanel/abcdefghijklm/sso/saml", "slo_url": null, "idp_type": "okta", "cert": "C=US/CN=duff/L=Springfield/O=Okta/OU=SSOProvider/ST=California/emailAddress=info@okta.com - 2031-08-10 13:39:00+00:00", "require_signed_response": true, "entity_id": "http://www.okta.com/abcdefghijk"}'
+        isotimestamp: "2021-10-12 21:33:40"
+        timestamp: "2021-10-12 21:33:40"
+        username: Homer Simpson
+      Name: SSO Update
+DedupPeriodMinutes: 60
+LogTypes:
+    - Duo.Administrator
+RuleID: Duo.Admin.SSO.SAML.Requirement.Disabled
+Threshold: 1

--- a/rules/duo_rules/duo_admin_user_mfa_bypass_enabled.py
+++ b/rules/duo_rules/duo_admin_user_mfa_bypass_enabled.py
@@ -1,0 +1,24 @@
+from panther_duo_helpers import (
+    deserialize_administrator_log_event_description,
+    duo_alert_context,
+)
+
+
+def rule(event):
+    if event.get("action") == "user_update":
+        description = deserialize_administrator_log_event_description(event)
+        if "status" in description:
+            return description.get("status") == "Bypass"
+    return False
+
+
+def title(event):
+    return (
+        f"Duo: [{event.get('username', '<username_not_found>')}] "
+        f"updated account [{event.get('object', '<object_not_found>')}] "
+        " to not require two-factor authentication."
+    )
+
+
+def alert_context(event):
+    return duo_alert_context(event)

--- a/rules/duo_rules/duo_admin_user_mfa_bypass_enabled.yml
+++ b/rules/duo_rules/duo_admin_user_mfa_bypass_enabled.yml
@@ -1,0 +1,48 @@
+AnalysisType: rule
+Description: An Administrator enabled a user to authenticate without MFA.
+DisplayName: Duo Admin User MFA Bypass Enabled
+Enabled: true
+Filename: duo_admin_user_mfa_bypass_enabled.py
+Severity: Medium
+Tests:
+    - ExpectedResult: false
+      Log:
+        action: user_update
+        description: '{"status": "Active"}'
+        isotimestamp: "2021-10-05 22:45:33"
+        object: bart.simpson@simpsons.com
+        timestamp: "2021-10-05 22:45:33"
+        username: Homer Simpson
+      Name: Account Active
+    - ExpectedResult: false
+      Log:
+        action: user_update
+        description: '{"status": "Disabled"}'
+        isotimestamp: "2021-10-05 22:45:33"
+        object: bart.simpson@simpsons.com
+        timestamp: "2021-10-05 22:45:33"
+        username: Homer Simpson
+      Name: Account Disabled
+    - ExpectedResult: true
+      Log:
+        action: user_update
+        description: '{"status": "Bypass"}'
+        isotimestamp: "2021-10-05 22:45:33"
+        object: bart.simpson@simpsons.com
+        timestamp: "2021-10-05 22:45:33"
+        username: Homer Simpson
+      Name: Bypass Enabled
+    - ExpectedResult: false
+      Log:
+        action: user_update
+        description: '{"phones": ""}'
+        isotimestamp: "2021-07-02 19:06:40"
+        object: homer.simpson@simpsons.com
+        timestamp: "2021-07-02 19:06:40"
+        username: Homer Simpson
+      Name: Phones Update
+DedupPeriodMinutes: 60
+LogTypes:
+    - Duo.Administrator
+RuleID: Duo.Admin.User.MFA.Bypass.Enabled
+Threshold: 1


### PR DESCRIPTION
### Background

rules/duo_rules/duo_admin_mfa_restrictions_updated.py
Duo admin MFA restrictions updated

rules/duo_rules/duo_admin_sso_saml_requirement_disabled.py
Duo Admin SSO Requirement Disabled

rules/duo_rules/duo_admin_user_mfa_bypass_enabled.py
User MFA Bypass Enabled

### Testing

Duo.Admin.MFA.Restrictions.Updated
	[PASS] Admin MFA Update Event
		[PASS] [rule] true
		[PASS] [title] Duo Admin MFA Restrictions Updated by [Homer Simpson]
		[PASS] [dedup] Duo Admin MFA Restrictions Updated by [Homer Simpson]
		[PASS] [alertContext] {"action": "update_admin_factor_restrictions", "description": "{\"allowed_factors\": \"Duo mobile passcodes, Hardware tokens, Duo push, Yubikey aes\"}", "username": "Homer Simpson", "timestamp": "2022-02-21 21:48:06"}
	[PASS] Login Event
		[PASS] [rule] false

Duo.Admin.SSO.SAML.Requirement.Disabled
	[PASS] Enforcement Disabled
		[PASS] [rule] true
		[PASS] [title] Duo: [Homer Simpson] changed SAML authentication requirements for Administrators to [disabled]
		[PASS] [dedup] Duo: [Homer Simpson] changed SAML authentication requirements for Administrators to [disabled]
		[PASS] [alertContext] {"action": "admin_single_sign_on_update", "description": "{\"enforcement_status\": \"disabled\"}", "username": "Homer Simpson", "timestamp": "2021-10-12 21:29:22"}
	[PASS] Enforcement Optional
		[PASS] [rule] true
		[PASS] [title] Duo: [Homer Simpson] changed SAML authentication requirements for Administrators to [optional]
		[PASS] [dedup] Duo: [Homer Simpson] changed SAML authentication requirements for Administrators to [optional]
		[PASS] [alertContext] {"action": "admin_single_sign_on_update", "description": "{\"enforcement_status\": \"optional\"}", "username": "Homer Simpson", "timestamp": "2021-10-12 21:29:22"}
	[PASS] Enforcement Required
		[PASS] [rule] false
	[PASS] SSO Update
		[PASS] [rule] false

Duo.Admin.User.MFA.Bypass.Enabled
	[PASS] Account Active
		[PASS] [rule] false
	[PASS] Account Disabled
		[PASS] [rule] false
	[PASS] Bypass Enabled
		[PASS] [rule] true
		[PASS] [title] Duo: [Homer Simpson] updated account [bart.simpson@simpsons.com]  to not require two-factor authentication.
		[PASS] [dedup] Duo: [Homer Simpson] updated account [bart.simpson@simpsons.com]  to not require two-factor authentication.
		[PASS] [alertContext] {"action": "user_update", "description": "{\"status\": \"Bypass\"}", "username": "Homer Simpson", "timestamp": "2021-10-05 22:45:33"}
	[PASS] Phones Update
		[PASS] [rule] false

