### PR TITLE
Cloud infrastructure discovery in AWS CloudTrail

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_cloudtrail_infrastructure_discovery.py
+++ b/rules/aws_cloudtrail_rules/aws_cloudtrail_infrastructure_discovery.py
@@ -20,7 +20,8 @@ DISCOVERY_EVENTS = [
     "DescribeVolumes",
     "DescribeVpcs",
     "ListAutoScalingGroups",
-    "ListCloudFormationStacks" "ListDBInstances",
+    "ListCloudFormationStacks",
+    "ListDBInstances",
     "ListImages",
     "ListInstances",
     "ListInternetGateways",
@@ -35,7 +36,7 @@ DISCOVERY_EVENTS = [
     "ListSubnets",
     "ListTables",
     "ListVolumes",
-    "ListVpcs",
+    "ListVpcs"
 ]
 
 

--- a/rules/aws_cloudtrail_rules/aws_cloudtrail_infrastructure_discovery.py
+++ b/rules/aws_cloudtrail_rules/aws_cloudtrail_infrastructure_discovery.py
@@ -36,7 +36,7 @@ DISCOVERY_EVENTS = [
     "ListSubnets",
     "ListTables",
     "ListVolumes",
-    "ListVpcs"
+    "ListVpcs",
 ]
 
 

--- a/rules/aws_cloudtrail_rules/aws_cloudtrail_infrastructure_discovery.py
+++ b/rules/aws_cloudtrail_rules/aws_cloudtrail_infrastructure_discovery.py
@@ -1,0 +1,54 @@
+from panther_base_helpers import aws_rule_context, deep_get
+
+DISCOVERY_EVENTS = [
+    "DescribeAutoScalingGroups",
+    "DescribeCloudFormationStacks",
+    "DescribeDBInstances",
+    "DescribeImages",
+    "DescribeInstances",
+    "DescribeInternetGateways",
+    "DescribeKeyPairs",
+    "DescribeLambdaFunctions",
+    "DescribeLaunchConfigurations",
+    "DescribeNetworkInterfaces",
+    "DescribeRouteTables",
+    "DescribeS3Buckets",
+    "DescribeSecurityGroups",
+    "DescribeSnapshots",
+    "DescribeSubnets",
+    "DescribeTables",
+    "DescribeVolumes",
+    "DescribeVpcs",
+    "ListAutoScalingGroups",
+    "ListCloudFormationStacks" "ListDBInstances",
+    "ListImages",
+    "ListInstances",
+    "ListInternetGateways",
+    "ListKeyPairs",
+    "ListLambdaFunctions",
+    "ListLaunchConfigurations",
+    "ListNetworkInterfaces",
+    "ListRouteTables",
+    "ListS3Buckets",
+    "ListSecurityGroups",
+    "ListSnapshots",
+    "ListSubnets",
+    "ListTables",
+    "ListVolumes",
+    "ListVpcs",
+]
+
+
+def rule(event):
+    return event.get("eventName") in DISCOVERY_EVENTS
+
+
+def title(event):
+    user_arn = deep_get(event, "useridentity", "arn", default="<MISSING_ARN>")
+    return (
+        f"Cloud Infrastructure Discovery detected in AWS CloudTrail from [{user_arn}]"
+    )
+
+
+def alert_context(event):
+    return aws_rule_context(event)

--- a/rules/aws_cloudtrail_rules/aws_cloudtrail_infrastructure_discovery.yml
+++ b/rules/aws_cloudtrail_rules/aws_cloudtrail_infrastructure_discovery.yml
@@ -1,0 +1,59 @@
+AnalysisType: rule
+Description: This detection looks for Describe* and List* events in AWS CloudTrail logs. If these events occur in a short period of time from the same ARN, it could constitute Cloud Infrastructure Discovery reconnaissance.
+DisplayName: AWS CloudTrail Infrastructure Discovery
+Enabled: false
+Filename: aws_cloudtrail_infrastructure_discovery.py
+Reports:
+    MITRE ATT&CK:
+        - TA0007:T1580
+Severity: Info
+Tests:
+    - ExpectedResult: true
+      Log:
+        awsregion: ap-northeast-2
+        eventcategory: Management
+        eventid: cb2c7673-326e-490e-99be-8d062fe5f328
+        eventname: DescribeInstances
+        eventsource: ec2.amazonaws.com
+        eventtime: "2023-01-10 21:16:37"
+        eventtype: AwsApiCall
+        eventversion: "1.08"
+        managementevent: true
+        useridentity:
+            arn: arn:aws:test_arn
+      Name: Describe* Event
+    - ExpectedResult: true
+      Log:
+        apiversion: "2012-08-10"
+        awsregion: eu-west-1
+        eventcategory: Management
+        eventid: bc68d763-b374-4e19-a53f-317a1f23ffc1
+        eventname: ListTables
+        eventsource: dynamodb.amazonaws.com
+        eventtime: "2023-01-10 20:28:16"
+        eventtype: AwsApiCall
+        eventversion: "1.08"
+        managementevent: true
+        useridentity:
+            arn: arn:aws:test_arn
+      Name: List* Event
+    - ExpectedResult: false
+      Log:
+        apiversion: "2012-08-10"
+        awsregion: eu-west-1
+        eventcategory: Data
+        eventid: 5d4b45ed-a15c-41b6-80e9-031729fa060d
+        eventname: GetRecords
+        eventsource: dynamodb.amazonaws.com
+        eventtime: "2023-01-10 21:04:02"
+        eventtype: AwsApiCall
+        eventversion: "1.08"
+        managementevent: false
+        useridentity:
+            arn: arn:aws:test_arn
+      Name: Non-Discovery Event
+DedupPeriodMinutes: 30
+LogTypes:
+    - AWS.CloudTrail
+RuleID: AWS.CloudTrail.Infrastructure.Discovery
+Threshold: 5


### PR DESCRIPTION
### Background

Created initial AWS CloudTrail detection to look for Describe* and List* events, the appearance of which can indicate reconnaissance.