### PR TITLE
fix: github_advanced_security detection had some confusing title text

### DIFF
--- a/rules/github_rules/github_advanced_security_change.py
+++ b/rules/github_rules/github_advanced_security_change.py
@@ -70,14 +70,16 @@ ADV_SEC_ACTIONS = {
 
 
 def rule(event):
-    return event.get("action") in ADV_SEC_ACTIONS
+    return event.get("action", "") in ADV_SEC_ACTIONS
 
 
 def title(event):
     advanced_sec_text = ""
-    if event.get("action").startswith("business") or "advanced_security" in event.get("action", ""):
+    if event.get("action", "").startswith("business") or "advanced_security" in event.get(
+        "action", ""
+    ):
         advanced_sec_text = "Advanced "
-    return f"Change detected to GitHub {advanced_sec_text}Security - {event.get('action')}"
+    return f"Change detected to GitHub {advanced_sec_text}Security - {event.get('action', '')}"
 
 
 def alert_context(event):
@@ -93,7 +95,7 @@ def dedup(event):
     # Dedup on
     # 1. Actor
     # 2. Action
-    # 3. Extra things. These are ok to return None
+    # 3. Extra things. Ignored if absent
     #    3a. business ( aka enterprise )
     #    3a. org
     #    3c. repo

--- a/rules/github_rules/github_advanced_security_change.py
+++ b/rules/github_rules/github_advanced_security_change.py
@@ -92,21 +92,9 @@ def severity(event):
 
 
 def dedup(event):
-    # Dedup on
     # 1. Actor
     # 2. Action
-    # 3. Extra things. Ignored if absent
-    #    3a. business ( aka enterprise )
-    #    3a. org
-    #    3c. repo
-    # We should dedup on actor - action - <repo_if_exists>
+    # We should dedup on actor - action
     actor = event.get("actor", "<NO_ACTOR>")
     action = event.get("action", "<NO_ACTION>")
-    suffixes = []
-    if "business" in event:
-        suffixes.append(event.get("business"))  # aka enterprise
-    if "org" in event:
-        suffixes.append(event.get("org"))
-    if "repo" in event:
-        suffixes.append(event.get("repo"))
-    return "_".join([actor, action] + suffixes).replace("/", "__")
+    return "_".join([actor, action])

--- a/rules/github_rules/github_advanced_security_change.py
+++ b/rules/github_rules/github_advanced_security_change.py
@@ -74,10 +74,10 @@ def rule(event):
 
 
 def title(event):
+    action = event.get("action", "")
     advanced_sec_text = ""
-    if event.get("action", "").startswith("business") or "advanced_security" in event.get(
-        "action", ""
-    ):
+    # https://docs.github.com/en/get-started/learning-about-github/about-github-advanced-security#about-advanced-security-features
+    if "advanced_security" in action or "secret_scanning" in action:
         advanced_sec_text = "Advanced "
     return f"Change detected to GitHub {advanced_sec_text}Security - {event.get('action', '')}"
 

--- a/rules/github_rules/github_advanced_security_change.py
+++ b/rules/github_rules/github_advanced_security_change.py
@@ -1,5 +1,11 @@
 from panther_base_helpers import github_alert_context
 
+# List of actions in markdown format
+# pylint: disable=line-too-long
+# https://github.com/github/docs/blob/main/content/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/audit-log-events-for-your-enterprise.md
+# grep '^| `' audit-log-events-for-your-enterprise.md.txt | sed -e 's/\| //' -e 's/`//g' | awk -F\| '{if ($1 ~ /business/) {print $1}}'
+# pylint: enable=line-too-long
+
 # {GitHub Action: Alert Severity}
 ADV_SEC_ACTIONS = {
     "dependabot_alerts.disable": "CRITICAL",
@@ -10,6 +16,56 @@ ADV_SEC_ACTIONS = {
     "secret_scanning.disable": "CRITICAL",
     "secret_scanning_new_repos.disable": "HIGH",
     "bypass": "MEDIUM",  # Bypass secret scanner push protection for a detected secret.
+    # pylint: disable=line-too-long
+    # The events that begin with "business" are seemingly from enterprise logs
+    # business.disable_oidc  -  OIDC single sign-on was disabled for an enterprise.
+    "business.disable_oidc": "CRITICAL",
+    # business.disable_saml  -  SAML single sign-on was disabled for an enterprise.
+    "business.disable_saml": "CRITICAL",
+    # business.disable_two_factor_requirement  -  The requirement for members to
+    #    have two-factor authentication enabled to access an enterprise was disabled.
+    "business.disable_two_factor_requirement": "CRITICAL",
+    # business.members_can_update_protected_branches.disable  -  The ability for
+    #    enterprise members to update branch protection rules was disabled.
+    #    Only enterprise owners can update protected branches.
+    "business.members_can_update_protected_branches.disable": "MEDIUM",
+    # business.referrer_override_disable  -  An enterprise owner or site administrator
+    #    disabled the referrer policy override.
+    "business.referrer_override_disable": "MEDIUM",
+    # business_advanced_security.disabled  -  {% data
+    #    variables.product.prodname_GH_advanced_security %}
+    #    was disabled for your enterprise. For more information, see "[Managing
+    #    {% data variables.product.prodname_GH_advanced_security %}
+    #    features for your enterprise]
+    #    (/admin/code-security/managing-github-advanced-security-for-your-enterprise/managing-github-advanced-security-features-for-your-enterprise)."
+    "business_advanced_security.disabled": "CRITICAL",
+    # business_advanced_security.disabled_for_new_repos  -  {% data
+    #    variables.product.prodname_GH_advanced_security %} was disabled for
+    #    new repositories in your enterprise. For more information, see
+    #    "[Managing {% data variables.product.prodname_GH_advanced_security %} features
+    #    for your enterprise](/admin/code-security/managing-github-advanced-security-for-your-enterprise/managing-github-advanced-security-features-for-your-enterprise)."
+    "business_advanced_security.disabled_for_new_repos": "HIGH",
+    # business_secret_scanning.disable  -  {% data variables.product.prodname_secret_scanning_caps %} was disabled for your enterprise. For more information, see "[Managing {% data variables.product.prodname_GH_advanced_security %} features for your enterprise](/admin/code-security/managing-github-advanced-security-for-your-enterprise/managing-github-advanced-security-features-for-your-enterprise)."
+    "business_secret_scanning.disable": "CRITICAL",
+    # business_secret_scanning.disabled_for_new_repos  -  {% data variables.product.prodname_secret_scanning_caps %} was disabled for new repositories in your enterprise. For more information, see "[Managing {% data variables.product.prodname_GH_advanced_security %} features for your enterprise](/admin/code-security/managing-github-advanced-security-for-your-enterprise/managing-github-advanced-security-features-for-your-enterprise)."
+    "business_secret_scanning.disabled_for_new_repos": "CRITICAL",
+    # business_secret_scanning_custom_pattern_push_protection.disabled  -  Push protection for a custom pattern for {% data variables.product.prodname_secret_scanning %} was disabled for your enterprise. For more information, see "[Defining custom patterns for {% data variables.product.prodname_secret_scanning %}](/code-security/secret-scanning/defining-custom-patterns-for-secret-scanning#defining-a-custom-pattern-for-an-enterprise-account)."
+    "business_secret_scanning_custom_pattern_push_protection.disabled": "HIGH",
+    # business_secret_scanning_push_protection.disable  -  Push protection for {% data variables.product.prodname_secret_scanning %} was disabled for your enterprise. For more information, see "[Managing {% data variables.product.prodname_GH_advanced_security %} features for your enterprise](/admin/code-security/managing-github-advanced-security-for-your-enterprise/managing-github-advanced-security-features-for-your-enterprise)."
+    "business_secret_scanning_push_protection.disable": "CRITICAL",
+    # business_secret_scanning_push_protection.disabled_for_new_repos  -  Push protection for {% data variables.product.prodname_secret_scanning %} was disabled for new repositories in your enterprise. For more information, see "[Managing {% data variables.product.prodname_GH_advanced_security %} features for your enterprise](/admin/code-security/managing-github-advanced-security-for-your-enterprise/managing-github-advanced-security-features-for-your-enterprise)."
+    "business_secret_scanning_push_protection.disabled_for_new_repos": "HIGH",
+    # business_secret_scanning_push_protection_custom_message.disable  -  The custom message triggered by an attempted push to a push-protected repository was disabled for your enterprise. For more information, see "[Managing {% data variables.product.prodname_GH_advanced_security %} features for your enterprise](/admin/code-security/managing-github-advanced-security-for-your-enterprise/managing-github-advanced-security-features-for-your-enterprise)."
+    "business_secret_scanning_push_protection_custom_message.disable": "XXXX",
+    #
+    # There are also correlating github _org_ level events
+    "org.advanced_security_disabled_for_new_repos": "HIGH",
+    "org.advanced_security_disabled_on_all_repos": "CRITICAL",
+    # org.advanced_security_policy_selected_member_disabled - An enterprise owner prevented {% data variables.product.prodname_GH_advanced_security %} features from being enabled for repositories owned by the organization. {% data reusables.advanced-security.more-information-about-enforcement-policy %}
+    # pylint: enable=line-too-long
+    "org.advanced_security_policy_selected_member_disabled": "HIGH",
+    "repo.advanced_security_disabled": "CRITICAL",
+    "repo.advanced_security_policy_selected_member_disabled": "HIGH",
 }
 
 
@@ -18,7 +74,10 @@ def rule(event):
 
 
 def title(event):
-    return f"Change detected to GitHub Advanced Security - {event.get('action')}"
+    advanced_sec_text = ""
+    if event.get("action").startswith("business") or "advanced_security" in event.get("action", ""):
+        advanced_sec_text = "Advanced "
+    return f"Change detected to GitHub {advanced_sec_text}Security - {event.get('action')}"
 
 
 def alert_context(event):
@@ -28,3 +87,24 @@ def alert_context(event):
 # Use the per action severity configured above
 def severity(event):
     return ADV_SEC_ACTIONS.get(event.get("action", ""), "Low")
+
+
+def dedup(event):
+    # Dedup on
+    # 1. Actor
+    # 2. Action
+    # 3. Extra things. These are ok to return None
+    #    3a. business ( aka enterprise )
+    #    3a. org
+    #    3c. repo
+    # We should dedup on actor - action - <repo_if_exists>
+    actor = event.get("actor", "<NO_ACTOR>")
+    action = event.get("action", "<NO_ACTION>")
+    suffixes = []
+    if "business" in event:
+        suffixes.append(event.get("business"))  # aka enterprise
+    if "org" in event:
+        suffixes.append(event.get("org"))
+    if "repo" in event:
+        suffixes.append(event.get("repo"))
+    return "_".join([actor, action] + suffixes).replace("/", "__")

--- a/rules/github_rules/github_advanced_security_change.yml
+++ b/rules/github_rules/github_advanced_security_change.yml
@@ -1,7 +1,7 @@
 AnalysisType: rule
 Filename: github_advanced_security_change.py
 RuleID: GitHub.Advanced.Security.Change
-DisplayName: GitHub Advanced Security Change
+DisplayName: GitHub Security Change, includes GitHub Advanced Security
 Enabled: true
 LogTypes:
   - GitHub.Audit
@@ -11,7 +11,7 @@ Reports:
   MITRE ATT&CK:
     - TA0005:T1562
 Severity: Low
-Description: The rule alerts when GitHub Advanced Security tools (Depndabot or Secret Scanner) are disabled.
+Description: The rule alerts when GitHub Security tools (Dependabot, Secret Scanner, etc) are disabled.
 Runbook: Confirm with GitHub administrators and re-enable the tools as applicable. 
 Tests:
   -
@@ -142,5 +142,39 @@ Tests:
         "repo": "an-org/a-repo",
         "user": "bobert"
       }
-    
-    
+  -
+    Name: Enterprise Log - business_advanced_security.enabled
+    ExpectedResult: False
+    Log:
+      {
+        "@timestamp": 1671111111111,
+        "_document_id": "gAcccccccccccccccccccc",
+        "action": "business_advanced_security.enabled",
+        "actor": "bobert",
+        "actor_ip": "12.12.12.12",
+        "actor_location": {
+            "country_code": "US"
+        },
+        "business": "example-enterprise",
+        "created_at": 1671111111111,
+        "operation_type": "modify",
+        "user": "bobert"
+      }
+  -
+    Name: Enterprise Log - business_advanced_security.disabled
+    ExpectedResult: True
+    Log:
+      {
+        "@timestamp": 1671111111111,
+        "_document_id": "gAcccccccccccccccccccc",
+        "action": "business_advanced_security.disabled",
+        "actor": "bobert",
+        "actor_ip": "12.12.12.12",
+        "actor_location": {
+            "country_code": "US"
+        },
+        "business": "example-enterprise",
+        "created_at": 1671111111111,
+        "operation_type": "modify",
+        "user": "bobert"
+      }


### PR DESCRIPTION
### Background
A user mentioned getting an alert with a title mentioning GitHub Advanced Security, yet they did not subscribe to the Advanced Security feature in GitHub.  

The inclusion of the word `Advanced` in the title of the alert is now conditional on the event falling under the [rules on this page from docs.github.com](https://docs.github.com/en/get-started/learning-about-github/about-github-advanced-security#about-advanced-security-features). Sadly that page doesn't mention audit log event names, so it's possible we'll miss on the inclusion or exclusion of that text in some cases. 

When investigating this, I also uncovered [this docs page]( https://github.com/github/docs/blob/main/content/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/audit-log-events-for-your-enterprise.md) which enumerates the possible events in the audit log. **This revealed a substantial number of security related events that weren't in this detection.** There are some markdown shenanigans happening in that file that gate the visibility of certain events based on the product you've purchased. Not knowing all of the SKUs exactly, I opted to include them all. 

Due to `$reasons`, I did not change the RuleID or the Filename for this detection. 

### Changes
This change updates the github_advanced_security detection to
    1. Be a general "GitHub Security Settings Changed" detection
    2. Modifies the `title()` accordingly. If the change is related to GitHub Advanced Security, then the word Advanced will appear in the alert title. 
    3. Extends the list of security events. Some events would not appear in a Org audit log, and would only appear in an Enterprise audit log. It was difficult to programmatically sort out which events were domained to the org log, so I included all of them. If we one day can ingest Enterprise Audit Logs, we'll be covered. 
    4. Updates `dedup()` to be limited based on the `actor` and the `action`. If a user turns off scanning on 50 repos, we'll get one alert with 50 events underneath it. 

### Testing
* New test cases were added for one of the new events. I double-checked both title() and dedup() outputs for all test cases. 

```shell
sh $ pipenv run  panther_analysis_tool test --filter RuleID="GitHub.Advanced.Security.Change"  
[INFO]: Testing analysis items in .

GitHub.Advanced.Security.Change
	[PASS] Secret Scanning Disabled on a Repo
		[PASS] [rule] true
		[PASS] [title] Change detected to GitHub Advanced Security - repository_secret_scanning_push_protection.disable
		[PASS] [dedup] bobert_repository_secret_scanning_push_protection.disable
		[PASS] [alertContext] {"action": "repository_secret_scanning_push_protection.disable", "actor": "bobert", "actor_location": "US", "org": "an-org", "repo": "an-org/a-repo", "user": "bobert"}
		[PASS] [severity] HIGH
	[PASS] Secret Scanning Disabled Org Wide
		[PASS] [rule] true
		[PASS] [title] Change detected to GitHub Advanced Security - secret_scanning.disable
		[PASS] [dedup] bobert_secret_scanning.disable
		[PASS] [alertContext] {"action": "secret_scanning.disable", "actor": "bobert", "actor_location": "US", "org": "an-org", "repo": "an-org/a-repo", "user": "bobert"}
		[PASS] [severity] CRITICAL
	[PASS] Secret Scanning Disabled for New Repos
		[PASS] [rule] true
		[PASS] [title] Change detected to GitHub Advanced Security - secret_scanning_new_repos.disable
		[PASS] [dedup] bobert_secret_scanning_new_repos.disable
		[PASS] [alertContext] {"action": "secret_scanning_new_repos.disable", "actor": "bobert", "actor_location": "US", "org": "an-org", "repo": "an-org/a-repo", "user": "bobert"}
		[PASS] [severity] HIGH
	[PASS] Dependabot Alerts Disabled Org Wide
		[PASS] [rule] true
		[PASS] [title] Change detected to GitHub Security - dependabot_alerts.disable
		[PASS] [dedup] bobert_dependabot_alerts.disable
		[PASS] [alertContext] {"action": "dependabot_alerts.disable", "actor": "bobert", "actor_location": "US", "org": "an-org", "repo": "an-org/a-repo", "user": "bobert"}
		[PASS] [severity] CRITICAL
	[PASS] Dependabot Alerts Disabled on New Repos
		[PASS] [rule] true
		[PASS] [title] Change detected to GitHub Security - dependabot_alerts_new_repos.disable
		[PASS] [dedup] bobert_dependabot_alerts_new_repos.disable
		[PASS] [alertContext] {"action": "dependabot_alerts_new_repos.disable", "actor": "bobert", "actor_location": "US", "org": "an-org", "repo": "an-org/a-repo", "user": "bobert"}
		[PASS] [severity] HIGH
	[PASS] Dependabot Disabled Org Wide
		[PASS] [rule] true
		[PASS] [title] Change detected to GitHub Security - dependabot_security_updates.disable
		[PASS] [dedup] bobert_dependabot_security_updates.disable
		[PASS] [alertContext] {"action": "dependabot_security_updates.disable", "actor": "bobert", "actor_location": "US", "org": "an-org", "repo": "an-org/a-repo", "user": "bobert"}
		[PASS] [severity] CRITICAL
	[PASS] Dependabot Disabled on New Repos
		[PASS] [rule] true
		[PASS] [title] Change detected to GitHub Security - dependabot_security_updates_new_repos.disable
		[PASS] [dedup] bobert_dependabot_security_updates_new_repos.disable
		[PASS] [alertContext] {"action": "dependabot_security_updates_new_repos.disable", "actor": "bobert", "actor_location": "US", "org": "an-org", "repo": "an-org/a-repo", "user": "bobert"}
		[PASS] [severity] HIGH
	[PASS] Non-GitHub Adv Sec Action
		[PASS] [rule] false
	[PASS] Enterprise Log - business_advanced_security.enabled
		[PASS] [rule] false
	[PASS] Enterprise Log - business_advanced_security.disabled
		[PASS] [rule] true
		[PASS] [title] Change detected to GitHub Advanced Security - business_advanced_security.disabled
		[PASS] [dedup] bobert_business_advanced_security.disabled
		[PASS] [alertContext] {"action": "business_advanced_security.disabled", "actor": "bobert", "actor_location": "US", "org": "", "repo": "", "user": "bobert"}
		[PASS] [severity] CRITICAL

--------------------------
Panther CLI Test Summary
	Path: .
	Passed: 1
	Failed: 0
	Invalid: 0



```