### PR TITLE
fix: tune aws_iam_user_recon_denied down to Info level

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_iam_user_recon_denied.yml
+++ b/rules/aws_cloudtrail_rules/aws_iam_user_recon_denied.yml
@@ -11,7 +11,7 @@ Tags:
 Reports:
   MITRE ATT&CK:
     - TA0007:T1526
-Severity: Medium
+Severity: Info
 Threshold: 15
 DedupPeriodMinutes: 10
 Description: An IAM user has a high volume of access denied API calls.


### PR DESCRIPTION
### Background

We've observed that this is a very chatty alert in several environments. Since this is a risk-ranking signal alert without a strong call to action behind it, it makes sense to have the severity be Info. 

### Changes

* 

### Testing

* 
