### PR TITLE
fix: set default state to disable for aws_modify_cloud_compute_infra. change severity to Medium. remove from AWS pack

### DIFF
--- a/packs/aws.yml
+++ b/packs/aws.yml
@@ -41,7 +41,6 @@ PackDefinition:
     - AWS.EC2.RouteTableModified
     - AWS.EC2.VPCModified
     - AWS.IPSet.Modified
-    - AWS.Modify.Cloud.Compute.Infrastructure
     - AWS.CloudTrail.NetworkACLPermissiveEntry
     - AWS.DNS.Crypto.Domain
     - AWS.VPC.HealthyLogStatus

--- a/rules/aws_cloudtrail_rules/aws_modify_cloud_compute_infrastructure.yml
+++ b/rules/aws_cloudtrail_rules/aws_modify_cloud_compute_infrastructure.yml
@@ -1,13 +1,24 @@
 AnalysisType: rule
-Description: Detection when the cloud compute infrastructure is modified.
+Description: Detection when EC2 compute infrastructure is modified outside of expected automation methods.
 DisplayName: AWS Modify Cloud Compute Infrastructure
-Enabled: true
+Enabled: false
 Filename: aws_modify_cloud_compute_infrastructure.py
 Reference: https://attack.mitre.org/techniques/T1578/
-Severity: High
+Severity: Medium
 Reports:
   MITRE ATT&CK:
     - TA0005:T1578
+Tags:
+  # Note: This detection doesn't require configuration. It carries the Configuration Required
+  # tag due to checks for Enabled:false and Pack content
+  - Configuration Required
+Runbook: >
+  This detection reports on eventSource ec2 Change events. This detection excludes Cross-Service
+  change events.  As such, this detection will perform well in environments where changes are 
+  expected to originate only from AWS service entities.
+
+  This detection will emit alerts frequently in environments where users are
+  making ec2 related changes.
 Tests:
     - ExpectedResult: true
       Log:


### PR DESCRIPTION
### Background

This detection was observed to be emitting alerts with high frequency in several environments.  To remediate, we are setting this detection to have a default state of `Enabled: false` and we're additionally setting the default severity to `Medium`.


### Changes

*

### Testing

*
