### PR TITLE
fix: deprecates aws_snapshot_backup_exfiltration in favor of aws_snapshot_made_public

### DIFF
--- a/packs/aws.yml
+++ b/packs/aws.yml
@@ -20,7 +20,6 @@ PackDefinition:
     - AWS.EC2.Traffic.Mirroring
     - AWS.Macie.Evasion
     - AWS.CloudTrail.ResourceMadePublic
-    - AWS.Snapshot.Backup.Exfiltration
     - AWS.CloudTrail.SnapshotMadePublic
     # Encryption Status
     - AWS.DynamoDB.TableEncryption

--- a/rules/aws_cloudtrail_rules/aws_snapshot_backup_exfiltration.yml
+++ b/rules/aws_cloudtrail_rules/aws_snapshot_backup_exfiltration.yml
@@ -1,7 +1,7 @@
 AnalysisType: rule
 Description: Detects the modification of an EC2 snapshot's permissions to enable access from another account.
-DisplayName: AWS Snapshot Backup Exfiltration
-Enabled: true
+DisplayName: --DEPRECATED-- Snapshot Backup Exfiltration
+Enabled: False
 Filename: aws_snapshot_backup_exfiltration.py
 Reports:
     MITRE ATT&CK:


### PR DESCRIPTION
### Background
aws_snapshot_backup_exfiltration was alerting on any `ec2:ModifySnapshotAttribute` change. This detection has been deprecated in favor of the overlapping and more specific snapshot modification details inspected in aws_snapshot_made_public 


### Changes

* 

### Testing

* 
