### PR TITLE
fix: update GSuite.DriveVisibility to more explicitly demonstrate that it needs configuration

### DIFF
--- a/rules/gsuite_reports_rules/gsuite_drive_visibility_change.py
+++ b/rules/gsuite_reports_rules/gsuite_drive_visibility_change.py
@@ -94,7 +94,7 @@ def rule(event):
             details.get("type") == "acl_change"
             and details.get("name") == "change_document_visibility"
             and param_lookup(details.get("parameters", {}), "new_value") != ["private"]
-            and param_lookup(details.get("parameters", {}), "target_domain") not in ALLOWED_DOMAINS
+            and not param_lookup(details.get("parameters", {}), "target_domain") in ALLOWED_DOMAINS
             and param_lookup(details.get("parameters", {}), "visibility") in VISIBILITY
         ):
             ALERT_DETAILS[log]["TARGET_DOMAIN"] = param_lookup(

--- a/rules/gsuite_reports_rules/gsuite_drive_visibility_change.py
+++ b/rules/gsuite_reports_rules/gsuite_drive_visibility_change.py
@@ -1,7 +1,11 @@
+import json
+from unittest.mock import MagicMock
+
 from panther_base_helpers import deep_get
 from panther_base_helpers import gsuite_parameter_lookup as param_lookup
 
-EXCLUDED_DOMAINS = {"example.com"}
+# Add any domain name(s) that you expect to share documents with in the ALLOWED_DOMAINS set
+ALLOWED_DOMAINS = set()
 
 PUBLIC_PROVIDERS = {
     "gmail.com",
@@ -50,7 +54,11 @@ def init_alert_details(log):
 
 
 def user_is_external(target_user):
-    for domain in EXCLUDED_DOMAINS:
+    global ALLOWED_DOMAINS  # pylint: disable=global-statement
+    # We need to type-cast ALLOWED_DOMAINS for unit testing mocks
+    if isinstance(ALLOWED_DOMAINS, MagicMock):
+        ALLOWED_DOMAINS = set(json.loads(ALLOWED_DOMAINS()))  # pylint: disable=not-callable
+    for domain in ALLOWED_DOMAINS:
         if domain in target_user:
             return False
     return True
@@ -58,6 +66,7 @@ def user_is_external(target_user):
 
 def rule(event):
     # pylint: disable=too-complex
+    global ALLOWED_DOMAINS  # pylint: disable=global-statement
     if deep_get(event, "id", "applicationName") != "drive":
         return False
 
@@ -76,12 +85,16 @@ def rule(event):
     # for visibility changes that apply to a domain, not a user
     change_document_visibility = False
 
+    # We need to type-cast ALLOWED_DOMAINS for unit testing mocks
+    if isinstance(ALLOWED_DOMAINS, MagicMock):
+        ALLOWED_DOMAINS = set(json.loads(ALLOWED_DOMAINS()))  # pylint: disable=not-callable
+
     for details in event.get("events", [{}]):
         if (
             details.get("type") == "acl_change"
             and details.get("name") == "change_document_visibility"
             and param_lookup(details.get("parameters", {}), "new_value") != ["private"]
-            and param_lookup(details.get("parameters", {}), "target_domain") not in EXCLUDED_DOMAINS
+            and param_lookup(details.get("parameters", {}), "target_domain") not in ALLOWED_DOMAINS
             and param_lookup(details.get("parameters", {}), "visibility") in VISIBILITY
         ):
             ALERT_DETAILS[log]["TARGET_DOMAIN"] = param_lookup(

--- a/rules/gsuite_reports_rules/gsuite_drive_visibility_change.yml
+++ b/rules/gsuite_reports_rules/gsuite_drive_visibility_change.yml
@@ -107,7 +107,7 @@ Tests:
         "p_row_id": "111222"
       }
   -
-    Name: Doc Became Public - Link (Allowlisted Domain Not Set)
+    Name: Doc Became Public - Link (Allowlisted Domain Not Configured)
     ExpectedResult: true
     Log:
       {

--- a/rules/gsuite_reports_rules/gsuite_drive_visibility_change.yml
+++ b/rules/gsuite_reports_rules/gsuite_drive_visibility_change.yml
@@ -607,3 +607,169 @@ Tests:
           }
         ]
       }
+  -
+    Name: Doc Shared With Multiple Users All From ALLOWED_DOMAINS
+    ExpectedResult: false
+    Mocks:
+      - objectName: ALLOWED_DOMAINS
+        returnValue: >-
+           [
+             "example.com", "notexample.com"
+           ]
+    Log:
+      {
+        "id": {
+          "applicationName": "drive"
+        },
+        "actor": {
+          "email": "bobert@example.com"
+        },
+        "kind": "admin#reports#activity",
+        "ipAddress": "1.1.1.1",
+        "events": [
+          {
+            "type": "access",
+            "name": "edit",
+            "parameters": [
+              {
+                "name": "primary_event"
+              },
+              {
+                "name": "doc_title",
+                "value": "Hosted Accounts"
+              },
+              {
+                "name": "visibility",
+                "value": "shared_externally"
+              }
+            ]
+          },
+          {
+            "type": "acl_change",
+            "name": "change_user_access",
+            "parameters": [
+              {
+                "name": "primary_event",
+                "boolValue": true
+              },
+              {
+                "name": "visibility_change",
+                "value": "external"
+              },
+              {
+                "name": "target_user",
+                "value": "someone@notexample.com"
+              },
+              {
+                "name": "old_value",
+                "multiValue": [
+                  "none"
+                ]
+              },
+              {
+                "name": "new_value",
+                "multiValue": [
+                  "can_view"
+                ]
+              },
+              {
+                "name": "old_visibility",
+                "value": "people_within_domain_with_link"
+              },
+              {
+                "name": "doc_title",
+                "value": "Hosted Accounts"
+              },
+              {
+                "name": "visibility",
+                "value": "shared_externally"
+              }
+            ]
+          },
+          {
+            "type": "acl_change",
+            "name": "change_user_access",
+            "parameters": [
+              {
+                "name": "primary_event",
+                "boolValue": true
+              },
+              {
+                "name": "visibility_change",
+                "value": "external"
+              },
+              {
+                "name": "target_user",
+                "value": "someoneelse@example.com"
+              },
+              {
+                "name": "old_value",
+                "multiValue": [
+                  "none"
+                ]
+              },
+              {
+                "name": "new_value",
+                "multiValue": [
+                  "can_view"
+                ]
+              },
+              {
+                "name": "old_visibility",
+                "value": "people_within_domain_with_link"
+              },
+              {
+                "name": "doc_title",
+                "value": "Hosted Accounts"
+              },
+              {
+                "name": "visibility",
+                "value": "shared_externally"
+              }
+            ]
+          },
+          {
+            "type": "acl_change",
+            "name": "change_user_access",
+            "parameters": [
+              {
+                "name": "primary_event",
+                "boolValue": true
+              },
+              {
+                "name": "visibility_change",
+                "value": "external"
+              },
+              {
+                "name": "target_user",
+                "value": "notbobert@example.com"
+              },
+              {
+                "name": "old_value",
+                "multiValue": [
+                  "none"
+                ]
+              },
+              {
+                "name": "new_value",
+                "multiValue": [
+                  "can_view"
+                ]
+              },
+              {
+                "name": "old_visibility",
+                "value": "people_within_domain_with_link"
+              },
+              {
+                "name": "doc_title",
+                "value": "Hosted Accounts"
+              },
+              {
+                "name": "visibility",
+                "value": "shared_externally"
+              }
+            ]
+          }
+        ]
+      }
+ 

--- a/rules/gsuite_reports_rules/gsuite_drive_visibility_change.yml
+++ b/rules/gsuite_reports_rules/gsuite_drive_visibility_change.yml
@@ -107,8 +107,70 @@ Tests:
         "p_row_id": "111222"
       }
   -
-    Name: Doc Became Public - Link (Allowlisted Domain)
+    Name: Doc Became Public - Link (Allowlisted Domain Not Set)
+    ExpectedResult: true
+    Log:
+      {
+        "actor": {
+          "email": "bobert@example.com"
+        },
+        "events": [
+          {
+            "parameters": [
+              {
+                "name": "visibility_change",
+                "value": "external"
+              },
+              {
+                "name": "doc_title",
+                "value": "my shared document"
+              },
+              {
+                "name": "target_domain",
+                "value": "example.com"
+              },
+              {
+                "name": "visibility",
+                "value": "people_within_domain_with_link"
+              },
+              {
+                "name": "new_value",
+                "multiValue": [
+                  "people_with_link"
+                ]
+              }
+            ],
+            "name": "change_document_visibility",
+            "type": "acl_change"
+          },
+          {
+            "parameters": [
+              {
+                "name": "new_value",
+                "multiValue": [
+                  "can_view"
+                ]
+              }
+            ],
+            "name": "change_document_access_scope",
+            "type": "acl_change"
+          }
+        ],
+        "id": {
+          "applicationName": "drive"
+        },
+        "p_row_id": "111222"
+      }
+ 
+  -
+    Name: Doc Became Public - Link (Allowlisted Domain Is Configured)
     ExpectedResult: false
+    Mocks:
+      - objectName: ALLOWED_DOMAINS
+        returnValue: >-
+           [
+             "example.com"
+           ]
     Log:
       {
         "actor": {


### PR DESCRIPTION
### Background

GSuite.DriveVisibility needs configuration, which was made more clear in #618. 

I believe this detection needed a few more tweaks to make its behavior more clear. I have updated the thing called `EXCLUDED_DOMAINS` to be called `ALLOWED_DOMAINS`.

I have also updated the detection to have the empty set as the default value for the domain allow-list, and updated test fixtures to use Mock facilities to both demonstrate that historical behavior has been maintained in the event that configuration is applied

### Changes

* 

### Testing

* 
