### PR TITLE
Add in initial IsPublic flag support to public s3 bucket policies

### DIFF
--- a/policies/aws_s3_policies/aws_s3_bucket_public_read.py
+++ b/policies/aws_s3_policies/aws_s3_bucket_public_read.py
@@ -8,6 +8,9 @@ PERMISSIONS = {"READ"}
 
 
 def policy(resource):
+    if 'IsPublic' in resource and resource['IsPublic']:
+        return False
+
     for grant in resource["Grants"] or []:
         if deep_get(grant, "Grantee", "URI") in GRANTEES and grant.get("Permission") in PERMISSIONS:
             return False

--- a/policies/aws_s3_policies/aws_s3_bucket_public_read.py
+++ b/policies/aws_s3_policies/aws_s3_bucket_public_read.py
@@ -8,7 +8,7 @@ PERMISSIONS = {"READ"}
 
 
 def policy(resource):
-    if 'IsPublic' in resource and resource['IsPublic']:
+    if "IsPublic" in resource and resource["IsPublic"]:
         return False
 
     for grant in resource["Grants"] or []:

--- a/policies/aws_s3_policies/aws_s3_bucket_public_read.yml
+++ b/policies/aws_s3_policies/aws_s3_bucket_public_read.yml
@@ -58,6 +58,41 @@ Tests:
             "Permission": "WRITE"
           }
         ],
+        "IsPublic": false,
+        "LifecycleRules": null,
+        "Location": "us-east-2",
+        "LoggingPolicy": null,
+        "MFADelete": null,
+        "Name": "bucket-name",
+        "Owner": {
+          "DisplayName": "user.name",
+          "ID": "11112223334445556667778899aaabbbcccdddeeee"
+        },
+        "Policy": null,
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": false,
+          "BlockPublicPolicy": false,
+          "IgnorePublicAcls": false,
+          "RestrictPublicBuckets": false
+        },
+        "Versioning": null
+      }
+  -
+    Name: Bucket Allows READ Access with IsPublic flag
+    ExpectedResult: false
+    Resource:
+      {
+        "CreationDate": "2019-01-01T00:00:00Z",
+        "EncryptionRules": [
+          {
+            "ApplyServerSideEncryptionByDefault": {
+              "KMSMasterKeyID": null,
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ],
+        "Grants": [],
+        "IsPublic": true,
         "LifecycleRules": null,
         "Location": "us-east-2",
         "LoggingPolicy": null,
@@ -112,6 +147,7 @@ Tests:
             "Permission": "WRITE"
           }
         ],
+        "IsPublic": false,
         "LifecycleRules": null,
         "Location": "us-east-2",
         "LoggingPolicy": null,
@@ -166,6 +202,7 @@ Tests:
             "Permission": "WRITE"
           }
         ],
+        "IsPublic": false,
         "LifecycleRules": null,
         "Location": "us-east-2",
         "LoggingPolicy": null,
@@ -196,6 +233,7 @@ Tests:
         "ObjectLockConfiguration": null,
         "LifecycleRules": null,
         "Grants": null,
+        "IsPublic": null,
         "Versioning": null,
         "EncryptionRules": null,
         "PublicAccessBlockConfiguration": null,


### PR DESCRIPTION
### Background
Adds  in checks for `IsPublic` flag on S3 public bucket read policy. See https://github.com/panther-labs/panther-enterprise/pull/10432

### Changes

* Add in `IsPublic` support 

### Testing

* Additional test case added
