### PR TITLE
fix: eks_source_ip_multiple403s was triggering on naive web-scanners. so many naive web scanners.

### DIFF
--- a/rules/aws_eks_rules/source_ip_multiple_403.py
+++ b/rules/aws_eks_rules/source_ip_multiple_403.py
@@ -13,6 +13,10 @@ def rule(event):
     # We include only 403
     if event.get("responseStatus", {}).get("code", 0) != 403:
         return False
+    # And we only want things that might naively be kubernetes api endpoints
+    # we do not want to alert on scanners casting non-kubernetes requests.
+    if not event.get('requestURI', '').startswith(('/api/', '/apis/')):
+        return False
     p_eks = eks_panther_obj_ref(event)
     if ip_address(p_eks.get("sourceIPs")[0]).is_private:
         return False

--- a/rules/aws_eks_rules/source_ip_multiple_403.py
+++ b/rules/aws_eks_rules/source_ip_multiple_403.py
@@ -15,7 +15,7 @@ def rule(event):
         return False
     # And we only want things that might naively be kubernetes api endpoints
     # we do not want to alert on scanners casting non-kubernetes requests.
-    if not event.get('requestURI', '').startswith(('/api/', '/apis/')):
+    if not event.get("requestURI", "").startswith(("/api/", "/apis/")):
         return False
     p_eks = eks_panther_obj_ref(event)
     if ip_address(p_eks.get("sourceIPs")[0]).is_private:

--- a/rules/aws_eks_rules/source_ip_multiple_403.yml
+++ b/rules/aws_eks_rules/source_ip_multiple_403.yml
@@ -10,7 +10,7 @@ Tags:
 Reports:
   MITRE ATT&CK:
     - 'TA0007:T1613'
-Severity: Medium
+Severity: Info
 Description: > # (Optional)
   This detection identifies if a public sourceIP is generating multiple 403s
   with the Kubernetes API server.


### PR DESCRIPTION
### Background

There are many naive web-scanners scanning EKS kube-api endpoints hosted in AWS ( checking things like `/phpinfo.php` `/cgi-bin/` ). 

It makes sense to me that we should ignore those types of scanners.. Since all kube api server endpoints begin the requestURI with either `/api/` or `/apis/` , we can leverage `string.startswith()` to do some (naive) exclusion filtering for this alert. 


### Changes

* 

### Testing

* 
