### PR TITLE
fix: adding already existing and tested policies to aws pack in prod 

### DIFF
--- a/packs/aws.yml
+++ b/packs/aws.yml
@@ -54,6 +54,7 @@ PackDefinition:
     # User and Account Policies and Rules
     - AWS.Console.LoginWithoutMFA
     - AWS.Console.LoginWithoutSAML
+    - AWS.PasswordPolicy.PasswordReuse
     - AWS.Suspicious.SAML.Activity
     - AWS.IAM.Entity.InlinePolicyDoesNotGrantNetworkAdminAccess
     - AWS.IAM.User.MFA
@@ -69,6 +70,7 @@ PackDefinition:
     - AWS.User.Login.Profile.Modified
     # General Policies and Rules
     - AWS.ACM.Certificate.Valid
+    - AWS.ACM.Certificate.Expiration
     - AWS.CloudTrail.Created
     - AWS.CloudTrail.Enabled
     - AWS.CloudTrail.Stopped
@@ -98,6 +100,14 @@ PackDefinition:
     - AWS.CloudTrail.UnauthorizedAPICall
     - Amazon.EKS.Audit.Multiple403
     - Amazon.EKS.Audit.SystemNamespaceFromPublicIP
+    - AWS.CloudFormation.Stack.Drifted
+    - AWS.CloudFormation.Stack.UsesIAMServiceRole
+    - AWS.CloudFormation.Stack.TerminationProtection
+    - AWS.CloudWatchLogs.DataRetention1Year
+    - AWS.CloudWatchLogs.Encrypted
+    - AWS.Config.RecordAllResourceTypes
+    - AWS.Config.GlobalResources
+    - AWS.DynamoDB.Autoscaling
     # AWS DataModels
     - Standard.AWS.ALB
     - Standard.AWS.CloudTrail


### PR DESCRIPTION


### Background

<High level overview here>

### Changes

* pushing already existing and tested policies into prod for the policies->packs work
* added:  
- AWS.Modify.Cloud.Compute.Infrastructure
- AWS.PasswordPolicy.PasswordReuse
- AWS.ACM.Certificate.Expiration
- AWS.CloudFormation.Stack.Drifted
- AWS.CloudFormation.Stack.UsesIAMServiceRole
- AWS.CloudFormation.Stack.TerminationProtection
- AWS.CloudWatchLogs.DataRetention1Year
- AWS.CloudWatchLogs.Encrypted
- AWS.Config.RecordAllResourceTypes
- AWS.Config.GlobalResources
- AWS.DynamoDB.Autoscaling

### Testing

* <Testing steps>
