### PR TITLE
github/branch-protection-disabled: add the actor who did the disabling to the alert message

### DIFF
--- a/rules/github_rules/github_branch_protection_disabled.py
+++ b/rules/github_rules/github_branch_protection_disabled.py
@@ -5,5 +5,5 @@ def rule(event):
 def title(event):
     return (
         f"A branch protection was removed from the "
-        f"repository [{event.get('repo', '<UNKNOWN_REPO>')}]"
+        f"repository [{event.get('repo', '<UNKNOWN_REPO>')}], actor [{event.get('actor', '<UNKNOWN_ACTOR>')}]"
     )


### PR DESCRIPTION
### Background

It would be useful, especially when working with alerts via Slack, if the actor who disabled the branch protection would be displayed in the alert title. When using the new slackbot boomerang feature this makes it easier to quickly boomerang the actor and ask for justification.

### Changes

* Add `actor` to the github `A branch protection was removed from the <REPO>..` alert title. Falling back to `UNKNOWN_ACTOR` if the log entry does not have `actor` set.


