### PR TITLE
Added support for dictionary values in DynamoDB

### DIFF
--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -274,18 +274,17 @@ def get_dictionary(key: str) -> dict:
     # Retrieve the item from DynamoDB
     response = kv_table().get_item(Key={"key": key})
 
-    # Check if the item was found
-    if "Item" in response:
-        item = response.get("Item", {}).get(_DICT_COL, {})
+    item = response.get("Item", {}).get(_DICT_COL, {})
 
-        if item:
-            try:
-                # Deserialize from JSON to a Python dictionary
-                return json.loads(item)
-            except json.decoder.JSONDecodeError as exc:
-                raise Exception(
-                    "get_dictionary(): Data found in DynamoDB could not be decoded into JSON"
-                ) from exc
+    # Check if the item was found
+    if item:
+        try:
+            # Deserialize from JSON to a Python dictionary
+            return json.loads(item)
+        except json.decoder.JSONDecodeError as exc:
+            raise Exception(
+                "get_dictionary(): Data found in DynamoDB could not be decoded into JSON"
+            ) from exc
 
     return {}
 

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -235,6 +235,33 @@ def set_key_expiration(key: str, epoch_seconds: int) -> None:
     )
 
 
+def put_dictionary(key: str, val: dict, epoch_seconds: int = None):
+    # Convert the data dictionary to a JSON string
+    data = json.dumps(val)
+
+    # Store the item in DynamoDB
+    kv_table().put_item(Item={'key': key, 'data': {'S': data}})
+
+    if epoch_seconds:
+        set_key_expiration(key, epoch_seconds)
+
+
+def get_dictionary(key: str) -> dict:
+    # Retrieve the item from DynamoDB
+    response = kv_table().get_item(Key={'key': key})
+
+    # Check if the item was found
+    if 'Item' in response:
+        item = response.get('Item', {})
+
+        # Deserialize the 'data' attribute back to a Python dictionary
+        data = json.loads(item.get('data', {}).get('S', {}))
+        return data
+    
+    return dict()
+
+
+
 def get_string_set(key: str) -> Set[str]:
     """Get a string set's current value (defaulting to empty set if key does not exit)."""
     response = kv_table().get_item(

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -252,16 +252,16 @@ def put_dictionary(key: str, val: dict, epoch_seconds: int = None):
         val: A Python dictionary
         epoch_seconds: (Optional) Set string expiration time
     """
-    if isinstance(val, dict):
-        try:
-            # Serialize 'val' to a JSON string
-            data = json.dumps(val)
-        except TypeError as exc:
-            raise Exception(
-                "put_dictionary(): value is a dictionary, but it is not JSON serializable"
-            ) from exc
-    else:
-        raise Exception("put_dictionary(): value is not a dictionary")
+    if not isinstance(val, dict):
+        raise Exception("panther_oss_helpers.put_dictionary: value is not a dictionary")
+
+    try:
+        # Serialize 'val' to a JSON string
+        data = json.dumps(val)
+    except TypeError as exc:
+        raise Exception(
+            "panther_oss_helpers.put_dictionary: value is a dictionary, but it is not JSON serializable"
+        ) from exc
 
     # Store the item in DynamoDB
     kv_table().put_item(Item={"key": key, _DICT_COL: data})
@@ -276,17 +276,17 @@ def get_dictionary(key: str) -> dict:
 
     item = response.get("Item", {}).get(_DICT_COL, {})
 
-    # Check if the item was found
-    if item:
-        try:
-            # Deserialize from JSON to a Python dictionary
-            return json.loads(item)
-        except json.decoder.JSONDecodeError as exc:
-            raise Exception(
-                "get_dictionary(): Data found in DynamoDB could not be decoded into JSON"
-            ) from exc
+    # Check if the item was not found, if so return empty dictionary
+    if not item:
+        return {}
 
-    return {}
+    try:
+        # Deserialize from JSON to a Python dictionary
+        return json.loads(item)
+    except json.decoder.JSONDecodeError as exc:
+        raise Exception(
+            "panther_oss_helpers.get_dictionary: Data found in DynamoDB could not be decoded into JSON"
+        ) from exc
 
 
 def get_string_set(key: str) -> Set[str]:

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -257,8 +257,8 @@ def get_dictionary(key: str) -> dict:
         # Deserialize the 'data' attribute back to a Python dictionary
         data = json.loads(item.get('data', {}).get('S', {}))
         return data
-    
-    return dict()
+
+    return {}
 
 
 

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -133,7 +133,8 @@ def resource_table() -> boto3.resource:
     if not _RESOURCE_TABLE:
         # pylint: disable=no-member
         _RESOURCE_TABLE = boto3.resource(
-            "dynamodb", endpoint_url="https://dynamodb" + FIPS_SUFFIX if FIPS_ENABLED else None
+            "dynamodb",
+            endpoint_url="https://dynamodb" + FIPS_SUFFIX if FIPS_ENABLED else None,
         ).Table("panther-resources")
     return _RESOURCE_TABLE
 
@@ -178,7 +179,8 @@ def kv_table() -> boto3.resource:
     if not _KV_TABLE:
         # pylint: disable=no-member
         _KV_TABLE = boto3.resource(
-            "dynamodb", endpoint_url="https://dynamodb" + FIPS_SUFFIX if FIPS_ENABLED else None
+            "dynamodb",
+            endpoint_url="https://dynamodb" + FIPS_SUFFIX if FIPS_ENABLED else None,
         ).Table("panther-kv-store")
     return _KV_TABLE
 
@@ -240,7 +242,7 @@ def put_dictionary(key: str, val: dict, epoch_seconds: int = None):
     data = json.dumps(val)
 
     # Store the item in DynamoDB
-    kv_table().put_item(Item={'key': key, 'data': {'S': data}})
+    kv_table().put_item(Item={"key": key, "data": {"S": data}})
 
     if epoch_seconds:
         set_key_expiration(key, epoch_seconds)
@@ -248,18 +250,17 @@ def put_dictionary(key: str, val: dict, epoch_seconds: int = None):
 
 def get_dictionary(key: str) -> dict:
     # Retrieve the item from DynamoDB
-    response = kv_table().get_item(Key={'key': key})
+    response = kv_table().get_item(Key={"key": key})
 
     # Check if the item was found
-    if 'Item' in response:
-        item = response.get('Item', {})
+    if "Item" in response:
+        item = response.get("Item", {})
 
         # Deserialize the 'data' attribute back to a Python dictionary
-        data = json.loads(item.get('data', {}).get('S', {}))
+        data = json.loads(item.get("data", {}).get("S", {}))
         return data
 
     return {}
-
 
 
 def get_string_set(key: str) -> Set[str]:
@@ -356,7 +357,9 @@ def reset_string_set(key: str) -> None:
     )
 
 
-def evaluate_threshold(key: str, threshold: int = 10, expiry_seconds: int = 3600) -> bool:
+def evaluate_threshold(
+    key: str, threshold: int = 10, expiry_seconds: int = 3600
+) -> bool:
     hourly_error_count = increment_counter(key)
     if hourly_error_count == 1:
         set_key_expiration(key, int(time.time()) + expiry_seconds)
@@ -408,9 +411,9 @@ def geoinfo_from_ip_formatted(ip: str) -> str:  # pylint: disable=invalid-name
 def time_delta(time1, time2: str) -> str:
     time1_truncated = nano_to_micro(time1)
     time2_truncated = nano_to_micro(time2)
-    delta_timedelta = resolve_timestamp_string(time2_truncated) - resolve_timestamp_string(
-        time1_truncated
-    )
+    delta_timedelta = resolve_timestamp_string(
+        time2_truncated
+    ) - resolve_timestamp_string(time1_truncated)
     days = delta_timedelta.days
     hours, remainder = divmod(delta_timedelta.seconds, 3600)
     minutes, seconds = divmod(remainder, 60)

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -357,9 +357,7 @@ def reset_string_set(key: str) -> None:
     )
 
 
-def evaluate_threshold(
-    key: str, threshold: int = 10, expiry_seconds: int = 3600
-) -> bool:
+def evaluate_threshold(key: str, threshold: int = 10, expiry_seconds: int = 3600) -> bool:
     hourly_error_count = increment_counter(key)
     if hourly_error_count == 1:
         set_key_expiration(key, int(time.time()) + expiry_seconds)
@@ -411,9 +409,9 @@ def geoinfo_from_ip_formatted(ip: str) -> str:  # pylint: disable=invalid-name
 def time_delta(time1, time2: str) -> str:
     time1_truncated = nano_to_micro(time1)
     time2_truncated = nano_to_micro(time2)
-    delta_timedelta = resolve_timestamp_string(
-        time2_truncated
-    ) - resolve_timestamp_string(time1_truncated)
+    delta_timedelta = resolve_timestamp_string(time2_truncated) - resolve_timestamp_string(
+        time1_truncated
+    )
     days = delta_timedelta.days
     hours, remainder = divmod(delta_timedelta.seconds, 3600)
     minutes, seconds = divmod(remainder, 60)

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -260,7 +260,8 @@ def put_dictionary(key: str, val: dict, epoch_seconds: int = None):
         data = json.dumps(val)
     except TypeError as exc:
         raise Exception(
-            "panther_oss_helpers.put_dictionary: value is a dictionary, but it is not JSON serializable"
+            "panther_oss_helpers.put_dictionary: "
+            "value is a dictionary, but it is not JSON serializable"
         ) from exc
 
     # Store the item in DynamoDB
@@ -285,7 +286,8 @@ def get_dictionary(key: str) -> dict:
         return json.loads(item)
     except json.decoder.JSONDecodeError as exc:
         raise Exception(
-            "panther_oss_helpers.get_dictionary: Data found in DynamoDB could not be decoded into JSON"
+            "panther_oss_helpers.get_dictionary: "
+            "Data found in DynamoDB could not be decoded into JSON"
         ) from exc
 
 


### PR DESCRIPTION
### Background

- DynamoDB caching enables stateful detections in Panther. This PR adds the `put_dictionary()` and `get_dictionary()` methods as helper functions in `panther_oss_helpers`.
- With the code introduced in this PR, detection writers can send `string` keys and `dict` values to `put_dictionary()` in the same way they can send string sets to `put_string_set()`.
- This eliminates the need for detection writers to serialize and deserialize dictionaries. 

### Changes

- Added `put_dictionary()` and `get_dictionary()` into `panther_oss_helpers`

### Testing

- Tests were conducted in an internal Panther instance leveraging Unit Tests via the Panther console