### PR TITLE
feat: update panther_analysis_tool to v0.19.1, which has a bulk-upload bugfix that is important

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ click = "~=8.1"
 decorator = "~=5.1"
 isort = "~=5.10.0"
 mypy = "~=0.950"
-panther-analysis-tool = "~=0.19.0"
+panther-analysis-tool = "~=0.19.1"
 pylint = "~=2.15.0"
 pylint-print = "~=1.0.0"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2b107b4a46774b457af37a8938f66f71f21748913c2e40d0df8536cf2deb5787"
+            "sha256": "da2c77a14f563462221bca6e984c6afe7a847a193bcce3b5b675bb4392b035c5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -313,19 +313,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:4e876ba5d64928cde0c416dd844f04f22d6b73d14002bbc3ca55591f80f49927",
-                "sha256:c729bb0af76e85a2776b6bd3da8d9fa0f4b91b425eab51612aa53956f644ee23"
+                "sha256:34ee771a5cc84c16e75d4b9ef4672f51c2bafdce66ec457bbaac630b37d9cd5e",
+                "sha256:7d9cebb507fc96e6eb429621ccb2e731b75e7bbb8d6d9f0cf0c08089ee3c1ab7"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.26.54"
+            "version": "==1.26.59"
         },
         "botocore": {
             "hashes": [
-                "sha256:ca3ef7588daa664fe196d3234718db5f6b5dab961507500b4bb921e31133eea1",
-                "sha256:f2fe17ed6b8e163769a715f81cb6ce3d4628d172918de535256bdf34d29b704f"
+                "sha256:5533644ddefaccfaa98460a63eb73e61a46aad019771226d103b1054b0df6103",
+                "sha256:bc75d41c5eecf624a2f9875483135aa78088a50c8d29847793f92756697cfed5"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.29.54"
+            "version": "==1.29.59"
         },
         "certifi": {
             "hashes": [
@@ -795,10 +795,10 @@
         },
         "panther-analysis-tool": {
             "hashes": [
-                "sha256:1aa6c68d637e981c7c246eeb510df7c97248bf230e8ce80e0a8ff38c59e697ac"
+                "sha256:fb5f05b3f5f74ce8c3567bf98accd4463bc3c090fd51e87d504c851606352bed"
             ],
             "index": "pypi",
-            "version": "==0.19.0"
+            "version": "==0.19.1"
         },
         "panther-core": {
             "hashes": [
@@ -808,11 +808,11 @@
         },
         "pathspec": {
             "hashes": [
-                "sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6",
-                "sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6"
+                "sha256:3a66eb970cbac598f9e5ccb5b2cf58930cd8e3ed86d393d541eaf2d8b1705229",
+                "sha256:64d338d4e0914e91c1792321e6907b5a593f1ab1851de7fc269557a21b30ebbc"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.10.3"
+            "version": "==0.11.0"
         },
         "pbr": {
             "hashes": [


### PR DESCRIPTION
### Background

panther_analysis_tool v0.19.1 has a bugfix relating to bulk-upload which we want to bring into this repo. 

### Changes

* 

### Testing

```shell
(panther-analysis) user@computer:~/Sources/PAN/panther-analysis $ pipenv run panther_analysis_tool --version | pbcopy 
panther_analysis_tool 0.19.1

```
