### PR TITLE
new rule: alerts when zoom user toggles Require that all meetings are secured with one security option: from On to Off

### DIFF
--- a/packs/zoom.yml
+++ b/packs/zoom.yml
@@ -6,6 +6,7 @@ PackDefinition:
   IDs:
     - Zoom.PasscodeDisabled
     - Zoom.User.Promoted.to.Privileged.Role
+    - Zoom.All.Meetings.Secured.With.One.Option.Disabled
     # Data Models used in these detections
     - Standard.Zoom.Operation
     # Globals used in these detections

--- a/rules/zoom_operation_rules/zoom_all_meetings_secured_with_one_option_disabled.py
+++ b/rules/zoom_operation_rules/zoom_all_meetings_secured_with_one_option_disabled.py
@@ -1,0 +1,18 @@
+def rule(event):
+    operation_detail = event.get("operation_detail", "<NO_OPS_DETAIL>")
+    operation_flag = (
+        "Require that all meetings are secured with one security option: from On to Off"
+    )
+
+    return (
+        event.get("action", "<NO_ACTION>") == "Update"
+        and event.get("category_type", "<NO_CATEGORY_TYPE>") == "Account"
+        and operation_flag in operation_detail
+    )
+
+
+def title(event):
+    return (
+        f"Zoom User [{event.get('operator', '<NO_OPERATOR>')}] turned off your organization's "
+        f"requirement to secure all meetings with one security option."
+    )

--- a/rules/zoom_operation_rules/zoom_all_meetings_secured_with_one_option_disabled.yml
+++ b/rules/zoom_operation_rules/zoom_all_meetings_secured_with_one_option_disabled.yml
@@ -26,8 +26,8 @@ Tests:
       Log:
         action: Update
         category_type: User
-        operation_detail: 'Update User lisa@panther.io  - Job Title: set to Contractor'
-        operator: homer@panther.io
+        operation_detail: 'Update User example@example.io  - Job Title: set to Contractor'
+        operator: homer@example.io
       Name: Non admin user update
 DedupPeriodMinutes: 60
 LogTypes:

--- a/rules/zoom_operation_rules/zoom_all_meetings_secured_with_one_option_disabled.yml
+++ b/rules/zoom_operation_rules/zoom_all_meetings_secured_with_one_option_disabled.yml
@@ -1,0 +1,36 @@
+AnalysisType: rule
+Description: A Zoom User turned off your organization's requirement that all meetings are secured with one security option.
+DisplayName: Zoom All Meetings Secured With One Option Disabled
+Enabled: true
+Filename: zoom_all_meetings_secured_with_one_option_disabled.py
+Runbook: Confirm this user acted with valid business intent and determine whether this activity was authorized.
+Severity: Medium
+Tests:
+    - ExpectedResult: true
+      Log:
+        action: Update
+        category_type: Account
+        operation_detail: 'Security  - Require that all meetings are secured with one security option: from On to Off'
+        operator: example@example.io
+        time: "2022-12-16 18:15:38"
+      Name: Turn off
+    - ExpectedResult: false
+      Log:
+        action: Update
+        category_type: Account
+        operation_detail: 'Security  - Require that all meetings are secured with one security option: from Off to On'
+        operator: example@example.io
+        time: "2022-12-16 18:15:38"
+      Name: Turn on
+    - ExpectedResult: false
+      Log:
+        action: Update
+        category_type: User
+        operation_detail: 'Update User lisa@panther.io  - Job Title: set to Contractor'
+        operator: homer@panther.io
+      Name: Non admin user update
+DedupPeriodMinutes: 60
+LogTypes:
+    - Zoom.Operation
+RuleID: Zoom.All.Meetings.Secured.With.One.Option.Disabled
+Threshold: 1


### PR DESCRIPTION
### Background

<High level overview here>

### Changes

* extending zoom pack with new rule

### Testing

* 
![Screenshot 2023-01-31 at 1 58 20 PM](https://user-images.githubusercontent.com/117778222/215881786-09f615f4-bfa4-4dea-afb7-a78d8d064ec0.png)

