### PR TITLE
tune: standard_rule/brute_force_by_ip

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ click = "~=8.1"
 decorator = "~=5.1"
 isort = "~=5.10.0"
 mypy = "~=0.950"
-panther-analysis-tool = "~=0.19.0"
+panther-analysis-tool = "~=0.19.1"
 pylint = "~=2.15.0"
 pylint-print = "~=1.0.0"
 

--- a/rules/standard_rules/brute_force_by_ip.yml
+++ b/rules/standard_rules/brute_force_by_ip.yml
@@ -13,11 +13,11 @@ LogTypes:
   - Okta.SystemLog
   - OneLogin.Events
   - OnePassword.SignInAttempt
-Severity: Medium
+Severity: Info
 Tags:
   - DataModel
   - Credential Access:Brute Force
-Threshold: 5
+Threshold: 20
 Reports:
   MITRE ATT&CK:
     - TA0006:T1110


### PR DESCRIPTION
### Background
standard_rule/brute_force_by_ip detects failed logon attempts for various services. 

This detection had a relatively low threshold of detection ( 5 events in a 60 minute period ). 
This detection doesn't have a particularly prescriptive call to action, and as such moving severity from Medium to Info. 

### Changes

* 

### Testing

* 