### PR TITLE
Converting deep_get results to strings where strings are expected

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_ec2_monitoring.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_monitoring.py
@@ -27,7 +27,7 @@ def rule(event):
         event.get("sourceIPAddress", "").endswith(".amazonaws.com")
         or deep_get(event, "userIdentity", "type", default="") == "AWSService"
         or deep_get("userIdentity", "invokedBy", default="") == "AWS Internal"
-        or deep_get("userIdentity", "invokedBy", default="").endswith(".amazonaws.com")
+        or str(deep_get("userIdentity", "invokedBy", default="")).endswith(".amazonaws.com")
     ):
         return False
     # Dry run operations get logged as SES Internal in the sourceIPAddress

--- a/rules/aws_cloudtrail_rules/aws_iam_user_key_created.py
+++ b/rules/aws_cloudtrail_rules/aws_iam_user_key_created.py
@@ -8,7 +8,7 @@ def rule(event):
         and event.get("eventSource") == "iam.amazonaws.com"
         and event.get("eventName") == "CreateAccessKey"
         and (
-            not deep_get(event, "userIdentity", "arn", default="").endswith(
+            not str(deep_get(event, "userIdentity", "arn", default="")).endswith(
                 f"user/{deep_get(event, 'responseElements', 'accessKey', 'userName', default='')}"
             )
         )

--- a/rules/aws_cloudtrail_rules/aws_modify_cloud_compute_infrastructure.py
+++ b/rules/aws_cloudtrail_rules/aws_modify_cloud_compute_infrastructure.py
@@ -49,7 +49,7 @@ def rule(event):
         event.get("sourceIPAddress", "").endswith(".amazonaws.com")
         or deep_get(event, "userIdentity", "type", default="") == "AWSService"
         or deep_get("userIdentity", "invokedBy", default="") == "AWS Internal"
-        or deep_get("userIdentity", "invokedBy", default="").endswith(".amazonaws.com")
+        or str(deep_get("userIdentity", "invokedBy", default="")).endswith(".amazonaws.com")
     ):
         return False
     # Dry run operations get logged as SES Internal in the sourceIPAddress

--- a/rules/aws_cloudtrail_rules/aws_saml_activity.py
+++ b/rules/aws_cloudtrail_rules/aws_saml_activity.py
@@ -5,7 +5,7 @@ SAML_ACTIONS = ["UpdateSAMLProvider", "CreateSAMLProvider", "DeleteSAMLProvider"
 
 def rule(event):
     # Allow AWSSSO to manage
-    if deep_get(event, "userIdentity", "arn", default="").endswith(
+    if str(deep_get(event, "userIdentity", "arn", default="")).endswith(
         ":assumed-role/AWSServiceRoleForSSO/AWS-SSO"
     ):
         return False

--- a/rules/aws_cloudtrail_rules/aws_user_login_profile_modified.py
+++ b/rules/aws_cloudtrail_rules/aws_user_login_profile_modified.py
@@ -6,7 +6,7 @@ def rule(event):
         event.get("eventSource", "") == "iam.amazonaws.com"
         and event.get("eventName", "") == "UpdateLoginProfile"
         and not deep_get(event, "requestParameters", "passwordResetRequired", default=False)
-        and not deep_get(event, "userIdentity", "arn", default="").endswith(
+        and not str(deep_get(event, "userIdentity", "arn", default="")).endswith(
             f"/{deep_get(event, 'requestParameters', 'userName', default='')}"
         )
     )

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_enhanced_predelivery_scanning.py
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_enhanced_predelivery_scanning.py
@@ -4,13 +4,13 @@ from panther_base_helpers import deep_get
 def rule(event):
     # the shape of the items in parameters can change a bit ( like NEW_VALUE can be an array )
     #  when the applicationName is something other than admin
-    if not deep_get(event, "id", "applicationName", default="").lower() == "admin":
+    if not str(deep_get(event, "id", "applicationName", default="")).lower() == "admin":
         return False
     if all(
         [
             (event.get("name", "") == "CHANGE_APPLICATION_SETTING"),
-            (deep_get(event, "parameters", "APPLICATION_NAME", default="").lower() == "gmail"),
-            (deep_get(event, "parameters", "NEW_VALUE", default="").lower() == "true"),
+            (str(deep_get(event, "parameters", "APPLICATION_NAME", default="")).lower() == "gmail"),
+            (str(deep_get(event, "parameters", "NEW_VALUE", default="")).lower() == "true"),
             (
                 deep_get(event, "parameters", "SETTING_NAME", default="")
                 == "DelayedDeliverySettingsProto disable_delayed_delivery_for_suspicious_email"

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_security_sandbox_disabled.py
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_gmail_security_sandbox_disabled.py
@@ -2,13 +2,13 @@ from panther_base_helpers import deep_get
 
 
 def rule(event):
-    if not deep_get(event, "id", "applicationName", default="").lower() == "admin":
+    if not str(deep_get(event, "id", "applicationName", default="")).lower() == "admin":
         return False
     if all(
         [
             (event.get("name", "") == "CHANGE_APPLICATION_SETTING"),
-            (deep_get(event, "parameters", "APPLICATION_NAME", default="").lower() == "gmail"),
-            (deep_get(event, "parameters", "NEW_VALUE", default="").lower() == "false"),
+            (str(deep_get(event, "parameters", "APPLICATION_NAME", default="")).lower() == "gmail"),
+            (str(deep_get(event, "parameters", "NEW_VALUE", default="")).lower() == "false"),
             (
                 deep_get(event, "parameters", "SETTING_NAME", default="")
                 == "AttachmentDeepScanningSettingsProto deep_scanning_enabled"

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_password_enforce_strong_disabled.py
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_password_enforce_strong_disabled.py
@@ -2,13 +2,13 @@ from panther_base_helpers import deep_get
 
 
 def rule(event):
-    if not deep_get(event, "id", "applicationName", default="").lower() == "admin":
+    if not str(deep_get(event, "id", "applicationName", default="")).lower() == "admin":
         return False
     if all(
         [
             (event.get("name", "") == "CHANGE_APPLICATION_SETTING"),
             (event.get("type", "") == "APPLICATION_SETTINGS"),
-            (deep_get(event, "parameters", "NEW_VALUE", default="").lower() == "off"),
+            (str(deep_get(event, "parameters", "NEW_VALUE", default="")).lower() == "off"),
             (
                 deep_get(event, "parameters", "SETTING_NAME", default="")
                 == "Password Management - Enforce strong password"

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_password_reuse_enabled.py
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_password_reuse_enabled.py
@@ -2,13 +2,13 @@ from panther_base_helpers import deep_get
 
 
 def rule(event):
-    if not deep_get(event, "id", "applicationName", default="").lower() == "admin":
+    if not str(deep_get(event, "id", "applicationName", default="")).lower() == "admin":
         return False
     if all(
         [
             (event.get("name", "") == "CHANGE_APPLICATION_SETTING"),
             (event.get("type", "") == "APPLICATION_SETTINGS"),
-            (deep_get(event, "parameters", "NEW_VALUE", default="").lower() == "true"),
+            (str(deep_get(event, "parameters", "NEW_VALUE", default="")).lower() == "true"),
             (
                 deep_get(event, "parameters", "SETTING_NAME", default="")
                 == "Password Management - Enable password reuse"


### PR DESCRIPTION
### Background

Panther's `deep_get` helper function makes no guarantees that a string is returned.  However, some rule call-sites make the assumption that a string is returned and attempt to call string methods on the result.  This causes errors when an event embeds a _null_ type that gets converts to the `None` type in Python;  The provided default is not used as `deep_get` returns a value, albeit `None`.  Thus, errors can be encountered when string methods like `lower()` or `endswith()` are called on non string values (i.e. `None`).

In the wild, we have seen errors like `AttributeError("'NoneType' object has no attribute 'lower'")`.

### Changes

* Wrapped all identified `deep_get` call-sites that directly call string methods on the result in `str()`, forcing conversion to a string.
  * Basically, I searched for `default="").` and manually verified it was a `deep_get` call that passed to a string method.  There may be other similar call-sites that I did not identify this way.

### Testing

* Local testing only
