### PR TITLE
chore: tune out aws config checking on ec2 traffic mirroring

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_ec2_traffic_mirroring.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_traffic_mirroring.py
@@ -1,4 +1,4 @@
-from panther_base_helpers import aws_rule_context
+from panther_base_helpers import aws_rule_context, deep_get
 
 
 def rule(event):
@@ -19,6 +19,8 @@ def rule(event):
         "ModifyTrafficMirrorFilterRule",
         "ModifyTrafficMirrorSession",
     ]
+    if deep_get(event, "userIdentity", "invokedBy", default="") == "config.amazonaws.com":
+        return False
     return (
         event.get("eventSource", "") == "ec2.amazonaws.com"
         and event.get("eventName", "") in event_names

--- a/rules/aws_cloudtrail_rules/aws_ec2_traffic_mirroring.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_traffic_mirroring.py
@@ -19,7 +19,7 @@ def rule(event):
         "ModifyTrafficMirrorFilterRule",
         "ModifyTrafficMirrorSession",
     ]
-    if deep_get(event, "userIdentity", "invokedBy", default="") == "config.amazonaws.com":
+    if deep_get(event, "userIdentity", "invokedBy", default="").endswith(".amazonaws.com"):
         return False
     return (
         event.get("eventSource", "") == "ec2.amazonaws.com"

--- a/rules/aws_cloudtrail_rules/aws_ec2_traffic_mirroring.yml
+++ b/rules/aws_cloudtrail_rules/aws_ec2_traffic_mirroring.yml
@@ -507,6 +507,51 @@ Tests:
                 webIdFederationData: {}
             type: AssumedRole
       Name: UnrelatedEvent
+    - Name: AWS Config Runs DescribeTrafficMirrorTargets
+      ExpectedResult: false
+      Log:
+        {
+            "awsRegion": "us-west-2",
+            "eventCategory": "Management",
+            "eventID": "c98e81a7-15ee-4888-bbbb-cccccccccccc",
+            "eventName": "DescribeTrafficMirrorTargets",
+            "eventSource": "ec2.amazonaws.com",
+            "eventTime": "2023-02-10 18:08:33",
+            "eventType": "AwsApiCall",
+            "eventVersion": "1.08",
+            "managementEvent": true,
+            "readOnly": true,
+            "recipientAccountId": "123456789012",
+            "requestID": "1531eeee-5ddd-4fff-8111-844444444444",
+            "requestParameters": {
+                "DescribeTrafficMirrorTargetsRequest": {
+                    "MaxResults": 1000
+                }
+            },
+            "sourceIPAddress": "config.amazonaws.com",
+            "userAgent": "config.amazonaws.com",
+            "userIdentity": {
+                "accountId": "123456789012",
+                "arn": "arn:aws:sts::123456789012:assumed-role/SomeAWSConfig/ConfigResourceCompositionSession",
+                "invokedBy": "config.amazonaws.com",
+                "principalId": "AROAAAAAAAAAAAAAAAAAA:ConfigResourceCompositionSession",
+                "sessionContext": {
+                    "attributes": {
+                        "creationDate": "2023-02-13T18:08:33Z",
+                        "mfaAuthenticated": "false"
+                    },
+                    "sessionIssuer": {
+                        "accountId": "123456789012",
+                        "arn": "arn:aws:iam::123456789012:role/PantherAWSConfig",
+                        "principalId": "AROAAAAAAAAAAAAAAAAAA",
+                        "type": "Role",
+                        "userName": "PantherAWSConfig"
+                    },
+                    "webIdFederationData": {}
+                },
+                "type": "AssumedRole"
+            }
+        }
 DedupPeriodMinutes: 60
 LogTypes:
     - AWS.CloudTrail


### PR DESCRIPTION
### Background

AWS Config can run the `ec2:DescribeTrafficMirroring`, which we should not raise an alert upon. Some other EC2 

I believe there are fewer pathways to initiating the TrafficMirroring calls, and so am not recreating the full list in [the other ec2 modification](https://github.com/panther-labs/panther-analysis/blob/master/rules/aws_cloudtrail_rules/aws_ec2_monitoring.py#L27) detection

### Changes

* 

### Testing

```shell
AWS.EC2.Traffic.Mirroring
	[PASS] CreateTrafficMirrorFilter
		[PASS] [rule] true
		[PASS] [title] arn:aws:sts::123123123123:assumed-role/MakeStuffPublic ec2 activity found for CreateTrafficMirrorFilter in account 123451234515 in region us-east-1.
		[PASS] [dedup] arn:aws:sts::123123123123:assumed-role/MakeStuffPublic
		[PASS] [alertContext] {"eventName": "CreateTrafficMirrorFilter", "eventSource": "ec2.amazonaws.com", "awsRegion": "us-east-1", "recipientAccountId": "123451234515", "sourceIPAddress": "AWS Internal", "userAgent": "AWS Internal", "userIdentity": {"accessKeyId": "ASIA57JLR4M2ZZDJUXY3", "accountId": "123451234516", "arn": "arn:aws:sts::123123123123:assumed-role/MakeStuffPublic", "principalId": "AROA57JLR4M2SBAPVC4BO", "sessionContext": {"attributes": {"creationDate": "2022-11-15T22:38:17Z", "mfaAuthenticated": "true"}, "sessionIssuer": {"accountId": "123123123123", "arn": "arn:aws:iam::123123123123:role/MakeStuffPublic", "principalId": "AROA57JLR4M2SBAPVC4BO", "type": "Role", "userName": "MakeStuffPublic"}, "webIdFederationData": {}}, "type": "AssumedRole"}}
	[PASS] CreateTrafficMirrorFilterRule
		[PASS] [rule] true
		[PASS] [title] arn:aws:sts::123123123123:assumed-role/MakeStuffPublic ec2 activity found for CreateTrafficMirrorFilterRule in account 123451234566 in region us-east-1.
		[PASS] [dedup] arn:aws:sts::123123123123:assumed-role/MakeStuffPublic
		[PASS] [alertContext] {"eventName": "CreateTrafficMirrorFilterRule", "eventSource": "ec2.amazonaws.com", "awsRegion": "us-east-1", "recipientAccountId": "123451234566", "sourceIPAddress": "AWS Internal", "userAgent": "AWS Internal", "userIdentity": {"accessKeyId": "ASIA57JLR4M2ZZDJUXY3", "accountId": "123123123123", "arn": "arn:aws:sts::123123123123:assumed-role/MakeStuffPublic", "principalId": "AROA57JLR4M2SBAPVC4BO:MakeStuffPublic", "sessionContext": {"attributes": {"creationDate": "2022-11-15T22:38:17Z", "mfaAuthenticated": "true"}, "sessionIssuer": {"accountId": "123123123123", "arn": "arn:aws:iam::123123123123:role/MakeStuffPublic", "principalId": "AROA57JLR4M2SBAPVC4BO", "type": "Role", "userName": "MakeStuffPublic"}, "webIdFederationData": {}}, "type": "AssumedRole"}}
	[PASS] CreateTrafficMirrorSession
		[PASS] [rule] true
		[PASS] [title] arn:aws:sts::123123123123:assumed-role/MakeStuffPublic ec2 activity found for CreateTrafficMirrorSession in account 123123123123 in region us-east-1.
		[PASS] [dedup] arn:aws:sts::123123123123:assumed-role/MakeStuffPublic
		[PASS] [alertContext] {"eventName": "CreateTrafficMirrorSession", "eventSource": "ec2.amazonaws.com", "awsRegion": "us-east-1", "recipientAccountId": "123123123123", "sourceIPAddress": "AWS Internal", "userAgent": "AWS Internal", "userIdentity": {"accessKeyId": "ASIA57JLR4M2ZZDJUXY3", "accountId": "123123123123", "arn": "arn:aws:sts::123123123123:assumed-role/MakeStuffPublic", "principalId": "AROA57JLR4M2SBAPVC4BO:MakeStuffPublic", "sessionContext": {"attributes": {"creationDate": "2022-11-15T22:38:17Z", "mfaAuthenticated": "true"}, "sessionIssuer": {"accountId": "123123123123", "arn": "arn:aws:iam::123123123123:role/MakeStuffPublic", "principalId": "AROA57JLR4M2SBAPVC4BO", "type": "Role", "userName": "MakeStuffPublic"}, "webIdFederationData": {}}, "type": "AssumedRole"}}
	[PASS] CreateTrafficMirrorTarget
		[PASS] [rule] true
		[PASS] [title] arn:aws:sts::123123123123:assumed-role/MakeStuffPublic ec2 activity found for CreateTrafficMirrorTarget in account 123123123123 in region us-east-1.
		[PASS] [dedup] arn:aws:sts::123123123123:assumed-role/MakeStuffPublic
		[PASS] [alertContext] {"eventName": "CreateTrafficMirrorTarget", "eventSource": "ec2.amazonaws.com", "awsRegion": "us-east-1", "recipientAccountId": "123123123123", "sourceIPAddress": "AWS Internal", "userAgent": "AWS Internal", "userIdentity": {"accessKeyId": "ASIA57JLR4M2ZZDJUXY3", "accountId": "123123123123", "arn": "arn:aws:sts::123123123123:assumed-role/MakeStuffPublic", "principalId": "AROA57JLR4M2SBAPVC4BO", "sessionContext": {"attributes": {"creationDate": "2022-11-15T22:38:17Z", "mfaAuthenticated": "true"}, "sessionIssuer": {"accountId": "123123123123", "arn": "arn:aws:iam::123123123123:role/MakeStuffPublic", "principalId": "AROA57JLR4M2SBAPVC4BO", "type": "Role", "userName": "MakeStuffPublic"}, "webIdFederationData": {}}, "type": "AssumedRole"}}
	[PASS] DeleteTrafficMirrorTarget
		[PASS] [rule] true
		[PASS] [title] arn:aws:sts::123123123123:assumed-role/MakeStuffPublic ec2 activity found for DeleteTrafficMirrorTarget in account 123123123123 in region us-east-1.
		[PASS] [dedup] arn:aws:sts::123123123123:assumed-role/MakeStuffPublic
		[PASS] [alertContext] {"eventName": "DeleteTrafficMirrorTarget", "eventSource": "ec2.amazonaws.com", "awsRegion": "us-east-1", "recipientAccountId": "123123123123", "sourceIPAddress": "AWS Internal", "userAgent": "AWS Internal", "userIdentity": {"accessKeyId": "ASIA57JLR4M2ZZDJUXY3", "accountId": "123123123123", "arn": "arn:aws:sts::123123123123:assumed-role/MakeStuffPublic", "principalId": "AROA57JLR4M2SBAPVC4BO", "sessionContext": {"attributes": {"creationDate": "2022-11-15T22:38:17Z", "mfaAuthenticated": "true"}, "sessionIssuer": {"accountId": "123123123123", "arn": "arn:aws:iam::123123123123:role/MakeStuffPublic", "principalId": "AROA57JLR4M2SBAPVC4BO", "type": "Role", "userName": "MakeStuffPublic"}, "webIdFederationData": {}}, "type": "AssumedRole"}}
	[PASS] DescribeTrafficMirrorTargets
		[PASS] [rule] true
		[PASS] [title] arn:aws:sts::123123123123:assumed-role/MakeStuffPublic ec2 activity found for DescribeTrafficMirrorTargets in account 123123123123 in region us-east-1.
		[PASS] [dedup] arn:aws:sts::123123123123:assumed-role/MakeStuffPublic
		[PASS] [alertContext] {"eventName": "DescribeTrafficMirrorTargets", "eventSource": "ec2.amazonaws.com", "awsRegion": "us-east-1", "recipientAccountId": "123123123123", "sourceIPAddress": "AWS Internal", "userAgent": "AWS Internal", "userIdentity": {"accessKeyId": "ASIA57JLR4M2ZZDJUXY3", "accountId": "123123123123", "arn": "arn:aws:sts::123123123123:assumed-role/MakeStuffPublic", "principalId": "AROA57JLR4M2SBAPVC4BO", "sessionContext": {"attributes": {"creationDate": "2022-11-15T22:38:17Z", "mfaAuthenticated": "true"}, "sessionIssuer": {"accountId": "123123123123", "arn": "arn:aws:iam::123123123123:role/MakeStuffPublic", "principalId": "AROA57JLR4M2SBAPVC4BO", "type": "Role", "userName": "MakeStuffPublic"}, "webIdFederationData": {}}, "type": "AssumedRole"}}
	[PASS] ModifyTrafficMirrorSession
		[PASS] [rule] true
		[PASS] [title] arn:aws:sts::123123123123:assumed-role/MakeStuffPublic ec2 activity found for ModifyTrafficMirrorSession in account 123123123123 in region us-east-1.
		[PASS] [dedup] arn:aws:sts::123123123123:assumed-role/MakeStuffPublic
		[PASS] [alertContext] {"eventName": "ModifyTrafficMirrorSession", "eventSource": "ec2.amazonaws.com", "awsRegion": "us-east-1", "recipientAccountId": "123123123123", "sourceIPAddress": "AWS Internal", "userAgent": "AWS Internal", "userIdentity": {"accessKeyId": "ASIA57JLR4M2ZZDJUXY3", "accountId": "123123123", "arn": "arn:aws:sts::123123123123:assumed-role/MakeStuffPublic", "principalId": "AROA57JLR4M2SBAPVC4BO", "sessionContext": {"attributes": {"creationDate": "2022-11-15T22:38:17Z", "mfaAuthenticated": "true"}, "sessionIssuer": {"accountId": "123123123123", "arn": "arn:aws:iam::123123123123:role/MakeStuffPublic", "principalId": "AROA57JLR4M2SBAPVC4BO", "type": "Role", "userName": "MakeStuffPublic"}, "webIdFederationData": {}}, "type": "AssumedRole"}}
	[PASS] UnrelatedEvent
		[PASS] [rule] false
	[PASS] AWS Config Runs DescribeTrafficMirrorTargets
		[PASS] [rule] false

--------------------------
Panther CLI Test Summary
	Path: .
	Passed: 1
	Failed: 0
	Invalid: 0



```
