### PR TITLE
Bump PAT version to 0.19.6

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ click = "~=8.1"
 decorator = "~=5.1"
 isort = "~=5.10.0"
 mypy = "~=0.950"
-panther-analysis-tool = "~=0.19.5"
+panther-analysis-tool = "~=0.19.6"
 pylint = "~=2.15.0"
 pylint-print = "~=1.0.0"
 


### PR DESCRIPTION
### Background

Relates to https://github.com/panther-labs/panther_analysis_tool/releases/tag/v0.19.6

### Changes

* Bumps `panther-analysis-tool` requirement to `0.19.6`

### Testing

* `make install` and `make test` succeed locally
