### PR TITLE
Update Pipefile.lock for PAT 0.19.6

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b950524d820a55615e5198b4482f5ce175f54a2f40cf4ca71de5dd90d09c55a7"
+            "sha256": "7514015f97aaa99fa8f6a59c4be753888a5a9c33fb6c4fd527833adfa4999e0e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -313,19 +313,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:9a0a29179957cb26fa8c3c1fddf66b18efaeaf633e08db5fb53815ffb0421419",
-                "sha256:eb8cde24a4c5755c35126e8cd460e6b51c63d04292419e7e95721232720c7e5b"
+                "sha256:98efcc8472c58060856bf42e9afe10eefb60c0e52680db0a43daf96e7a1216de",
+                "sha256:bd92def38355ea055c6c29bd599832878eecc19cad21dab34ade38280e1b403b"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.26.69"
+            "version": "==1.26.73"
         },
         "botocore": {
             "hashes": [
-                "sha256:2a4ab8bcb3177daa425019e125c09996b9a6a1a62bb0baaaeeb86ffd552719cc",
-                "sha256:7e1bebca013544fbc298cb58603bfccd5f71b49c720a5c33c07cf5dfc8145a1f"
+                "sha256:a9f0e006b3342424d59d5e23dc1ca0c6972c909a727dcd0811c9b20966d4adf8",
+                "sha256:df467573a96d2e1ba1196b5a30b0a5e4a83fd960d27b5c2f8f128c9148dc120e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.29.69"
+            "version": "==1.29.73"
         },
         "certifi": {
             "hashes": [
@@ -559,11 +559,11 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:769c2d83e13f5d938b7688479da374c4e3d49f71549aaf462b646db9602ea6f8",
-                "sha256:cd455b0000615c60e286208ba540271af9fe531fa6a87cc590a7298785ab2882"
+                "sha256:8ce3bcf69adfdf7c7d503e78fd3b1c492af782d58893b650adb2ac8912ddd573",
+                "sha256:f04893614f6aa713a60cbbe1e6a97403ef633103cdd0ef5eb6efe0deb98dbe8d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.30"
+            "version": "==3.1.31"
         },
         "gql": {
             "hashes": [
@@ -796,16 +796,16 @@
         },
         "panther-analysis-tool": {
             "hashes": [
-                "sha256:727e7a13b57cb284445c228918b57af0398cb9dfb5ab0450ba9d9047383818c4"
+                "sha256:73377f551b00f6bc08552ad1253f03f25e4373eb20a4443ac74ff390cef3fcc6"
             ],
             "index": "pypi",
-            "version": "==0.19.5"
+            "version": "==0.19.6"
         },
         "panther-core": {
             "hashes": [
-                "sha256:a8f15c235c7fe2f2a8d09a71650333307ec974a3530e35e28d1f848b924c5952"
+                "sha256:01a4d743cacd1b4ec07bef399b8bf2b16d7c8f3b717b3cc80e1a3eda59dff5f1"
             ],
-            "version": "==0.4.8"
+            "version": "==0.4.9"
         },
         "pathspec": {
             "hashes": [
@@ -1029,11 +1029,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
-                "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
+                "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+                "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"
             ],
             "markers": "python_version < '3.10'",
-            "version": "==4.4.0"
+            "version": "==4.5.0"
         },
         "urllib3": {
             "hashes": [


### PR DESCRIPTION
### Background

`Pipfile.lock` needed to updated in #684

### Changes

* Updated `Pipfile.lock` via `pipenv install --dev panther-analysis-tool`

### Testing

```sh
$ source /Users/evangibler/.local/share/virtualenvs/panther-analysis-xBQFy9Wh/bin/activate.fish
$ panther_analysis_tool --version
panther_analysis_tool 0.19.6
```