### PR TITLE
Refactor: slack_user_privilege_escalation

### DIFF
--- a/rules/slack_rules/slack_user_privilege_escalation.py
+++ b/rules/slack_rules/slack_user_privilege_escalation.py
@@ -23,10 +23,10 @@ def title(event):
         return f"Slack User, {username} ({email}), assigned permissions"
 
     if event.get("action") == "role_change_to_admin":
-        return f"Slack User {username} ({email}) promoted to admin"
+        return f"Slack User, {username} ({email}), promoted to admin"
 
     if event.get("action") == "role_change_to_owner":
-        return f"Slack User {username} ({email}) promoted to Owner"
+        return f"Slack User, {username} ({email}), promoted to Owner"
 
     return "Slack User Privilege Escalation event {event.get('action')} on {username} ({email})"
 

--- a/rules/slack_rules/slack_user_privilege_escalation.py
+++ b/rules/slack_rules/slack_user_privilege_escalation.py
@@ -34,12 +34,8 @@ def title(event):
 def severity(event):
     # Downgrade severity for users assigned permissions
     if event.get("action") == "permissions_assigned":
-       return "Medium"
-    if (
-        event.get("action") == "role_change_to_admin"
-        or "role_change_to_owner"
-        or "owner_transferred"
-    ):
+        return "Medium"
+    if event.get("action") == "role_change_to_admin" or "role_change_to_owner":
         return "Critical"
     return "High"
 

--- a/rules/slack_rules/slack_user_privilege_escalation.py
+++ b/rules/slack_rules/slack_user_privilege_escalation.py
@@ -35,7 +35,11 @@ def severity(event):
     # Downgrade severity for users assigned permissions
     if event.get("action") == "permissions_assigned":
         return "Medium"
-    if event.get("action") == "role_change_to_admin" or "role_change_to_owner":
+    if event.get("action") == "role_change_to_admin":
+        return "Critical"
+    if event.get("action") == "role_change_to_owner":
+        return "Critical"
+    if event.get("action") == "owner_transferred":
         return "Critical"
     return "High"
 

--- a/rules/slack_rules/slack_user_privilege_escalation.py
+++ b/rules/slack_rules/slack_user_privilege_escalation.py
@@ -23,25 +23,19 @@ def title(event):
         return f"Slack User, {username} ({email}), assigned permissions"
 
     if event.get("action") == "role_change_to_admin":
-        return f"{username} ({email}) promoted to admin"
+        return f"Slack User {username} ({email}) promoted to admin"
 
     if event.get("action") == "role_change_to_owner":
-        return f"{username} ({email}) promoted to Owner"
+        return f"Slack User {username} ({email}) promoted to Owner"
 
-    return "Slack User Privilege Escalation"
+    return "Slack User Privilege Escalation event {event.get('action')} on {username} ({email})"
 
 
 def severity(event):
     # Downgrade severity for users assigned permissions
     if event.get("action") == "permissions_assigned":
         return "Medium"
-    if event.get("action") == "role_change_to_admin":
-        return "Critical"
-    if event.get("action") == "role_change_to_owner":
-        return "Critical"
-    if event.get("action") == "owner_transferred":
-        return "Critical"
-    return "High"
+    return "Critical"
 
 
 def alert_context(event):

--- a/rules/slack_rules/slack_user_privilege_escalation.py
+++ b/rules/slack_rules/slack_user_privilege_escalation.py
@@ -28,7 +28,7 @@ def title(event):
     if event.get("action") == "role_change_to_owner":
         return f"Slack User, {username} ({email}), promoted to Owner"
 
-    return "Slack User Privilege Escalation event {event.get('action')} on {username} ({email})"
+    return f"Slack User Privilege Escalation event {event.get('action')} on {username} ({email})"
 
 
 def severity(event):

--- a/rules/slack_rules/slack_user_privilege_escalation.yml
+++ b/rules/slack_rules/slack_user_privilege_escalation.yml
@@ -8,7 +8,7 @@ LogTypes:
 Tags:
   - Slack
 Severity: High
-Description: Detects when a Slack App has had its permission scopes expanded
+Description: Detects when a Slack user gains escalated privileges
 Reference: https://api.slack.com/admins/audit-logs
 DedupPeriodMinutes: 60
 Threshold:  1


### PR DESCRIPTION
### Background

When looking for an example detection I noticed that the description for slack_user_privilege_escalation was inaccurate. This PR fixes that along with making the titles more expressive. 

Also fixes a TODO item which elevates the severity level if admin/owner permissions is granted or ownership is transferred/granted to a critical severity. 

### Changes

* Fixes description of the detection 
* Makes titles more expressive passing the affected user. 
* Increases severity to critical if admin/owner is granted or ownership is transferred/grante.

### Testing

```
Slack.AuditLogs.UserPrivilegeEscalation
	[PASS] Owner Transferred
		[PASS] [rule] true
		[PASS] [title] Slack Owner Transferred from username (user@example.com)
		[PASS] [dedup] Slack Owner Transferred from username (user@example.com)
		[PASS] [alertContext] {"actor-name": "username", "actor-email": "user@example.com", "actor-ip": "1.2.3.4", "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"}
		[PASS] [severity] CRITICAL
	[PASS] Permissions Assigned
		[PASS] [rule] true
		[PASS] [title] Slack User, username (user@example.com), assigned permissions
		[PASS] [dedup] Slack User, username (user@example.com), assigned permissions
		[PASS] [alertContext] {"actor-name": "username", "actor-email": "user@example.com", "actor-ip": "1.2.3.4", "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"}
		[PASS] [severity] MEDIUM
	[PASS] Role Changed to Admin
		[PASS] [rule] true
		[PASS] [title] username (user@example.com) promoted to admin
		[PASS] [dedup] username (user@example.com) promoted to admin
		[PASS] [alertContext] {"actor-name": "username", "actor-email": "user@example.com", "actor-ip": "1.2.3.4", "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"}
		[PASS] [severity] CRITICAL
	[PASS] Role Changed to Owner
		[PASS] [rule] true
		[PASS] [title] username (user@example.com) promoted to Owner
		[PASS] [dedup] username (user@example.com) promoted to Owner
		[PASS] [alertContext] {"actor-name": "username", "actor-email": "user@example.com", "actor-ip": "1.2.3.4", "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"}
		[PASS] [severity] CRITICAL
	[PASS] User Logout
		[PASS] [rule] false

--------------------------
Panther CLI Test Summary
	Path: rules/slack_rules
	Passed: 21
	Failed: 0
	Invalid: 0
```
