### PR TITLE
Add Dropbox Team Member Linked App Rule

### DIFF
--- a/rules/dropbox_rules/dropbox_linked_team_application_added.py
+++ b/rules/dropbox_rules/dropbox_linked_team_application_added.py
@@ -1,0 +1,56 @@
+from panther_base_helpers import deep_get
+
+
+def rule(event):
+    return all(
+        [
+            deep_get(event, "event_type", "_tag", default="") == "app_link_team",
+            deep_get(event, "event_type", "description", default="") == "Linked app for team",
+            ]
+    )
+
+
+def severity(event):
+    # Anything involving non-team members should be High
+    if event.get("involve_non_team_member", False):
+        return "High"
+    return "Low"
+
+
+def title(event):
+    # This will either be "user" or "admin"; find the intersection and use that for the key
+    actor_key = set(tuple(event.get("actor", {}).keys())).intersection(("user", "admin"))
+    if len(actor_key) == 1:
+        display_name = deep_get(event, "actor", tuple(actor_key)[0], "display_name", default="<Unknown>")
+    # Explicitly use "<Unknown>" if we find any length of keys != 1
+    else:
+        display_name = "<Unknown>"
+    return f"Dropbox Team Member Linked App by [{display_name}]"
+
+
+def user_details(event):
+    details = {}
+    for actor_key, actor_value in event.get("actor", {}).items():
+        if actor_key == "_tag":
+            continue
+        for user_key, user_info in actor_value.items():
+            if user_key in ("_tag", "display_name"):
+                continue
+            details[user_key] = user_info
+    return details
+
+
+def alert_context(event):
+    additional_user_details = user_details(event)
+    return {
+        "additional_user_details": additional_user_details,
+        "app_display_name": deep_get(
+            event, "details", "app_info", "display_name", default="<Unknown app display name>"
+        ),
+        "ip_address": deep_get(
+            event, "origin", "geo_location", "ip_address", default="<Unknown IP address>"
+        ),
+        "request_id": deep_get(
+            event, "origin", "access_method", "request_id", default="<Unknown request ID>"
+        ),
+    }

--- a/rules/dropbox_rules/dropbox_linked_team_application_added.py
+++ b/rules/dropbox_rules/dropbox_linked_team_application_added.py
@@ -21,7 +21,8 @@ def title(event):
     # This will either be "user" or "admin"; find the intersection and use that for the key
     actor_key = set(tuple(event.get("actor", {}).keys())).intersection(("user", "admin"))
     if len(actor_key) == 1:
-        display_name = deep_get(event, "actor", tuple(actor_key)[0], "display_name", default="<Unknown>")
+        display_name = deep_get(event, "actor", tuple(actor_key)[0],
+                                "display_name", default="<Unknown>")
     # Explicitly use "<Unknown>" if we find any length of keys != 1
     else:
         display_name = "<Unknown>"

--- a/rules/dropbox_rules/dropbox_linked_team_application_added.py
+++ b/rules/dropbox_rules/dropbox_linked_team_application_added.py
@@ -17,9 +17,27 @@ def severity(event):
     return "Low"
 
 
+def get_actor_type():
+    return (
+        # Admin who performed the action
+        "admin",
+        # Anonymous actor
+        "anonymous",
+        # Application that performed the action
+        "app"
+        # Action performed by Dropbox
+        "dropbox",
+        # Action performed by reseller
+        "reseller",
+        # User who performed the action
+        "user",
+    )
+
+
 def title(event):
-    # This will either be "user" or "admin"; find the intersection and use that for the key
-    actor_key = set(tuple(event.get("actor", {}).keys())).intersection(("user", "admin"))
+    # This will be one of the types returned by get_actor_type;
+    # find the intersection and use that for the key
+    actor_key = set(tuple(event.get("actor", {}).keys())).intersection(get_actor_type())
     if len(actor_key) == 1:
         display_name = deep_get(
             event, "actor", tuple(actor_key)[0], "display_name", default="<Unknown>"

--- a/rules/dropbox_rules/dropbox_linked_team_application_added.py
+++ b/rules/dropbox_rules/dropbox_linked_team_application_added.py
@@ -6,7 +6,7 @@ def rule(event):
         [
             deep_get(event, "event_type", "_tag", default="") == "app_link_team",
             deep_get(event, "event_type", "description", default="") == "Linked app for team",
-            ]
+        ]
     )
 
 
@@ -21,8 +21,9 @@ def title(event):
     # This will either be "user" or "admin"; find the intersection and use that for the key
     actor_key = set(tuple(event.get("actor", {}).keys())).intersection(("user", "admin"))
     if len(actor_key) == 1:
-        display_name = deep_get(event, "actor", tuple(actor_key)[0],
-                                "display_name", default="<Unknown>")
+        display_name = deep_get(
+            event, "actor", tuple(actor_key)[0], "display_name", default="<Unknown>"
+        )
     # Explicitly use "<Unknown>" if we find any length of keys != 1
     else:
         display_name = "<Unknown>"

--- a/rules/dropbox_rules/dropbox_linked_team_application_added.py
+++ b/rules/dropbox_rules/dropbox_linked_team_application_added.py
@@ -24,7 +24,7 @@ def get_actor_type():
         # Anonymous actor
         "anonymous",
         # Application that performed the action
-        "app"
+        "app",
         # Action performed by Dropbox
         "dropbox",
         # Action performed by reseller

--- a/rules/dropbox_rules/dropbox_linked_team_application_added.yml
+++ b/rules/dropbox_rules/dropbox_linked_team_application_added.yml
@@ -1,0 +1,123 @@
+AnalysisType: rule
+Description: An application was linked to your Dropbox Account
+DisplayName: Dropbox Linked Team Application Added
+Enabled: true
+Filename: dropbox_linked_team_application_added.py
+Reference: Ensure that the application is valid and not malicious
+Runbook: >
+  Verify that this is expected. If not, determine other actions taken by this user recently and reach out to the user.
+  If the event involved a non-team member, consider disabling the user's access while investigating.
+Severity: Low
+Tags:
+    - dropbox
+Tests:
+    - ExpectedResult: true
+      Log:
+        actor:
+            _tag: user
+            user:
+                _tag: team_member
+                account_id: dbid:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                display_name: user_name
+                email: user@domain.com
+                team_member_id: dbmid:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        context:
+            _tag: team
+        details:
+            .tag: app_link_team_details
+            app_info:
+                .tag: team_linked_app
+                app_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                display_name: dropbox-app-name
+        event_category:
+            _tag: apps
+        event_type:
+            _tag: app_link_team
+            description: Linked app for team
+        involve_non_team_member: false
+        origin:
+            access_method:
+                .tag: api
+                request_id: dbarod:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            geo_location:
+                city: Los Angeles
+                country: US
+                ip_address: 1.2.3.4
+                region: California
+        timestamp: "2023-02-16 20:39:34"
+      Name: App linked for team is LOW severity
+    - ExpectedResult: false
+      Log:
+        actor:
+            _tag: user
+            user:
+                _tag: team_member
+                account_id: dbid:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                display_name: user_name
+                email: user@domain.com
+                team_member_id: dbmid:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        context:
+            _tag: team
+        details:
+            .tag: app_link_member_details
+            app_info:
+                .tag: member_linked_app
+                app_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                display_name: personal-dropbox-app-name
+        event_category:
+            _tag: apps
+        event_type:
+            _tag: app_link_member
+            description: Linked app for member
+        involve_non_team_member: false
+        origin:
+            access_method:
+                .tag: api
+                request_id: dbarod:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            geo_location:
+                city: Los Angeles
+                country: US
+                ip_address: 1.2.3.4
+                region: California
+        timestamp: "2023-02-16 20:39:34"
+      Name: A non-team linked event does not alert
+    - ExpectedResult: true
+      Log:
+        actor:
+            _tag: user
+            user:
+                _tag: team_member
+                account_id: dbid:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                display_name: user_name
+                email: user@domain.com
+                team_member_id: dbmid:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        context:
+            _tag: team
+        details:
+            .tag: app_link_team_details
+            app_info:
+                .tag: team_linked_app
+                app_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                display_name: dropbox-app-name
+        event_category:
+            _tag: apps
+        event_type:
+            _tag: app_link_team
+            description: Linked app for team
+        involve_non_team_member: true
+        origin:
+            access_method:
+                .tag: api
+                request_id: dbarod:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            geo_location:
+                city: Los Angeles
+                country: US
+                ip_address: 1.2.3.4
+                region: California
+        timestamp: "2023-02-16 20:39:34"
+      Name: App linked for team involving non-team member is HIGH severity
+DedupPeriodMinutes: 60
+LogTypes:
+    - Dropbox.TeamEvent
+RuleID: Dropbox.Linked.Team.Application.Added
+Threshold: 1


### PR DESCRIPTION
### Background

This is an initial `Dropbox.TeamEvent` rule, specifically for an app being linked to a team.

The rule looks for:
- an `event_type` of `app_link_team`
- an `event_description` of `Linked app for team`

The base alert severity is `LOW`, though `HIGH` is returned if a non-team member is involved.

### Changes

* Adds a `Dropbox.Linked.Team.Application.Added` rule
* Adds three accompanying tests:
  * Positive test case for `LOW` severity
  * Positive test case for `HIGH` severity
  * Negative test case

### Testing

```sh
Dropbox.Linked.Team.Application.Added
	[PASS] Test-5f682
		[PASS] [rule] true
		[PASS] [title] Dropbox Team Member Linked App by [user_name]
		[PASS] [dedup] Dropbox Team Member Linked App by [user_name]
		[PASS] [alertContext] {"additional_user_details": {"account_id": "dbid:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "email": "user@domain.com", "team_member_id": "dbmid:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}, "app_display_name": "dropbox-app-name", "ip_address": "1.2.3.4", "request_id": "dbarod:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
		[PASS] [severity] LOW
	[PASS] Test-d22a96
		[PASS] [rule] false
	[PASS] Test-e3dc75
		[PASS] [rule] true
		[PASS] [title] Dropbox Team Member Linked App by [user_name]
		[PASS] [dedup] Dropbox Team Member Linked App by [user_name]
		[PASS] [alertContext] {"additional_user_details": {"account_id": "dbid:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "email": "user@domain.com", "team_member_id": "dbmid:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}, "app_display_name": "dropbox-app-name", "ip_address": "1.2.3.4", "request_id": "dbarod:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
		[PASS] [severity] HIGH
```
