### PR TITLE
feat: logtype global filter for cloudflare events

### DIFF
--- a/global_helpers/global_filter_cloudflare.py
+++ b/global_helpers/global_filter_cloudflare.py
@@ -1,0 +1,18 @@
+from panther_base_helpers import deep_get  # pylint: disable=unused-import
+
+
+def filter_include_event(event) -> bool:  # pylint: disable=unused-argument
+    """
+    filter_include_event provides a global include filter for all cloudflare detections
+    Panther will not update this filter, and you can edit it without creating
+    merge conflicts in the future.
+
+    return True to include events, and False to exclude events
+    """
+    # This commented-out example would have the effect of
+    #   "only include events if ClientRequestHost contains www.example.com"
+    # if "www.example.com" in event.get("ClientRequestHost", ""):
+    #     return True
+    # return False
+    #
+    return True

--- a/global_helpers/global_filter_cloudflare.yml
+++ b/global_helpers/global_filter_cloudflare.yml
@@ -1,0 +1,12 @@
+AnalysisType: global
+Filename: global_filter_cloudflare.py
+GlobalID: global_filter_cloudflare
+Description: >
+  This module provides two filters that can apply to all cloudflare detections. 
+  The two functions in this module are included in every cloudflare detection, and 
+  define if we should include or exclude events. By default, all events are passed
+  through the filters. 
+
+  You can change the definition of these filters to work in your own environment. 
+  Panther will not change the definition of these, and should not create 
+  merge conflicts.

--- a/packs/cloudflare.yml
+++ b/packs/cloudflare.yml
@@ -12,4 +12,5 @@ PackDefinition:
     - Cloudflare.HttpRequest.BotHighVolumeGreyNoise
     # Globals used in these rules/policies
     - panther_cloudflare_helpers
+    - global_filter_cloudflare
     - panther_greynoise_helpers

--- a/rules/cloudflare_rules/cloudflare_firewall_ddos.py
+++ b/rules/cloudflare_rules/cloudflare_firewall_ddos.py
@@ -1,7 +1,10 @@
+from global_filter_cloudflare import filter_include_event
 from panther_cloudflare_helpers import cloudflare_fw_alert_context
 
 
 def rule(event):
+    if not filter_include_event(event):
+        return False
     return event.get("Source", "") == "l7ddos"
 
 

--- a/rules/cloudflare_rules/cloudflare_firewall_ddos.yml
+++ b/rules/cloudflare_rules/cloudflare_firewall_ddos.yml
@@ -112,4 +112,38 @@ Tests:
         "RuleID": "e35c9a670b864a3ba0203ffb1bc977d1",
         "Source": "firewallmanaged",
       }
-
+  -
+    Name: Traffic Marked as L7DDoS but blocked ( INFO level alert ) WITH FILTER
+    ExpectedResult: false
+    Mocks:
+      - objectName: filter_include_event
+        returnValue: False
+    Log:
+      {
+        "Action": "block",
+        "ClientASN": 55836,
+        "ClientASNDescription": "RELIANCEJIO-IN Reliance Jio Infocomm Limited",
+        "ClientCountry": "in",
+        "ClientIP": "127.0.0.1",
+        "ClientRequestHost": "example.com",
+        "ClientRequestMethod": "GET",
+        "ClientRequestPath": "/main.php",
+        "ClientRequestProtocol": "HTTP/1.1",
+        "ClientRequestQuery": "",
+        "ClientRequestScheme": "http",
+        "ClientRequestUserAgent": "Fuzz Faster U Fool v1.3.1-dev",
+        "Datetime": "2022-05-10 06:36:57",
+        "EdgeColoCode": "DEL",
+        "EdgeResponseStatus": 403,
+        "Kind": "firewall",
+        "MatchIndex": 0,
+        "Metadata": {
+          "dos-source": "dosd-edge"
+        },
+        "OriginResponseStatus": 0,
+        "OriginatorRayID": "00",
+        "RayID": "7090a9da88e333d8",
+        "RuleID": "ed651449c4a54f4b99c6e3bf863134d5",
+        "Source": "l7ddos",
+      }
+ 

--- a/rules/cloudflare_rules/cloudflare_firewall_high_volume_events_blocked.py
+++ b/rules/cloudflare_rules/cloudflare_firewall_high_volume_events_blocked.py
@@ -1,7 +1,10 @@
+from global_filter_cloudflare import filter_include_event
 from panther_cloudflare_helpers import cloudflare_fw_alert_context
 
 
 def rule(event):
+    if not filter_include_event(event):
+        return False
     return event.get("Action", "") == "block"
 
 

--- a/rules/cloudflare_rules/cloudflare_firewall_high_volume_events_blocked_greynoise.py
+++ b/rules/cloudflare_rules/cloudflare_firewall_high_volume_events_blocked_greynoise.py
@@ -1,10 +1,13 @@
 from ipaddress import ip_address
 
+from global_filter_cloudflare import filter_include_event
 from panther_cloudflare_helpers import cloudflare_fw_alert_context
 from panther_greynoise_helpers import GetGreyNoiseObject, GetGreyNoiseRiotObject
 
 
 def rule(event):
+    if not filter_include_event(event):
+        return False
     if event.get("Action") != "block":
         return False
 

--- a/rules/cloudflare_rules/cloudflare_firewall_suspicious_event_greynoise.py
+++ b/rules/cloudflare_rules/cloudflare_firewall_suspicious_event_greynoise.py
@@ -1,10 +1,13 @@
 from ipaddress import ip_address
 
+from global_filter_cloudflare import filter_include_event
 from panther_cloudflare_helpers import cloudflare_fw_alert_context
 from panther_greynoise_helpers import GetGreyNoiseObject, GetGreyNoiseRiotObject
 
 
 def rule(event):
+    if not filter_include_event(event):
+        return False
     if event.get("Action") == "block":
         return False
     # Validate the IP is actually an IP

--- a/rules/cloudflare_rules/cloudflare_httpreq_bot_high_volume.py
+++ b/rules/cloudflare_rules/cloudflare_httpreq_bot_high_volume.py
@@ -1,7 +1,14 @@
+from unittest.mock import MagicMock
+
+from global_filter_cloudflare import filter_include_event
 from panther_cloudflare_helpers import cloudflare_http_alert_context
 
 
 def rule(event):
+    if isinstance(filter_include_event, MagicMock):
+        pass
+    if not filter_include_event(event):
+        return False
     # Bot scores are [0, 99] where scores >0 && <30 indicating likely automated
     # https://developers.cloudflare.com/bots/concepts/bot-score/
     return all(

--- a/rules/cloudflare_rules/cloudflare_httpreq_bot_high_volume_greynoise.py
+++ b/rules/cloudflare_rules/cloudflare_httpreq_bot_high_volume_greynoise.py
@@ -1,10 +1,13 @@
 from ipaddress import ip_address
 
+from global_filter_cloudflare import filter_include_event
 from panther_cloudflare_helpers import cloudflare_http_alert_context
 from panther_greynoise_helpers import GetGreyNoiseObject, GetGreyNoiseRiotObject
 
 
 def rule(event):
+    if not filter_include_event(event):
+        return False
     # Bot scores are [0, 99] where scores >=1 && <30 indicating likely automated
     # https://developers.cloudflare.com/bots/concepts/bot-score/
     if not all(

--- a/rules/crowdstrike_rules/crowdstrike_detection_passthrough.py
+++ b/rules/crowdstrike_rules/crowdstrike_detection_passthrough.py
@@ -1,4 +1,7 @@
-from panther_base_helpers import crowdstrike_detection_alert_context, get_crowdstrike_field
+from panther_base_helpers import (
+    crowdstrike_detection_alert_context,
+    get_crowdstrike_field,
+)
 
 
 def rule(event):

--- a/rules/crowdstrike_rules/crowdstrike_dns_request.py
+++ b/rules/crowdstrike_rules/crowdstrike_dns_request.py
@@ -1,4 +1,7 @@
-from panther_base_helpers import get_crowdstrike_field, filter_crowdstrike_fdr_event_type
+from panther_base_helpers import (
+    filter_crowdstrike_fdr_event_type,
+    get_crowdstrike_field,
+)
 
 # baddomain.com is present for testing purposes. Add domains you wish to be alerted on to this list
 DENYLIST = ["baddomain.com"]


### PR DESCRIPTION
### Background

This PR introduces a global filter function for cloudflare events which users can modify to incorporate the local considerations for which events to include and exclude for rule processing.  I believe this approach of establishing a single module that includes a single filtering function incorporated into all detections for a given LogType will provide a way for users to define include/exclude filters for detections without also needing to consider the implications of future merge conflicts. 


I added a test case on rules/cloudflare_rules/cloudflare_firewall_ddos.yml called `Traffic Marked as L7DDoS but blocked ( INFO level alert ) WITH FILTER` which demonstrates the effect of a customer giving a custom definition to the global filter.  There is no special unittest case handling needed because this test case mocks out a `bool` return value

### Changes

* adds global_filter_cloudflare file in global-helpers
* incorporates the `filter_include_event` function into all cloudflare detections.
* added additional test case and Mock for `filter_include_event` to `Cloudflare.Firewall.L7DDoS` to demonstrate the effect of providing a custom definition to the filter. 
* Extend cloudflare pack to include this new module
* **Note: I did not identify any CloudFlare detections do not appear in other packs**

### Testing

```shell
(panther-analysis) user@computer:~/Sources/PAN/panther-analysis $ pipenv run panther_analysis_tool test --filter RuleID=Cloudflare.Firewall.L7DDoS
[INFO]: Testing analysis items in .

Cloudflare.Firewall.L7DDoS
        [PASS] Traffic Marked as L7DDoS
                [PASS] [rule] true
                [PASS] [title] Cloudflare: Detected L7 DDoSfrom [127.0.0.1] to [example.com] and took action [skip]
                [PASS] [dedup] Cloudflare: Detected L7 DDoSfrom [127.0.0.1] to [example.com] and took action [skip]
                [PASS] [alertContext] {"Action": "skip", "ClientIP": "127.0.0.1", "ClientRequestHost": "example.com", "Datetime": "2022-05-10 06:36:57", "EdgeColoCode": "DEL", "EdgeResponseStatus": 403, "Kind": "firewall", "RuleID": "ed651449c4a54f4b99c6e3bf863134d5", "Source": "l7ddos", "pan_cf_source": "L7 DDoS"}
                [PASS] [severity] MEDIUM
        [PASS] Traffic Marked as L7DDoS but blocked ( INFO level alert )
                [PASS] [rule] true
                [PASS] [title] Cloudflare: Detected L7 DDoSfrom [127.0.0.1] to [example.com] and took action [block]
                [PASS] [dedup] Cloudflare: Detected L7 DDoSfrom [127.0.0.1] to [example.com] and took action [block]
                [PASS] [alertContext] {"Action": "block", "ClientIP": "127.0.0.1", "ClientRequestHost": "example.com", "Datetime": "2022-05-10 06:36:57", "EdgeColoCode": "DEL", "EdgeResponseStatus": 403, "Kind": "firewall", "RuleID": "ed651449c4a54f4b99c6e3bf863134d5", "Source": "l7ddos", "pan_cf_source": "L7 DDoS"}
                [PASS] [severity] INFO
        [PASS] Traffic Not Marked as L7DDoS
                [PASS] [rule] false
        [PASS] Traffic Marked as L7DDoS but blocked ( INFO level alert ) WITH FILTER
                [PASS] [rule] false

--------------------------
Panther CLI Test Summary
        Path: .
        Passed: 1
        Failed: 0
        Invalid: 0
```
