### PR TITLE
fix: let panther_default global helper use its file name for IDE happiness

### DIFF
--- a/global_helpers/panther_default.py
+++ b/global_helpers/panther_default.py
@@ -2,7 +2,7 @@
 #
 # Example usage:
 #
-# import panther
+# import panther_default
 # def policy(resource):
 #     return panther.example_helper()
 #

--- a/global_helpers/panther_default.yml
+++ b/global_helpers/panther_default.yml
@@ -1,4 +1,4 @@
 AnalysisType: global
-GlobalID: panther
+GlobalID: panther_default
 Filename: panther_default.py
 Description: The default global accessible via the Panther web UI.

--- a/packs/aws.yml
+++ b/packs/aws.yml
@@ -139,4 +139,4 @@ PackDefinition:
     - panther_base_helpers
     - panther_event_type_helpers
     - panther_oss_helpers
-    - panther
+    - panther_default

--- a/packs/standard_ruleset.yml
+++ b/packs/standard_ruleset.yml
@@ -27,4 +27,4 @@ PackDefinition:
     # Global Helpers
     - panther_event_type_helpers
     - panther_oss_helpers
-    - panther
+    - panther_default

--- a/rules/aws_cloudtrail_rules/aws_ami_modified_for_public_access.py
+++ b/rules/aws_cloudtrail_rules/aws_ami_modified_for_public_access.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
 
 

--- a/rules/aws_cloudtrail_rules/aws_cloudtrail_created.py
+++ b/rules/aws_cloudtrail_rules/aws_cloudtrail_created.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
 
 # API calls that are indicative of CloudTrail changes

--- a/rules/aws_cloudtrail_rules/aws_cloudtrail_stopped.py
+++ b/rules/aws_cloudtrail_rules/aws_cloudtrail_stopped.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success, lookup_aws_account_name
+from panther_default import aws_cloudtrail_success, lookup_aws_account_name
 from panther_base_helpers import aws_rule_context, deep_get
 
 # API calls that are indicative of CloudTrail changes

--- a/rules/aws_cloudtrail_rules/aws_codebuild_made_public.py
+++ b/rules/aws_cloudtrail_rules/aws_codebuild_made_public.py
@@ -1,4 +1,4 @@
-from panther import lookup_aws_account_name
+from panther_default import lookup_aws_account_name
 from panther_base_helpers import aws_rule_context, deep_get
 
 

--- a/rules/aws_cloudtrail_rules/aws_config_service_created.py
+++ b/rules/aws_cloudtrail_rules/aws_config_service_created.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
 
 # API calls that are indicative of an AWS Config Service change

--- a/rules/aws_cloudtrail_rules/aws_config_service_disabled_deleted.py
+++ b/rules/aws_cloudtrail_rules/aws_config_service_disabled_deleted.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
 
 # API calls that are indicative of an AWS Config Service change

--- a/rules/aws_cloudtrail_rules/aws_console_login_failed.py
+++ b/rules/aws_cloudtrail_rules/aws_console_login_failed.py
@@ -1,4 +1,4 @@
-from panther import lookup_aws_account_name
+from panther_default import lookup_aws_account_name
 from panther_base_helpers import aws_rule_context, deep_get
 
 

--- a/rules/aws_cloudtrail_rules/aws_console_login_without_mfa.py
+++ b/rules/aws_cloudtrail_rules/aws_console_login_without_mfa.py
@@ -1,6 +1,6 @@
 import logging
 
-from panther import lookup_aws_account_name
+from panther_default import lookup_aws_account_name
 from panther_base_helpers import aws_rule_context, deep_get
 from panther_oss_helpers import check_account_age
 

--- a/rules/aws_cloudtrail_rules/aws_console_login_without_saml.py
+++ b/rules/aws_cloudtrail_rules/aws_console_login_without_saml.py
@@ -1,4 +1,4 @@
-from panther import lookup_aws_account_name
+from panther_default import lookup_aws_account_name
 from panther_base_helpers import aws_rule_context, deep_get
 
 

--- a/rules/aws_cloudtrail_rules/aws_console_root_login.py
+++ b/rules/aws_cloudtrail_rules/aws_console_root_login.py
@@ -1,4 +1,4 @@
-from panther import lookup_aws_account_name
+from panther_default import lookup_aws_account_name
 from panther_base_helpers import deep_get
 from panther_oss_helpers import geoinfo_from_ip_formatted
 

--- a/rules/aws_cloudtrail_rules/aws_console_root_login_failed.py
+++ b/rules/aws_cloudtrail_rules/aws_console_root_login_failed.py
@@ -1,4 +1,4 @@
-from panther import lookup_aws_account_name
+from panther_default import lookup_aws_account_name
 from panther_base_helpers import aws_rule_context, deep_get
 
 

--- a/rules/aws_cloudtrail_rules/aws_ec2_gateway_modified.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_gateway_modified.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
 
 # API calls that are indicative of an EC2 Network Gateway modification

--- a/rules/aws_cloudtrail_rules/aws_ec2_manual_security_group_changes.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_manual_security_group_changes.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get, pattern_match_list
 
 PROD_ACCOUNT_IDS = {"11111111111111", "112233445566"}

--- a/rules/aws_cloudtrail_rules/aws_ec2_network_acl_modified.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_network_acl_modified.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
 
 # API calls that are indicative of an EC2 Network ACL modification

--- a/rules/aws_cloudtrail_rules/aws_ec2_route_table_modified.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_route_table_modified.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
 
 # API calls that are indicative of an EC2 Route Table modification

--- a/rules/aws_cloudtrail_rules/aws_ec2_security_group_modified.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_security_group_modified.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
 
 # API calls that are indicative of an EC2 SecurityGroup modification

--- a/rules/aws_cloudtrail_rules/aws_ec2_vpc_modified.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_vpc_modified.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
 
 # API calls that are indicative of an EC2 VPC modification

--- a/rules/aws_cloudtrail_rules/aws_iam_anything_changed.py
+++ b/rules/aws_cloudtrail_rules/aws_iam_anything_changed.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
 
 IAM_CHANGE_ACTIONS = [

--- a/rules/aws_cloudtrail_rules/aws_iam_assume_role_blocklist_ignored.py
+++ b/rules/aws_cloudtrail_rules/aws_iam_assume_role_blocklist_ignored.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
 
 # This is a list of role ARNs that should not be assumed by users in normal operations

--- a/rules/aws_cloudtrail_rules/aws_iam_entity_created_without_cloudformation.py
+++ b/rules/aws_cloudtrail_rules/aws_iam_entity_created_without_cloudformation.py
@@ -1,6 +1,6 @@
 import re
 
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
 
 # The role dedicated for IAM administration

--- a/rules/aws_cloudtrail_rules/aws_iam_policy_modified.py
+++ b/rules/aws_cloudtrail_rules/aws_iam_policy_modified.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
 
 # API calls that are indicative of IAM Policy changes

--- a/rules/aws_cloudtrail_rules/aws_iam_user_key_created.py
+++ b/rules/aws_cloudtrail_rules/aws_iam_user_key_created.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
 
 

--- a/rules/aws_cloudtrail_rules/aws_iam_user_recon_denied.py
+++ b/rules/aws_cloudtrail_rules/aws_iam_user_recon_denied.py
@@ -1,6 +1,6 @@
 from ipaddress import ip_address
 
-from panther import lookup_aws_account_name
+from panther_default import lookup_aws_account_name
 from panther_base_helpers import aws_rule_context, deep_get
 
 # service/event patterns to monitor

--- a/rules/aws_cloudtrail_rules/aws_kms_cmk_loss.py
+++ b/rules/aws_cloudtrail_rules/aws_kms_cmk_loss.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
 
 # API calls that are indicative of KMS CMK Deletion

--- a/rules/aws_cloudtrail_rules/aws_network_acl_permissive_entry.py
+++ b/rules/aws_cloudtrail_rules/aws_network_acl_permissive_entry.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
 
 

--- a/rules/aws_cloudtrail_rules/aws_resource_made_public.py
+++ b/rules/aws_cloudtrail_rules/aws_resource_made_public.py
@@ -1,6 +1,6 @@
 import json
 
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
 from policyuniverse.policy import Policy
 

--- a/rules/aws_cloudtrail_rules/aws_root_activity.py
+++ b/rules/aws_cloudtrail_rules/aws_root_activity.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success, lookup_aws_account_name
+from panther_default import aws_cloudtrail_success, lookup_aws_account_name
 from panther_base_helpers import deep_get
 
 EVENT_ALLOW_LIST = {"CreateServiceLinkedRole"}

--- a/rules/aws_cloudtrail_rules/aws_s3_bucket_deleted.py
+++ b/rules/aws_cloudtrail_rules/aws_s3_bucket_deleted.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
 
 

--- a/rules/aws_cloudtrail_rules/aws_s3_bucket_policy_modified.py
+++ b/rules/aws_cloudtrail_rules/aws_s3_bucket_policy_modified.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
 
 # API calls that are indicative of KMS CMK Deletion

--- a/rules/aws_cloudtrail_rules/aws_security_configuration_change.py
+++ b/rules/aws_cloudtrail_rules/aws_security_configuration_change.py
@@ -1,6 +1,6 @@
 from fnmatch import fnmatch
 
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
 
 SECURITY_CONFIG_ACTIONS = {

--- a/rules/aws_cloudtrail_rules/aws_snapshot_made_public.py
+++ b/rules/aws_cloudtrail_rules/aws_snapshot_made_public.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping
 
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
 
 

--- a/rules/aws_cloudtrail_rules/aws_update_credentials.py
+++ b/rules/aws_cloudtrail_rules/aws_update_credentials.py
@@ -1,4 +1,4 @@
-from panther import aws_cloudtrail_success
+from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
 
 UPDATE_EVENTS = {"ChangePassword", "CreateAccessKey", "CreateLoginProfile", "CreateUser"}

--- a/rules/standard_rules/brute_force_by_ip.py
+++ b/rules/standard_rules/brute_force_by_ip.py
@@ -1,7 +1,7 @@
 from json import loads
 
 import panther_event_type_helpers as event_type
-from panther import lookup_aws_account_name
+from panther_default import lookup_aws_account_name
 from panther_oss_helpers import add_parse_delay, geoinfo_from_ip
 
 


### PR DESCRIPTION
### Background

It is frustrating for developers when their IDE cannot resolve the `panther` module. The `panther` module is contained in a global helpers file spelled `panther_default.py`. Developers that use an IDE will continue to need to inform the IDE that `global_helpers` directory should be considered part of **$PYTHONPATH** ( in VSCODE the settings.json keys that control this are   `"python.analysis.extraPaths"` and `"python.autoComplete.extraPaths"` )

This PR updates the `panther_default` global_helper's .yml file to call the module `panther_default`. 
This PR updates detection importers to spell the import as `panther_default`
This PR updates packs to spell the global_helper as `panther_default` 

### Changes
![Screenshot 2023-02-23 at 11 39 43](https://user-images.githubusercontent.com/932424/221013045-70c72771-de99-4a4d-87ff-ef0d61657277.png)

![Screenshot 2023-02-23 at 11 40 19](https://user-images.githubusercontent.com/932424/221013082-5f55e2da-3093-4f9f-bf5e-8e33dbd347ca.png)


### Testing

```shell
(panther-analysis) user@computer:~/Sources/PAN/panther-analysis $ make test 2>&1 | tail -n 7
--------------------------
Panther CLI Test Summary
        Path: .
        Passed: 437
        Failed: 0
        Invalid: 0
```
