### PR TITLE
chore: let automagic release note generation do more for us 

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,41 @@
+# This file controls how the automagically generated
+# release notes get represented in the release-notes
+# template
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+# .github/release.yml
+changelog:
+  exclude:
+    labels:
+      - updatebot
+  categories:
+    - title: 🕵️ New Detections
+      labels:
+        - rules
+      exclude:
+        labels:
+          - tuning
+    - title: ⛅️️ New Policies
+      labels:
+        - policies
+      exclude:
+        labels:
+          - tuning
+    - title:  🔍️️ New Queries
+      labels:
+        - queries
+      exclude:
+        labels:
+          - tuning
+    - title:  🗓️️ Scheduled Rules
+      labels:
+        - queries
+      exclude:
+        labels:
+          - tuning
+    - title: 🐛 Bug Fixes and Tunes
+      labels:
+        - tuning
+        - bug
+    - title: 🏡 Miscellaneous
+      labels:
+        - '*'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -32,6 +32,12 @@ changelog:
       exclude:
         labels:
           - tuning
+    - title: 🌯 New Packs and Pack Expansion
+      labels:
+        - packs
+      exclude:
+        labels:
+          - tuning
     - title: 🐛 Bug Fixes and Tunes
       labels:
         - tuning

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -28,7 +28,7 @@ changelog:
           - tuning
     - title:  🗓️️ Scheduled Rules
       labels:
-        - queries
+        - scheduled_rules
       exclude:
         labels:
           - tuning


### PR DESCRIPTION
### Background

GitHub releases can honor an in-repo [release.yml](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) file when represent. 

In-repo releases work based on PR tags, so the following are the rules as I anticipate them
## The Sections that will be manifested based on PR Labels
* `tuning` -> Goes into its own section, without regard to what it is that is being tuned.  ( appears at end of release notes )
* `rules` -> Means new rules are in the PR.
* `policies` -> Means new policies are in the PR 
* `queries` -> means new queries are in the PR
* `scheduled_rules` -> means new scheduled_rules are in the PR 
* `bugs` -> Equivalent to `tuning`
* `Anything Else` -> Goes into Miscellaneous 

### Changes

* creates release notes template

### Testing

* 
