### PR TITLE
chore: make fmt wanted to reorder a few imports based on panther being renamed panther_default

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_ami_modified_for_public_access.py
+++ b/rules/aws_cloudtrail_rules/aws_ami_modified_for_public_access.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import aws_cloudtrail_success
 
 
 def rule(event):

--- a/rules/aws_cloudtrail_rules/aws_cloudtrail_created.py
+++ b/rules/aws_cloudtrail_rules/aws_cloudtrail_created.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import aws_cloudtrail_success
 
 # API calls that are indicative of CloudTrail changes
 CLOUDTRAIL_CREATE_UPDATE = {

--- a/rules/aws_cloudtrail_rules/aws_cloudtrail_stopped.py
+++ b/rules/aws_cloudtrail_rules/aws_cloudtrail_stopped.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success, lookup_aws_account_name
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import aws_cloudtrail_success, lookup_aws_account_name
 
 # API calls that are indicative of CloudTrail changes
 CLOUDTRAIL_STOP_DELETE = {

--- a/rules/aws_cloudtrail_rules/aws_codebuild_made_public.py
+++ b/rules/aws_cloudtrail_rules/aws_codebuild_made_public.py
@@ -1,5 +1,5 @@
-from panther_default import lookup_aws_account_name
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import lookup_aws_account_name
 
 
 def rule(event):

--- a/rules/aws_cloudtrail_rules/aws_config_service_created.py
+++ b/rules/aws_cloudtrail_rules/aws_config_service_created.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
+from panther_default import aws_cloudtrail_success
 
 # API calls that are indicative of an AWS Config Service change
 CONFIG_SERVICE_CREATE_EVENTS = {

--- a/rules/aws_cloudtrail_rules/aws_config_service_disabled_deleted.py
+++ b/rules/aws_cloudtrail_rules/aws_config_service_disabled_deleted.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
+from panther_default import aws_cloudtrail_success
 
 # API calls that are indicative of an AWS Config Service change
 CONFIG_SERVICE_DISABLE_DELETE_EVENTS = {

--- a/rules/aws_cloudtrail_rules/aws_console_login_failed.py
+++ b/rules/aws_cloudtrail_rules/aws_console_login_failed.py
@@ -1,5 +1,5 @@
-from panther_default import lookup_aws_account_name
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import lookup_aws_account_name
 
 
 def rule(event):

--- a/rules/aws_cloudtrail_rules/aws_console_login_without_mfa.py
+++ b/rules/aws_cloudtrail_rules/aws_console_login_without_mfa.py
@@ -1,7 +1,7 @@
 import logging
 
-from panther_default import lookup_aws_account_name
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import lookup_aws_account_name
 from panther_oss_helpers import check_account_age
 
 # Set to True for environments that permit direct role assumption via external IDP

--- a/rules/aws_cloudtrail_rules/aws_console_login_without_saml.py
+++ b/rules/aws_cloudtrail_rules/aws_console_login_without_saml.py
@@ -1,5 +1,5 @@
-from panther_default import lookup_aws_account_name
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import lookup_aws_account_name
 
 
 def rule(event):

--- a/rules/aws_cloudtrail_rules/aws_console_root_login.py
+++ b/rules/aws_cloudtrail_rules/aws_console_root_login.py
@@ -1,5 +1,5 @@
-from panther_default import lookup_aws_account_name
 from panther_base_helpers import deep_get
+from panther_default import lookup_aws_account_name
 from panther_oss_helpers import geoinfo_from_ip_formatted
 
 

--- a/rules/aws_cloudtrail_rules/aws_console_root_login_failed.py
+++ b/rules/aws_cloudtrail_rules/aws_console_root_login_failed.py
@@ -1,5 +1,5 @@
-from panther_default import lookup_aws_account_name
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import lookup_aws_account_name
 
 
 def rule(event):

--- a/rules/aws_cloudtrail_rules/aws_ec2_gateway_modified.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_gateway_modified.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
+from panther_default import aws_cloudtrail_success
 
 # API calls that are indicative of an EC2 Network Gateway modification
 EC2_GATEWAY_MODIFIED_EVENTS = {

--- a/rules/aws_cloudtrail_rules/aws_ec2_manual_security_group_changes.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_manual_security_group_changes.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get, pattern_match_list
+from panther_default import aws_cloudtrail_success
 
 PROD_ACCOUNT_IDS = {"11111111111111", "112233445566"}
 SG_CHANGE_EVENTS = {

--- a/rules/aws_cloudtrail_rules/aws_ec2_network_acl_modified.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_network_acl_modified.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
+from panther_default import aws_cloudtrail_success
 
 # API calls that are indicative of an EC2 Network ACL modification
 EC2_NACL_MODIFIED_EVENTS = {

--- a/rules/aws_cloudtrail_rules/aws_ec2_route_table_modified.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_route_table_modified.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
+from panther_default import aws_cloudtrail_success
 
 # API calls that are indicative of an EC2 Route Table modification
 EC2_RT_MODIFIED_EVENTS = {

--- a/rules/aws_cloudtrail_rules/aws_ec2_security_group_modified.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_security_group_modified.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
+from panther_default import aws_cloudtrail_success
 
 # API calls that are indicative of an EC2 SecurityGroup modification
 EC2_SG_MODIFIED_EVENTS = {

--- a/rules/aws_cloudtrail_rules/aws_ec2_vpc_modified.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_vpc_modified.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
+from panther_default import aws_cloudtrail_success
 
 # API calls that are indicative of an EC2 VPC modification
 EC2_VPC_MODIFIED_EVENTS = {

--- a/rules/aws_cloudtrail_rules/aws_iam_anything_changed.py
+++ b/rules/aws_cloudtrail_rules/aws_iam_anything_changed.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
+from panther_default import aws_cloudtrail_success
 
 IAM_CHANGE_ACTIONS = [
     "Add",

--- a/rules/aws_cloudtrail_rules/aws_iam_assume_role_blocklist_ignored.py
+++ b/rules/aws_cloudtrail_rules/aws_iam_assume_role_blocklist_ignored.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import aws_cloudtrail_success
 
 # This is a list of role ARNs that should not be assumed by users in normal operations
 ASSUME_ROLE_BLOCKLIST = [

--- a/rules/aws_cloudtrail_rules/aws_iam_entity_created_without_cloudformation.py
+++ b/rules/aws_cloudtrail_rules/aws_iam_entity_created_without_cloudformation.py
@@ -1,7 +1,7 @@
 import re
 
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import aws_cloudtrail_success
 
 # The role dedicated for IAM administration
 IAM_ADMIN_ROLES = {

--- a/rules/aws_cloudtrail_rules/aws_iam_policy_modified.py
+++ b/rules/aws_cloudtrail_rules/aws_iam_policy_modified.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
+from panther_default import aws_cloudtrail_success
 
 # API calls that are indicative of IAM Policy changes
 POLICY_CHANGE_EVENTS = {

--- a/rules/aws_cloudtrail_rules/aws_iam_user_key_created.py
+++ b/rules/aws_cloudtrail_rules/aws_iam_user_key_created.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import aws_cloudtrail_success
 
 
 def rule(event):

--- a/rules/aws_cloudtrail_rules/aws_iam_user_recon_denied.py
+++ b/rules/aws_cloudtrail_rules/aws_iam_user_recon_denied.py
@@ -1,7 +1,7 @@
 from ipaddress import ip_address
 
-from panther_default import lookup_aws_account_name
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import lookup_aws_account_name
 
 # service/event patterns to monitor
 RECON_ACTIONS = {

--- a/rules/aws_cloudtrail_rules/aws_kms_cmk_loss.py
+++ b/rules/aws_cloudtrail_rules/aws_kms_cmk_loss.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context
+from panther_default import aws_cloudtrail_success
 
 # API calls that are indicative of KMS CMK Deletion
 KMS_LOSS_EVENTS = {"DisableKey", "ScheduleKeyDeletion"}

--- a/rules/aws_cloudtrail_rules/aws_network_acl_permissive_entry.py
+++ b/rules/aws_cloudtrail_rules/aws_network_acl_permissive_entry.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import aws_cloudtrail_success
 
 
 def rule(event):

--- a/rules/aws_cloudtrail_rules/aws_resource_made_public.py
+++ b/rules/aws_cloudtrail_rules/aws_resource_made_public.py
@@ -1,7 +1,7 @@
 import json
 
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import aws_cloudtrail_success
 from policyuniverse.policy import Policy
 
 

--- a/rules/aws_cloudtrail_rules/aws_root_activity.py
+++ b/rules/aws_cloudtrail_rules/aws_root_activity.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success, lookup_aws_account_name
 from panther_base_helpers import deep_get
+from panther_default import aws_cloudtrail_success, lookup_aws_account_name
 
 EVENT_ALLOW_LIST = {"CreateServiceLinkedRole"}
 

--- a/rules/aws_cloudtrail_rules/aws_s3_bucket_deleted.py
+++ b/rules/aws_cloudtrail_rules/aws_s3_bucket_deleted.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import aws_cloudtrail_success
 
 
 def rule(event):

--- a/rules/aws_cloudtrail_rules/aws_s3_bucket_policy_modified.py
+++ b/rules/aws_cloudtrail_rules/aws_s3_bucket_policy_modified.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import aws_cloudtrail_success
 
 # API calls that are indicative of KMS CMK Deletion
 S3_POLICY_CHANGE_EVENTS = {

--- a/rules/aws_cloudtrail_rules/aws_security_configuration_change.py
+++ b/rules/aws_cloudtrail_rules/aws_security_configuration_change.py
@@ -1,7 +1,7 @@
 from fnmatch import fnmatch
 
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import aws_cloudtrail_success
 
 SECURITY_CONFIG_ACTIONS = {
     "DeleteAccountPublicAccessBlock",

--- a/rules/aws_cloudtrail_rules/aws_snapshot_made_public.py
+++ b/rules/aws_cloudtrail_rules/aws_snapshot_made_public.py
@@ -1,7 +1,7 @@
 from collections.abc import Mapping
 
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import aws_cloudtrail_success
 
 
 def rule(event):

--- a/rules/aws_cloudtrail_rules/aws_update_credentials.py
+++ b/rules/aws_cloudtrail_rules/aws_update_credentials.py
@@ -1,5 +1,5 @@
-from panther_default import aws_cloudtrail_success
 from panther_base_helpers import aws_rule_context, deep_get
+from panther_default import aws_cloudtrail_success
 
 UPDATE_EVENTS = {"ChangePassword", "CreateAccessKey", "CreateLoginProfile", "CreateUser"}
 


### PR DESCRIPTION
### Background

One of the linters wants imports to be alphabetically ordered. `make lint` was satisfied with them being in non-alpha order, but `make fmt` did want to reorder the imports. 

This PR satisfies `make fmt`  and contains no functional changes.

### Changes

* `make fmt`

### Testing


