### PR TITLE
chore: typo in the word resource

### DIFF
--- a/rules/gsuite_activityevent_rules/gsuite_google_access.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_google_access.yml
@@ -1,7 +1,7 @@
 AnalysisType: rule
 Filename: gsuite_google_access.py
 RuleID: GSuite.GoogleAccess
-DisplayName: Google Accessed a GSuite Reource
+DisplayName: Google Accessed a GSuite Resource
 Enabled: true
 LogTypes:
   - GSuite.ActivityEvent


### PR DESCRIPTION
### Background

This detection spelled resource as reource

### Changes

* 

### Testing

* 
