### PR TITLE
feat: run codespell as part of make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 dirs := $(shell ls | egrep 'policies|rules|helpers|models|templates' | xargs)
 
+spellcheck:
+	pipenv run codespell -L marge $(dirs)
+
 ci:
 	pipenv run $(MAKE) lint test
 
@@ -38,7 +41,7 @@ fmt:
 install:
 	pipenv sync --dev
 
-test: global-helpers-unit-test
+test: global-helpers-unit-test lint spellcheck
 	pipenv run panther_analysis_tool test
 
 docker-build:

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ mypy = "~=0.950"
 panther-analysis-tool = "~=0.19.8"
 pylint = "~=2.15.0"
 pylint-print = "~=1.0.0"
+codespell = "*"
 
 [packages]
 policyuniverse = "==1.5.0.20220613"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "92fbd5d930abe6727e8d6f6d1f2188313120cd99709d15faad872139e6c1defc"
+            "sha256": "edcdcf2a74a0b987819e220f05d762b27b2d1deaddb8697304b73fbdfd6adae9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -300,19 +300,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:09929b24aaec4951e435d53d31f800e2ca52244af049dc11e5385ce062e106e9",
-                "sha256:e819812f16fab46fadf9b2853a46aaa126e108e7f038502dde555ebbbfc80133"
+                "sha256:1e543a27a7f0cddef298492d70bf7ea67db02960ec704c1af26d2b543cdefb43",
+                "sha256:df541c06ff1018675097e102f2f2aa2abc31ea5d197c7fc229afbe30950ba131"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.26.89"
+            "version": "==1.26.93"
         },
         "botocore": {
             "hashes": [
-                "sha256:ac8da651f73a9d5759cf5d80beba68deda407e56aaaeb10d249fd557459f3b56",
-                "sha256:b757e59feca82ac62934f658918133116b4535cf66f1d72ff4935fa24e522527"
+                "sha256:39c2ad2d44c7e1ef25a98e957b63fa760b87bcf32423a033dceeb359976c37d7",
+                "sha256:940201ae2f5edbf4ccbf1066e345cf7f5224568bd702fa9e80a92e5c479fa649"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.29.89"
+            "version": "==1.29.93"
         },
         "certifi": {
             "hashes": [
@@ -410,6 +410,14 @@
             ],
             "index": "pypi",
             "version": "==8.1.3"
+        },
+        "codespell": {
+            "hashes": [
+                "sha256:0b4620473c257d9cde1ff8998b26b2bb209a35c2b7489f5dc3436024298ce83a",
+                "sha256:7d984b8130108e6f82524b7d09f8b7bf2fb1e398c5d4b37d9e2bd310145b3e29"
+            ],
+            "index": "pypi",
+            "version": "==2.2.4"
         },
         "contextlib2": {
             "hashes": [
@@ -551,7 +559,7 @@
                 "sha256:06d2aad0ac723e35b1cb47885d3e5c45e956a53bc1b209a9fc5369007fe46676",
                 "sha256:5766780452bd5ec8ba133f8bf287dc92713e3868ddd83aee4faab9fc3e303dc3"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==3.2.3"
         },
         "idna": {
@@ -786,10 +794,10 @@
         },
         "panther-analysis-tool": {
             "hashes": [
-                "sha256:644ace8efbde5250a9d466cdd5918f618ebeb2641cb0f60bd9e08dd9e89101e5"
+                "sha256:8e5aafb49cf9c342e198d43d3fb55d772dc1be85e5aec44fd4c4831cbeda328c"
             ],
             "index": "pypi",
-            "version": "==0.19.8"
+            "version": "==0.19.9"
         },
         "panther-core": {
             "hashes": [
@@ -799,11 +807,11 @@
         },
         "pathspec": {
             "hashes": [
-                "sha256:3a66eb970cbac598f9e5ccb5b2cf58930cd8e3ed86d393d541eaf2d8b1705229",
-                "sha256:64d338d4e0914e91c1792321e6907b5a593f1ab1851de7fc269557a21b30ebbc"
+                "sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687",
+                "sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.11.0"
+            "version": "==0.11.1"
         },
         "pbr": {
             "hashes": [
@@ -919,7 +927,7 @@
                 "sha256:91954fe80cfb7985727a467ca98a7618e5dd15178cc2da10f553b36a93859001",
                 "sha256:a104f37270bf677148d8acb07d33be1569eeee87e2d1beb286a4e9113caf6f2f"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_full_version >= '3.7.0'",
             "version": "==13.3.2"
         },
         "ruamel.yaml": {
@@ -1040,7 +1048,7 @@
                 "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
                 "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.10'",
             "version": "==4.5.0"
         },
         "urllib3": {


### PR DESCRIPTION
### Background

Import [codespell](https://github.com/codespell-project/codespell/) and leverage it as a test target. 

This PR is going to be created with `make spellcheck` as part of `make test`, though I will un-do that addition to the default behavior of `make test` once I can validate/see that the spell check fails

### Changes

* 

### Testing


