### PR TITLE
Reconfiguring login_history snowflake table dependent queries.

### DIFF
--- a/queries/snowflake_queries/snowflake_brute_force_ip_query.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_ip_query.yml
@@ -18,8 +18,9 @@ SnowflakeQuery: >
     ARRAY_AGG(DISTINCT error_message) as error_messages,
     COUNT(event_id) AS counts
   FROM snowflake.account_usage.login_history
-  WHERE 1=1
-    AND p_occurs_since('24 h', event_timestamp)
+  WHERE
+    DATEDIFF(HOUR, event_timestamp, CURRENT_TIMESTAMP) < 24
+    AND event_type = 'LOGIN'
     AND error_code is NOT NULL
   GROUP BY client_ip, reported_client_type
   HAVING counts >= 5

--- a/queries/snowflake_queries/snowflake_brute_force_ip_query.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_ip_query.yml
@@ -23,7 +23,7 @@ SnowflakeQuery: >
     AND event_type = 'LOGIN'
     AND error_code is NOT NULL
   GROUP BY client_ip, reported_client_type
-  HAVING counts >= 5
+  HAVING counts >= 5;
 Schedule:
   RateMinutes: 60
   TimeoutMinutes: 1

--- a/queries/snowflake_queries/snowflake_brute_force_username_query.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_username_query.yml
@@ -18,8 +18,9 @@ SnowflakeQuery: >
     ARRAY_AGG(DISTINCT error_message) as error_messages,
     COUNT(event_id) AS counts
   FROM snowflake.account_usage.login_history
-  WHERE 1=1
-    AND p_occurs_since('24 h', event_timestamp)
+  WHERE
+    DATEDIFF(HOUR, event_timestamp, CURRENT_TIMESTAMP) < 24
+    AND event_type = 'LOGIN'
     AND error_code IS NOT NULL
   GROUP BY reported_client_type, user_name
   HAVING counts >=5;

--- a/queries/snowflake_queries/snowflake_login_without_mfa_query.yml
+++ b/queries/snowflake_queries/snowflake_login_without_mfa_query.yml
@@ -21,7 +21,8 @@ SnowflakeQuery: >
     second_authentication_factor
   FROM snowflake.account_usage.login_history
     WHERE
-      p_occurs_since('1 h', event_timestamp)
+      DATEDIFF(HOUR, event_timestamp, CURRENT_TIMESTAMP) < 24
+      AND event_type = 'LOGIN'
       AND first_authentication_factor = 'PASSWORD'
       AND second_authentication_factor IS null
   ORDER BY event_timestamp desc


### PR DESCRIPTION
### Background

As part of the snowflake initiative, we are working to update current snowflake queries in an effort to strengthen query logic and ensure compatibility with our backend and customer environments, as well as add functionality in areas where logic has yet to cover. This PR is the first to be put out for this initiative, and focuses on queries dependent on the login_history table.

### Changes

* The following three queries: 
snowflake_brute_force_ip_query.yml
snowflake_brute_force_username_query.yml
snowflake_login_without_mfa_query.yml
have all been updated to contain additional logical constraints. This is to ensure the limiting of results to only relevant events. 
### Testing

* The queries have been run both in king of spades and within our backend snowflake instance and have been confirmed to return the same results. (additional evidence of this may be provided if requested)
