### PR TITLE
feat: Snyk rules for policy settings

### DIFF
--- a/rules/snyk_rules/snyk_system_policysetting.py
+++ b/rules/snyk_rules/snyk_system_policysetting.py
@@ -1,0 +1,53 @@
+from global_filter_snyk import filter_include_event
+from panther_base_helpers import deep_get
+from panther_snyk_helpers import snyk_alert_context
+
+ACTIONS = [
+    "group.policy.create",
+    "group.policy.delete",
+    "group.policy.edit",
+    "org.policy.edit",
+    "org.ignore_policy.edit",
+]
+
+
+def rule(event):
+    if not filter_include_event(event):
+        return False
+    action = deep_get(event, "event", default="<NO_EVENT>")
+    return action in ACTIONS
+
+
+def title(event):
+    policy_type = "<NO_POLICY_TYPE_FOUND>"
+    license_or_rule = deep_get(event, "content", "after", "configuration", default={})
+    if "rules" in license_or_rule:
+        policy_type = "security"
+    elif "licenses" in license_or_rule:
+        policy_type = "license"
+    return (
+        f"Snyk: System [{policy_type}] Policy Setting event "
+        f"[{deep_get(event, 'event', default='<NO_EVENT>')}] "
+        f"performed by [{deep_get(event, 'userId', default='<NO_USERID>')}]"
+    )
+
+
+def alert_context(event):
+    a_c = snyk_alert_context(event)
+    a_c["policy_type"] = "<NO_POLICY_TYPE_FOUND>"
+    license_or_rule = deep_get(event, "content", "after", "configuration", default={})
+    if "rules" in license_or_rule:
+        a_c["policy_type"] = "security"
+    elif "licenses" in license_or_rule:
+        a_c["policy_type"] = "license"
+    return a_c
+
+
+def dedup(event):
+    # Licenses can apply at org or group levels
+    return (
+        f"{deep_get(event, 'userId', default='<NO_USERID>')}"
+        f"{deep_get(event, 'orgId', default='<NO_GROUPID>')}"
+        f"{deep_get(event, 'groupId', default='<NO_ORGID>')}"
+        f"{deep_get(event, 'content', 'publicId', default='<NO_PUBLICID>')}"
+    )

--- a/rules/snyk_rules/snyk_system_policysetting.yml
+++ b/rules/snyk_rules/snyk_system_policysetting.yml
@@ -1,0 +1,176 @@
+AnalysisType: rule
+Filename: snyk_system_policysetting.py
+RuleID: Snyk.System.PolicySetting
+DisplayName: Snyk System Policy Settings Changed
+Enabled: true
+LogTypes:
+  - Snyk.GroupAudit
+  - Snyk.OrgAudit
+Tags:
+  - Snyk
+Severity: High
+Description: >
+  Detects Snyk Policy Settings have been changed.
+  Policies define Snyk's behavior when encountering security and licensing issues.
+Runbook: >
+  Snyk Policies can cause alerts to raise or not based on found security and
+  license issues. Validate that that this change is expected.
+Reference: https://docs.snyk.io/manage-issues/policies/shared-policies-overview
+DedupPeriodMinutes: 60
+Threshold:  1
+SummaryAttributes:
+  - event
+Tests:
+  -
+    Name: Snyk System Policy Setting event happened ( Security Policy )
+    ExpectedResult: true
+    Log:
+      {
+        "content": {
+          "after": {
+            "configuration": {
+              "rules": [
+                {
+                  "actions": [
+                    {
+                      "data": {
+                        "severity": "high"
+                      },
+                      "type": "severity-override"
+                    }
+                  ],
+                  "conditions": {
+                    "AND": [
+                      {
+                        "field": "exploit-maturity",
+                        "operator": "includes",
+                        "value": [
+                          "mature"
+                        ]
+                      }
+                    ]
+                  },
+                  "name": "Rule 1"
+                }
+              ]
+            },
+            "description": "This is a security policy",
+            "group": "8fffffff-1555-4444-b000-b55555555555",
+            "name": "Example Security Policy"
+          },
+          "before": {},
+          "publicId": "21111111-a222-4eee-8ddd-a99999999999"
+        },
+        "created": "2023-03-03 00:13:45.497",
+        "event": "group.policy.create",
+        "groupId": "8fffffff-1555-4444-b000-b55555555555",
+        "userId": "05555555-3333-4ddd-8ccc-755555555555"
+      }
+  -
+    Name: Snyk System Policy Setting event happened ( License Policy )
+    ExpectedResult: true
+    Log:
+      {
+        "content": {
+          "after": {
+            "configuration": {
+              "licenses": [
+                {
+                  "instructions": "",
+                  "licenseType": "ADSL",
+                  "severity": "medium"
+                },
+                {
+                  "instructions": "",
+                  "licenseType": "AGPL-3.0",
+                  "severity": "medium"
+                },
+                {
+                  "instructions": "",
+                  "licenseType": "AGPL-3.0-only",
+                  "severity": "high"
+                }
+              ]
+            },
+            "description": "this is a policy description",
+            "group": "8fffffff-1555-4444-b000-b55555555555",
+            "name": "Example License Policy",
+            "projectAttributes": {
+              "criticality": [],
+              "environment": [],
+              "lifecycle": []
+            }
+          },
+          "before": {},
+          "publicId": "21111111-a222-4eee-8ddd-a99999999999"
+        },
+        "created": "2023-03-03 00:10:02.351",
+        "event": "group.policy.create",
+        "groupId": "8fffffff-1555-4444-b000-b55555555555",
+        "userId": "05555555-3333-4ddd-8ccc-755555555555"
+      }
+  -
+    Name: Snyk System Policy Setting event happened ( License Policy ) excluded by filter
+    ExpectedResult: false
+    Mocks:
+      - objectName: filter_include_event
+        returnValue: false
+    Log:
+      {
+        "content": {
+          "after": {
+            "configuration": {
+              "licenses": [
+                {
+                  "instructions": "",
+                  "licenseType": "ADSL",
+                  "severity": "medium"
+                },
+                {
+                  "instructions": "",
+                  "licenseType": "AGPL-3.0",
+                  "severity": "medium"
+                },
+                {
+                  "instructions": "",
+                  "licenseType": "AGPL-3.0-only",
+                  "severity": "high"
+                }
+              ]
+            },
+            "description": "this is a policy description",
+            "group": "8fffffff-1555-4444-b000-b55555555555",
+            "name": "Example License Policy",
+            "projectAttributes": {
+              "criticality": [],
+              "environment": [],
+              "lifecycle": []
+            }
+          },
+          "before": {},
+          "publicId": "21111111-a222-4eee-8ddd-a99999999999"
+        },
+        "created": "2023-03-03 00:10:02.351",
+        "event": "group.policy.create",
+        "groupId": "8fffffff-1555-4444-b000-b55555555555",
+        "userId": "05555555-3333-4ddd-8ccc-755555555555"
+      }
+  -
+    Name: Snyk Group SSO Membership sync
+    ExpectedResult: false
+    Log:
+      {
+        "content": {
+          "addAsOrgAdmin": [],
+          "addAsOrgCollaborator": [
+            "group.name"
+          ],
+          "addAsOrgCustomRole": [],
+          "addAsOrgRestrictedCollaborator": [],
+          "removedOrgMemberships": [],
+          "userPublicId": "05555555-3333-4ddd-8ccc-755555555555"
+        },
+        "created": "2023-03-15 13:13:13.133",
+        "event": "group.sso.membership.sync",
+        "groupId": "8fffffff-1555-4444-b000-b55555555555",
+      }


### PR DESCRIPTION
### Background

Snyk [Policies](https://snyk.io/learn/security-policies/) define license and other security boundaries within the Snyk product. 

### Changes

* adds detections that look for Snyk policy CRUD operations

### Testing

```shell
Snyk.System.PolicySetting
	[PASS] Snyk System Policy Setting event happened ( Security Policy )
		[PASS] [rule] true
		[PASS] [title] Snyk: System [security] Policy Setting event [group.policy.create] performed by [05555555-3333-4ddd-8ccc-755555555555]
		[PASS] [dedup] 05555555-3333-4ddd-8ccc-755555555555<NO_GROUPID>8fffffff-1555-4444-b000-b5555555555521111111-a222-4eee-8ddd-a99999999999
		[PASS] [alertContext] {"actor": "05555555-3333-4ddd-8ccc-755555555555", "action": "group.policy.create", "orgId": "<NO_ORGID>", "groupId": "8fffffff-1555-4444-b000-b55555555555", "policy_type": "security"}
	[PASS] Snyk System Policy Setting event happened ( License Policy )
		[PASS] [rule] true
		[PASS] [title] Snyk: System [license] Policy Setting event [group.policy.create] performed by [05555555-3333-4ddd-8ccc-755555555555]
		[PASS] [dedup] 05555555-3333-4ddd-8ccc-755555555555<NO_GROUPID>8fffffff-1555-4444-b000-b5555555555521111111-a222-4eee-8ddd-a99999999999
		[PASS] [alertContext] {"actor": "05555555-3333-4ddd-8ccc-755555555555", "action": "group.policy.create", "orgId": "<NO_ORGID>", "groupId": "8fffffff-1555-4444-b000-b55555555555", "policy_type": "license"}
	[PASS] Snyk System Policy Setting event happened ( License Policy ) excluded by filter
		[PASS] [rule] false
	[PASS] Snyk Group SSO Membership sync
		[PASS] [rule] false

--------------------------
Panther CLI Test Summary
	Path: .
	Passed: 1
	Failed: 0
	Invalid: 0
```
