### PR TITLE
feat: Snyk detections for OU changes and external access changes

### DIFF
--- a/rules/snyk_rules/snyk_ou_change.py
+++ b/rules/snyk_rules/snyk_ou_change.py
@@ -1,0 +1,59 @@
+from global_filter_snyk import filter_include_event
+from panther_base_helpers import deep_get
+from panther_snyk_helpers import snyk_alert_context
+
+ACTIONS = [
+    "group.create",
+    "group.delete",
+    "group.edit",
+    "group.feature_flags.edit",
+    "group.org.add",
+    "group.org.remove",
+    "group.settings.edit",
+    "group.settings.feature_flag.edit",
+    "org.create",
+    "org.delete",
+    "org.edit",
+    "org.settings.feature_flag.edit",
+]
+
+
+def rule(event):
+    if not filter_include_event(event):
+        return False
+    action = deep_get(event, "event", default="<NO_EVENT>")
+    return action in ACTIONS
+
+
+def title(event):
+    group_or_org = "<GROUP_OR_ORG>"
+    action = deep_get(event, "event", default="<NO_EVENT>")
+    if "." in action:
+        group_or_org = action.split(".")[0].title()
+    return (
+        f"Snyk: [{group_or_org}] Organizational Unit settings have been modified "
+        f"via [{action}] "
+        f"performed by [{deep_get(event, 'userId', default='<NO_USERID>')}]"
+    )
+
+
+def alert_context(event):
+    return snyk_alert_context(event)
+
+
+def dedup(event):
+    return (
+        f"{deep_get(event, 'userId', default='<NO_USERID>')}"
+        f"{deep_get(event, 'orgId', default='<NO_ORGID>')}"
+        f"{deep_get(event, 'groupId', default='<NO_GROUPID>')}"
+        f"{deep_get(event, 'event', default='<NO_EVENT>')}"
+    )
+
+
+def severity(event):
+    action = deep_get(event, "event", default="<NO_EVENT>")
+    if action.endswith((".remove", ".delete")):
+        return "HIGH"
+    if action.endswith((".edit")):
+        return "MEDIUM"
+    return "INFO"

--- a/rules/snyk_rules/snyk_ou_change.yml
+++ b/rules/snyk_rules/snyk_ou_change.yml
@@ -1,0 +1,91 @@
+AnalysisType: rule
+Filename: snyk_ou_change.py
+RuleID: "Snyk.OU.Change"
+DisplayName: "Snyk Org or Group Settings Change"
+Enabled: true
+LogTypes:
+  - Snyk.GroupAudit
+  - Snyk.OrgAudit
+Tags:
+  - Snyk
+Severity: High
+Description: >
+  Detects when Snyk Group or Organization Settings are changed.
+Runbook: >
+  These actions in the Snyk Audit logs indicate that a Organization or 
+  Group setting has changed, including Group and Org creation/deletion.
+  Deletion events are marked with HIGH severity
+  Creation events are marked with INFO severity
+  Edit events are marked with MEDIUM Severity
+  
+Reference: https://docs.snyk.io/snyk-admin/introduction-to-snyk-administration
+DedupPeriodMinutes: 60
+Threshold:  1
+SummaryAttributes:
+  - event
+Tests:
+  -
+    Name: Snyk Org Deletion ( HIGH )
+    ExpectedResult: true
+    Log:
+      {
+        "groupId": "8fffffff-1555-4444-b000-b55555555555",
+        "orgId": "21111111-a222-4eee-8ddd-a99999999999",
+        "event": "org.delete",
+        "content": {
+            "orgName": "expendable-org"
+        },
+        "created": "2023-04-09T23:32:14.649Z",
+        "userId": "05555555-3333-4ddd-8ccc-755555555555"
+      }
+  - 
+    Name: Snyk Group Org Remove ( HIGH )
+    ExpectedResult: true
+    Log:
+      {
+        "groupId": "8fffffff-1555-4444-b000-b55555555555",
+        "orgId": "21111111-a222-4eee-8ddd-a99999999999",
+        "event": "group.org.remove",
+        "content": {
+            "orgName": "expendable-org"
+        },
+        "created": "2023-04-09T23:32:14.649Z",
+        "userId": "05555555-3333-4ddd-8ccc-755555555555"
+      }
+  - 
+    Name: Snyk Group Edit ( MEDIUM )
+    ExpectedResult: true
+    Log:
+      {
+        "groupId": "8fffffff-1555-4444-b000-b55555555555",
+        "event": "group.edit",
+        "content": {
+            "updatedValues": {
+                "projectTestFrequencySetting": "daily"
+            }
+        },
+        "created": "2023-04-11T23:22:57.667Z"
+      }
+  - 
+    Name: Snyk Org Create ( INFO )
+    ExpectedResult: true
+    Log:
+      {
+        "groupId": "8fffffff-1555-4444-b000-b55555555555",
+        "event": "org.create",
+        "content": {
+            "newOrgPublicId": "21111111-a222-4eee-8ddd-a99999999999"
+        },
+        "created": "2023-04-11T23:12:33.206Z",
+        "userId": "05555555-3333-4ddd-8ccc-755555555555"
+      }
+  -
+    Name: Snyk Group SSO Membership sync
+    ExpectedResult: false
+    Log:
+      {
+        "content": {},
+        "created": "2023-03-15 13:13:13.133",
+        "event": "group.sso.membership.sync",
+        "groupId": "8fffffff-1555-4444-b000-b55555555555",
+      }

--- a/rules/snyk_rules/snyk_system_externalaccess.py
+++ b/rules/snyk_rules/snyk_system_externalaccess.py
@@ -1,0 +1,49 @@
+from global_filter_snyk import filter_include_event
+from panther_base_helpers import deep_get
+from panther_snyk_helpers import snyk_alert_context
+
+ACTIONS = [
+    "group.request_access_settings.edit",
+    "org.request_access_settings.edit",
+]
+
+
+def rule(event):
+    if not filter_include_event(event):
+        return False
+    action = deep_get(event, "event", default="<NO_EVENT>")
+    return action in ACTIONS
+
+
+def title(event):
+    current_setting = deep_get(event, "content", "after", "isEnabled", default=False)
+    action = deep_get(event, "event", default="<NO_EVENT>")
+    if "." in action:
+        action = action.split(".")[0].title()
+    return (
+        f"Snyk: [{action}] External Access settings have been modified "
+        f"to PermitExternalUsers:[{current_setting}] "
+        f"performed by [{deep_get(event, 'userId', default='<NO_USERID>')}]"
+    )
+
+
+def alert_context(event):
+    a_c = snyk_alert_context(event)
+    current_setting = deep_get(event, "content", "after", "isEnabled", default=False)
+    a_c["current_setting"] = current_setting
+    return a_c
+
+
+def dedup(event):
+    return (
+        f"{deep_get(event, 'userId', default='<NO_USERID>')}"
+        f"{deep_get(event, 'orgId', default='<NO_ORGID>')}"
+        f"{deep_get(event, 'groupId', default='<NO_GROUPID>')}"
+    )
+
+
+def severity(event):
+    current_setting = deep_get(event, "content", "after", "isEnabled", default=False)
+    if current_setting:
+        return "HIGH"
+    return "INFO"

--- a/rules/snyk_rules/snyk_system_externalaccess.yml
+++ b/rules/snyk_rules/snyk_system_externalaccess.yml
@@ -1,0 +1,92 @@
+AnalysisType: rule
+Filename: snyk_system_externalaccess.py
+RuleID: "Snyk.System.ExternalAccess"
+DisplayName: "Snyk System External Access Settings Changed"
+Enabled: true
+LogTypes:
+  - Snyk.GroupAudit
+  - Snyk.OrgAudit
+Tags:
+  - Snyk
+Severity: High
+Description: >
+  Detects when Snyk Settings that control access for external parties have been changed.
+Runbook: >
+  This action in the Snyk Audit logs indicate that the setting for allowing external
+  parties to request access to your Snyk installation have changed. 
+Reference: https://docs.snyk.io/snyk-admin/manage-users-and-permissions/organization-access-requests
+DedupPeriodMinutes: 60
+Threshold:  1
+SummaryAttributes:
+  - event
+Tests:
+  -
+    Name: Snyk External Access Allowed By External Parties - Enabled
+    ExpectedResult: true
+    Log:
+       {
+        "groupId": "8fffffff-1555-4444-b000-b55555555555",
+        "event": "group.request_access_settings.edit",
+        "content": {
+            "after": {
+                "isEnabled": true
+            },
+            "before": {}
+        },
+        "created": "2023-03-03T19:52:01.628Z",
+        "userId": "05555555-3333-4ddd-8ccc-755555555555"
+      }
+  -
+    Name: Snyk External Access Allowed By External Parties - Disabled
+    ExpectedResult: true
+    Log:
+       {
+        "groupId": "8fffffff-1555-4444-b000-b55555555555",
+        "event": "group.request_access_settings.edit",
+        "content": {
+            "after": {},
+            "before": {
+                "isEnabled": true
+            }
+        },
+        "created": "2023-03-03T20:52:01.628Z",
+        "userId": "05555555-3333-4ddd-8ccc-755555555555"
+      }
+  -
+    Name: Snyk External Access Allowed By External Parties - Disabled - excluded by filter
+    ExpectedResult: false
+    Mocks:
+      - objectName: filter_include_event
+        returnValue: false
+    Log:
+       {
+        "groupId": "8fffffff-1555-4444-b000-b55555555555",
+        "event": "group.request_access_settings.edit",
+        "content": {
+            "after": {},
+            "before": {
+                "isEnabled": true
+            }
+        },
+        "created": "2023-03-03T20:52:01.628Z",
+        "userId": "05555555-3333-4ddd-8ccc-755555555555"
+      }
+  -
+    Name: Snyk Group SSO Membership sync
+    ExpectedResult: false
+    Log:
+      {
+        "content": {
+          "addAsOrgAdmin": [],
+          "addAsOrgCollaborator": [
+            "group.name"
+          ],
+          "addAsOrgCustomRole": [],
+          "addAsOrgRestrictedCollaborator": [],
+          "removedOrgMemberships": [],
+          "userPublicId": "05555555-3333-4ddd-8ccc-755555555555"
+        },
+        "created": "2023-03-15 13:13:13.133",
+        "event": "group.sso.membership.sync",
+        "groupId": "8fffffff-1555-4444-b000-b55555555555",
+      }

--- a/rules/snyk_rules/snyk_system_policysetting.py
+++ b/rules/snyk_rules/snyk_system_policysetting.py
@@ -47,7 +47,7 @@ def dedup(event):
     # Licenses can apply at org or group levels
     return (
         f"{deep_get(event, 'userId', default='<NO_USERID>')}"
-        f"{deep_get(event, 'orgId', default='<NO_GROUPID>')}"
-        f"{deep_get(event, 'groupId', default='<NO_ORGID>')}"
+        f"{deep_get(event, 'orgId', default='<NO_ORGID>')}"
+        f"{deep_get(event, 'groupId', default='<NO_GROUPID>')}"
         f"{deep_get(event, 'content', 'publicId', default='<NO_PUBLICID>')}"
     )


### PR DESCRIPTION
### Background
Detections for some Snyk changes
* OU Changes ( several )
* Setting that allows Snyk users external to the Org/Group access to the group/org projects

There's also a typo fix in dedup on `Snyk.System.PolicySetting`, which should be a no-op. 

### Changes


### Testing

```shell
Snyk.OU.Change
	[PASS] Snyk Org Deletion ( HIGH )
		[PASS] [rule] true
		[PASS] [title] Snyk: [Org] Organizational Unit settings have been modified via [org.delete] performed by [05555555-3333-4ddd-8ccc-755555555555]
		[PASS] [dedup] 05555555-3333-4ddd-8ccc-75555555555521111111-a222-4eee-8ddd-a999999999998fffffff-1555-4444-b000-b55555555555org.delete
		[PASS] [alertContext] {"actor": "05555555-3333-4ddd-8ccc-755555555555", "action": "org.delete", "orgId": "21111111-a222-4eee-8ddd-a99999999999", "groupId": "8fffffff-1555-4444-b000-b55555555555"}
		[PASS] [severity] HIGH
	[PASS] Snyk Group Org Remove ( HIGH )
		[PASS] [rule] true
		[PASS] [title] Snyk: [Group] Organizational Unit settings have been modified via [group.org.remove] performed by [05555555-3333-4ddd-8ccc-755555555555]
		[PASS] [dedup] 05555555-3333-4ddd-8ccc-75555555555521111111-a222-4eee-8ddd-a999999999998fffffff-1555-4444-b000-b55555555555group.org.remove
		[PASS] [alertContext] {"actor": "05555555-3333-4ddd-8ccc-755555555555", "action": "group.org.remove", "orgId": "21111111-a222-4eee-8ddd-a99999999999", "groupId": "8fffffff-1555-4444-b000-b55555555555"}
		[PASS] [severity] HIGH
	[PASS] Snyk Group Edit ( MEDIUM )
		[PASS] [rule] true
		[PASS] [title] Snyk: [Group] Organizational Unit settings have been modified via [group.edit] performed by [<NO_USERID>]
		[PASS] [dedup] <NO_USERID><NO_ORGID>8fffffff-1555-4444-b000-b55555555555group.edit
		[PASS] [alertContext] {"actor": "<NO_USERID>", "action": "group.edit", "orgId": "<NO_ORGID>", "groupId": "8fffffff-1555-4444-b000-b55555555555"}
		[PASS] [severity] MEDIUM
	[PASS] Snyk Org Create ( INFO )
		[PASS] [rule] true
		[PASS] [title] Snyk: [Org] Organizational Unit settings have been modified via [org.create] performed by [05555555-3333-4ddd-8ccc-755555555555]
		[PASS] [dedup] 05555555-3333-4ddd-8ccc-755555555555<NO_ORGID>8fffffff-1555-4444-b000-b55555555555org.create
		[PASS] [alertContext] {"actor": "05555555-3333-4ddd-8ccc-755555555555", "action": "org.create", "orgId": "<NO_ORGID>", "groupId": "8fffffff-1555-4444-b000-b55555555555"}
		[PASS] [severity] INFO
	[PASS] Snyk Group SSO Membership sync
		[PASS] [rule] false

Snyk.System.ExternalAccess
	[PASS] Snyk External Access Allowed By External Parties - Enabled
		[PASS] [rule] true
		[PASS] [title] Snyk: [Group] External Access settings have been modified to PermitExternalUsers:[True] performed by [05555555-3333-4ddd-8ccc-755555555555]
		[PASS] [dedup] 05555555-3333-4ddd-8ccc-755555555555<NO_ORGID>8fffffff-1555-4444-b000-b55555555555
		[PASS] [alertContext] {"actor": "05555555-3333-4ddd-8ccc-755555555555", "action": "group.request_access_settings.edit", "orgId": "<NO_ORGID>", "groupId": "8fffffff-1555-4444-b000-b55555555555", "current_setting": true}
		[PASS] [severity] HIGH
	[PASS] Snyk External Access Allowed By External Parties - Disabled
		[PASS] [rule] true
		[PASS] [title] Snyk: [Group] External Access settings have been modified to PermitExternalUsers:[False] performed by [05555555-3333-4ddd-8ccc-755555555555]
		[PASS] [dedup] 05555555-3333-4ddd-8ccc-755555555555<NO_ORGID>8fffffff-1555-4444-b000-b55555555555
		[PASS] [alertContext] {"actor": "05555555-3333-4ddd-8ccc-755555555555", "action": "group.request_access_settings.edit", "orgId": "<NO_ORGID>", "groupId": "8fffffff-1555-4444-b000-b55555555555", "current_setting": false}
		[PASS] [severity] INFO
	[PASS] Snyk External Access Allowed By External Parties - Disabled - excluded by filter
		[PASS] [rule] false
	[PASS] Snyk Group SSO Membership sync
		[PASS] [rule] false

--------------------------
Panther CLI Test Summary
	Path: .
	Passed: 2
	Failed: 0
	Invalid: 0

```
