### PR TITLE
Adding Panther.Audit to the Greynoise LUTs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "python.analysis.extraPaths": [
-        "./global_helpers"
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.analysis.extraPaths": [
+        "./global_helpers"
+    ]
+}

--- a/lookup_tables/greynoise/advanced/noise_advanced.yml
+++ b/lookup_tables/greynoise/advanced/noise_advanced.yml
@@ -183,6 +183,9 @@ LogTypeMap:
     - LogType: OnePassword.SignInAttempt
       Selectors:
         - "$.client.ip_address"
+    - LogType: Panther.Audit
+      Selectors:
+        - "sourceIP"
     - LogType: Salesforce.Login
       Selectors:
         - "CLIENT_IP"

--- a/lookup_tables/greynoise/advanced/riot_advanced.yml
+++ b/lookup_tables/greynoise/advanced/riot_advanced.yml
@@ -183,6 +183,9 @@ LogTypeMap:
     - LogType: OnePassword.SignInAttempt
       Selectors:
         - "$.client.ip_address"
+    - LogType: Panther.Audit
+      Selectors:
+        - "sourceIP"
     - LogType: Salesforce.Login
       Selectors:
         - "CLIENT_IP"

--- a/lookup_tables/greynoise/basic/noise_basic.yml
+++ b/lookup_tables/greynoise/basic/noise_basic.yml
@@ -183,6 +183,9 @@ LogTypeMap:
     - LogType: OnePassword.SignInAttempt
       Selectors:
         - "$.client.ip_address"
+    - LogType: Panther.Audit
+      Selectors:
+        - "sourceIP"
     - LogType: Salesforce.Login
       Selectors:
         - "CLIENT_IP"

--- a/lookup_tables/greynoise/basic/riot_basic.yml
+++ b/lookup_tables/greynoise/basic/riot_basic.yml
@@ -183,6 +183,9 @@ LogTypeMap:
     - LogType: OnePassword.SignInAttempt
       Selectors:
         - "$.client.ip_address"
+    - LogType: Panther.Audit
+      Selectors:
+        - "sourceIP"
     - LogType: Salesforce.Login
       Selectors:
         - "CLIENT_IP"


### PR DESCRIPTION
### Background

The audit logs for Panther Console was left out of the mappings for the Greynoise lookup tables. This PR adds them in!

### Changes

Updated the Greynoise .yml files with the appropriate metadata. 
