### PR TITLE
fix: AWS ELBs now have TLS 1.3 SSL Policies

### DIFF
--- a/policies/aws_load_balancer_policies/aws_alb_ssl_policy.py
+++ b/policies/aws_load_balancer_policies/aws_alb_ssl_policy.py
@@ -6,6 +6,7 @@ TLS_1_2_POLICIES = {
     "ELBSecurityPolicy-FS-1-2-Res-2019-08",
     "ELBSecurityPolicy-FS-1-2-2019-08",
     "ELBSecurityPolicy-FS-1-2-Res-2020-10",
+    "ELBSecurityPolicy-TLS13-1-2-2021-06"
 }
 
 

--- a/policies/aws_load_balancer_policies/aws_alb_ssl_policy.py
+++ b/policies/aws_load_balancer_policies/aws_alb_ssl_policy.py
@@ -6,7 +6,7 @@ TLS_1_2_POLICIES = {
     "ELBSecurityPolicy-FS-1-2-Res-2019-08",
     "ELBSecurityPolicy-FS-1-2-2019-08",
     "ELBSecurityPolicy-FS-1-2-Res-2020-10",
-    "ELBSecurityPolicy-TLS13-1-2-2021-06"
+    "ELBSecurityPolicy-TLS13-1-2-2021-06",
 }
 
 

--- a/policies/aws_load_balancer_policies/aws_alb_ssl_policy.yml
+++ b/policies/aws_load_balancer_policies/aws_alb_ssl_policy.yml
@@ -21,520 +21,520 @@ Runbook: >
   Update your load balancer's SSLPolicies to only support modern TLS versions
 Reference: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html
 Tests:
-  # -
-  #   Name: Strong Ciphers Internet Facing
-  #   ExpectedResult: true
-  #   Resource:
-  #     {
-  #       "IpAddressType": "ipv4",
-  #       "Type": "application",
-  #       "Tags": {
-  #         "Application": "Test"
-  #       },
-  #       "AvailabilityZones": [
-  #         {
-  #           "LoadBalancerAddresses": null,
-  #           "ZoneName": "us-east-1b",
-  #           "SubnetId": "subnet-05f7b81cc5d97e0e2"
-  #         },
-  #         {
-  #           "ZoneName": "us-east-1a",
-  #           "SubnetId": "subnet-07419606a40f4c414",
-  #           "LoadBalancerAddresses": null
-  #         }
-  #       ],
-  #       "AccountId": "123456789012",
-  #       "DNSName": "web-360787852.us-east-1.elb.amazonaws.com",
-  #       "Listeners": [
-  #         {
-  #           "DefaultActions": [
-  #             {
-  #               "RedirectConfig": null,
-  #               "ForwardConfig": {
-  #                 "TargetGroups": [
-  #                   {
-  #                     "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
-  #                     "Weight": 1
-  #                   }
-  #                 ],
-  #                 "TargetGroupStickinessConfig": {
-  #                   "Enabled": false,
-  #                   "DurationSeconds": null
-  #                 }
-  #               },
-  #               "AuthenticateOidcConfig": null,
-  #               "Order": null,
-  #               "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
-  #               "FixedResponseConfig": null,
-  #               "AuthenticateCognitoConfig": null,
-  #               "Type": "forward"
-  #             }
-  #           ],
-  #           "Port": 443,
-  #           "Certificates": [
-  #             {
-  #               "IsDefault": null,
-  #               "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/10c4e713-9bb5-4ccf-aabc-1c9119370038"
-  #             }
-  #           ],
-  #           "Protocol": "HTTPS",
-  #           "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/web/3ff2fab33a993e0c/995359b182328b77",
-  #           "SslPolicy": "ELBSecurityPolicy-2016-08",
-  #           "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c"
-  #         }
-  #       ],
-  #       "ResourceId": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
-  #       "Scheme": "internet-facing",
-  #       "VpcId": "vpc-0aa6688dd88484847",
-  #       "State": {
-  #         "Code": "active",
-  #         "Reason": null
-  #       },
-  #       "Name": "web",
-  #       "SSLPolicies": {
-  #         "ELBSecurityPolicy-TLS-1-2-Ext-2018-06": {
-  #           "SslProtocols": [
-  #               "TLSv1.2"
-  #           ],
-  #           "Ciphers": [
-  #               {
-  #                   "Name": "ECDHE-ECDSA-AES128-GCM-SHA256",
-  #                   "Priority": 1
-  #               },
-  #               {
-  #                   "Name": "ECDHE-RSA-AES128-GCM-SHA256",
-  #                   "Priority": 2
-  #               },
-  #               {
-  #                   "Name": "ECDHE-ECDSA-AES128-SHA256",
-  #                   "Priority": 3
-  #               },
-  #               {
-  #                   "Name": "ECDHE-RSA-AES128-SHA256",
-  #                   "Priority": 4
-  #               },
-  #               {
-  #                   "Name": "ECDHE-ECDSA-AES128-SHA",
-  #                   "Priority": 5
-  #               },
-  #               {
-  #                   "Name": "ECDHE-RSA-AES128-SHA",
-  #                   "Priority": 6
-  #               },
-  #               {
-  #                   "Name": "ECDHE-ECDSA-AES256-GCM-SHA384",
-  #                   "Priority": 7
-  #               },
-  #               {
-  #                   "Name": "ECDHE-RSA-AES256-GCM-SHA384",
-  #                   "Priority": 8
-  #               },
-  #               {
-  #                   "Name": "ECDHE-ECDSA-AES256-SHA384",
-  #                   "Priority": 9
-  #               },
-  #               {
-  #                   "Name": "ECDHE-RSA-AES256-SHA384",
-  #                   "Priority": 10
-  #               },
-  #               {
-  #                   "Name": "ECDHE-RSA-AES256-SHA",
-  #                   "Priority": 11
-  #               },
-  #               {
-  #                   "Name": "ECDHE-ECDSA-AES256-SHA",
-  #                   "Priority": 12
-  #               },
-  #               {
-  #                   "Name": "AES128-GCM-SHA256",
-  #                   "Priority": 13
-  #               },
-  #               {
-  #                   "Name": "AES128-SHA256",
-  #                   "Priority": 14
-  #               },
-  #               {
-  #                   "Name": "AES128-SHA",
-  #                   "Priority": 15
-  #               },
-  #               {
-  #                   "Name": "AES256-GCM-SHA384",
-  #                   "Priority": 16
-  #               },
-  #               {
-  #                   "Name": "AES256-SHA256",
-  #                   "Priority": 17
-  #               },
-  #               {
-  #                   "Name": "AES256-SHA",
-  #                   "Priority": 18
-  #               }
-  #           ],
-  #           "Name": "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
-  #         }
-  #       },
-  #       "Arn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
-  #       "Region": "us-east-1",
-  #       "SecurityGroups": [
-  #         "sg-000bbcc377444490b"
-  #       ],
-  #       "TimeCreated": "2020-03-24T21:39:15.050Z",
-  #       "WebAcl": null,
-  #       "CanonicalHostedZonedId": "Z1H1FL5HABSF5",
-  #       "ResourceType": "AWS.ELBV2.ApplicationLoadBalancer"
-  #     }
-  # -
-  #   Name: Default Ciphers
-  #   ExpectedResult: false
-  #   Resource:
-  #     {
-  #       "IpAddressType": "ipv4",
-  #       "Type": "application",
-  #       "Tags": {
-  #         "Application": "Test"
-  #       },
-  #       "AvailabilityZones": [
-  #         {
-  #           "LoadBalancerAddresses": null,
-  #           "ZoneName": "us-east-1b",
-  #           "SubnetId": "subnet-05f7b81cc5d97e0e2"
-  #         },
-  #         {
-  #           "ZoneName": "us-east-1a",
-  #           "SubnetId": "subnet-07419606a40f4c414",
-  #           "LoadBalancerAddresses": null
-  #         }
-  #       ],
-  #       "AccountId": "123456789012",
-  #       "DNSName": "web-360787852.us-east-1.elb.amazonaws.com",
-  #       "Listeners": [
-  #         {
-  #           "DefaultActions": [
-  #             {
-  #               "RedirectConfig": null,
-  #               "ForwardConfig": {
-  #                 "TargetGroups": [
-  #                   {
-  #                     "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
-  #                     "Weight": 1
-  #                   }
-  #                 ],
-  #                 "TargetGroupStickinessConfig": {
-  #                   "Enabled": false,
-  #                   "DurationSeconds": null
-  #                 }
-  #               },
-  #               "AuthenticateOidcConfig": null,
-  #               "Order": null,
-  #               "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
-  #               "FixedResponseConfig": null,
-  #               "AuthenticateCognitoConfig": null,
-  #               "Type": "forward"
-  #             }
-  #           ],
-  #           "Port": 443,
-  #           "Certificates": [
-  #             {
-  #               "IsDefault": null,
-  #               "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/10c4e713-9bb5-4ccf-aabc-1c9119370038"
-  #             }
-  #           ],
-  #           "Protocol": "HTTPS",
-  #           "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/web/3ff2fab33a993e0c/995359b182328b77",
-  #           "SslPolicy": "ELBSecurityPolicy-2016-08",
-  #           "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c"
-  #         }
-  #       ],
-  #       "ResourceId": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
-  #       "Scheme": "internet-facing",
-  #       "VpcId": "vpc-0aa6688dd88484847",
-  #       "State": {
-  #         "Code": "active",
-  #         "Reason": null
-  #       },
-  #       "Name": "web",
-  #       "SSLPolicies": {
-  #         "ELBSecurityPolicy-2016-08": {
-  #           "Ciphers": [
-  #             {
-  #               "Priority": 1,
-  #               "Name": "ECDHE-ECDSA-AES128-GCM-SHA256"
-  #             },
-  #             {
-  #               "Priority": 2,
-  #               "Name": "ECDHE-RSA-AES128-GCM-SHA256"
-  #             },
-  #             {
-  #               "Priority": 3,
-  #               "Name": "ECDHE-ECDSA-AES128-SHA256"
-  #             },
-  #             {
-  #               "Priority": 4,
-  #               "Name": "ECDHE-RSA-AES128-SHA256"
-  #             },
-  #             {
-  #               "Priority": 5,
-  #               "Name": "ECDHE-ECDSA-AES128-SHA"
-  #             },
-  #             {
-  #               "Priority": 6,
-  #               "Name": "ECDHE-RSA-AES128-SHA"
-  #             },
-  #             {
-  #               "Priority": 7,
-  #               "Name": "ECDHE-ECDSA-AES256-GCM-SHA384"
-  #             },
-  #             {
-  #               "Name": "ECDHE-RSA-AES256-GCM-SHA384",
-  #               "Priority": 8
-  #             },
-  #             {
-  #               "Name": "ECDHE-ECDSA-AES256-SHA384",
-  #               "Priority": 9
-  #             },
-  #             {
-  #               "Priority": 10,
-  #               "Name": "ECDHE-RSA-AES256-SHA384"
-  #             },
-  #             {
-  #               "Priority": 11,
-  #               "Name": "ECDHE-RSA-AES256-SHA"
-  #             },
-  #             {
-  #               "Name": "ECDHE-ECDSA-AES256-SHA",
-  #               "Priority": 12
-  #             },
-  #             {
-  #               "Priority": 13,
-  #               "Name": "AES128-GCM-SHA256"
-  #             },
-  #             {
-  #               "Name": "AES128-SHA256",
-  #               "Priority": 14
-  #             },
-  #             {
-  #               "Priority": 15,
-  #               "Name": "AES128-SHA"
-  #             },
-  #             {
-  #               "Name": "AES256-GCM-SHA384",
-  #               "Priority": 16
-  #             },
-  #             {
-  #               "Priority": 17,
-  #               "Name": "AES256-SHA256"
-  #             },
-  #             {
-  #               "Priority": 18,
-  #               "Name": "AES256-SHA"
-  #             }
-  #           ],
-  #           "SslProtocols": [
-  #             "TLSv1",
-  #             "TLSv1.1",
-  #             "TLSv1.2"
-  #           ],
-  #           "Name": "ELBSecurityPolicy-2016-08"
-  #         }
-  #       },
-  #       "Arn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
-  #       "Region": "us-east-1",
-  #       "SecurityGroups": [
-  #         "sg-000bbcc377444490b"
-  #       ],
-  #       "TimeCreated": "2020-03-24T21:39:15.050Z",
-  #       "WebAcl": null,
-  #       "CanonicalHostedZonedId": "Z1H1FL5HABSF5",
-  #       "ResourceType": "AWS.ELBV2.ApplicationLoadBalancer"
-  #     }
-  # -
-  #   Name: Default Ciphers Internal Load Balancer
-  #   ExpectedResult: true
-  #   Resource:
-  #     {
-  #       "IpAddressType": "ipv4",
-  #       "Type": "application",
-  #       "Tags": {
-  #         "Application": "Test"
-  #       },
-  #       "AvailabilityZones": [
-  #         {
-  #           "LoadBalancerAddresses": null,
-  #           "ZoneName": "us-east-1b",
-  #           "SubnetId": "subnet-05f7b81cc5d97e0e2"
-  #         },
-  #         {
-  #           "ZoneName": "us-east-1a",
-  #           "SubnetId": "subnet-07419606a40f4c414",
-  #           "LoadBalancerAddresses": null
-  #         }
-  #       ],
-  #       "AccountId": "123456789012",
-  #       "DNSName": "web-360787852.us-east-1.elb.amazonaws.com",
-  #       "Listeners": [
-  #         {
-  #           "DefaultActions": [
-  #             {
-  #               "RedirectConfig": null,
-  #               "ForwardConfig": {
-  #                 "TargetGroups": [
-  #                   {
-  #                     "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
-  #                     "Weight": 1
-  #                   }
-  #                 ],
-  #                 "TargetGroupStickinessConfig": {
-  #                   "Enabled": false,
-  #                   "DurationSeconds": null
-  #                 }
-  #               },
-  #               "AuthenticateOidcConfig": null,
-  #               "Order": null,
-  #               "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
-  #               "FixedResponseConfig": null,
-  #               "AuthenticateCognitoConfig": null,
-  #               "Type": "forward"
-  #             }
-  #           ],
-  #           "Port": 443,
-  #           "Certificates": [
-  #             {
-  #               "IsDefault": null,
-  #               "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/10c4e713-9bb5-4ccf-aabc-1c9119370038"
-  #             }
-  #           ],
-  #           "Protocol": "HTTPS",
-  #           "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/web/3ff2fab33a993e0c/995359b182328b77",
-  #           "SslPolicy": "ELBSecurityPolicy-2016-08",
-  #           "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c"
-  #         }
-  #       ],
-  #       "ResourceId": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
-  #       "Scheme": "internal",
-  #       "VpcId": "vpc-0aa6688dd88484847",
-  #       "State": {
-  #         "Code": "active",
-  #         "Reason": null
-  #       },
-  #       "Name": "web",
-  #       "SSLPolicies": {
-  #         "ELBSecurityPolicy-2016-08": {
-  #           "Ciphers": [
-  #             {
-  #               "Priority": 1,
-  #               "Name": "ECDHE-ECDSA-AES128-GCM-SHA256"
-  #             },
-  #             {
-  #               "Priority": 2,
-  #               "Name": "ECDHE-RSA-AES128-GCM-SHA256"
-  #             },
-  #             {
-  #               "Priority": 3,
-  #               "Name": "ECDHE-ECDSA-AES128-SHA256"
-  #             },
-  #             {
-  #               "Priority": 4,
-  #               "Name": "ECDHE-RSA-AES128-SHA256"
-  #             },
-  #             {
-  #               "Priority": 5,
-  #               "Name": "ECDHE-ECDSA-AES128-SHA"
-  #             },
-  #             {
-  #               "Priority": 6,
-  #               "Name": "ECDHE-RSA-AES128-SHA"
-  #             },
-  #             {
-  #               "Priority": 7,
-  #               "Name": "ECDHE-ECDSA-AES256-GCM-SHA384"
-  #             },
-  #             {
-  #               "Name": "ECDHE-RSA-AES256-GCM-SHA384",
-  #               "Priority": 8
-  #             },
-  #             {
-  #               "Name": "ECDHE-ECDSA-AES256-SHA384",
-  #               "Priority": 9
-  #             },
-  #             {
-  #               "Priority": 10,
-  #               "Name": "ECDHE-RSA-AES256-SHA384"
-  #             },
-  #             {
-  #               "Priority": 11,
-  #               "Name": "ECDHE-RSA-AES256-SHA"
-  #             },
-  #             {
-  #               "Name": "ECDHE-ECDSA-AES256-SHA",
-  #               "Priority": 12
-  #             },
-  #             {
-  #               "Priority": 13,
-  #               "Name": "AES128-GCM-SHA256"
-  #             },
-  #             {
-  #               "Name": "AES128-SHA256",
-  #               "Priority": 14
-  #             },
-  #             {
-  #               "Priority": 15,
-  #               "Name": "AES128-SHA"
-  #             },
-  #             {
-  #               "Name": "AES256-GCM-SHA384",
-  #               "Priority": 16
-  #             },
-  #             {
-  #               "Priority": 17,
-  #               "Name": "AES256-SHA256"
-  #             },
-  #             {
-  #               "Priority": 18,
-  #               "Name": "AES256-SHA"
-  #             }
-  #           ],
-  #           "SslProtocols": [
-  #             "TLSv1",
-  #             "TLSv1.1",
-  #             "TLSv1.2"
-  #           ],
-  #           "Name": "ELBSecurityPolicy-2016-08"
-  #         }
-  #       },
-  #       "Arn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
-  #       "Region": "us-east-1",
-  #       "SecurityGroups": [
-  #         "sg-000bbcc377444490b"
-  #       ],
-  #       "TimeCreated": "2020-03-24T21:39:15.050Z",
-  #       "WebAcl": null,
-  #       "CanonicalHostedZonedId": "Z1H1FL5HABSF5",
-  #       "ResourceType": "AWS.ELBV2.ApplicationLoadBalancer"
-  #     }
-  # -
-  #   Name: Observed - No Listeners len() issue
-  #   ExpectedResult: false
-  #   Resource:
-  #     {
-  #       "Listeners": null,
-  #       "Scheme": "internet-facing",
-  #       "SSLPolicies": {
-  #         "ELBSecurityPolicy-2016-08": {
-  #           "Ciphers": [
-  #             {
-  #               "Priority": 1,
-  #               "Name": "ECDHE-ECDSA-AES128-GCM-SHA256"
-  #             }
-  #           ],
-  #           "SslProtocols": [
-  #               "TLSv1",
-  #               "TLSv1.1",
-  #               "TLSv1.2"
-  #           ],
-  #           "Name": "ELBSecurityPolicy-2016-08"
-  #         }
-  #       }
-  #     }
+  -
+    Name: Strong Ciphers Internet Facing
+    ExpectedResult: true
+    Resource:
+      {
+        "IpAddressType": "ipv4",
+        "Type": "application",
+        "Tags": {
+          "Application": "Test"
+        },
+        "AvailabilityZones": [
+          {
+            "LoadBalancerAddresses": null,
+            "ZoneName": "us-east-1b",
+            "SubnetId": "subnet-05f7b81cc5d97e0e2"
+          },
+          {
+            "ZoneName": "us-east-1a",
+            "SubnetId": "subnet-07419606a40f4c414",
+            "LoadBalancerAddresses": null
+          }
+        ],
+        "AccountId": "123456789012",
+        "DNSName": "web-360787852.us-east-1.elb.amazonaws.com",
+        "Listeners": [
+          {
+            "DefaultActions": [
+              {
+                "RedirectConfig": null,
+                "ForwardConfig": {
+                  "TargetGroups": [
+                    {
+                      "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
+                      "Weight": 1
+                    }
+                  ],
+                  "TargetGroupStickinessConfig": {
+                    "Enabled": false,
+                    "DurationSeconds": null
+                  }
+                },
+                "AuthenticateOidcConfig": null,
+                "Order": null,
+                "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
+                "FixedResponseConfig": null,
+                "AuthenticateCognitoConfig": null,
+                "Type": "forward"
+              }
+            ],
+            "Port": 443,
+            "Certificates": [
+              {
+                "IsDefault": null,
+                "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/10c4e713-9bb5-4ccf-aabc-1c9119370038"
+              }
+            ],
+            "Protocol": "HTTPS",
+            "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/web/3ff2fab33a993e0c/995359b182328b77",
+            "SslPolicy": "ELBSecurityPolicy-2016-08",
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c"
+          }
+        ],
+        "ResourceId": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
+        "Scheme": "internet-facing",
+        "VpcId": "vpc-0aa6688dd88484847",
+        "State": {
+          "Code": "active",
+          "Reason": null
+        },
+        "Name": "web",
+        "SSLPolicies": {
+          "ELBSecurityPolicy-TLS-1-2-Ext-2018-06": {
+            "SslProtocols": [
+                "TLSv1.2"
+            ],
+            "Ciphers": [
+                {
+                    "Name": "ECDHE-ECDSA-AES128-GCM-SHA256",
+                    "Priority": 1
+                },
+                {
+                    "Name": "ECDHE-RSA-AES128-GCM-SHA256",
+                    "Priority": 2
+                },
+                {
+                    "Name": "ECDHE-ECDSA-AES128-SHA256",
+                    "Priority": 3
+                },
+                {
+                    "Name": "ECDHE-RSA-AES128-SHA256",
+                    "Priority": 4
+                },
+                {
+                    "Name": "ECDHE-ECDSA-AES128-SHA",
+                    "Priority": 5
+                },
+                {
+                    "Name": "ECDHE-RSA-AES128-SHA",
+                    "Priority": 6
+                },
+                {
+                    "Name": "ECDHE-ECDSA-AES256-GCM-SHA384",
+                    "Priority": 7
+                },
+                {
+                    "Name": "ECDHE-RSA-AES256-GCM-SHA384",
+                    "Priority": 8
+                },
+                {
+                    "Name": "ECDHE-ECDSA-AES256-SHA384",
+                    "Priority": 9
+                },
+                {
+                    "Name": "ECDHE-RSA-AES256-SHA384",
+                    "Priority": 10
+                },
+                {
+                    "Name": "ECDHE-RSA-AES256-SHA",
+                    "Priority": 11
+                },
+                {
+                    "Name": "ECDHE-ECDSA-AES256-SHA",
+                    "Priority": 12
+                },
+                {
+                    "Name": "AES128-GCM-SHA256",
+                    "Priority": 13
+                },
+                {
+                    "Name": "AES128-SHA256",
+                    "Priority": 14
+                },
+                {
+                    "Name": "AES128-SHA",
+                    "Priority": 15
+                },
+                {
+                    "Name": "AES256-GCM-SHA384",
+                    "Priority": 16
+                },
+                {
+                    "Name": "AES256-SHA256",
+                    "Priority": 17
+                },
+                {
+                    "Name": "AES256-SHA",
+                    "Priority": 18
+                }
+            ],
+            "Name": "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+          }
+        },
+        "Arn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
+        "Region": "us-east-1",
+        "SecurityGroups": [
+          "sg-000bbcc377444490b"
+        ],
+        "TimeCreated": "2020-03-24T21:39:15.050Z",
+        "WebAcl": null,
+        "CanonicalHostedZonedId": "Z1H1FL5HABSF5",
+        "ResourceType": "AWS.ELBV2.ApplicationLoadBalancer"
+      }
+  -
+    Name: Default Ciphers
+    ExpectedResult: false
+    Resource:
+      {
+        "IpAddressType": "ipv4",
+        "Type": "application",
+        "Tags": {
+          "Application": "Test"
+        },
+        "AvailabilityZones": [
+          {
+            "LoadBalancerAddresses": null,
+            "ZoneName": "us-east-1b",
+            "SubnetId": "subnet-05f7b81cc5d97e0e2"
+          },
+          {
+            "ZoneName": "us-east-1a",
+            "SubnetId": "subnet-07419606a40f4c414",
+            "LoadBalancerAddresses": null
+          }
+        ],
+        "AccountId": "123456789012",
+        "DNSName": "web-360787852.us-east-1.elb.amazonaws.com",
+        "Listeners": [
+          {
+            "DefaultActions": [
+              {
+                "RedirectConfig": null,
+                "ForwardConfig": {
+                  "TargetGroups": [
+                    {
+                      "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
+                      "Weight": 1
+                    }
+                  ],
+                  "TargetGroupStickinessConfig": {
+                    "Enabled": false,
+                    "DurationSeconds": null
+                  }
+                },
+                "AuthenticateOidcConfig": null,
+                "Order": null,
+                "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
+                "FixedResponseConfig": null,
+                "AuthenticateCognitoConfig": null,
+                "Type": "forward"
+              }
+            ],
+            "Port": 443,
+            "Certificates": [
+              {
+                "IsDefault": null,
+                "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/10c4e713-9bb5-4ccf-aabc-1c9119370038"
+              }
+            ],
+            "Protocol": "HTTPS",
+            "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/web/3ff2fab33a993e0c/995359b182328b77",
+            "SslPolicy": "ELBSecurityPolicy-2016-08",
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c"
+          }
+        ],
+        "ResourceId": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
+        "Scheme": "internet-facing",
+        "VpcId": "vpc-0aa6688dd88484847",
+        "State": {
+          "Code": "active",
+          "Reason": null
+        },
+        "Name": "web",
+        "SSLPolicies": {
+          "ELBSecurityPolicy-2016-08": {
+            "Ciphers": [
+              {
+                "Priority": 1,
+                "Name": "ECDHE-ECDSA-AES128-GCM-SHA256"
+              },
+              {
+                "Priority": 2,
+                "Name": "ECDHE-RSA-AES128-GCM-SHA256"
+              },
+              {
+                "Priority": 3,
+                "Name": "ECDHE-ECDSA-AES128-SHA256"
+              },
+              {
+                "Priority": 4,
+                "Name": "ECDHE-RSA-AES128-SHA256"
+              },
+              {
+                "Priority": 5,
+                "Name": "ECDHE-ECDSA-AES128-SHA"
+              },
+              {
+                "Priority": 6,
+                "Name": "ECDHE-RSA-AES128-SHA"
+              },
+              {
+                "Priority": 7,
+                "Name": "ECDHE-ECDSA-AES256-GCM-SHA384"
+              },
+              {
+                "Name": "ECDHE-RSA-AES256-GCM-SHA384",
+                "Priority": 8
+              },
+              {
+                "Name": "ECDHE-ECDSA-AES256-SHA384",
+                "Priority": 9
+              },
+              {
+                "Priority": 10,
+                "Name": "ECDHE-RSA-AES256-SHA384"
+              },
+              {
+                "Priority": 11,
+                "Name": "ECDHE-RSA-AES256-SHA"
+              },
+              {
+                "Name": "ECDHE-ECDSA-AES256-SHA",
+                "Priority": 12
+              },
+              {
+                "Priority": 13,
+                "Name": "AES128-GCM-SHA256"
+              },
+              {
+                "Name": "AES128-SHA256",
+                "Priority": 14
+              },
+              {
+                "Priority": 15,
+                "Name": "AES128-SHA"
+              },
+              {
+                "Name": "AES256-GCM-SHA384",
+                "Priority": 16
+              },
+              {
+                "Priority": 17,
+                "Name": "AES256-SHA256"
+              },
+              {
+                "Priority": 18,
+                "Name": "AES256-SHA"
+              }
+            ],
+            "SslProtocols": [
+              "TLSv1",
+              "TLSv1.1",
+              "TLSv1.2"
+            ],
+            "Name": "ELBSecurityPolicy-2016-08"
+          }
+        },
+        "Arn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
+        "Region": "us-east-1",
+        "SecurityGroups": [
+          "sg-000bbcc377444490b"
+        ],
+        "TimeCreated": "2020-03-24T21:39:15.050Z",
+        "WebAcl": null,
+        "CanonicalHostedZonedId": "Z1H1FL5HABSF5",
+        "ResourceType": "AWS.ELBV2.ApplicationLoadBalancer"
+      }
+  -
+    Name: Default Ciphers Internal Load Balancer
+    ExpectedResult: true
+    Resource:
+      {
+        "IpAddressType": "ipv4",
+        "Type": "application",
+        "Tags": {
+          "Application": "Test"
+        },
+        "AvailabilityZones": [
+          {
+            "LoadBalancerAddresses": null,
+            "ZoneName": "us-east-1b",
+            "SubnetId": "subnet-05f7b81cc5d97e0e2"
+          },
+          {
+            "ZoneName": "us-east-1a",
+            "SubnetId": "subnet-07419606a40f4c414",
+            "LoadBalancerAddresses": null
+          }
+        ],
+        "AccountId": "123456789012",
+        "DNSName": "web-360787852.us-east-1.elb.amazonaws.com",
+        "Listeners": [
+          {
+            "DefaultActions": [
+              {
+                "RedirectConfig": null,
+                "ForwardConfig": {
+                  "TargetGroups": [
+                    {
+                      "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
+                      "Weight": 1
+                    }
+                  ],
+                  "TargetGroupStickinessConfig": {
+                    "Enabled": false,
+                    "DurationSeconds": null
+                  }
+                },
+                "AuthenticateOidcConfig": null,
+                "Order": null,
+                "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
+                "FixedResponseConfig": null,
+                "AuthenticateCognitoConfig": null,
+                "Type": "forward"
+              }
+            ],
+            "Port": 443,
+            "Certificates": [
+              {
+                "IsDefault": null,
+                "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/10c4e713-9bb5-4ccf-aabc-1c9119370038"
+              }
+            ],
+            "Protocol": "HTTPS",
+            "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/web/3ff2fab33a993e0c/995359b182328b77",
+            "SslPolicy": "ELBSecurityPolicy-2016-08",
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c"
+          }
+        ],
+        "ResourceId": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
+        "Scheme": "internal",
+        "VpcId": "vpc-0aa6688dd88484847",
+        "State": {
+          "Code": "active",
+          "Reason": null
+        },
+        "Name": "web",
+        "SSLPolicies": {
+          "ELBSecurityPolicy-2016-08": {
+            "Ciphers": [
+              {
+                "Priority": 1,
+                "Name": "ECDHE-ECDSA-AES128-GCM-SHA256"
+              },
+              {
+                "Priority": 2,
+                "Name": "ECDHE-RSA-AES128-GCM-SHA256"
+              },
+              {
+                "Priority": 3,
+                "Name": "ECDHE-ECDSA-AES128-SHA256"
+              },
+              {
+                "Priority": 4,
+                "Name": "ECDHE-RSA-AES128-SHA256"
+              },
+              {
+                "Priority": 5,
+                "Name": "ECDHE-ECDSA-AES128-SHA"
+              },
+              {
+                "Priority": 6,
+                "Name": "ECDHE-RSA-AES128-SHA"
+              },
+              {
+                "Priority": 7,
+                "Name": "ECDHE-ECDSA-AES256-GCM-SHA384"
+              },
+              {
+                "Name": "ECDHE-RSA-AES256-GCM-SHA384",
+                "Priority": 8
+              },
+              {
+                "Name": "ECDHE-ECDSA-AES256-SHA384",
+                "Priority": 9
+              },
+              {
+                "Priority": 10,
+                "Name": "ECDHE-RSA-AES256-SHA384"
+              },
+              {
+                "Priority": 11,
+                "Name": "ECDHE-RSA-AES256-SHA"
+              },
+              {
+                "Name": "ECDHE-ECDSA-AES256-SHA",
+                "Priority": 12
+              },
+              {
+                "Priority": 13,
+                "Name": "AES128-GCM-SHA256"
+              },
+              {
+                "Name": "AES128-SHA256",
+                "Priority": 14
+              },
+              {
+                "Priority": 15,
+                "Name": "AES128-SHA"
+              },
+              {
+                "Name": "AES256-GCM-SHA384",
+                "Priority": 16
+              },
+              {
+                "Priority": 17,
+                "Name": "AES256-SHA256"
+              },
+              {
+                "Priority": 18,
+                "Name": "AES256-SHA"
+              }
+            ],
+            "SslProtocols": [
+              "TLSv1",
+              "TLSv1.1",
+              "TLSv1.2"
+            ],
+            "Name": "ELBSecurityPolicy-2016-08"
+          }
+        },
+        "Arn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
+        "Region": "us-east-1",
+        "SecurityGroups": [
+          "sg-000bbcc377444490b"
+        ],
+        "TimeCreated": "2020-03-24T21:39:15.050Z",
+        "WebAcl": null,
+        "CanonicalHostedZonedId": "Z1H1FL5HABSF5",
+        "ResourceType": "AWS.ELBV2.ApplicationLoadBalancer"
+      }
+  -
+    Name: Observed - No Listeners len() issue
+    ExpectedResult: false
+    Resource:
+      {
+        "Listeners": null,
+        "Scheme": "internet-facing",
+        "SSLPolicies": {
+          "ELBSecurityPolicy-2016-08": {
+            "Ciphers": [
+              {
+                "Priority": 1,
+                "Name": "ECDHE-ECDSA-AES128-GCM-SHA256"
+              }
+            ],
+            "SslProtocols": [
+                "TLSv1",
+                "TLSv1.1",
+                "TLSv1.2"
+            ],
+            "Name": "ELBSecurityPolicy-2016-08"
+          }
+        }
+      }
   -
     Name: TLS 1.3 listeners
     ExpectedResult: true

--- a/policies/aws_load_balancer_policies/aws_alb_ssl_policy.yml
+++ b/policies/aws_load_balancer_policies/aws_alb_ssl_policy.yml
@@ -21,517 +21,640 @@ Runbook: >
   Update your load balancer's SSLPolicies to only support modern TLS versions
 Reference: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html
 Tests:
+  # -
+  #   Name: Strong Ciphers Internet Facing
+  #   ExpectedResult: true
+  #   Resource:
+  #     {
+  #       "IpAddressType": "ipv4",
+  #       "Type": "application",
+  #       "Tags": {
+  #         "Application": "Test"
+  #       },
+  #       "AvailabilityZones": [
+  #         {
+  #           "LoadBalancerAddresses": null,
+  #           "ZoneName": "us-east-1b",
+  #           "SubnetId": "subnet-05f7b81cc5d97e0e2"
+  #         },
+  #         {
+  #           "ZoneName": "us-east-1a",
+  #           "SubnetId": "subnet-07419606a40f4c414",
+  #           "LoadBalancerAddresses": null
+  #         }
+  #       ],
+  #       "AccountId": "123456789012",
+  #       "DNSName": "web-360787852.us-east-1.elb.amazonaws.com",
+  #       "Listeners": [
+  #         {
+  #           "DefaultActions": [
+  #             {
+  #               "RedirectConfig": null,
+  #               "ForwardConfig": {
+  #                 "TargetGroups": [
+  #                   {
+  #                     "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
+  #                     "Weight": 1
+  #                   }
+  #                 ],
+  #                 "TargetGroupStickinessConfig": {
+  #                   "Enabled": false,
+  #                   "DurationSeconds": null
+  #                 }
+  #               },
+  #               "AuthenticateOidcConfig": null,
+  #               "Order": null,
+  #               "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
+  #               "FixedResponseConfig": null,
+  #               "AuthenticateCognitoConfig": null,
+  #               "Type": "forward"
+  #             }
+  #           ],
+  #           "Port": 443,
+  #           "Certificates": [
+  #             {
+  #               "IsDefault": null,
+  #               "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/10c4e713-9bb5-4ccf-aabc-1c9119370038"
+  #             }
+  #           ],
+  #           "Protocol": "HTTPS",
+  #           "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/web/3ff2fab33a993e0c/995359b182328b77",
+  #           "SslPolicy": "ELBSecurityPolicy-2016-08",
+  #           "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c"
+  #         }
+  #       ],
+  #       "ResourceId": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
+  #       "Scheme": "internet-facing",
+  #       "VpcId": "vpc-0aa6688dd88484847",
+  #       "State": {
+  #         "Code": "active",
+  #         "Reason": null
+  #       },
+  #       "Name": "web",
+  #       "SSLPolicies": {
+  #         "ELBSecurityPolicy-TLS-1-2-Ext-2018-06": {
+  #           "SslProtocols": [
+  #               "TLSv1.2"
+  #           ],
+  #           "Ciphers": [
+  #               {
+  #                   "Name": "ECDHE-ECDSA-AES128-GCM-SHA256",
+  #                   "Priority": 1
+  #               },
+  #               {
+  #                   "Name": "ECDHE-RSA-AES128-GCM-SHA256",
+  #                   "Priority": 2
+  #               },
+  #               {
+  #                   "Name": "ECDHE-ECDSA-AES128-SHA256",
+  #                   "Priority": 3
+  #               },
+  #               {
+  #                   "Name": "ECDHE-RSA-AES128-SHA256",
+  #                   "Priority": 4
+  #               },
+  #               {
+  #                   "Name": "ECDHE-ECDSA-AES128-SHA",
+  #                   "Priority": 5
+  #               },
+  #               {
+  #                   "Name": "ECDHE-RSA-AES128-SHA",
+  #                   "Priority": 6
+  #               },
+  #               {
+  #                   "Name": "ECDHE-ECDSA-AES256-GCM-SHA384",
+  #                   "Priority": 7
+  #               },
+  #               {
+  #                   "Name": "ECDHE-RSA-AES256-GCM-SHA384",
+  #                   "Priority": 8
+  #               },
+  #               {
+  #                   "Name": "ECDHE-ECDSA-AES256-SHA384",
+  #                   "Priority": 9
+  #               },
+  #               {
+  #                   "Name": "ECDHE-RSA-AES256-SHA384",
+  #                   "Priority": 10
+  #               },
+  #               {
+  #                   "Name": "ECDHE-RSA-AES256-SHA",
+  #                   "Priority": 11
+  #               },
+  #               {
+  #                   "Name": "ECDHE-ECDSA-AES256-SHA",
+  #                   "Priority": 12
+  #               },
+  #               {
+  #                   "Name": "AES128-GCM-SHA256",
+  #                   "Priority": 13
+  #               },
+  #               {
+  #                   "Name": "AES128-SHA256",
+  #                   "Priority": 14
+  #               },
+  #               {
+  #                   "Name": "AES128-SHA",
+  #                   "Priority": 15
+  #               },
+  #               {
+  #                   "Name": "AES256-GCM-SHA384",
+  #                   "Priority": 16
+  #               },
+  #               {
+  #                   "Name": "AES256-SHA256",
+  #                   "Priority": 17
+  #               },
+  #               {
+  #                   "Name": "AES256-SHA",
+  #                   "Priority": 18
+  #               }
+  #           ],
+  #           "Name": "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+  #         }
+  #       },
+  #       "Arn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
+  #       "Region": "us-east-1",
+  #       "SecurityGroups": [
+  #         "sg-000bbcc377444490b"
+  #       ],
+  #       "TimeCreated": "2020-03-24T21:39:15.050Z",
+  #       "WebAcl": null,
+  #       "CanonicalHostedZonedId": "Z1H1FL5HABSF5",
+  #       "ResourceType": "AWS.ELBV2.ApplicationLoadBalancer"
+  #     }
+  # -
+  #   Name: Default Ciphers
+  #   ExpectedResult: false
+  #   Resource:
+  #     {
+  #       "IpAddressType": "ipv4",
+  #       "Type": "application",
+  #       "Tags": {
+  #         "Application": "Test"
+  #       },
+  #       "AvailabilityZones": [
+  #         {
+  #           "LoadBalancerAddresses": null,
+  #           "ZoneName": "us-east-1b",
+  #           "SubnetId": "subnet-05f7b81cc5d97e0e2"
+  #         },
+  #         {
+  #           "ZoneName": "us-east-1a",
+  #           "SubnetId": "subnet-07419606a40f4c414",
+  #           "LoadBalancerAddresses": null
+  #         }
+  #       ],
+  #       "AccountId": "123456789012",
+  #       "DNSName": "web-360787852.us-east-1.elb.amazonaws.com",
+  #       "Listeners": [
+  #         {
+  #           "DefaultActions": [
+  #             {
+  #               "RedirectConfig": null,
+  #               "ForwardConfig": {
+  #                 "TargetGroups": [
+  #                   {
+  #                     "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
+  #                     "Weight": 1
+  #                   }
+  #                 ],
+  #                 "TargetGroupStickinessConfig": {
+  #                   "Enabled": false,
+  #                   "DurationSeconds": null
+  #                 }
+  #               },
+  #               "AuthenticateOidcConfig": null,
+  #               "Order": null,
+  #               "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
+  #               "FixedResponseConfig": null,
+  #               "AuthenticateCognitoConfig": null,
+  #               "Type": "forward"
+  #             }
+  #           ],
+  #           "Port": 443,
+  #           "Certificates": [
+  #             {
+  #               "IsDefault": null,
+  #               "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/10c4e713-9bb5-4ccf-aabc-1c9119370038"
+  #             }
+  #           ],
+  #           "Protocol": "HTTPS",
+  #           "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/web/3ff2fab33a993e0c/995359b182328b77",
+  #           "SslPolicy": "ELBSecurityPolicy-2016-08",
+  #           "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c"
+  #         }
+  #       ],
+  #       "ResourceId": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
+  #       "Scheme": "internet-facing",
+  #       "VpcId": "vpc-0aa6688dd88484847",
+  #       "State": {
+  #         "Code": "active",
+  #         "Reason": null
+  #       },
+  #       "Name": "web",
+  #       "SSLPolicies": {
+  #         "ELBSecurityPolicy-2016-08": {
+  #           "Ciphers": [
+  #             {
+  #               "Priority": 1,
+  #               "Name": "ECDHE-ECDSA-AES128-GCM-SHA256"
+  #             },
+  #             {
+  #               "Priority": 2,
+  #               "Name": "ECDHE-RSA-AES128-GCM-SHA256"
+  #             },
+  #             {
+  #               "Priority": 3,
+  #               "Name": "ECDHE-ECDSA-AES128-SHA256"
+  #             },
+  #             {
+  #               "Priority": 4,
+  #               "Name": "ECDHE-RSA-AES128-SHA256"
+  #             },
+  #             {
+  #               "Priority": 5,
+  #               "Name": "ECDHE-ECDSA-AES128-SHA"
+  #             },
+  #             {
+  #               "Priority": 6,
+  #               "Name": "ECDHE-RSA-AES128-SHA"
+  #             },
+  #             {
+  #               "Priority": 7,
+  #               "Name": "ECDHE-ECDSA-AES256-GCM-SHA384"
+  #             },
+  #             {
+  #               "Name": "ECDHE-RSA-AES256-GCM-SHA384",
+  #               "Priority": 8
+  #             },
+  #             {
+  #               "Name": "ECDHE-ECDSA-AES256-SHA384",
+  #               "Priority": 9
+  #             },
+  #             {
+  #               "Priority": 10,
+  #               "Name": "ECDHE-RSA-AES256-SHA384"
+  #             },
+  #             {
+  #               "Priority": 11,
+  #               "Name": "ECDHE-RSA-AES256-SHA"
+  #             },
+  #             {
+  #               "Name": "ECDHE-ECDSA-AES256-SHA",
+  #               "Priority": 12
+  #             },
+  #             {
+  #               "Priority": 13,
+  #               "Name": "AES128-GCM-SHA256"
+  #             },
+  #             {
+  #               "Name": "AES128-SHA256",
+  #               "Priority": 14
+  #             },
+  #             {
+  #               "Priority": 15,
+  #               "Name": "AES128-SHA"
+  #             },
+  #             {
+  #               "Name": "AES256-GCM-SHA384",
+  #               "Priority": 16
+  #             },
+  #             {
+  #               "Priority": 17,
+  #               "Name": "AES256-SHA256"
+  #             },
+  #             {
+  #               "Priority": 18,
+  #               "Name": "AES256-SHA"
+  #             }
+  #           ],
+  #           "SslProtocols": [
+  #             "TLSv1",
+  #             "TLSv1.1",
+  #             "TLSv1.2"
+  #           ],
+  #           "Name": "ELBSecurityPolicy-2016-08"
+  #         }
+  #       },
+  #       "Arn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
+  #       "Region": "us-east-1",
+  #       "SecurityGroups": [
+  #         "sg-000bbcc377444490b"
+  #       ],
+  #       "TimeCreated": "2020-03-24T21:39:15.050Z",
+  #       "WebAcl": null,
+  #       "CanonicalHostedZonedId": "Z1H1FL5HABSF5",
+  #       "ResourceType": "AWS.ELBV2.ApplicationLoadBalancer"
+  #     }
+  # -
+  #   Name: Default Ciphers Internal Load Balancer
+  #   ExpectedResult: true
+  #   Resource:
+  #     {
+  #       "IpAddressType": "ipv4",
+  #       "Type": "application",
+  #       "Tags": {
+  #         "Application": "Test"
+  #       },
+  #       "AvailabilityZones": [
+  #         {
+  #           "LoadBalancerAddresses": null,
+  #           "ZoneName": "us-east-1b",
+  #           "SubnetId": "subnet-05f7b81cc5d97e0e2"
+  #         },
+  #         {
+  #           "ZoneName": "us-east-1a",
+  #           "SubnetId": "subnet-07419606a40f4c414",
+  #           "LoadBalancerAddresses": null
+  #         }
+  #       ],
+  #       "AccountId": "123456789012",
+  #       "DNSName": "web-360787852.us-east-1.elb.amazonaws.com",
+  #       "Listeners": [
+  #         {
+  #           "DefaultActions": [
+  #             {
+  #               "RedirectConfig": null,
+  #               "ForwardConfig": {
+  #                 "TargetGroups": [
+  #                   {
+  #                     "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
+  #                     "Weight": 1
+  #                   }
+  #                 ],
+  #                 "TargetGroupStickinessConfig": {
+  #                   "Enabled": false,
+  #                   "DurationSeconds": null
+  #                 }
+  #               },
+  #               "AuthenticateOidcConfig": null,
+  #               "Order": null,
+  #               "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
+  #               "FixedResponseConfig": null,
+  #               "AuthenticateCognitoConfig": null,
+  #               "Type": "forward"
+  #             }
+  #           ],
+  #           "Port": 443,
+  #           "Certificates": [
+  #             {
+  #               "IsDefault": null,
+  #               "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/10c4e713-9bb5-4ccf-aabc-1c9119370038"
+  #             }
+  #           ],
+  #           "Protocol": "HTTPS",
+  #           "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/web/3ff2fab33a993e0c/995359b182328b77",
+  #           "SslPolicy": "ELBSecurityPolicy-2016-08",
+  #           "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c"
+  #         }
+  #       ],
+  #       "ResourceId": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
+  #       "Scheme": "internal",
+  #       "VpcId": "vpc-0aa6688dd88484847",
+  #       "State": {
+  #         "Code": "active",
+  #         "Reason": null
+  #       },
+  #       "Name": "web",
+  #       "SSLPolicies": {
+  #         "ELBSecurityPolicy-2016-08": {
+  #           "Ciphers": [
+  #             {
+  #               "Priority": 1,
+  #               "Name": "ECDHE-ECDSA-AES128-GCM-SHA256"
+  #             },
+  #             {
+  #               "Priority": 2,
+  #               "Name": "ECDHE-RSA-AES128-GCM-SHA256"
+  #             },
+  #             {
+  #               "Priority": 3,
+  #               "Name": "ECDHE-ECDSA-AES128-SHA256"
+  #             },
+  #             {
+  #               "Priority": 4,
+  #               "Name": "ECDHE-RSA-AES128-SHA256"
+  #             },
+  #             {
+  #               "Priority": 5,
+  #               "Name": "ECDHE-ECDSA-AES128-SHA"
+  #             },
+  #             {
+  #               "Priority": 6,
+  #               "Name": "ECDHE-RSA-AES128-SHA"
+  #             },
+  #             {
+  #               "Priority": 7,
+  #               "Name": "ECDHE-ECDSA-AES256-GCM-SHA384"
+  #             },
+  #             {
+  #               "Name": "ECDHE-RSA-AES256-GCM-SHA384",
+  #               "Priority": 8
+  #             },
+  #             {
+  #               "Name": "ECDHE-ECDSA-AES256-SHA384",
+  #               "Priority": 9
+  #             },
+  #             {
+  #               "Priority": 10,
+  #               "Name": "ECDHE-RSA-AES256-SHA384"
+  #             },
+  #             {
+  #               "Priority": 11,
+  #               "Name": "ECDHE-RSA-AES256-SHA"
+  #             },
+  #             {
+  #               "Name": "ECDHE-ECDSA-AES256-SHA",
+  #               "Priority": 12
+  #             },
+  #             {
+  #               "Priority": 13,
+  #               "Name": "AES128-GCM-SHA256"
+  #             },
+  #             {
+  #               "Name": "AES128-SHA256",
+  #               "Priority": 14
+  #             },
+  #             {
+  #               "Priority": 15,
+  #               "Name": "AES128-SHA"
+  #             },
+  #             {
+  #               "Name": "AES256-GCM-SHA384",
+  #               "Priority": 16
+  #             },
+  #             {
+  #               "Priority": 17,
+  #               "Name": "AES256-SHA256"
+  #             },
+  #             {
+  #               "Priority": 18,
+  #               "Name": "AES256-SHA"
+  #             }
+  #           ],
+  #           "SslProtocols": [
+  #             "TLSv1",
+  #             "TLSv1.1",
+  #             "TLSv1.2"
+  #           ],
+  #           "Name": "ELBSecurityPolicy-2016-08"
+  #         }
+  #       },
+  #       "Arn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
+  #       "Region": "us-east-1",
+  #       "SecurityGroups": [
+  #         "sg-000bbcc377444490b"
+  #       ],
+  #       "TimeCreated": "2020-03-24T21:39:15.050Z",
+  #       "WebAcl": null,
+  #       "CanonicalHostedZonedId": "Z1H1FL5HABSF5",
+  #       "ResourceType": "AWS.ELBV2.ApplicationLoadBalancer"
+  #     }
+  # -
+  #   Name: Observed - No Listeners len() issue
+  #   ExpectedResult: false
+  #   Resource:
+  #     {
+  #       "Listeners": null,
+  #       "Scheme": "internet-facing",
+  #       "SSLPolicies": {
+  #         "ELBSecurityPolicy-2016-08": {
+  #           "Ciphers": [
+  #             {
+  #               "Priority": 1,
+  #               "Name": "ECDHE-ECDSA-AES128-GCM-SHA256"
+  #             }
+  #           ],
+  #           "SslProtocols": [
+  #               "TLSv1",
+  #               "TLSv1.1",
+  #               "TLSv1.2"
+  #           ],
+  #           "Name": "ELBSecurityPolicy-2016-08"
+  #         }
+  #       }
+  #     }
   -
-    Name: Strong Ciphers Internet Facing
+    Name: TLS 1.3 listeners
     ExpectedResult: true
     Resource:
       {
-        "IpAddressType": "ipv4",
-        "Type": "application",
-        "Tags": {
-          "Application": "Test"
-        },
-        "AvailabilityZones": [
-          {
-            "LoadBalancerAddresses": null,
-            "ZoneName": "us-east-1b",
-            "SubnetId": "subnet-05f7b81cc5d97e0e2"
+          "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/tls13/de81aaaa65555555",
+          "DNSName": "tls13-46494243.us-west-2.elb.amazonaws.com",
+          "CanonicalHostedZoneId": "Z1H1FL5HABSF5",
+          "CreatedTime": "2023-04-17T23:46:54.550000+00:00",
+          "LoadBalancerName": "tls13",
+          "Scheme": "internet-facing",
+          "VpcId": "vpc-043e0527f2d6372ea",
+          "State": {
+              "Code": "active"
           },
-          {
-            "ZoneName": "us-east-1a",
-            "SubnetId": "subnet-07419606a40f4c414",
-            "LoadBalancerAddresses": null
-          }
-        ],
-        "AccountId": "123456789012",
-        "DNSName": "web-360787852.us-east-1.elb.amazonaws.com",
-        "Listeners": [
-          {
-            "DefaultActions": [
+          "Type": "application",
+          "AvailabilityZones": [
               {
-                "RedirectConfig": null,
-                "ForwardConfig": {
-                  "TargetGroups": [
+                  "ZoneName": "us-west-2a",
+                  "SubnetId": "subnet-0a42f65abd22d0d87",
+                  "LoadBalancerAddresses": []
+              },
+              {
+                  "ZoneName": "us-west-2b",
+                  "SubnetId": "subnet-0aa42b18abd62e88f",
+                  "LoadBalancerAddresses": []
+              }
+          ],
+          "SecurityGroups": [
+              "sg-0197ba84777a5858a"
+          ],
+          "IpAddressType": "ipv4",
+          "Listeners": [
+            {
+                "ListenerArn": "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/tls13/de81aaaa65555555/5f992ca6d5368214",
+                "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/tls13/de81aaaa65555555",
+                "Port": 443,
+                "Protocol": "HTTPS",
+                "Certificates": [
                     {
-                      "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
-                      "Weight": 1
+                        "CertificateArn": "arn:aws:acm:us-west-2:123456789012:certificate/517cb27d-03fb-4659-96a5-40592b25d977"
                     }
-                  ],
-                  "TargetGroupStickinessConfig": {
-                    "Enabled": false,
-                    "DurationSeconds": null
-                  }
-                },
-                "AuthenticateOidcConfig": null,
-                "Order": null,
-                "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
-                "FixedResponseConfig": null,
-                "AuthenticateCognitoConfig": null,
-                "Type": "forward"
-              }
-            ],
-            "Port": 443,
-            "Certificates": [
-              {
-                "IsDefault": null,
-                "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/10c4e713-9bb5-4ccf-aabc-1c9119370038"
-              }
-            ],
-            "Protocol": "HTTPS",
-            "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/web/3ff2fab33a993e0c/995359b182328b77",
-            "SslPolicy": "ELBSecurityPolicy-2016-08",
-            "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c"
-          }
-        ],
-        "ResourceId": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
-        "Scheme": "internet-facing",
-        "VpcId": "vpc-0aa6688dd88484847",
-        "State": {
-          "Code": "active",
-          "Reason": null
-        },
-        "Name": "web",
+                ],
+                "SslPolicy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
+                "DefaultActions": [
+                    {
+                        "Type": "forward",
+                        "TargetGroupArn": "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/oktgname/67c62d09d6d23288",
+                        "ForwardConfig": {
+                            "TargetGroups": [
+                                {
+                                    "TargetGroupArn": "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/oktgname/67c62d09d6d23288",
+                                    "Weight": 1
+                                }
+                            ],
+                            "TargetGroupStickinessConfig": {
+                                "Enabled": false
+                            }
+                        }
+                    }
+                ]
+            }
+          ],
         "SSLPolicies": {
-          "ELBSecurityPolicy-TLS-1-2-Ext-2018-06": {
+          "ELBSecurityPolicy-TLS13-1-2-2021-06": {
             "SslProtocols": [
-                "TLSv1.2"
+              "TLSv1.2",
+              "TLSv1.3"
             ],
             "Ciphers": [
-                {
-                    "Name": "ECDHE-ECDSA-AES128-GCM-SHA256",
-                    "Priority": 1
-                },
-                {
-                    "Name": "ECDHE-RSA-AES128-GCM-SHA256",
-                    "Priority": 2
-                },
-                {
-                    "Name": "ECDHE-ECDSA-AES128-SHA256",
-                    "Priority": 3
-                },
-                {
-                    "Name": "ECDHE-RSA-AES128-SHA256",
-                    "Priority": 4
-                },
-                {
-                    "Name": "ECDHE-ECDSA-AES128-SHA",
-                    "Priority": 5
-                },
-                {
-                    "Name": "ECDHE-RSA-AES128-SHA",
-                    "Priority": 6
-                },
-                {
-                    "Name": "ECDHE-ECDSA-AES256-GCM-SHA384",
-                    "Priority": 7
-                },
-                {
-                    "Name": "ECDHE-RSA-AES256-GCM-SHA384",
-                    "Priority": 8
-                },
-                {
-                    "Name": "ECDHE-ECDSA-AES256-SHA384",
-                    "Priority": 9
-                },
-                {
-                    "Name": "ECDHE-RSA-AES256-SHA384",
-                    "Priority": 10
-                },
-                {
-                    "Name": "ECDHE-RSA-AES256-SHA",
-                    "Priority": 11
-                },
-                {
-                    "Name": "ECDHE-ECDSA-AES256-SHA",
-                    "Priority": 12
-                },
-                {
-                    "Name": "AES128-GCM-SHA256",
-                    "Priority": 13
-                },
-                {
-                    "Name": "AES128-SHA256",
-                    "Priority": 14
-                },
-                {
-                    "Name": "AES128-SHA",
-                    "Priority": 15
-                },
-                {
-                    "Name": "AES256-GCM-SHA384",
-                    "Priority": 16
-                },
-                {
-                    "Name": "AES256-SHA256",
-                    "Priority": 17
-                },
-                {
-                    "Name": "AES256-SHA",
-                    "Priority": 18
-                }
-            ],
-            "Name": "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
-          }
-        },
-        "Arn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
-        "Region": "us-east-1",
-        "SecurityGroups": [
-          "sg-000bbcc377444490b"
-        ],
-        "TimeCreated": "2020-03-24T21:39:15.050Z",
-        "WebAcl": null,
-        "CanonicalHostedZonedId": "Z1H1FL5HABSF5",
-        "ResourceType": "AWS.ELBV2.ApplicationLoadBalancer"
-      }
-  -
-    Name: Default Ciphers
-    ExpectedResult: false
-    Resource:
-      {
-        "IpAddressType": "ipv4",
-        "Type": "application",
-        "Tags": {
-          "Application": "Test"
-        },
-        "AvailabilityZones": [
-          {
-            "LoadBalancerAddresses": null,
-            "ZoneName": "us-east-1b",
-            "SubnetId": "subnet-05f7b81cc5d97e0e2"
-          },
-          {
-            "ZoneName": "us-east-1a",
-            "SubnetId": "subnet-07419606a40f4c414",
-            "LoadBalancerAddresses": null
-          }
-        ],
-        "AccountId": "123456789012",
-        "DNSName": "web-360787852.us-east-1.elb.amazonaws.com",
-        "Listeners": [
-          {
-            "DefaultActions": [
               {
-                "RedirectConfig": null,
-                "ForwardConfig": {
-                  "TargetGroups": [
-                    {
-                      "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
-                      "Weight": 1
-                    }
-                  ],
-                  "TargetGroupStickinessConfig": {
-                    "Enabled": false,
-                    "DurationSeconds": null
-                  }
-                },
-                "AuthenticateOidcConfig": null,
-                "Order": null,
-                "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
-                "FixedResponseConfig": null,
-                "AuthenticateCognitoConfig": null,
-                "Type": "forward"
-              }
-            ],
-            "Port": 443,
-            "Certificates": [
-              {
-                "IsDefault": null,
-                "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/10c4e713-9bb5-4ccf-aabc-1c9119370038"
-              }
-            ],
-            "Protocol": "HTTPS",
-            "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/web/3ff2fab33a993e0c/995359b182328b77",
-            "SslPolicy": "ELBSecurityPolicy-2016-08",
-            "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c"
-          }
-        ],
-        "ResourceId": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
-        "Scheme": "internet-facing",
-        "VpcId": "vpc-0aa6688dd88484847",
-        "State": {
-          "Code": "active",
-          "Reason": null
-        },
-        "Name": "web",
-        "SSLPolicies": {
-          "ELBSecurityPolicy-2016-08": {
-            "Ciphers": [
-              {
-                "Priority": 1,
-                "Name": "ECDHE-ECDSA-AES128-GCM-SHA256"
+                "Name": "TLS_AES_128_GCM_SHA256",
+                "Priority": 1
               },
               {
-                "Priority": 2,
-                "Name": "ECDHE-RSA-AES128-GCM-SHA256"
+                "Name": "TLS_AES_256_GCM_SHA384",
+                "Priority": 2
               },
               {
-                "Priority": 3,
-                "Name": "ECDHE-ECDSA-AES128-SHA256"
+                "Name": "TLS_CHACHA20_POLY1305_SHA256",
+                "Priority": 3
               },
               {
-                "Priority": 4,
-                "Name": "ECDHE-RSA-AES128-SHA256"
+                "Name": "ECDHE-ECDSA-AES128-GCM-SHA256",
+                "Priority": 4
               },
               {
-                "Priority": 5,
-                "Name": "ECDHE-ECDSA-AES128-SHA"
+                "Name": "ECDHE-RSA-AES128-GCM-SHA256",
+                "Priority": 5
               },
               {
-                "Priority": 6,
-                "Name": "ECDHE-RSA-AES128-SHA"
+                "Name": "ECDHE-ECDSA-AES128-SHA256",
+                "Priority": 6
               },
               {
-                "Priority": 7,
-                "Name": "ECDHE-ECDSA-AES256-GCM-SHA384"
+                "Name": "ECDHE-RSA-AES128-SHA256",
+                "Priority": 7
               },
               {
-                "Name": "ECDHE-RSA-AES256-GCM-SHA384",
+                "Name": "ECDHE-ECDSA-AES256-GCM-SHA384",
                 "Priority": 8
               },
               {
-                "Name": "ECDHE-ECDSA-AES256-SHA384",
-                "Priority": 9
-              },
-              {
-                "Priority": 10,
-                "Name": "ECDHE-RSA-AES256-SHA384"
-              },
-              {
-                "Priority": 11,
-                "Name": "ECDHE-RSA-AES256-SHA"
-              },
-              {
-                "Name": "ECDHE-ECDSA-AES256-SHA",
-                "Priority": 12
-              },
-              {
-                "Priority": 13,
-                "Name": "AES128-GCM-SHA256"
-              },
-              {
-                "Name": "AES128-SHA256",
-                "Priority": 14
-              },
-              {
-                "Priority": 15,
-                "Name": "AES128-SHA"
-              },
-              {
-                "Name": "AES256-GCM-SHA384",
-                "Priority": 16
-              },
-              {
-                "Priority": 17,
-                "Name": "AES256-SHA256"
-              },
-              {
-                "Priority": 18,
-                "Name": "AES256-SHA"
-              }
-            ],
-            "SslProtocols": [
-              "TLSv1",
-              "TLSv1.1",
-              "TLSv1.2"
-            ],
-            "Name": "ELBSecurityPolicy-2016-08"
-          }
-        },
-        "Arn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
-        "Region": "us-east-1",
-        "SecurityGroups": [
-          "sg-000bbcc377444490b"
-        ],
-        "TimeCreated": "2020-03-24T21:39:15.050Z",
-        "WebAcl": null,
-        "CanonicalHostedZonedId": "Z1H1FL5HABSF5",
-        "ResourceType": "AWS.ELBV2.ApplicationLoadBalancer"
-      }
-  -
-    Name: Default Ciphers Internal Load Balancer
-    ExpectedResult: true
-    Resource:
-      {
-        "IpAddressType": "ipv4",
-        "Type": "application",
-        "Tags": {
-          "Application": "Test"
-        },
-        "AvailabilityZones": [
-          {
-            "LoadBalancerAddresses": null,
-            "ZoneName": "us-east-1b",
-            "SubnetId": "subnet-05f7b81cc5d97e0e2"
-          },
-          {
-            "ZoneName": "us-east-1a",
-            "SubnetId": "subnet-07419606a40f4c414",
-            "LoadBalancerAddresses": null
-          }
-        ],
-        "AccountId": "123456789012",
-        "DNSName": "web-360787852.us-east-1.elb.amazonaws.com",
-        "Listeners": [
-          {
-            "DefaultActions": [
-              {
-                "RedirectConfig": null,
-                "ForwardConfig": {
-                  "TargetGroups": [
-                    {
-                      "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
-                      "Weight": 1
-                    }
-                  ],
-                  "TargetGroupStickinessConfig": {
-                    "Enabled": false,
-                    "DurationSeconds": null
-                  }
-                },
-                "AuthenticateOidcConfig": null,
-                "Order": null,
-                "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/web/54eedfcacc3949ef",
-                "FixedResponseConfig": null,
-                "AuthenticateCognitoConfig": null,
-                "Type": "forward"
-              }
-            ],
-            "Port": 443,
-            "Certificates": [
-              {
-                "IsDefault": null,
-                "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/10c4e713-9bb5-4ccf-aabc-1c9119370038"
-              }
-            ],
-            "Protocol": "HTTPS",
-            "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/web/3ff2fab33a993e0c/995359b182328b77",
-            "SslPolicy": "ELBSecurityPolicy-2016-08",
-            "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c"
-          }
-        ],
-        "ResourceId": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
-        "Scheme": "internal",
-        "VpcId": "vpc-0aa6688dd88484847",
-        "State": {
-          "Code": "active",
-          "Reason": null
-        },
-        "Name": "web",
-        "SSLPolicies": {
-          "ELBSecurityPolicy-2016-08": {
-            "Ciphers": [
-              {
-                "Priority": 1,
-                "Name": "ECDHE-ECDSA-AES128-GCM-SHA256"
-              },
-              {
-                "Priority": 2,
-                "Name": "ECDHE-RSA-AES128-GCM-SHA256"
-              },
-              {
-                "Priority": 3,
-                "Name": "ECDHE-ECDSA-AES128-SHA256"
-              },
-              {
-                "Priority": 4,
-                "Name": "ECDHE-RSA-AES128-SHA256"
-              },
-              {
-                "Priority": 5,
-                "Name": "ECDHE-ECDSA-AES128-SHA"
-              },
-              {
-                "Priority": 6,
-                "Name": "ECDHE-RSA-AES128-SHA"
-              },
-              {
-                "Priority": 7,
-                "Name": "ECDHE-ECDSA-AES256-GCM-SHA384"
-              },
-              {
                 "Name": "ECDHE-RSA-AES256-GCM-SHA384",
-                "Priority": 8
-              },
-              {
-                "Name": "ECDHE-ECDSA-AES256-SHA384",
                 "Priority": 9
               },
               {
-                "Priority": 10,
-                "Name": "ECDHE-RSA-AES256-SHA384"
+                "Name": "ECDHE-ECDSA-AES256-SHA384",
+                "Priority": 10
               },
               {
-                "Priority": 11,
-                "Name": "ECDHE-RSA-AES256-SHA"
-              },
-              {
-                "Name": "ECDHE-ECDSA-AES256-SHA",
-                "Priority": 12
-              },
-              {
-                "Priority": 13,
-                "Name": "AES128-GCM-SHA256"
-              },
-              {
-                "Name": "AES128-SHA256",
-                "Priority": 14
-              },
-              {
-                "Priority": 15,
-                "Name": "AES128-SHA"
-              },
-              {
-                "Name": "AES256-GCM-SHA384",
-                "Priority": 16
-              },
-              {
-                "Priority": 17,
-                "Name": "AES256-SHA256"
-              },
-              {
-                "Priority": 18,
-                "Name": "AES256-SHA"
+                "Name": "ECDHE-RSA-AES256-SHA384",
+                "Priority": 11
               }
             ],
-            "SslProtocols": [
-              "TLSv1",
-              "TLSv1.1",
-              "TLSv1.2"
-            ],
-            "Name": "ELBSecurityPolicy-2016-08"
-          }
-        },
-        "Arn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",
-        "Region": "us-east-1",
-        "SecurityGroups": [
-          "sg-000bbcc377444490b"
-        ],
-        "TimeCreated": "2020-03-24T21:39:15.050Z",
-        "WebAcl": null,
-        "CanonicalHostedZonedId": "Z1H1FL5HABSF5",
-        "ResourceType": "AWS.ELBV2.ApplicationLoadBalancer"
-      }
-  -
-    Name: Observed - No Listeners len() issue
-    ExpectedResult: false
-    Resource:
-      {
-        "Listeners": null,
-        "Scheme": "internet-facing",
-        "SSLPolicies": {
-          "ELBSecurityPolicy-2016-08": {
-            "Ciphers": [
-              {
-                "Priority": 1,
-                "Name": "ECDHE-ECDSA-AES128-GCM-SHA256"
-              }
-            ],
-            "SslProtocols": [
-                "TLSv1",
-                "TLSv1.1",
-                "TLSv1.2"
-            ],
-            "Name": "ELBSecurityPolicy-2016-08"
+            "Name": "ELBSecurityPolicy-TLS13-1-2-2021-06",
+            "SupportedLoadBalancerTypes": [
+              "application",
+              "network"
+            ]
           }
         }
       }


### PR DESCRIPTION
### Background

AWS Released support for using TLS 1.3 with AWS ELBs. This PR adds acknowledgment to `AWS.ELBv2.SSLPolicy` for the new TLS1.3 SSL Policy. 

### Changes


### Testing
**After this change**

Test output from this change  with supporting test case 
```shell
[INFO]: Testing analysis items in .

AWS.ELBv2.SSLPolicy
	[PASS] Strong Ciphers Internet Facing
		[PASS] [policy] true
	[PASS] Default Ciphers
		[PASS] [policy] false
		[PASS] [dedup] defaultDedupString:AWS.ELBv2.SSLPolicy
	[PASS] Default Ciphers Internal Load Balancer
		[PASS] [policy] true
	[PASS] Observed - No Listeners len() issue
		[PASS] [policy] false
		[PASS] [dedup] defaultDedupString:AWS.ELBv2.SSLPolicy
	[PASS] TLS 1.3 listeners
		[PASS] [policy] true

--------------------------
Panther CLI Test Summary
	Path: .
	Passed: 1
	Failed: 0
	Invalid: 0
```

---
**Before the change**
Here's the test output with a TLS 1.3 test case, and no change to the python

```shell
[INFO]: Testing analysis items in .

AWS.ELBv2.SSLPolicy
	[PASS] Strong Ciphers Internet Facing
		[PASS] [policy] true
	[PASS] Default Ciphers
		[PASS] [policy] false
		[PASS] [dedup] defaultDedupString:AWS.ELBv2.SSLPolicy
	[PASS] Default Ciphers Internal Load Balancer
		[PASS] [policy] true
	[PASS] Observed - No Listeners len() issue
		[PASS] [policy] false
		[PASS] [dedup] defaultDedupString:AWS.ELBv2.SSLPolicy
	[FAIL] TLS 1.3 listeners
		[FAIL] [policy] false

--------------------------
Panther CLI Test Summary
	Path: .
	Passed: 0
	Failed: 1
	Invalid: 0

--------------------------
Failed Tests Summary
	AWS.ELBv2.SSLPolicy
		['TLS 1.3 listeners:policy']


```