### PR TITLE
fix: add testcase for gsuite activityevent where parameters.NEW_VALUE has a null value

### DIFF
--- a/rules/gsuite_activityevent_rules/gsuite_workspace_password_reuse_enabled.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_password_reuse_enabled.yml
@@ -115,3 +115,31 @@ Tests:
           },
           "type": "access"
       }
+  -
+    Name: NoneType 
+    ExpectedResult: false
+    Log: 
+      {
+        "actor": {
+          "callerType": "USER",
+          "email": "user@example.com",
+          "profileId": "118111111111111111111"
+        },
+        "id": {
+          "applicationName": "admin",
+          "customerId": "D12345",
+          "time": "2023-04-05 18:55:09.951000000",
+          "uniqueQualifier": "-6635845506543894676"
+        },
+        "ipAddress": "8.9.9.111",
+        "kind": "admin#reports#activity",
+        "name": "UPDATE_CALENDAR_RESOURCE",
+        "parameters": {
+          "FIELD_NAME": "feature_instances.feature_instances[0].feature.visibility",
+          "NEW_VALUE": null,
+          "OLD_VALUE": "PROMINENT",
+          "RESOURCE_IDENTIFIER": "(id: 4836861543277, name: Gan)"
+        },
+        "type": "CALENDAR_SETTINGS"
+      }
+


### PR DESCRIPTION
### Background

see test output. this relates to #723 

### Changes



### Testing

```shell
GSuite.Workspace.PasswordReuseEnabled
	[PASS] Workspace Admin Enabled Password Reuse
		[PASS] [rule] true
		[PASS] [title] GSuite Workspace Password Reuse Has Been Enabled By [example@example.io]
		[PASS] [dedup] GSuite Workspace Password Reuse Has Been Enabled By [example@example.io]
	[PASS] Admin Set Default Calendar SHARING_OUTSIDE_DOMAIN Setting to READ_ONLY_ACCESS
		[PASS] [rule] false
	[PASS] ListObject Type
		[PASS] [rule] false
	[PASS] NoneType
		[PASS] [rule] false

--------------------------
Panther CLI Test Summary
	Path: .
	Passed: 1
	Failed: 0
	Invalid: 0


```
