### PR TITLE
fix: add Zeek IP addresses to Enrichment LUTs

### DIFF
--- a/lookup_tables/greynoise/advanced/noise_advanced.yml
+++ b/lookup_tables/greynoise/advanced/noise_advanced.yml
@@ -216,10 +216,46 @@ LogTypeMap:
       Selectors:
         - "dest_ip"
         - "src_ip"
+    - LogType: Zeek.Conn
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
     - LogType: Zeek.DNS
       Selectors:
-        - "id.orig_h"
-        - "id.resp_h"
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.DPD
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.HTTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Notice
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.NTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssh
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssl
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Tunnel
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Weird
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
     - LogType: Zendesk.Audit
       Selectors:
         - "ip_address"

--- a/lookup_tables/greynoise/advanced/riot_advanced.yml
+++ b/lookup_tables/greynoise/advanced/riot_advanced.yml
@@ -216,10 +216,46 @@ LogTypeMap:
       Selectors:
         - "dest_ip"
         - "src_ip"
+    - LogType: Zeek.Conn
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
     - LogType: Zeek.DNS
       Selectors:
-        - "id.orig_h"
-        - "id.resp_h"
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.DPD
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.HTTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Notice
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.NTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssh
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssl
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Tunnel
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Weird
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
     - LogType: Zendesk.Audit
       Selectors:
         - "ip_address"

--- a/lookup_tables/greynoise/basic/noise_basic.yml
+++ b/lookup_tables/greynoise/basic/noise_basic.yml
@@ -216,10 +216,46 @@ LogTypeMap:
       Selectors:
         - "dest_ip"
         - "src_ip"
+    - LogType: Zeek.Conn
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
     - LogType: Zeek.DNS
       Selectors:
-        - "id.orig_h"
-        - "id.resp_h"
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.DPD
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.HTTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Notice
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.NTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssh
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssl
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Tunnel
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Weird
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
     - LogType: Zendesk.Audit
       Selectors:
         - "ip_address"

--- a/lookup_tables/greynoise/basic/riot_basic.yml
+++ b/lookup_tables/greynoise/basic/riot_basic.yml
@@ -216,10 +216,46 @@ LogTypeMap:
       Selectors:
         - "dest_ip"
         - "src_ip"
+    - LogType: Zeek.Conn
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
     - LogType: Zeek.DNS
       Selectors:
-        - "id.orig_h"
-        - "id.resp_h"
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.DPD
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.HTTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Notice
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.NTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssh
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssl
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Tunnel
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Weird
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
     - LogType: Zendesk.Audit
       Selectors:
         - "ip_address"

--- a/lookup_tables/ipinfo/ipinfo_asn.yml
+++ b/lookup_tables/ipinfo/ipinfo_asn.yml
@@ -282,7 +282,43 @@ LogTypeMap:
     - LogType: Workday.SignOnAttempt
       Selectors:
         - 'Session_IP_Address'
+    - LogType: Zeek.Conn
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
     - LogType: Zeek.DNS
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.DPD
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.HTTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Notice
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.NTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssh
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssl
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Tunnel
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Weird
       Selectors:
         - 'id.orig_h'
         - 'id.resp_h'

--- a/lookup_tables/ipinfo/ipinfo_asn_datalake.yml
+++ b/lookup_tables/ipinfo/ipinfo_asn_datalake.yml
@@ -282,7 +282,43 @@ LogTypeMap:
     - LogType: Workday.SignOnAttempt
       Selectors:
         - 'Session_IP_Address'
+    - LogType: Zeek.Conn
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
     - LogType: Zeek.DNS
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.DPD
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.HTTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Notice
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.NTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssh
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssl
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Tunnel
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Weird
       Selectors:
         - 'id.orig_h'
         - 'id.resp_h'

--- a/lookup_tables/ipinfo/ipinfo_location.yml
+++ b/lookup_tables/ipinfo/ipinfo_location.yml
@@ -282,7 +282,43 @@ LogTypeMap:
     - LogType: Workday.SignOnAttempt
       Selectors:
         - 'Session_IP_Address'
+    - LogType: Zeek.Conn
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
     - LogType: Zeek.DNS
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.DPD
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.HTTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Notice
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.NTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssh
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssl
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Tunnel
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Weird
       Selectors:
         - 'id.orig_h'
         - 'id.resp_h'

--- a/lookup_tables/ipinfo/ipinfo_location_datalake.yml
+++ b/lookup_tables/ipinfo/ipinfo_location_datalake.yml
@@ -282,7 +282,43 @@ LogTypeMap:
     - LogType: Workday.SignOnAttempt
       Selectors:
         - 'Session_IP_Address'
+    - LogType: Zeek.Conn
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
     - LogType: Zeek.DNS
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.DPD
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.HTTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Notice
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.NTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssh
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssl
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Tunnel
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Weird
       Selectors:
         - 'id.orig_h'
         - 'id.resp_h'

--- a/lookup_tables/ipinfo/ipinfo_privacy.yml
+++ b/lookup_tables/ipinfo/ipinfo_privacy.yml
@@ -282,7 +282,43 @@ LogTypeMap:
     - LogType: Workday.SignOnAttempt
       Selectors:
         - 'Session_IP_Address'
+    - LogType: Zeek.Conn
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
     - LogType: Zeek.DNS
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.DPD
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.HTTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Notice
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.NTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssh
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssl
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Tunnel
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Weird
       Selectors:
         - 'id.orig_h'
         - 'id.resp_h'

--- a/lookup_tables/ipinfo/ipinfo_privacy_datalake.yml
+++ b/lookup_tables/ipinfo/ipinfo_privacy_datalake.yml
@@ -282,7 +282,43 @@ LogTypeMap:
     - LogType: Workday.SignOnAttempt
       Selectors:
         - 'Session_IP_Address'
+    - LogType: Zeek.Conn
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
     - LogType: Zeek.DNS
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.DPD
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.HTTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Notice
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.NTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssh
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssl
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Tunnel
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Weird
       Selectors:
         - 'id.orig_h'
         - 'id.resp_h'

--- a/lookup_tables/tor/tor_exit_nodes.yml
+++ b/lookup_tables/tor/tor_exit_nodes.yml
@@ -285,7 +285,43 @@ LogTypeMap:
     - LogType: Workday.SignOnAttempt
       Selectors:
         - 'Session_IP_Address'
+    - LogType: Zeek.Conn
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
     - LogType: Zeek.DNS
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.DPD
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.HTTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Notice
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.NTP
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssh
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Ssl
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Tunnel
+      Selectors:
+        - 'id.orig_h'
+        - 'id.resp_h'
+    - LogType: Zeek.Weird
       Selectors:
         - 'id.orig_h'
         - 'id.resp_h'


### PR DESCRIPTION
### Background

Adds Zeek `id.orig_h` and `id.resp_h` IP address fields to Enrichment LUTs.

Closes https://app.asana.com/0/1203154630469853/1204469385965390/f

### Changes

Adds Zeek `id.orig_h` and `id.resp_h` fields to Enrichment LUTs:
 - `advanced/noise_advanced`
 - `advanced/riot_advanced`
 - `basic/noise_basic`
 - `basic/riot_advanced`
 - `ipinfo_asn_datalake`
 - `ipinfo_asn`
 - `ipinfo_location_datalake`
 - `ipinfo_location`
 - `ipinfo_privacy_datalake`
 - `ipinfo_privacy`
 - `tor_exit_nodes`

### Changes

Uploaded them to my Panther instance where I've set up live data ingestion with Zeek.
