### PR TITLE
Safely handle Zoom user group context

### DIFF
--- a/rules/zoom_operation_rules/zoom_operation_passcode_disabled.py
+++ b/rules/zoom_operation_rules/zoom_operation_passcode_disabled.py
@@ -6,7 +6,9 @@ def rule(event):
         return False
 
     context = get_context(event)
-    return "Passcode" in context["Change"] and context["DisabledSetting"]
+    changed = "Passcode" in context.get("Change", "")
+    disabled = context.get("DisabledSetting", False)
+    return changed and disabled
 
 
 def title(event):

--- a/rules/zoom_operation_rules/zoom_operation_passcode_disabled.yml
+++ b/rules/zoom_operation_rules/zoom_operation_passcode_disabled.yml
@@ -44,3 +44,15 @@ Tests:
         "operation_detail": "Edit Group Springfield  - Personal Meeting ID (PMI) Passcode: from Off to On",
         "p_log_type": "Zoom.Operation",
         }
+  -
+    Name: Add User Group
+    ExpectedResult: false
+    Log:
+      {
+        "time": "2021-11-17 00:37:24Z",
+        "operator": "homer@panther.io",
+        "category_type": "User Group",
+        "action": "Add",
+        "operation_detail": "Add Group Engineers",
+        "p_log_type": "Zoom.Operation",
+        }


### PR DESCRIPTION
### Background

When handling `Add` and `Delete` events, the `zoom_operation_passcode_disabled`
rule causes a run-time `KeyError` when attempting to access `"Change"`.

### Changes

* Safely access `Change` and `DisabledSetting`. This seemed safer than filtering
  only for `Update` events, but I'm happy to refactor and take that approach as
  well.

### Testing

* N/A
