### PR TITLE
chore: downgrades log4j alert severity

### DIFF
--- a/rules/panther_ioc_rules/log4j_exploit_iocs.yml
+++ b/rules/panther_ioc_rules/log4j_exploit_iocs.yml
@@ -27,7 +27,7 @@ Tags:
 Reports:
   MITRE ATT&CK:
     - TA0002:T1203
-Severity: Critical
+Severity: Info
 Description: >
   Monitors for potential exploit attempts agains CVE-2021-44228, Log4J remote code execution
 Reference: >


### PR DESCRIPTION
### Background

Downgrades severity of Log4J alert to `Info`.

[Related discussion](https://panther-labs.slack.com/archives/C03GVSBB2CD/p1682339156152899).

### Changes

* <Describe changes here>

### Testing

* <Testing steps>
