### PR TITLE
chore: there was a little copy-pasta in the global filter yaml file for Snyk

### DIFF
--- a/global_helpers/global_filter_snyk.yml
+++ b/global_helpers/global_filter_snyk.yml
@@ -2,7 +2,7 @@ AnalysisType: global
 Filename: global_filter_snyk.py
 GlobalID: "global_filter_snyk"
 Description: >
-  This module provides one filter that is included in all github detections.
+  This module provides one filter that is included in all Snyk detections.
   
   This filter defines if events should be included or excluded.
 


### PR DESCRIPTION
### Background

My expectation is that this change would not have any impact in forks or private copies. 

### Changes

* There was a typo in the yml file that describes the global filter for Snyk detections. 

### Testing


