### PR TITLE
feat: Tines.Audit detections and pack

### DIFF
--- a/global_helpers/global_filter_tines.py
+++ b/global_helpers/global_filter_tines.py
@@ -1,0 +1,20 @@
+from panther_base_helpers import deep_get  # pylint: disable=unused-import
+
+
+def filter_include_event(event) -> bool:  # pylint: disable=unused-argument
+    """
+    filter_include_event provides a global include filter for all Tines detections
+    Panther will not update this filter, and you can edit it without creating
+    merge conflicts in the future.
+
+    return True to include events, and False to exclude events
+    """
+    # This commented-out example would have the effect of
+    # including only:
+    #    1. the specific tenant_id mentioned.
+    #    2. events where tenant_id is undefined
+    #
+    # tenant_id = deep_get(event, "tenant_id", default="")
+    # return tenant_id in ["1234", ""]
+    #
+    return True

--- a/global_helpers/global_filter_tines.yml
+++ b/global_helpers/global_filter_tines.yml
@@ -1,0 +1,11 @@
+AnalysisType: global
+Filename: global_filter_tines.py
+GlobalID: "global_filter_tines"
+Description: >
+  This module provides one filter that is included in all tines detections.
+  
+  This filter defines if events should be included or excluded.
+
+  You can change the definition of this filter to work in your own environment. 
+  Panther will not change the filter definition, and should not create 
+  merge conflicts.

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -806,6 +806,8 @@ class TestTinesHelpers(unittest.TestCase):
                 "request_ip": "<NO_REQUESTIP>",
             },
         )
+
+
 class TestAuth0Helpers(unittest.TestCase):
     def setUp(self):
         self.event = {

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -15,6 +15,7 @@ import panther_base_helpers as p_b_h  # pylint: disable=C0413
 import panther_cloudflare_helpers as p_cf_h  # pylint: disable=C0413
 import panther_ipinfo_helpers as p_i_h  # pylint: disable=C0413
 import panther_snyk_helpers as p_snyk_h  # pylint: disable=C0413
+import panther_tines_helpers as p_tines_h  # pylint: disable=C0413
 import panther_tor_helpers as p_tor_h  # pylint: disable=C0413
 
 
@@ -761,6 +762,31 @@ class TestSnykHelpers(unittest.TestCase):
         self.assertEqual(returns.get("action", ""), "<NO_EVENT>")
         self.assertEqual(returns.get("groupId", ""), "<NO_GROUPID>")
         self.assertEqual(returns.get("orgId", ""), "<NO_ORGID>")
+
+
+class TestTinesHelpers(unittest.TestCase):
+    def setUp(self):
+        self.event = {
+            "created_at": "2023-05-01 01:02:03",
+            "id": 7206820,
+            "operation_name": "Login",
+            "request_ip": "12.12.12.12",
+            "request_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) UserAgent",
+            "tenant_id": "1234",
+            "user_email": "user@domain.com",
+            "user_id": "17171",
+            "user_name": "user at domain dot com",
+        }
+
+    def test_alert_context(self):
+        returns = p_tines_h.tines_alert_context(self.event)
+        self.assertEqual(returns.get("actor", ""), "user@domain.com")
+        self.assertEqual(returns.get("action", ""), "Login")
+        self.assertEqual(returns.get("tenant_id", ""), "1234")
+        returns = p_tines_h.tines_alert_context({})
+        self.assertEqual(returns.get("actor", ""), "<NO_USEREMAIL>")
+        self.assertEqual(returns.get("action", ""), "<NO_OPERATION>")
+        self.assertEqual(returns.get("tenant_id", ""), "<NO_TENANTID>")
 
 
 if __name__ == "__main__":

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -780,13 +780,31 @@ class TestTinesHelpers(unittest.TestCase):
 
     def test_alert_context(self):
         returns = p_tines_h.tines_alert_context(self.event)
-        self.assertEqual(returns.get("actor", ""), "user@domain.com")
-        self.assertEqual(returns.get("action", ""), "Login")
-        self.assertEqual(returns.get("tenant_id", ""), "1234")
+        self.assertEqual(
+            returns,
+            {
+                "actor": "user@domain.com",
+                "action": "Login",
+                "tenant_id": "1234",
+                "user_email": "user@domain.com",
+                "user_id": "17171",
+                "operation_name": "Login",
+                "request_ip": "12.12.12.12",
+            },
+        )
         returns = p_tines_h.tines_alert_context({})
-        self.assertEqual(returns.get("actor", ""), "<NO_USEREMAIL>")
-        self.assertEqual(returns.get("action", ""), "<NO_OPERATION>")
-        self.assertEqual(returns.get("tenant_id", ""), "<NO_TENANTID>")
+        self.assertEqual(
+            returns,
+            {
+                "actor": "<NO_USEREMAIL>",
+                "action": "<NO_OPERATION>",
+                "tenant_id": "<NO_TENANTID>",
+                "user_email": "<NO_USEREMAIL>",
+                "user_id": "<NO_USERID>",
+                "operation_name": "<NO_OPERATION>",
+                "request_ip": "<NO_REQUESTIP>",
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/global_helpers/panther_tines_helpers.py
+++ b/global_helpers/panther_tines_helpers.py
@@ -3,4 +3,8 @@ def tines_alert_context(event) -> dict:
     a_c["actor"] = event.get("user_email", "<NO_USEREMAIL>")
     a_c["action"] = event.get("operation_name", "<NO_OPERATION>")
     a_c["tenant_id"] = event.get("tenant_id", "<NO_TENANTID>")
+    a_c["user_email"] = event.get("user_email", "<NO_USEREMAIL>")
+    a_c["user_id"] = event.get("user_id", "<NO_USERID>")
+    a_c["operation_name"] = event.get("operation_name", "<NO_OPERATION>")
+    a_c["request_ip"] = event.get("request_ip", "<NO_REQUESTIP>")
     return a_c

--- a/global_helpers/panther_tines_helpers.py
+++ b/global_helpers/panther_tines_helpers.py
@@ -1,0 +1,6 @@
+def tines_alert_context(event) -> dict:
+    a_c = {}
+    a_c["actor"] = event.get("user_email", "<NO_USEREMAIL>")
+    a_c["action"] = event.get("operation_name", "<NO_OPERATION>")
+    a_c["tenant_id"] = event.get("tenant_id", "<NO_TENANTID>")
+    return a_c

--- a/global_helpers/panther_tines_helpers.yml
+++ b/global_helpers/panther_tines_helpers.yml
@@ -1,0 +1,5 @@
+AnalysisType: global
+Filename: panther_tines_helpers.py
+GlobalID: "panther_tines_helpers"
+Description: >
+  Global helpers for Tines detections

--- a/packs/tines.yml
+++ b/packs/tines.yml
@@ -1,0 +1,11 @@
+AnalysisType: pack
+PackID: PantherManaged.Tines
+Description: Group of all Tines detections
+DisplayName: "Panther Tines Pack"
+PackDefinition:
+  IDs:
+    - Tines.SSO.Settings
+    # Globals
+    - global_filter_tines
+    - panther_base_helpers
+    - panther_tines_helpers

--- a/rules/tines_rules/tines_sso_settings.py
+++ b/rules/tines_rules/tines_sso_settings.py
@@ -1,0 +1,36 @@
+from global_filter_tines import filter_include_event
+from panther_base_helpers import deep_get
+from panther_tines_helpers import tines_alert_context
+
+ACTIONS = [
+    "SsoConfigurationDefaultSet",
+    "SsoConfigurationOidcSet",
+    "SsoConfigurationSamlSet",
+]
+
+
+def rule(event):
+    if not filter_include_event(event):
+        return False
+    action = deep_get(event, "operation_name", default="<NO_OPERATION_NAME>")
+    return action in ACTIONS
+
+
+def title(event):
+    action = deep_get(event, "operation_name", default="<NO_OPERATION_NAME>")
+    return (
+        f"Tines: [{action}] Setting "
+        f"changed by [{deep_get(event, 'user_email', default='<NO_USEREMAIL>')}]"
+    )
+
+
+def alert_context(event):
+    return tines_alert_context(event)
+
+
+def dedup(event):
+    return (
+        f"{deep_get(event, 'user_id', default='<NO_USERID>')}"
+        "_"
+        f"{deep_get(event, 'operation_name', default='<NO_OPERATION>')}"
+    )

--- a/rules/tines_rules/tines_sso_settings.yml
+++ b/rules/tines_rules/tines_sso_settings.yml
@@ -1,0 +1,53 @@
+AnalysisType: rule
+Filename: tines_sso_settings.py
+RuleID: Tines.SSO.Settings
+DisplayName: Tines SSO Settings
+Enabled: true
+LogTypes:
+  - Tines.Audit
+Tags:
+  - Tines
+  - IAM - Credential Security
+Severity: High
+Description: >
+  Detects when Tines SSO settings are changed
+DedupPeriodMinutes: 60
+Threshold:  1
+SummaryAttributes:
+  - event
+Tests:
+  -
+    Name: Tines SsoConfigurationSamlSet
+    ExpectedResult: true
+    Log:
+      {
+        "created_at": "2023-05-16 23:26:46",
+        "id": 1111111,
+        "inputs": {
+          "domainId": "REDACTED",
+          "fingerprint": "REDACTED",
+          "idpCertificate": "REDACTED",
+          "targetUrl": "REDACTED"
+        },
+        "operation_name": "SsoConfigurationSamlSet",
+        "request_ip": "12.12.12.12",
+        "request_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36",
+        "tenant_id": "8888",
+        "user_email": "user@company.com",
+        "user_id": "17171",
+        "user_name": "user at company dot com"
+      }
+  - Name: Tines Login
+    ExpectedResult: false
+    Log:
+      {
+        "created_at": "2023-05-17 14:45:19",
+        "id": 7888888,
+        "operation_name": "Login",
+        "request_ip": "12.12.12.12",
+        "request_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36",
+        "tenant_id": "8888",
+        "user_email": "user@company.com",
+        "user_id": "17171",
+        "user_name": "user at company dot com"
+      }


### PR DESCRIPTION
### Background

Tines.Audit logtype is in beta and here is the initialization of detections using this log type.
This change request adds
1. a rule for SSO settings being changed
2. a pack to group the rule(s)
3. global filters for tines to include/exclude tenants ( or whatever your criteria may be )
4. a global helper that provides alert_context for Tines detections


### Testing

```text
Tines.SSO.Settings
	[PASS] Tines SsoConfigurationSamlSet
		[PASS] [rule] true
		[PASS] [title] Tines: [SsoConfigurationSamlSet] Setting changed by [user@company.com]
		[PASS] [dedup] 17171_SsoConfigurationSamlSet
		[PASS] [alertContext] {"actor": "user@company.com", "action": "SsoConfigurationSamlSet", "tenant_id": "8888", "user_email": "user@company.com", "user_id": "17171", "operation_name": "SsoConfigurationSamlSet", "request_ip": "12.12.12.12"}
	[PASS] Tines Login
		[PASS] [rule] false

--------------------------
Panther CLI Test Summary
	Path: .
	Passed: 1
	Failed: 0
	Invalid: 0

```
