### PR TITLE
maxrichmond: removing detections as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 
 # These owners will be the default owners for everything in the repo.
 
-*       @panther-labs/detections @panther-labs/security
+*       @panther-labs/security


### PR DESCRIPTION
### Background

Team Detections used to be more involved with changes to this repo. But they no longer are involved.

### Changes

* Removed team detections as code owners

