### PR TITLE
chore: add a clickable link to snyk alert context to identify users

### DIFF
--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -754,15 +754,27 @@ class TestSnykHelpers(unittest.TestCase):
 
     def test_alert_context(self):
         returns = p_snyk_h.snyk_alert_context(self.event)
-        self.assertEqual(returns.get("actor", ""), "05555555-3333-4ddd-8ccc-755555555555")
-        self.assertEqual(returns.get("action", ""), "api.access")
-        self.assertEqual(returns.get("groupId", ""), "8fffffff-1555-4444-b000-b55555555555")
-        self.assertEqual(returns.get("orgId", ""), "21111111-a222-4eee-8ddd-a99999999999")
+        self.assertEqual(
+            returns,
+            {
+                # pylint: disable=line-too-long
+                "actor": "05555555-3333-4ddd-8ccc-755555555555",
+                "action": "api.access",
+                "groupId": "8fffffff-1555-4444-b000-b55555555555",
+                "orgId": "21111111-a222-4eee-8ddd-a99999999999",
+                "actor_link": "https://app.snyk.io/group/8fffffff-1555-4444-b000-b55555555555/manage/member/05555555-3333-4ddd-8ccc-755555555555",
+            },
+        )
         returns = p_snyk_h.snyk_alert_context({})
-        self.assertEqual(returns.get("actor", ""), "<NO_USERID>")
-        self.assertEqual(returns.get("action", ""), "<NO_EVENT>")
-        self.assertEqual(returns.get("groupId", ""), "<NO_GROUPID>")
-        self.assertEqual(returns.get("orgId", ""), "<NO_ORGID>")
+        self.assertEqual(
+            returns,
+            {
+                "actor": "<NO_USERID>",
+                "action": "<NO_EVENT>",
+                "groupId": "<NO_GROUPID>",
+                "orgId": "<NO_ORGID>",
+            },
+        )
 
 
 class TestTinesHelpers(unittest.TestCase):

--- a/global_helpers/panther_snyk_helpers.py
+++ b/global_helpers/panther_snyk_helpers.py
@@ -4,4 +4,8 @@ def snyk_alert_context(event) -> dict:
     a_c["action"] = event.get("event", "<NO_EVENT>")
     for pass_thru in ["orgId", "groupId"]:
         a_c[pass_thru] = event.get(pass_thru, f"<NO_{pass_thru}>".upper())
+    if a_c.get("actor", "") != "<NO_USERID>" and a_c.get("groupId") != "<NO_GROUPID>":
+        a_c[
+            "actor_link"
+        ] = f"https://app.snyk.io/group/{a_c.get('groupId')}/manage/member/{a_c.get('actor')}"
     return a_c

--- a/global_helpers/panther_snyk_helpers.py
+++ b/global_helpers/panther_snyk_helpers.py
@@ -4,7 +4,10 @@ def snyk_alert_context(event) -> dict:
     a_c["action"] = event.get("event", "<NO_EVENT>")
     for pass_thru in ["orgId", "groupId"]:
         a_c[pass_thru] = event.get(pass_thru, f"<NO_{pass_thru}>".upper())
-    if a_c.get("actor", "") != "<NO_USERID>" and a_c.get("groupId") != "<NO_GROUPID>":
+    if (
+        a_c.get("actor", "<NO_USERID>") != "<NO_USERID>"
+        and a_c.get("groupId", "<NO_GROUPID>") != "<NO_GROUPID>"
+    ):
         a_c[
             "actor_link"
         ] = f"https://app.snyk.io/group/{a_c.get('groupId')}/manage/member/{a_c.get('actor')}"


### PR DESCRIPTION
### Background

Snyk audit logs log user by user_id, which is great. Being able to quickly get to which user is referred to by a user_id is also great, and this PR extends the Snyk alert_context helper to include a full url that identifies the user. 

### Changes



### Testing
Here's an example of `actor_link` in the `Snyk.Misc.Settings` detection. 

```text
Snyk.Misc.Settings
	[PASS] Snyk Feature Flags changed
		[PASS] [rule] true
		[PASS] [title] Snyk: [Group] Setting [Feature_Flags.Edit] performed by [05555555-3333-4ddd-8ccc-755555555555]
		[PASS] [dedup] 05555555-3333-4ddd-8ccc-75555555555521111111-a222-4eee-8ddd-a999999999998fffffff-1555-4444-b000-b55555555555group.feature_flags.edit
		[PASS] [alertContext] {"actor": "05555555-3333-4ddd-8ccc-755555555555", "action": "group.feature_flags.edit", "orgId": "21111111-a222-4eee-8ddd-a99999999999", "groupId": "8fffffff-1555-4444-b000-b55555555555", "actor_link": "https://app.snyk.io/group/8fffffff-1555-4444-b000-b55555555555/manage/member/05555555-3333-4ddd-8ccc-755555555555"}
	[PASS] Snyk User Invite Revoke
		[PASS] [rule] false

--------------------------
Panther CLI Test Summary
	Path: .
	Passed: 1
	Failed: 0
	Invalid: 0


```
