### PR TITLE
Adding credential security pack

### DIFF
--- a/packs/credential_security.yml
+++ b/packs/credential_security.yml
@@ -17,35 +17,36 @@ PackDefinition:
     - panther_default
     - panther_event_type_helpers
     # Rules
+    - AWS.CloudTrail.RootPasswordChanged
+    - AWS.IAM.AccessKeyCompromised
+    - AWS.IAM.CredentialsUpdated
+    - AWS.RDS.MasterPasswordUpdated
+    - AWS.Unsuccessful.MFA.attempt
+    - AWS.User.Login.Profile.Modified
+    - Asana.Workspace.Password.Requirements.Simple
     - Auth0.MFA.Policy.Disabled
     - Auth0.MFA.Risk.Assessment.Disabled
-    - Asana.Workspace.Password.Requirements.Simple
+    - Crowdstrike.Credential.Dumping.Tool
     - Dropbox.User.Disabled.2FA 
     - Duo.Admin.App.Integration.Secret.Key.Viewed
     - Duo.Admin.Bypass.Code.Created
     - Duo.Admin.Bypass.Code.Viewed
-    - GitHub.Secret.Scanning.Alert.Created
     - GSuite.LeakedPassword
     - GSuite.Workspace.PasswordEnforceStrongDisabled
     - GSuite.Workspace.PasswordReuseEnabled
+    - GitHub.Secret.Scanning.Alert.Created
     - Microsoft365.MFA.Disabled
     - Okta.Global.MFA.Disabled
     - Okta.PasswordAccess
     - Okta.Support.Reset
-    - Okta.User.MFA.Reset.Single
     - Okta.User.MFA.Reset.All
+    - Okta.User.MFA.Reset.Single
+    - OneLogin.AuthFactorRemoved
     - OneLogin.PasswordAccess
     - OneLogin.PasswordChanged
-    - OneLogin.AuthFactorRemoved
     - OnePassword.Lut.Sensitive.Item
     - OnePassword.Sensitive.Item
     - Slack.AuditLogs.MFASettingsChanged
     - Standard.MFADisabled
     - Zoom.Two.Factor.Authentication.Disabled
-    - AWS.Unsuccessful.MFA.attempt
-    - AWS.IAM.AccessKeyCompromised
-    - AWS.RDS.MasterPasswordUpdated
-    - AWS.CloudTrail.RootPasswordChanged
-    - AWS.IAM.CredentialsUpdated
-    - AWS.User.Login.Profile.Modified
-    - Crowdstrike.Credential.Dumping.Tool
+

--- a/packs/credential_security.yml
+++ b/packs/credential_security.yml
@@ -21,7 +21,6 @@ PackDefinition:
     - AWS.IAM.AccessKeyCompromised
     - AWS.IAM.CredentialsUpdated
     - AWS.RDS.MasterPasswordUpdated
-    - AWS.Unsuccessful.MFA.attempt
     - AWS.User.Login.Profile.Modified
     - Asana.Workspace.Password.Requirements.Simple
     - Auth0.MFA.Policy.Disabled
@@ -44,9 +43,6 @@ PackDefinition:
     - OneLogin.AuthFactorRemoved
     - OneLogin.PasswordAccess
     - OneLogin.PasswordChanged
-    - OnePassword.Lut.Sensitive.Item
-    - OnePassword.Sensitive.Item
     - Slack.AuditLogs.MFASettingsChanged
     - Standard.MFADisabled
     - Zoom.Two.Factor.Authentication.Disabled
-

--- a/packs/credential_security.yml
+++ b/packs/credential_security.yml
@@ -1,0 +1,51 @@
+AnalysisType: pack
+PackID: PantherManaged.CredentialSecurity
+Description: Detections related to Credential Security
+DisplayName: "Panther Credential Security Pack"
+PackDefinition:
+  IDs:
+    # Data Models
+    - Standard.Atlassian.Audit
+    - Standard.Github.Audit
+    - Standard.Okta.SystemLog
+    - Standard.Zendesk.AuditLog
+    # Global Helpers
+    - global_filter_auth0
+    - global_filter_github
+    - panther_auth0_helpers
+    - panther_base_helpers
+    - panther_default
+    - panther_event_type_helpers
+    # Rules
+    - Auth0.MFA.Policy.Disabled
+    - Auth0.MFA.Risk.Assessment.Disabled
+    - Asana.Workspace.Password.Requirements.Simple
+    - Dropbox.User.Disabled.2FA 
+    - Duo.Admin.App.Integration.Secret.Key.Viewed
+    - Duo.Admin.Bypass.Code.Created
+    - Duo.Admin.Bypass.Code.Viewed
+    - GitHub.Secret.Scanning.Alert.Created
+    - GSuite.LeakedPassword
+    - GSuite.Workspace.PasswordEnforceStrongDisabled
+    - GSuite.Workspace.PasswordReuseEnabled
+    - Microsoft365.MFA.Disabled
+    - Okta.Global.MFA.Disabled
+    - Okta.PasswordAccess
+    - Okta.Support.Reset
+    - Okta.User.MFA.Reset.Single
+    - Okta.User.MFA.Reset.All
+    - OneLogin.PasswordAccess
+    - OneLogin.PasswordChanged
+    - OneLogin.AuthFactorRemoved
+    - OnePassword.Lut.Sensitive.Item
+    - OnePassword.Sensitive.Item
+    - Slack.AuditLogs.MFASettingsChanged
+    - Standard.MFADisabled
+    - Zoom.Two.Factor.Authentication.Disabled
+    - AWS.Unsuccessful.MFA.attempt
+    - AWS.IAM.AccessKeyCompromised
+    - AWS.RDS.MasterPasswordUpdated
+    - AWS.CloudTrail.RootPasswordChanged
+    - AWS.IAM.CredentialsUpdated
+    - AWS.User.Login.Profile.Modified
+    - Crowdstrike.Credential.Dumping.Tool

--- a/packs/credential_security.yml
+++ b/packs/credential_security.yml
@@ -1,6 +1,6 @@
 AnalysisType: pack
 PackID: PantherManaged.CredentialSecurity
-Description: Detections related to Credential Security
+Description: Detect compromised security credentials
 DisplayName: "Panther Credential Security Pack"
 PackDefinition:
   IDs:


### PR DESCRIPTION
### Background

Creating a pack for rules (and associated data models & globals) related to credential security.

### Changes

* Added a new `Credential Security` pack

### Testing

* I manually checked each rules imports to ensure all globals were covered, and manually checked the standard rule's log types to ensure data models were covered
