### PR TITLE
feat: a generic approach to impossible travel for login style events

### DIFF
--- a/data_models/aws_cloudtrail_data_model.py
+++ b/data_models/aws_cloudtrail_data_model.py
@@ -37,3 +37,9 @@ def load_ip_address(event):
         except ipaddress.AddressValueError:
             return None
     return source_ip
+
+
+def get_source_ip_field(event):  # pylint: disable=W0613
+    # get_source_ip_field is used when looking for
+    # source IP Address Enrichment info
+    return "sourceIPAddress"

--- a/data_models/aws_cloudtrail_data_model.yml
+++ b/data_models/aws_cloudtrail_data_model.yml
@@ -18,3 +18,5 @@ Mappings:
     Path: $.responseElements.user.userName
   - Name: user_account_id
     Path: $.responseElements.user.userId
+  - Name: source_ip_field
+    Method: get_source_ip_field 

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -1006,5 +1006,63 @@ class TestOssHelpers(unittest.TestCase):
         self.assertEqual(p_o_h.get_string_set("strs"), set())
 
 
+class TestKmBetweenTwoIPInfoLocs(unittest.TestCase):
+    def setUp(self):
+        self.loc_nyc = {
+            "city": "New York City",
+            "country": "US",
+            "lat": "40.71427",
+            "lng": "-74.00597",
+            "postal_code": "10004",
+            "region": "New York",
+            "region_code": "NY",
+            "timezone": "America/New_York",
+        }
+        self.loc_sfo = {
+            "city": "San Francisco",
+            "country": "US",
+            "lat": "37.77493",
+            "lng": "-122.41942",
+            "postal_code": "94102",
+            "region": "California",
+            "region_code": "CA",
+            "timezone": "America/Los_Angeles",
+        }
+        self.loc_athens = {
+            "city": "Athens",
+            "country": "GR",
+            "lat": "37.98376",
+            "lng": "23.72784",
+            "postal_code": "",
+            "region": "Attica",
+            "region_code": "I",
+            "timezone": "Europe/Athens",
+        }
+        self.loc_aukland = {
+            "city": "Auckland",
+            "country": "NZ",
+            "lat": "-36.84853",
+            "lng": "174.76349",
+            "postal_code": "1010",
+            "region": "Auckland",
+            "region_code": "AUK",
+            "timezone": "Pacific/Auckland",
+        }
+
+    def test_distances(self):
+        nyc_to_sfo = p_o_h.km_between_ipinfo_loc(self.loc_nyc, self.loc_sfo)
+        nyc_to_athens = p_o_h.km_between_ipinfo_loc(self.loc_nyc, self.loc_athens)
+        nyc_to_aukland = p_o_h.km_between_ipinfo_loc(self.loc_nyc, self.loc_aukland)
+        aukland_to_nyc = p_o_h.km_between_ipinfo_loc(self.loc_aukland, self.loc_nyc)
+        # I used https://www.nhc.noaa.gov/gccalc.shtml to get test comparison distances
+        #
+        # delta is set to 0.5% of total computed distanc from gccalc
+        self.assertAlmostEqual(nyc_to_sfo, 4126, delta=20.63)
+        self.assertAlmostEqual(nyc_to_athens, 7920, delta=39.6)
+        self.assertAlmostEqual(nyc_to_aukland, 14184, delta=70.92)
+        # and NYC to Aukland should be ~= Aukland to NYC
+        self.assertEqual(nyc_to_aukland, aukland_to_nyc)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/rules/standard_rules/impossible_travel_login.py
+++ b/rules/standard_rules/impossible_travel_login.py
@@ -1,0 +1,140 @@
+from datetime import datetime, timedelta
+from json import dumps, loads
+
+import panther_event_type_helpers as event_type
+from panther_base_helpers import deep_get
+from panther_oss_helpers import (
+    get_string_set,
+    km_between_ipinfo_loc,
+    put_string_set,
+    resolve_timestamp_string,
+)
+
+EVENT_CITY_TRACKING = {}
+CACHE_KEY = None
+
+
+def gen_key(event):
+    """
+    gen_key uses the data_model for the logtype to cache
+    an entry that is specific to the Log Source ID
+
+    The data_model needs to answer to "actor_user"
+    """
+    rule_name = deep_get(event, "p_source_label")
+    actor = event.udm("actor_user")
+    if None in [rule_name, actor]:
+        return None
+    return f"{rule_name.replace(' ', '')}..{actor}"
+
+
+def rule(event):
+    # too-many-return-statements due to error checking
+    # pylint: disable=global-statement,too-many-return-statements
+    global EVENT_CITY_TRACKING
+    global CACHE_KEY
+
+    # Only evaluate successful logins
+    if event.udm("event_type") != event_type.SUCCESSFUL_LOGIN:
+        return False
+
+    ipinfo_location_key = event.udm("source_ip_field")
+    # bail unless we know where to look in ip enrichment
+    if ipinfo_location_key is None or not isinstance(ipinfo_location_key, str):
+        return False
+
+    p_event_datetime = resolve_timestamp_string(deep_get(event, "p_event_time"))
+    if p_event_datetime is None:
+        # we couldn't go from p_event_time to a datetime object
+        # we need to do this in order to make later time comparisons generic
+        return False
+
+    new_login_stats = {
+        "p_event_time": p_event_datetime.isoformat(),
+        "source_ip": event.udm("source_ip"),
+    }
+    # stuff everything from ipinfo_location into the new_login_stats
+    # new_login_stats is the value that we will cache for this key
+    ipinfo_enrichment = deep_get(event, "p_enrichment", "ipinfo_location", ipinfo_location_key)
+    if ipinfo_enrichment is None:
+        return False
+    new_login_stats.update(ipinfo_enrichment)
+
+    # Bail out if we have a None value in set as it causes false positives
+    if None in new_login_stats.values():
+        return False
+
+    # Generate a unique cache key for each user per log type
+    CACHE_KEY = gen_key(event)
+    if CACHE_KEY is None:
+        # We can't save without a cache key
+        return False
+    # Retrieve the prior login info from the cache, if any
+    last_login = get_string_set(CACHE_KEY)
+    # If we haven't seen this user login in the past 1 day,
+    # store this login for future use and don't alert
+    if not last_login:
+        put_string_set(
+            key=CACHE_KEY,
+            val=[dumps(new_login_stats)],
+            epoch_seconds=int((datetime.utcnow() + timedelta(days=1)).timestamp()),
+        )
+        return False
+    # Load the last login from the cache into an object we can compare
+    # str check is in place for unit test mocking
+    if isinstance(last_login, str):
+        tmp_last_login = loads(last_login)
+        last_login = []
+        for l_l in tmp_last_login:
+            last_login.append(dumps(l_l))
+    last_login_stats = loads(last_login.pop())
+
+    distance = km_between_ipinfo_loc(last_login_stats, new_login_stats)
+    old_time = resolve_timestamp_string(deep_get(last_login_stats, "p_event_time"))
+    new_time = resolve_timestamp_string(deep_get(new_login_stats, "p_event_time"))
+    time_delta = (new_time - old_time).total_seconds() / 3600  # seconds in an hour
+
+    # Don't let time_delta be 0 (divide by zero error below)
+    time_delta = time_delta or 0.0001
+    # Calculate speed in Kilometers / Hour
+    speed = distance / time_delta
+
+    # Calculation is complete, write the current login to the cache
+    put_string_set(
+        key=CACHE_KEY,
+        val=[dumps(new_login_stats)],
+        epoch_seconds=int((datetime.utcnow() + timedelta(days=1)).timestamp()),
+    )
+
+    EVENT_CITY_TRACKING["previous"] = last_login_stats
+    EVENT_CITY_TRACKING["current"] = new_login_stats
+    EVENT_CITY_TRACKING["speed"] = int(speed)
+    EVENT_CITY_TRACKING["distance"] = int(distance)
+
+    return speed > 900  # Boeing 747 cruising speed
+
+
+def title(event):
+    #
+    log_source = deep_get(event, "p_source_label", default="<NO_SOURCE_LABEL>")
+    old_city = deep_get(EVENT_CITY_TRACKING, "previous", "city", default="<NO_PREV_CITY>")
+    new_city = deep_get(EVENT_CITY_TRACKING, "current", "city", default="<NO_PREV_CITY>")
+    speed = deep_get(EVENT_CITY_TRACKING, "speed", default="<NO_SPEED>")
+    distance = deep_get(EVENT_CITY_TRACKING, "distance", default="<NO_DISTANCE>")
+    return (
+        f"Impossible Travel: [{event.udm('actor_user')}] "
+        f"in [{log_source}] went [{speed}] km/h for [{distance}] km "
+        f"between [{old_city}] and [{new_city}]"
+    )
+
+
+def dedup(event):  # pylint: disable=W0613
+    return CACHE_KEY
+
+
+def alert_context(event):
+    context = {
+        "actor_user": event.udm("actor_user"),
+    }
+    context.update(EVENT_CITY_TRACKING)
+    return context

--- a/rules/standard_rules/impossible_travel_login.yml
+++ b/rules/standard_rules/impossible_travel_login.yml
@@ -1,0 +1,165 @@
+AnalysisType: rule
+Filename: impossible_travel_login.py
+RuleID: "Standard.ImpossibleTravel.Login"
+DisplayName: "Impossible Travel for Login Action"
+Enabled: true
+LogTypes:
+  - AWS.CloudTrail
+Tags:
+  - Identity & Access Management
+  - Initial Access:Valid Accounts
+Reports:
+  MITRE ATT&CK:
+    - TA0001:T1078
+Severity: High
+Description: A user has subsequent logins from two geographic locations that are very far apart
+Runbook: Reach out to the user if needed to validate the activity, then lock the account
+SummaryAttributes:
+  - p_any_user_names
+  - p_any_ip_addresses
+  - p_any_domain_names
+# All test cases for this detection will need to include:
+# * p_log_type ( for udm)
+# Alerting test cases for this detection will need to include: 
+# * p_source_label
+# * p_event_time
+# * p_enrichment.ipinfo_location.{UDM SOURCE_IP_FIELD}
+Tests:
+  - Name: CloudTrail not ConsoleLogin
+    ExpectedResult: false
+    Log:
+      {
+        "eventType": "logout",
+        "p_log_type": "AWS.CloudTrail"
+      }
+  - Name: CloudTrail ConsoleLogin no history
+    ExpectedResult: false
+    Mocks:
+      - objectName: put_string_set
+        returnValue: ""
+      - objectName: get_string_set
+        returnValue: >-
+    Log:
+      {
+        "additionalEventData": {
+          "MFAUsed": "No",
+          "MobileVersion": "No"
+        },
+        "awsRegion": "us-east-1",
+        "eventCategory": "Management",
+        "eventName": "ConsoleLogin",
+        "eventSource": "signin.amazonaws.com",
+        "eventTime": "2023-05-26 20:14:51",
+        "eventType": "AwsConsoleSignIn",
+        "eventVersion": "1.08",
+        "managementEvent": true,
+        "p_event_time": "2023-05-26 20:14:51",
+        "p_enrichment":  {
+          "ipinfo_location": {
+            "sourceIPAddress": {
+              "city": "Auckland",
+              "country": "NZ",
+              "lat": "-36.84853",
+              "lng": "174.76349",
+              "postal_code": "1010",
+              "region": "Auckland",
+              "region_code": "AUK",
+              "timezone": "Pacific/Auckland"
+            }
+          }
+        },
+        "p_log_type": "AWS.CloudTrail",
+        "p_parse_time": "2023-05-26 20:19:14.002",
+        "p_source_label": "LogSource Name",
+        "readOnly": false,
+        "recipientAccountId": "123456789012",
+        "responseElements": {
+          "ConsoleLogin": "Success"
+        },
+        "sourceIPAddress": "12.12.12.12",
+        "tlsDetails": {
+          "cipherSuite": "TLS_AES_128_GCM_SHA256",
+          "clientProvidedHostHeader": "signin.aws.amazon.com",
+          "tlsVersion": "TLSv1.3"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36",
+        "userIdentity": {
+          "type": "IAMUser",
+          "principalId": "1111",
+          "arn": "arn:aws:iam::123456789012:user/tester",
+          "accountId": "123456789012",
+          "userName": "tester"
+        }
+      }
+  - Name: CloudTrail ConsoleLogin with history
+    ExpectedResult: true
+    Mocks:
+      - objectName: put_string_set
+        returnValue: ""
+      - objectName: get_string_set
+        returnValue: >-
+          [
+           {
+            "p_event_time": "2023-05-26 18:14:51",
+            "city": "New York City",
+            "country": "US",
+            "lat": "40.71427",
+            "lng": "-74.00597",
+            "postal_code": "10004",
+            "region": "New York",
+            "region_code": "NY",
+            "timezone": "America/New_York"
+           }
+          ]
+    Log:
+      {
+        "additionalEventData": {
+          "MFAUsed": "No",
+          "MobileVersion": "No"
+        },
+        "awsRegion": "us-east-1",
+        "eventCategory": "Management",
+        "eventName": "ConsoleLogin",
+        "eventSource": "signin.amazonaws.com",
+        "eventTime": "2023-05-26 20:14:51",
+        "eventType": "AwsConsoleSignIn",
+        "eventVersion": "1.08",
+        "managementEvent": true,
+        "p_event_time": "2023-05-26 20:14:51",
+        "p_enrichment":  {
+          "ipinfo_location": {
+            "sourceIPAddress": {
+              "city": "Auckland",
+              "country": "NZ",
+              "lat": "-36.84853",
+              "lng": "174.76349",
+              "postal_code": "1010",
+              "region": "Auckland",
+              "region_code": "AUK",
+              "timezone": "Pacific/Auckland"
+            }
+          }
+        },
+        "p_log_type": "AWS.CloudTrail",
+        "p_parse_time": "2023-05-26 20:19:14.002",
+        "p_source_label": "LogSource Name",
+        "readOnly": false,
+        "recipientAccountId": "123456789012",
+        "responseElements": {
+          "ConsoleLogin": "Success"
+        },
+        "sourceIPAddress": "12.12.12.12",
+        "tlsDetails": {
+          "cipherSuite": "TLS_AES_128_GCM_SHA256",
+          "clientProvidedHostHeader": "signin.aws.amazon.com",
+          "tlsVersion": "TLSv1.3"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36",
+        "userIdentity": {
+          "type": "IAMUser",
+          "principalId": "1111",
+          "arn": "arn:aws:iam::123456789012:user/tester",
+          "accountId": "123456789012",
+          "userName": "tester"
+        }
+      }


### PR DESCRIPTION
### Background

Panther can leverage IPInfo based location data to make impossible travel computations for any log source. This detection is setup only for `AWS.CloudTrail` log type in this PR, and if we like this approach we can readily extend it to other LogTypes

This PR:
1. Creates `panther_oss_helpers.km_between_ipinfo_loc()` which uses the Haversine formula to find the distance between two ipinfo location entries as measured in kilometers
2. Creates unit test cases for ☝️ 
3. Establishes a detection leveraging the above which caches IPInfo location information for login events, and compares incoming login events against the cache. 



### Testing

```text
Standard.ImpossibleTravel.Login
	[PASS] CloudTrail not ConsoleLogin
		[PASS] [rule] false
	[PASS] CloudTrail ConsoleLogin no history
		[PASS] [rule] false
	[PASS] CloudTrail ConsoleLogin with history
		[PASS] [rule] true
		[PASS] [title] Impossible Travel: [tester] in [LogSource Name] went [7098] km/h for [14197] km between [New York City] and [Auckland]
		[PASS] [dedup] LogSourceName..tester
		[PASS] [alertContext] {"actor_user": "tester", "previous": {"p_event_time": "2023-05-26 18:14:51", "city": "New York City", "country": "US", "lat": "40.71427", "lng": "-74.00597", "postal_code": "10004", "region": "New York", "region_code": "NY", "timezone": "America/New_York"}, "current": {"p_event_time": "2023-05-26T20:14:51", "source_ip": "12.12.12.12", "city": "Auckland", "country": "NZ", "lat": "-36.84853", "lng": "174.76349", "postal_code": "1010", "region": "Auckland", "region_code": "AUK", "timezone": "Pacific/Auckland"}, "speed": 7098, "distance": 14197}

--------------------------
Panther CLI Test Summary
	Path: .
	Passed: 1
	Failed: 0
	Invalid: 0


```