### PR TITLE
fix: When Snyk users are added via SAML, the userId on the audit log entry is the same as the userid of the added user

### DIFF
--- a/rules/snyk_rules/snyk_user_mgmt.py
+++ b/rules/snyk_rules/snyk_user_mgmt.py
@@ -27,6 +27,14 @@ def rule(event):
     if not filter_include_event(event):
         return False
     action = deep_get(event, "event", default="<NO_EVENT>")
+    # for org.user.add/group.user.add via SAML/SCIM 
+    # the attributes .userId and .content.publicUserId 
+    # have the same value
+    if action.endswith(".user.add"):
+        targetUser = deep_get(event, "content", "userPublicId", default="<NO_CONTENT_UID>")
+        actor = deep_get(event, "userId", default="<NO_USERID>")
+        if targetUser == actor:
+            return False
     return action in ACTIONS
 
 

--- a/rules/snyk_rules/snyk_user_mgmt.py
+++ b/rules/snyk_rules/snyk_user_mgmt.py
@@ -27,13 +27,13 @@ def rule(event):
     if not filter_include_event(event):
         return False
     action = deep_get(event, "event", default="<NO_EVENT>")
-    # for org.user.add/group.user.add via SAML/SCIM 
-    # the attributes .userId and .content.publicUserId 
+    # for org.user.add/group.user.add via SAML/SCIM
+    # the attributes .userId and .content.publicUserId
     # have the same value
     if action.endswith(".user.add"):
-        targetUser = deep_get(event, "content", "userPublicId", default="<NO_CONTENT_UID>")
+        target_user = deep_get(event, "content", "userPublicId", default="<NO_CONTENT_UID>")
         actor = deep_get(event, "userId", default="<NO_USERID>")
-        if targetUser == actor:
+        if target_user == actor:
             return False
     return action in ACTIONS
 

--- a/rules/snyk_rules/snyk_user_mgmt.yml
+++ b/rules/snyk_rules/snyk_user_mgmt.yml
@@ -79,3 +79,18 @@ Tests:
           "unknown": "contents"
         }
       }
+  - Name: SAML User Added
+    ExpectedResult: false
+    Log:
+      {
+        "content": {
+          "role": "Org Collaborator",
+          "rolePublicId": "beeeeeee-dddd-4444-aaaa-133333333333",
+          "userPublicId": "05555555-3333-4ddd-8ccc-755555555555"
+        },
+        "created": "2023-06-01 03:14:42.776",
+        "event": "org.user.add",
+        "groupId": "8fffffff-1555-4444-b000-b55555555555",
+        "orgId": "21111111-a222-4eee-8ddd-a99999999999",
+        "userId": "05555555-3333-4ddd-8ccc-755555555555"
+      }


### PR DESCRIPTION
### Background

This change modifies the `Snyk.User.Management` detection so that there is no alert when users are added to Snyk via SAML sign-in

### Changes


### Testing

```text
Snyk.User.Management
	[PASS] Snyk User Removed
		[PASS] [rule] true
		[PASS] [title] Snyk: [Org] User [Remove] performed by [05555555-3333-4ddd-8ccc-755555555555]
		[PASS] [dedup] 05555555-3333-4ddd-8ccc-75555555555521111111-a222-4eee-8ddd-a999999999998fffffff-1555-4444-b000-b55555555555org.user.remove
		[PASS] [alertContext] {"actor": "05555555-3333-4ddd-8ccc-755555555555", "action": "org.user.remove", "orgId": "21111111-a222-4eee-8ddd-a99999999999", "groupId": "8fffffff-1555-4444-b000-b55555555555", "actor_link": "https://app.snyk.io/group/8fffffff-1555-4444-b000-b55555555555/manage/member/05555555-3333-4ddd-8ccc-755555555555"}
		[PASS] [severity] MEDIUM
	[PASS] Snyk User Invite Revoke
		[PASS] [rule] true
		[PASS] [title] Snyk: [Org] User [Invite.Revoke] performed by [05555555-3333-4ddd-8ccc-755555555555]
		[PASS] [dedup] 05555555-3333-4ddd-8ccc-75555555555521111111-a222-4eee-8ddd-a999999999998fffffff-1555-4444-b000-b55555555555org.user.invite.revoke
		[PASS] [alertContext] {"actor": "05555555-3333-4ddd-8ccc-755555555555", "action": "org.user.invite.revoke", "orgId": "21111111-a222-4eee-8ddd-a99999999999", "groupId": "8fffffff-1555-4444-b000-b55555555555", "actor_link": "https://app.snyk.io/group/8fffffff-1555-4444-b000-b55555555555/manage/member/05555555-3333-4ddd-8ccc-755555555555"}
		[PASS] [severity] MEDIUM
	[PASS] Snyk Group User add
		[PASS] [rule] true
		[PASS] [title] Snyk: [Group] User [Add] performed by [05555555-3333-4ddd-8ccc-755555555555]
		[PASS] [dedup] 05555555-3333-4ddd-8ccc-755555555555<NO_ORGID>8fffffff-1555-4444-b000-b55555555555group.user.add
		[PASS] [alertContext] {"actor": "05555555-3333-4ddd-8ccc-755555555555", "action": "group.user.add", "orgId": "<NO_ORGID>", "groupId": "8fffffff-1555-4444-b000-b55555555555", "actor_link": "https://app.snyk.io/group/8fffffff-1555-4444-b000-b55555555555/manage/member/05555555-3333-4ddd-8ccc-755555555555"}
		[PASS] [severity] MEDIUM
	[PASS] Snyk System SSO Setting event happened
		[PASS] [rule] false
	[PASS] SAML User Added
		[PASS] [rule] false

--------------------------
Panther CLI Test Summary
	Path: .
	Passed: 1
	Failed: 0
	Invalid: 0


```
