### PR TITLE
fix: Tune cloudflare bot alert up to 2req/sec. Disable some cloudflare blocked alerts due to cloudflare having blocked the request

### DIFF
--- a/packs/cloudflare.yml
+++ b/packs/cloudflare.yml
@@ -5,8 +5,6 @@ Description: Group of all Cloudflare detections
 PackDefinition:
   IDs:
     - Cloudflare.Firewall.L7DDoS
-    - Cloudflare.Firewall.HighVolumeEventsBlocked
-    - Cloudflare.Firewall.HighVolumeEventsBlockedGreyNoise
     - Cloudflare.Firewall.SuspiciousEventGreyNoise
     - Cloudflare.HttpRequest.BotHighVolume
     - Cloudflare.HttpRequest.BotHighVolumeGreyNoise

--- a/rules/cloudflare_rules/cloudflare_firewall_high_volume_events_blocked.yml
+++ b/rules/cloudflare_rules/cloudflare_firewall_high_volume_events_blocked.yml
@@ -1,7 +1,7 @@
 AnalysisType: rule
 Filename: cloudflare_firewall_high_volume_events_blocked.py
 RuleID: "Cloudflare.Firewall.HighVolumeEventsBlocked"
-DisplayName: "Cloudflare - High Volume Events Blocked"
+DisplayName: "--DEPRECATED-- Cloudflare - High Volume Events Blocked"
 Enabled: false
 LogTypes:
   - Cloudflare.Firewall

--- a/rules/cloudflare_rules/cloudflare_firewall_high_volume_events_blocked_greynoise.yml
+++ b/rules/cloudflare_rules/cloudflare_firewall_high_volume_events_blocked_greynoise.yml
@@ -1,8 +1,8 @@
 AnalysisType: rule
 Filename: cloudflare_firewall_high_volume_events_blocked_greynoise.py
 RuleID: "Cloudflare.Firewall.HighVolumeEventsBlockedGreyNoise"
-DisplayName: "Cloudflare High Volume Events Blocked - GreyNoise"
-Enabled: true
+DisplayName: "--DEPRECATED-- Cloudflare High Volume Events Blocked - GreyNoise"
+Enabled: false
 LogTypes:
   - Cloudflare.Firewall
 Tags:

--- a/rules/cloudflare_rules/cloudflare_httpreq_bot_high_volume.yml
+++ b/rules/cloudflare_rules/cloudflare_httpreq_bot_high_volume.yml
@@ -8,10 +8,10 @@ LogTypes:
 Tags:
   - Cloudflare
 Severity: Low
-Description: Monitors for high volume of likely automated HTTP Requests
+Description: Monitors for bots making HTTP Requests at a rate higher than 2req/sec
 Runbook: Inspect and monitor internet-facing services for potential outages
 DedupPeriodMinutes: 60 # 1 hour
-Threshold:  600
+Threshold:  7560 # 2req/sec is 7200 + 5% for just-in-case
 SummaryAttributes:
   - ClientIP
   - ClientRequestUserAgent

--- a/rules/cloudflare_rules/cloudflare_httpreq_bot_high_volume_greynoise.yml
+++ b/rules/cloudflare_rules/cloudflare_httpreq_bot_high_volume_greynoise.yml
@@ -12,7 +12,7 @@ Severity: Low
 Description: Monitors for high volume of likely automated HTTP Requests with GreyNoise enrichment
 Runbook: Inspect and monitor internet-facing services for potential outages
 DedupPeriodMinutes: 60 # 1 hour
-Threshold:  600
+Threshold:  7560 # 2req/sec is 7200 + 5% for just-in-case
 SummaryAttributes:
   - ClientIP
   - ClientRequestUserAgent


### PR DESCRIPTION
### Background

`Cloudflare.HttpRequest.BotHighVolume` detection had thresholding settings that worked out to one request every six seconds. This change tunes the alert volume of requests up to 2req/sec. Googlebot reports that 2 req/sec is the "HIGH" setting. 

We also have disabled-by-default 2 cloudflare detections which surfaced alerts when Cloudflare has blocked traffic. These disabled detections were also removed from the cloudflare pack. 

### Changes



### Testing

*  No testing changes needed. 
