### PR TITLE
feat: extend the Standard.ImpossibleTravel.Login detection to include Okta.SystemLog

### DIFF
--- a/data_models/okta_data_model.py
+++ b/data_models/okta_data_model.py
@@ -36,3 +36,9 @@ def get_actor_user(event):
     if actor == "unknown":
         actor = deep_get(event, "actor", "alternateId", default="Unknown User")
     return actor
+
+
+def get_source_ip_field(event):  # pylint: disable=W0613
+    # get_source_ip_field is used when looking for
+    # source IP Address Enrichment info
+    return "client.ipAddress"

--- a/data_models/okta_data_model.yml
+++ b/data_models/okta_data_model.yml
@@ -14,3 +14,5 @@ Mappings:
     Path: $.client.ipAddress
   - Name: user_agent
     Path: $.client.userAgent.rawUserAgent
+  - Name: source_ip_field
+    Method: get_source_ip_field 

--- a/packs/standard_ruleset.yml
+++ b/packs/standard_ruleset.yml
@@ -21,6 +21,7 @@ PackDefinition:
     # Standard Detections
     - Standard.AdminRoleAssigned
     - Standard.BruteForceByIP
+    - Standard.ImpossibleTravel.Login
     - Standard.MFADisabled
     - Standard.NewAWSAccountCreated
     - Standard.NewUserAccountCreated

--- a/rules/standard_rules/impossible_travel_login.yml
+++ b/rules/standard_rules/impossible_travel_login.yml
@@ -5,6 +5,7 @@ DisplayName: "Impossible Travel for Login Action"
 Enabled: true
 LogTypes:
   - AWS.CloudTrail
+  - Okta.SystemLog
 Tags:
   - Identity & Access Management
   - Initial Access:Valid Accounts
@@ -162,4 +163,98 @@ Tests:
           "accountId": "123456789012",
           "userName": "tester"
         }
+      }
+  - Name: Okta Not sign-in
+    ExpectedResult: false
+    Log:
+      {
+        "eventType": "logout",
+        "p_log_type": "Okta.SystemLog",
+      }
+  - Name: Okta sign-in with history and impossible travel
+    ExpectedResult: true
+    Mocks:
+      - objectName: put_string_set
+        returnValue: ""
+      - objectName: get_string_set
+        returnValue: >-
+          [
+           {
+            "p_event_time": "2023-05-26 18:14:51",
+            "city": "New York City",
+            "country": "US",
+            "lat": "40.71427",
+            "lng": "-74.00597",
+            "postal_code": "10004",
+            "region": "New York",
+            "region_code": "NY",
+            "timezone": "America/New_York"
+           }
+          ]
+    Log:
+      {
+        "actor": {
+          "alternateId": "homer.simpson@company.com",
+          "displayName": "Homer Simpson",
+          "id": "00uwuwuwuwuwuwuwuwuw",
+          "type": "User"
+        },
+        "authenticationContext": {
+          "authenticationStep": 0,
+          "externalSessionId": "idx1234"
+        },
+        "client": {
+          "device": "Computer",
+          "ipAddress": "12.12.12.12",
+          "userAgent": {
+            "browser": "CHROME",
+            "os": "Mac OS X",
+            "rawUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36"
+          },
+          "zone": "null"
+        },
+        "debugContext": {
+          "debugData": {
+          }
+        },
+        "device": {
+        },
+        "displayMessage": "User login to Okta",
+        "eventType": "user.session.start",
+        "legacyEventType": "core.user_auth.login_success",
+        "outcome": {
+          "result": "SUCCESS"
+        },
+        "p_event_time": "2023-05-26 20:18:51",
+        "p_enrichment":  {
+          "ipinfo_location": {
+            "client.ipAddress": {
+              "city": "Auckland",
+              "country": "NZ",
+              "lat": "-36.84853",
+              "lng": "174.76349",
+              "postal_code": "1010",
+              "region": "Auckland",
+              "region_code": "AUK",
+              "timezone": "Pacific/Auckland"
+            }
+          }
+        },
+        "p_log_type": "Okta.SystemLog",
+        "p_source_label": "Okta Logs",
+        "p_parse_time": "2023-05-26 20:22:51.888",
+        "published": "2023-05-26 20:18:51.888",
+        "request": {
+          "ipChain": [
+          ]
+        },
+        "securityContext": {
+        },
+        "severity": "INFO",
+        "target": [
+        ],
+        "transaction": {
+        },
+        "uuid": "79999999-ffff-eeee-bbbb-222222222222",
+        "version": "0"
       }


### PR DESCRIPTION
### Background
Standard.ImpossibleTravel.Login is now extended to include Okta.SystemLog. 

Additionally, this detection is now included in the Standard pack 


### Testing
```text
Standard.ImpossibleTravel.Login
	[PASS] CloudTrail not ConsoleLogin
		[PASS] [rule] false
	[PASS] CloudTrail ConsoleLogin no history
		[PASS] [rule] false
	[PASS] CloudTrail ConsoleLogin with history
		[PASS] [rule] true
		[PASS] [title] Impossible Travel: [tester] in [LogSource Name] went [7098] km/h for [14197] km between [New York City] and [Auckland]
		[PASS] [dedup] LogSourceName..tester
		[PASS] [alertContext] {"actor_user": "tester", "previous": {"p_event_time": "2023-05-26 18:14:51", "city": "New York City", "country": "US", "lat": "40.71427", "lng": "-74.00597", "postal_code": "10004", "region": "New York", "region_code": "NY", "timezone": "America/New_York"}, "current": {"p_event_time": "2023-05-26T20:14:51", "source_ip": "12.12.12.12", "city": "Auckland", "country": "NZ", "lat": "-36.84853", "lng": "174.76349", "postal_code": "1010", "region": "Auckland", "region_code": "AUK", "timezone": "Pacific/Auckland"}, "speed": 7098, "distance": 14197}
	[PASS] Okta Not sign-in
		[PASS] [rule] false
	[PASS] Okta sign-in with history and impossible travel
		[PASS] [rule] true
		[PASS] [title] Impossible Travel: [Homer Simpson] in [Okta Logs] went [6869] km/h for [14197] km between [New York City] and [Auckland]
		[PASS] [dedup] OktaLogs..Homer Simpson
		[PASS] [alertContext] {"actor_user": "Homer Simpson", "previous": {"p_event_time": "2023-05-26 18:14:51", "city": "New York City", "country": "US", "lat": "40.71427", "lng": "-74.00597", "postal_code": "10004", "region": "New York", "region_code": "NY", "timezone": "America/New_York"}, "current": {"p_event_time": "2023-05-26T20:18:51", "source_ip": "12.12.12.12", "city": "Auckland", "country": "NZ", "lat": "-36.84853", "lng": "174.76349", "postal_code": "1010", "region": "Auckland", "region_code": "AUK", "timezone": "Pacific/Auckland"}, "speed": 6869, "distance": 14197}

--------------------------
Panther CLI Test Summary
	Path: .
	Passed: 1
	Failed: 0
	Invalid: 0


```