### PR TITLE
chore: add units to alert_context on standard impossible travel

### DIFF
--- a/rules/standard_rules/impossible_travel_login.py
+++ b/rules/standard_rules/impossible_travel_login.py
@@ -109,7 +109,9 @@ def rule(event):
     EVENT_CITY_TRACKING["previous"] = last_login_stats
     EVENT_CITY_TRACKING["current"] = new_login_stats
     EVENT_CITY_TRACKING["speed"] = int(speed)
+    EVENT_CITY_TRACKING["speed_units"] = "km/h"
     EVENT_CITY_TRACKING["distance"] = int(distance)
+    EVENT_CITY_TRACKING["distance_units"] = "km"
 
     return speed > 900  # Boeing 747 cruising speed
 

--- a/rules/standard_rules/impossible_travel_login.yml
+++ b/rules/standard_rules/impossible_travel_login.yml
@@ -14,7 +14,11 @@ Reports:
     - TA0001:T1078
 Severity: High
 Description: A user has subsequent logins from two geographic locations that are very far apart
-Runbook: Reach out to the user if needed to validate the activity, then lock the account
+Runbook: >
+  Reach out to the user if needed to validate the activity, then lock the account. 
+
+  If the user responds that the geolocation on the new location is incorrect, you can directly
+  report the inaccuracy via  https://ipinfo.io/corrections
 SummaryAttributes:
   - p_any_user_names
   - p_any_ip_addresses


### PR DESCRIPTION
### Background

It's helpful for responders to have the units of measurement in the alert context and in the title. 

This PR also adds a link in the detection's runbook for how to inform IPInfo that an address has been incorrectly geolocated, should a user report that they are indeed not in some distant geography relative to their last login.

### Changes


### Testing

