### PR TITLE
Add detections for GCP DNS zone operations

### DIFF
--- a/global_helpers/gcp_base_helpers.py
+++ b/global_helpers/gcp_base_helpers.py
@@ -38,7 +38,7 @@ def get_flow_log_info(event):
 
 def gcp_alert_context(event):
     return {
-        "project": deep_get(event, "protoPayload", "resource", "labels", "project_id", default=""),
+        "project": deep_get(event, "resource", "labels", "project_id", default=""),
         "principal": deep_get(
             event, "protoPayload", "authenticationInfo", "principalEmail", default=""
         ),

--- a/rules/gcp_audit_rules/gcp_dns_zone_modified_or_deleted.py
+++ b/rules/gcp_audit_rules/gcp_dns_zone_modified_or_deleted.py
@@ -1,4 +1,5 @@
 from panther_base_helpers import deep_get
+from gcp_base_helpers import gcp_alert_context
 
 
 def rule(event):
@@ -15,15 +16,8 @@ def title(event):
     actor = deep_get(event, "protoPayload", "authenticationInfo", "principalEmail", default="")
     method = deep_get(event, "protoPayload", "methodName", default="")
     resource = deep_get(event, "protoPayload", "resourceName", default="")
-    return f"{actor} performed {method} on {resource}"
+    return f"[GCP] {actor} performed {method} on {resource}"
 
 
 def alert_context(event):
-    metadata = {}
-    for label, value in deep_get(event, "resource", "labels", default={}).items():
-        metadata[label] = value
-    metadata["type"] = deep_get(event, "resource", "type", default="")
-    metadata["callerIP"] = deep_get(
-        event, "protoPayload", "requestMetadata", "callerIP", default=""
-    )
-    return dict(sorted(metadata.items()))
+    return gcp_alert_context(event)

--- a/rules/gcp_audit_rules/gcp_dns_zone_modified_or_deleted.py
+++ b/rules/gcp_audit_rules/gcp_dns_zone_modified_or_deleted.py
@@ -1,0 +1,29 @@
+from panther_base_helpers import deep_get
+
+
+def rule(event):
+    methods = (
+        "dns.changes.create",
+        "dns.managedZones.delete",
+        "dns.managedZones.patch",
+        "dns.managedZones.update",
+    )
+    return deep_get(event, "protoPayload", "methodName", default="") in methods
+
+
+def title(event):
+    actor = deep_get(event, "protoPayload", "authenticationInfo", "principalEmail", default="")
+    method = deep_get(event, "protoPayload", "methodName", default="")
+    resource = deep_get(event, "protoPayload", "resourceName", default="")
+    return f"{actor} performed {method} on {resource}"
+
+
+def alert_context(event):
+    metadata = {}
+    for label, value in deep_get(event, "resource", "labels", default={}).items():
+        metadata[label] = value
+    metadata["type"] = deep_get(event, "resource", "type", default="")
+    metadata["callerIP"] = deep_get(
+        event, "protoPayload", "requestMetadata", "callerIP", default=""
+    )
+    return dict(sorted(metadata.items()))

--- a/rules/gcp_audit_rules/gcp_dns_zone_modified_or_deleted.yml
+++ b/rules/gcp_audit_rules/gcp_dns_zone_modified_or_deleted.yml
@@ -1,0 +1,248 @@
+AnalysisType: rule
+Description: Detection for GCP DNS zones that are deleted, patched, or updated.
+DisplayName: "GCP DNS Zone Modified or Deleted"
+Enabled: true
+Filename: gcp_dns_zone_modified_or_deleted.py
+Runbook: Verify that this modification or deletion was expected. These operations are high-impact events and can result in downtimes or total outages.
+Severity: Low
+Tests:
+    - ExpectedResult: true
+      Log:
+        insertid: -xxxxxxxxxxxx
+        logName: projects/test-project-123456/logs/cloudaudit.googleapis.com%2Factivity
+        protoPayload:
+            at_sign_type: type.googleapis.com/google.cloud.audit.AuditLog
+            authenticationInfo:
+                principalEmail: user@domain.com
+            authorizationInfo:
+                - granted: true
+                  permission: dns.managedZones.delete
+                  resourceAttributes: {}
+            methodName: dns.managedZones.delete
+            request:
+                '@type': type.googleapis.com/cloud.dns.api.ManagedZonesDeleteRequest
+                managedZone: test-zone
+                project: test-project-123456
+            requestMetadata:
+                callerIP: 12.12.12.12
+                destinationAttributes: {}
+                requestAttributes:
+                    auth: {}
+                    time: "2023-05-23T19:08:13.820007Z"
+            resourceName: managedZones/test-zone
+            response:
+                '@type': type.googleapis.com/cloud.dns.api.ManagedZonesDeleteResponse
+            serviceName: dns.googleapis.com
+            status: {}
+        receivetimestamp: "2023-05-23 19:08:14.305"
+        resource:
+            labels:
+                location: global
+                project_id: test-project-123456
+                zone_name: test-zone
+            type: dns_managed_zone
+        severity: NOTICE
+        timestamp: "2023-05-23 19:08:11.697"
+      Name: dns.managedZones.delete-should-alert
+    - ExpectedResult: true
+      Log:
+        insertid: -xxxxxxxxxxxx
+        logname: projects/test-project-123456/logs/cloudaudit.googleapis.com%2Factivity
+        protoPayload:
+            at_sign_type: type.googleapis.com/google.cloud.audit.AuditLog
+            authenticationInfo:
+                principalEmail: user@domain.com
+            authorizationInfo:
+                - granted: true
+                  permission: dns.managedZones.update
+                  resourceAttributes: {}
+            methodName: dns.managedZones.patch
+            request:
+                '@type': type.googleapis.com/cloud.dns.api.ManagedZonesPatchRequest
+                managedZone: test-zone
+                managedZoneResource:
+                    description: testing
+                    privateVisibilityConfig:
+                        networks:
+                            - networkUrl: https://www.googleapis.com/compute/v1/projects/test-project-123456/global/networks/default
+                project: test-project-123456
+            requestMetadata:
+                callerIP: 12.12.12.12
+                destinationAttributes: {}
+                requestAttributes:
+                    auth: {}
+                    time: "2023-05-23T19:07:25.568071Z"
+            resourceName: managedZones/test-zone
+            response:
+                '@type': type.googleapis.com/cloud.dns.api.ManagedZonesPatchResponse
+                managedZone:
+                    cloudLoggingConfig: {}
+                    creationTime: "2023-05-23T18:59:57.919Z"
+                    description: testing
+                    dnsName: test.detectiontesting.com.
+                    fingerprint: 3f961d0b0a9e6a8c000001884a024eed
+                    id: "4581881604156058252"
+                    name: test-zone
+                    nameServers:
+                        - ns-gcp-private.googledomains.com.
+                    privateVisibilityConfig:
+                        networks:
+                            - networkUrl: https://www.googleapis.com/compute/v1/projects/test-project-123456/global/networks/default
+                    rrsetCount: 2
+                    visibility: PRIVATE
+                operation:
+                    id: a7513a2c-e637-4b86-b223-1c4f8b0797be
+                    startTime: "2023-05-23T19:07:25.511Z"
+                    status: DONE
+                    type: UPDATE
+                    user: user@domain.com
+                    zoneContext:
+                        newValue:
+                            cloudLoggingConfig: {}
+                            creationTime: "2023-05-23T18:59:57.919Z"
+                            description: testing
+                            dnsName: test.detectiontesting.com.
+                            fingerprint: 3f961d0b0a9e6a8c000001884a024eed
+                            id: "4581881604156058252"
+                            name: test-zone
+                            nameServers:
+                                - ns-gcp-private.googledomains.com.
+                            privateVisibilityConfig:
+                                networks:
+                                    - networkUrl: https://www.googleapis.com/compute/v1/projects/test-project-123456/global/networks/default
+                            rrsetCount: 2
+                            visibility: PRIVATE
+                        oldValue:
+                            cloudLoggingConfig: {}
+                            creationTime: "2023-05-23T18:59:57.919Z"
+                            description: testing
+                            dnsName: test.detectiontesting.com.
+                            fingerprint: 3f961d0b0a9e6a8c0000018849fb7b5f
+                            id: "4581881604156058252"
+                            name: test-zone
+                            nameServers:
+                                - ns-gcp-private.googledomains.com.
+                            rrsetCount: 2
+                            visibility: PRIVATE
+            serviceName: dns.googleapis.com
+            status: {}
+        receivetimestamp: "2023-05-23 19:07:26.276"
+        resource:
+            labels:
+                location: global
+                project_id: test-project-123456
+                zone_name: test-zone
+            type: dns_managed_zone
+        severity: NOTICE
+        timestamp: "2023-05-23 19:07:25.282"
+      Name: dns.managedZones.patch-should-alert
+    - ExpectedResult: true
+      Log:
+        insertid: xxxxxxxxxxxx
+        logname: projects/test-project-123456/logs/cloudaudit.googleapis.com%2Factivity
+        protoPayload:
+            at_sign_type: type.googleapis.com/google.cloud.audit.AuditLog
+            authenticationInfo:
+                principalEmail: user@domain.com
+            authorizationInfo:
+                - granted: true
+                  permission: dns.changes.create
+                  resourceAttributes: {}
+            methodName: dns.changes.create
+            request:
+                '@type': type.googleapis.com/cloud.dns.api.ChangesCreateRequest
+                change:
+                    additions:
+                        - name: test.detectiontesting.com.
+                          rrdata:
+                            - ns-gcp-private.googledomains.com. cloud-dns-hostmaster.google.com. 1 21600 3600 259200 300
+                          ttl: 3600
+                          type: SOA
+                    deletions:
+                        - name: test.detectiontesting.com.
+                          rrdata:
+                            - ns-gcp-private.googledomains.com. cloud-dns-hostmaster.google.com. 1 21600 3600 259200 300
+                          ttl: 21600
+                          type: SOA
+                managedZone: test-zone
+                project: test-project-123456
+            requestMetadata:
+                callerIP: 12.12.12.12
+                destinationAttributes: {}
+                requestAttributes:
+                    auth: {}
+                    time: "2023-05-23T19:07:39.239275Z"
+            resourceName: managedZones/test-zone
+            response:
+                '@type': type.googleapis.com/cloud.dns.api.ChangesCreateResponse
+                change:
+                    additions:
+                        - name: test.detectiontesting.com.
+                          rrdata:
+                            - ns-gcp-private.googledomains.com. cloud-dns-hostmaster.google.com. 1 21600 3600 259200 300
+                          ttl: 3600
+                          type: SOA
+                    deletions:
+                        - name: test.detectiontesting.com.
+                          rrdata:
+                            - ns-gcp-private.googledomains.com. cloud-dns-hostmaster.google.com. 1 21600 3600 259200 300
+                          ttl: 21600
+                          type: SOA
+                    id: "1"
+                    startTime: "2023-05-23T19:07:39.155Z"
+                    status: PENDING
+            serviceName: dns.googleapis.com
+            status: {}
+        receivetimestamp: "2023-05-23 19:07:40.053"
+        resource:
+            labels:
+                location: global
+                project_id: test-project-123456
+                zone_name: test-zone
+            type: dns_managed_zone
+        severity: NOTICE
+        timestamp: "2023-05-23 19:07:39.132"
+      Name: dns.managedZones.update-should-alert
+    - ExpectedResult: false
+      Log:
+        insertid: -nkgd1se1zsiw
+        logName: projects/test-project-123456/logs/cloudaudit.googleapis.com%2Factivity
+        protoPayload:
+            at_sign_type: type.googleapis.com/google.cloud.audit.AuditLog
+            authenticationInfo:
+                principalEmail: staging@pantherstaging.io
+            authorizationInfo:
+                - granted: true
+                  permission: dns.managedZones.get
+                  resourceAttributes: {}
+            methodName: dns.managedZones.get
+            request:
+                '@type': type.googleapis.com/cloud.dns.api.ManagedZonesGetRequest
+                managedZone: test-zone
+                project: test-project-123456
+            requestMetadata:
+                callerIP: 12.12.12.12
+                destinationAttributes: {}
+                requestAttributes:
+                    auth: {}
+                    time: "2023-05-23T19:08:13.820007Z"
+            resourceName: managedZones/test-zone
+            response:
+                '@type': type.googleapis.com/cloud.dns.api.ManagedZonesGetResponse
+            serviceName: dns.googleapis.com
+            status: {}
+        receivetimestamp: "2023-05-23 19:08:14.305"
+        resource:
+            labels:
+                location: global
+                project_id: test-project-123456
+                zone_name: test-zone
+            type: dns_managed_zone
+        severity: NOTICE
+        timestamp: "2023-05-23 19:08:11.697"
+      Name: dns.managedZones.get-should-not-alert
+DedupPeriodMinutes: 60
+LogTypes:
+    - GCP.AuditLog
+RuleID: "GCP.DNS.Zone.Modified.or.Deleted"
+Threshold: 1


### PR DESCRIPTION
### Background

This PR adds detections for create, delete, patch, and update operations on GCP DNS zones. 

While the initial detection spec did not explicitly define `create` as a case, I opted to add it in as a match condition because the initial `update` example contained logs for a zone creation.

### Changes

- Adds a detection rule for the following methods:
    - `dns.changes.create`
    - `dns.managedZones.delete`
    - `dns.managedZones.patch`
    - `dns.managedZones.update`
- Adds four unit tests
    - Three `True`
    - One `False`

### Testing

- Tests pass as expected:
```
GCP.DNS.Zone.Modified.or.Deleted
        [PASS] dns.managedZones.delete-should-alert
                [PASS] [rule] true
                [PASS] [title] staging@pantherstaging.io performed dns.managedZones.delete on managedZones/test-zone
                [PASS] [dedup] staging@pantherstaging.io performed dns.managedZones.delete on managedZones/test-zone
                [PASS] [alertContext] {"callerIP": "12.12.12.12", "location": "global", "project_id": "test-project-123456", "type": "dns_managed_zone", "zone_name": "test-zone"}
        [PASS] dns.managedZones.patch-should-alert
                [PASS] [rule] true
                [PASS] [title] staging@pantherstaging.io performed dns.managedZones.patch on managedZones/test-zone
                [PASS] [dedup] staging@pantherstaging.io performed dns.managedZones.patch on managedZones/test-zone
                [PASS] [alertContext] {"callerIP": "12.12.12.12", "location": "global", "project_id": "test-project-123456", "type": "dns_managed_zone", "zone_name": "test-zone"}
        [PASS] dns.managedZones.update-should-alert
                [PASS] [rule] true
                [PASS] [title] staging@pantherstaging.io performed dns.changes.create on managedZones/test-zone
                [PASS] [dedup] staging@pantherstaging.io performed dns.changes.create on managedZones/test-zone
                [PASS] [alertContext] {"callerIP": "12.12.12.12", "location": "global", "project_id": "test-project-123456", "type": "dns_managed_zone", "zone_name": "test-zone"}
        [PASS] dns.managedZones.get-should-not-alert
                [PASS] [rule] false
```
