### PR TITLE
add: github rule add org moderator

### DIFF
--- a/rules/gcp_audit_rules/gcp_dns_zone_modified_or_deleted.py
+++ b/rules/gcp_audit_rules/gcp_dns_zone_modified_or_deleted.py
@@ -1,5 +1,5 @@
-from panther_base_helpers import deep_get
 from gcp_base_helpers import gcp_alert_context
+from panther_base_helpers import deep_get
 
 
 def rule(event):

--- a/rules/github_rules/github_org_moderators_add.py
+++ b/rules/github_rules/github_org_moderators_add.py
@@ -1,6 +1,7 @@
 from global_filter_github import filter_include_event
 from panther_base_helpers import github_alert_context
 
+
 def rule(event):
     if not filter_include_event(event):
         return False

--- a/rules/github_rules/github_org_moderators_add.py
+++ b/rules/github_rules/github_org_moderators_add.py
@@ -10,7 +10,8 @@ def rule(event):
 def title(event):
     return (
         f"GitHub.Audit: User [{event.get('actor', '<UNKNOWN_ACTOR>')}] added user "
-        f"[{event.get('user', '<UNKNOWN_USER>')}] to moderators in [{event.get('org','<UNKNOWN_ORG>')}]"
+        f"[{event.get('user', '<UNKNOWN_USER>')}] to moderators in "
+        f"[{event.get('org','<UNKNOWN_ORG>')}]"
     )
 
 

--- a/rules/github_rules/github_org_moderators_add.py
+++ b/rules/github_rules/github_org_moderators_add.py
@@ -1,0 +1,18 @@
+from global_filter_github import filter_include_event
+from panther_base_helpers import github_alert_context
+
+def rule(event):
+    if not filter_include_event(event):
+        return False
+    return event.get("action") == "organization_moderators.add_user"
+
+
+def title(event):
+    return (
+        f"GitHub.Audit: User [{event.get('actor', '<UNKNOWN_ACTOR>')}] added user "
+        f"[{event.get('user', '<UNKNOWN_USER>')}] to moderators in [{event.get('org','<UNKNOWN_ORG>')}]"
+    )
+
+
+def alert_context(event):
+    return github_alert_context(event)

--- a/rules/github_rules/github_org_moderators_add.yml
+++ b/rules/github_rules/github_org_moderators_add.yml
@@ -1,0 +1,45 @@
+AnalysisType: rule
+Filename: github_org_moderators_add.py
+RuleID: "GitHub.Org.Moderators.Add"
+DisplayName: "GitHub User Added to Org Moderators"
+Enabled: true
+LogTypes:
+  - GitHub.Audit
+Tags:
+  - GitHub
+  - Initial Access:Supply Chain Compromise
+Severity: Medium
+Description: Detects when a user is added to a GitHub org's list of moderators.
+Tests:
+  -
+    Name: GitHub - Org Moderator Added
+    ExpectedResult: true
+    Log:
+      {
+        "_document_id": "Ab123",
+        "action": "organization_moderators.add_user",
+        "actor": "sarah78",
+        "actor_location": {
+          "country_code": "US"
+        },
+        "at_sign_timestamp": "2022-12-11 05:17:28.078",
+        "created_at": "2022-12-11 05:17:28.078",
+        "org": "example-io",
+        "user": "john1987"
+      }
+  -
+    Name: GitHub - Org Moderator removed
+    ExpectedResult: false
+    Log:
+      {
+        "_document_id": "Ab123",
+        "action": "organization_moderators.remove_user",
+        "actor": "sarah78",
+        "actor_location": {
+          "country_code": "US"
+        },
+        "at_sign_timestamp": "2022-12-11 05:17:28.078",
+        "created_at": "2022-12-11 05:17:28.078",
+        "org": "example-io",
+        "user": "john1987"
+      }


### PR DESCRIPTION
### Background

Detection for adding a member to organization moderators.

### Testing
```
  GitHub.Org.Moderators.Add
  	[PASS] GitHub - Org Moderator Added
  		[PASS] [rule] true
  		[PASS] [title] GitHub.Audit: User [sarah78] added user [john1987] to moderators in [example-io]
  		[PASS] [dedup] GitHub.Audit: User [sarah78] added user [john1987] to moderators in [example-io]
  		[PASS] [alertContext] {"action": "organization_moderators.add_user", "actor": "sarah78", "actor_location": "US", "org": "example-io", "repo": "", "user": "john1987"}
  	[PASS] GitHub - Org Moderator removed
  		[PASS] [rule] false
```
* https://github.com/panther-labs/panther-analysis/actions/runs/5249536162/jobs/9482440906#step:8:4401
