### PR TITLE
remove dynamo encryption policy from pack

### DIFF
--- a/packs/aws.yml
+++ b/packs/aws.yml
@@ -26,7 +26,6 @@ PackDefinition:
     - AWS.CloudTrail.SnapshotMadePublic
     - AWS.EC2.Instance.DetailedMonitoring
     # Encryption Status
-    - AWS.DynamoDB.TableEncryption
     - AWS.EC2.Volume.Encryption
     - AWS.EC2.Volume.Snapshot.Encrypted
     - AWS.EC2.EBS.Encryption.Disabled


### PR DESCRIPTION
### Background

Deprecated dynamo db encryption policy removed from pack
