### PR TITLE
Create detection for GCP firewall rule modifications

### DIFF
--- a/rules/gcp_audit_rules/gcp_dns_zone_modified_or_deleted.py
+++ b/rules/gcp_audit_rules/gcp_dns_zone_modified_or_deleted.py
@@ -13,7 +13,9 @@ def rule(event):
 
 
 def title(event):
-    actor = deep_get(event, "protoPayload", "authenticationInfo", "principalEmail", default="<ACTOR_NOT_FOUND>")
+    actor = deep_get(
+        event, "protoPayload", "authenticationInfo", "principalEmail", default="<ACTOR_NOT_FOUND>"
+    )
     resource = deep_get(event, "protoPayload", "resourceName", default="<RESOURCE_NOT_FOUND>")
     return f"[GCP]: [{actor}] modified managed DNS zone [{resource}]"
 

--- a/rules/gcp_audit_rules/gcp_dns_zone_modified_or_deleted.py
+++ b/rules/gcp_audit_rules/gcp_dns_zone_modified_or_deleted.py
@@ -13,10 +13,9 @@ def rule(event):
 
 
 def title(event):
-    actor = deep_get(event, "protoPayload", "authenticationInfo", "principalEmail", default="")
-    method = deep_get(event, "protoPayload", "methodName", default="")
-    resource = deep_get(event, "protoPayload", "resourceName", default="")
-    return f"[GCP] {actor} performed {method} on {resource}"
+    actor = deep_get(event, "protoPayload", "authenticationInfo", "principalEmail", default="<ACTOR_NOT_FOUND>")
+    resource = deep_get(event, "protoPayload", "resourceName", default="<RESOURCE_NOT_FOUND>")
+    return f"[GCP]: [{actor}] modified managed DNS zone [{resource}]"
 
 
 def alert_context(event):

--- a/rules/gcp_audit_rules/gcp_firewall_rule_modified.py
+++ b/rules/gcp_audit_rules/gcp_firewall_rule_modified.py
@@ -11,10 +11,9 @@ def rule(event):
 
 
 def title(event):
-    actor = deep_get(event, "protoPayload", "authenticationInfo", "principalEmail", default="")
-    method = deep_get(event, "protoPayload", "methodName", default="")
-    resource = deep_get(event, "protoPayload", "resourceName", default="")
-    return f"[GCP] {actor} performed {method} on {resource}"
+    actor = deep_get(event, "protoPayload", "authenticationInfo", "principalEmail", default="<ACTOR_NOT_FOUND>")
+    resource = deep_get(event, "protoPayload", "resourceName", default="<RESOURCE_NOT_FOUND>")
+    return f"[GCP]: [{actor}] modified firewall rule on [{resource}]"
 
 
 def alert_context(event):

--- a/rules/gcp_audit_rules/gcp_firewall_rule_modified.py
+++ b/rules/gcp_audit_rules/gcp_firewall_rule_modified.py
@@ -1,15 +1,13 @@
+import re
+
 from gcp_base_helpers import gcp_alert_context
 from panther_base_helpers import deep_get
 
 
 def rule(event):
-    methods = (
-        "dns.changes.create",
-        "dns.managedZones.delete",
-        "dns.managedZones.patch",
-        "dns.managedZones.update",
-    )
-    return deep_get(event, "protoPayload", "methodName", default="") in methods
+    method_pattern = r"(?:\w+\.)*v1\.(?:Firewall\.Update)|(compute\.firewalls\.(patch|update))"
+    match = re.search(method_pattern, deep_get(event, "protoPayload", "methodName", default=""))
+    return match is not None
 
 
 def title(event):

--- a/rules/gcp_audit_rules/gcp_firewall_rule_modified.py
+++ b/rules/gcp_audit_rules/gcp_firewall_rule_modified.py
@@ -11,7 +11,9 @@ def rule(event):
 
 
 def title(event):
-    actor = deep_get(event, "protoPayload", "authenticationInfo", "principalEmail", default="<ACTOR_NOT_FOUND>")
+    actor = deep_get(
+        event, "protoPayload", "authenticationInfo", "principalEmail", default="<ACTOR_NOT_FOUND>"
+    )
     resource = deep_get(event, "protoPayload", "resourceName", default="<RESOURCE_NOT_FOUND>")
     return f"[GCP]: [{actor}] modified firewall rule on [{resource}]"
 

--- a/rules/gcp_audit_rules/gcp_firewall_rule_modified.yml
+++ b/rules/gcp_audit_rules/gcp_firewall_rule_modified.yml
@@ -1,0 +1,190 @@
+---
+AnalysisType: rule
+DedupPeriodMinutes: 60
+DisplayName: GCP Firewall Rule Modified
+Enabled: true
+Filename: gcp_firewall_rule_modified.py
+RuleID: "GCP.Firewall.Rule.Modified"
+Severity: Low
+LogTypes:
+  - GCP.AuditLog
+Tags:
+  - GCP
+  - Firewall
+  - Networking
+  - Infrastructure
+Description: >
+  This rule detects modifications to GCP firewall rules.
+Runbook: >
+  Ensure that the rule modification was expected. Firewall rule changes can cause service interruptions or outages.
+Reference: https://cloud.google.com/firewall/docs/about-firewalls
+Tests:
+  - Name: compute.firewalls.update-should-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: true
+    Log:
+      {
+      "insertid": "-xxxxxxxxxxxx",
+      "logname": "projects/test-project-123456/cloudaudit.googleapis.com%2Factivity",
+      "operation": {
+        "first": true,
+        "id": "operation-1684869580331-5fc6144d418a9-e1332ca3-59c615ac",
+        "producer": "compute.googleapis.com"
+      },
+      "protoPayload": {
+        "at_sign_type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "authenticationInfo": {
+          "principalEmail": "user@domain.com"
+        },
+        "authorizationInfo": [
+          {
+            "granted": true,
+            "permission": "compute.firewalls.update",
+            "resourceAttributes": {
+              "name": "projects/test-project-123456/global/firewalls/firewall-create",
+              "service": "compute",
+              "type": "compute.firewalls"
+            }
+          },
+          {
+            "granted": true,
+            "permission": "compute.networks.updatePolicy",
+            "resourceAttributes": {
+              "name": "projects/test-project-123456/global/networks/default",
+              "service": "compute",
+              "type": "compute.networks"
+            }
+          }
+        ],
+        "methodName": "v1.compute.firewalls.patch",
+        "request": {
+          "@type": "type.googleapis.com/compute.firewalls.patch",
+          "denieds": [
+            {
+              "IPProtocol": "all"
+            }
+          ]
+        },
+        "requestMetadata": {
+          "callerIP": "12.12.12.12",
+          "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36,gzip(gfe),gzip(gfe)",
+          "destinationAttributes": {},
+          "requestAttributes": {
+            "auth": {},
+            "reason": "8uSywAYQGg5Db2xpc2V1bSBGbG93cw",
+            "time": "2023-05-23T19:19:41.154751Z"
+          }
+        },
+        "resourceName": "projects/test-project-123456/global/firewalls/firewall-create",
+        "response": {
+          "@type": "type.googleapis.com/operation",
+          "id": "896785227463044899",
+          "insertTime": "2023-05-23T12:19:40.876-07:00",
+          "name": "operation-1684869580331-5fc6144d418a9-e1332ca3-59c615ac",
+          "operationType": "patch",
+          "progress": "0",
+          "selfLink": "https://www.googleapis.com/compute/v1/projects/test-project-123456/global/operations/operation-1684869580331-5fc6144d418a9-e1332ca3-59c615ac",
+          "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/test-project-123456/global/operations/896785227463044899",
+          "startTime": "2023-05-23T12:19:40.888-07:00",
+          "status": "RUNNING",
+          "targetId": "6563507997690081088",
+          "targetLink": "https://www.googleapis.com/compute/v1/projects/test-project-123456/global/firewalls/firewall-create",
+          "user": "user@domain.com"
+        },
+        "serviceName": "compute.googleapis.com"
+      },
+      "receivetimestamp": "2023-05-23 19:19:41.238",
+      "resource": {
+        "labels": {
+          "firewall_rule_id": "6563507997690081088",
+          "project_id": "test-project-123456"
+        },
+        "type": "gce_firewall_rule"
+      },
+      "severity": "NOTICE",
+      "timestamp": "2023-05-23 19:19:40.353"
+    }
+  - Name: appengine.firewall.update-should-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: true
+    Log:
+      {
+      "insertid": "-xxxxxxxxxxxx",
+      "logname": "projects/test-project-123456/logs/cloudaudit.googleapis.com%2Factivity",
+      "protopayload": {
+        "at_sign_type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "authenticationInfo": {
+          "principalEmail": "user@domain.com"
+        },
+        "authorizationInfo": [
+          {
+            "granted": true,
+            "permission": "appengine.applications.update",
+            "resource": "apps/test-project-123456/firewall/ingressRules/1000",
+            "resourceAttributes": {}
+          }
+        ],
+        "methodName": "google.appengine.v1.Firewall.UpdateIngressRule",
+        "requestMetadata": {
+          "callerIP": "12.12.12.12",
+          "destinationAttributes": {},
+          "requestAttributes": {
+            "auth": {},
+            "time": "2023-05-23T19:28:44.663413Z"
+          }
+        },
+        "resourceName": "apps/test-project-123456/firewall/ingressRules/1000",
+        "serviceData": {
+          "@type": "type.googleapis.com/google.appengine.v1beta4.AuditData"
+        },
+        "serviceName": "appengine.googleapis.com",
+        "status": {}
+      },
+      "receivetimestamp": "2023-05-23 19:28:45.473",
+      "resource": {
+        "labels": {
+          "module_id": "",
+          "project_id": "test-project-123456",
+          "version_id": "",
+          "zone": ""
+        },
+        "type": "gae_app"
+      },
+      "severity": "NOTICE",
+      "timestamp": "2023-05-23 19:28:44.562"
+    }
+  - Name: appengine.compute.non-update.firewall.method-should-not-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: false
+    Log:
+      {
+        "methodName": "appengine.compute.v1.Firewall.PatchIngressRule"
+      }
+  - Name: randomservice.firewall-update.method-should-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: true
+    Log: 
+      {
+        "protoPayload": {
+          "authenticationInfo": {
+            "principalEmail": "user@domain.com"
+          },
+          "methodName": "randomservice.compute.v1.Firewall.UpdateIngressRule",
+          "resourceName": "randomservice/test-project-123456/firewall/ingressRules/1000",
+          "requestMetadata": {
+              "callerIP": "12.12.12.12",
+              "destinationAttributes": {},
+              "requestAttributes": {
+                "auth": {},
+                "time": "2023-05-23T19:28:44.663413Z"
+              },
+          },
+        },
+        "resource": {
+            "labels": {
+              "firewall_rule_id": "6563507997690081088",
+              "project_id": "test-project-123456"
+            },
+            "type": "gce_firewall_rule"
+        },
+      }


### PR DESCRIPTION
### Background

This PR adds a detection for GCP firewall modification events. Rather than explicitly defining a tuple of firewall update-related methods, the rule uses a regex search with enough guardrails to lower the SNR of the rule (i.e., it should not evaluate to `True` on every firewall method or any other method).

Essentially, any service prefix before `v1` is allowed, but after that, only `Firewall.Update`, `compute.firewalls.patch`, or `compute.firewalls.update` methods are valid.

### Changes

* Adds `gcp_firewall_rule_modified.py`
* Adds `gcp_firewall_rule_modified.yml` with three `True` test cases and one `False` test cases

### Testing

* Tests pass as expected
```
GCP.Firewall.Rule.Modified
        [PASS] compute.firewalls.update-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP] user@domain.com performed v1.compute.firewalls.patch on projects/test-project-123456/global/firewalls/firewall-create
                [PASS] [dedup] [GCP] user@domain.com performed v1.compute.firewalls.patch on projects/test-project-123456/global/firewalls/firewall-create
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "v1.compute.firewalls.patch", "resourceName": "projects/test-project-123456/global/firewalls/firewall-create", "serviceName": "compute.googleapis.com"}
        [PASS] appengine.firewall.update-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP] user@domain.com performed google.appengine.v1.Firewall.UpdateIngressRule on apps/test-project-123456/firewall/ingressRules/1000
                [PASS] [dedup] [GCP] user@domain.com performed google.appengine.v1.Firewall.UpdateIngressRule on apps/test-project-123456/firewall/ingressRules/1000
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "google.appengine.v1.Firewall.UpdateIngressRule", "resourceName": "apps/test-project-123456/firewall/ingressRules/1000", "serviceName": "appengine.googleapis.com"}
        [PASS] appengine.compute.non-update.firewall.method-should-not-alert
                [PASS] [rule] false
        [PASS] randomservice.firewall-update.method-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP] user@domain.com performed randomservice.compute.v1.Firewall.UpdateIngressRule on randomservice/test-project-123456/firewall/ingressRules/1000
                [PASS] [dedup] [GCP] user@domain.com performed randomservice.compute.v1.Firewall.UpdateIngressRule on randomservice/test-project-123456/firewall/ingressRules/1000
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "randomservice.compute.v1.Firewall.UpdateIngressRule", "resourceName": "randomservice/test-project-123456/firewall/ingressRules/1000", "serviceName": ""}
```
