### PR TITLE
Tines Rule - Global Resource Destruction

### DIFF
--- a/rules/tines_rules/tines_global_resource_destruction.py
+++ b/rules/tines_rules/tines_global_resource_destruction.py
@@ -1,0 +1,7 @@
+def rule(event):
+    return event.get('operation_name') == 'GlobalResourceDestruction'
+
+def title(event):
+    user = event.get('user_email')
+    tines_instance = event.get('p_source_label')
+    return f"Tines Global Resource Destruction by {user} on {tines_instance}"

--- a/rules/tines_rules/tines_global_resource_destruction.yml
+++ b/rules/tines_rules/tines_global_resource_destruction.yml
@@ -1,0 +1,26 @@
+AnalysisType: rule
+DisplayName: "Tines Global Resource Destruction"
+Enabled: true
+Filename: tines_global_resource_destruction.py
+Severity: Low
+Tests:
+    - ExpectedResult: true
+      Log:
+        created_at: "2023-06-13 15:14:46"
+        id: 1234
+        inputs:
+            resourceId: 420
+        operation_name: GlobalResourceDestruction
+        p_source_label: tines-log-source-name
+        request_ip: 98.224.225.84
+        request_user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36
+        tenant_id: "1337"
+        user_email: user@email.com
+        user_id: "7331"
+        user_name: Tines User Person
+      Name: Detection Trigger
+DedupPeriodMinutes: 60
+LogTypes:
+    - Tines.Audit
+RuleID: "Tines.Global.Resource.Destruction"
+Threshold: 1


### PR DESCRIPTION
### Background

https://www.tines.com/api/audit-logs#:~:text=resource%20was%20created-,ResourceDestruction,-A%20global%20resource

Tines - Global Resource Destruction. Defaults, created via Panther Console and exported to PAT.
Default severity low but I have no strong opinion about that

### Changes

* Tines - Global Resource Destruction rule

### Testing

![image](https://github.com/panther-labs/panther-analysis/assets/101294262/df95fdd5-abc4-4843-9549-5d3d189f7aa8)
