### PR TITLE
Tines Rule - Team Destruction

### DIFF
--- a/packs/tines.yml
+++ b/packs/tines.yml
@@ -7,6 +7,7 @@ PackDefinition:
     - Tines.SSO.Settings
     - Tines.Tenant.AuthToken
     - Tines.Custom.CertificateAuthority
+    - Tines.Team.Destruction
     # Globals
     - global_filter_tines
     - panther_base_helpers

--- a/rules/tines_rules/tines_team_destruction.py
+++ b/rules/tines_rules/tines_team_destruction.py
@@ -1,8 +1,10 @@
+from panther_base_helpers import deep_get
+
 def rule(event):
     return event.get('operation_name') == 'TeamDestruction'
 
 def title(event):
-    operation = event.get('operation_name')
-    user = event.get('user_email')
-    tines_instance = event.get('p_source_label')
+    operation = deep_get(event, 'operation_name', default='Unknown Operation')
+    user = deep_get(event, 'user_email', default='Unknown User')
+    tines_instance = deep_get(event, 'p_source_label', default='Unknown Tines Instance')
     return f"Tines [{operation}] by [{user}] on [{tines_instance}]"

--- a/rules/tines_rules/tines_team_destruction.py
+++ b/rules/tines_rules/tines_team_destruction.py
@@ -5,4 +5,4 @@ def title(event):
     operation = event.get('operation_name')
     user = event.get('user_email')
     tines_instance = event.get('p_source_label')
-    return f"Tines {operation} by {user} on {tines_instance}"
+    return f"Tines [{operation}] by [{user}] on [{tines_instance}]"

--- a/rules/tines_rules/tines_team_destruction.py
+++ b/rules/tines_rules/tines_team_destruction.py
@@ -1,18 +1,21 @@
-from panther_base_helpers import deep_get
 from global_filter_tines import filter_include_event
+from panther_base_helpers import deep_get
 from panther_tines_helpers import tines_alert_context
+
 
 def rule(event):
     if not filter_include_event(event):
         return False
-    
-    return event.get('operation_name') == 'TeamDestruction'
+
+    return event.get("operation_name") == "TeamDestruction"
+
 
 def title(event):
-    operation = deep_get(event, 'operation_name', default='Unknown Operation')
-    user = deep_get(event, 'user_email', default='Unknown User')
-    tines_instance = deep_get(event, 'p_source_label', default='Unknown Tines Instance')
+    operation = deep_get(event, "operation_name", default="Unknown Operation")
+    user = deep_get(event, "user_email", default="Unknown User")
+    tines_instance = deep_get(event, "p_source_label", default="Unknown Tines Instance")
     return f"Tines [{operation}] by [{user}] on [{tines_instance}]"
+
 
 def alert_context(event):
     return tines_alert_context(event)

--- a/rules/tines_rules/tines_team_destruction.py
+++ b/rules/tines_rules/tines_team_destruction.py
@@ -1,7 +1,11 @@
 from panther_base_helpers import deep_get
+from global_filter_tines import filter_include_event
 from panther_tines_helpers import tines_alert_context
 
 def rule(event):
+    if not filter_include_event(event):
+        return False
+    
     return event.get('operation_name') == 'TeamDestruction'
 
 def title(event):

--- a/rules/tines_rules/tines_team_destruction.py
+++ b/rules/tines_rules/tines_team_destruction.py
@@ -7,7 +7,7 @@ def rule(event):
     if not filter_include_event(event):
         return False
 
-    return event.get("operation_name") == "TeamDestruction"
+    return deep_get(event, "operation_name") == "TeamDestruction"
 
 
 def title(event):

--- a/rules/tines_rules/tines_team_destruction.py
+++ b/rules/tines_rules/tines_team_destruction.py
@@ -7,14 +7,15 @@ def rule(event):
     if not filter_include_event(event):
         return False
 
-    return deep_get(event, "operation_name") == "TeamDestruction"
+    return deep_get(event, "operation_name", default="<NO_OPERATION_NAME>") == "TeamDestruction"
 
 
 def title(event):
-    operation = deep_get(event, "operation_name", default="Unknown Operation")
-    user = deep_get(event, "user_email", default="Unknown User")
-    tines_instance = deep_get(event, "p_source_label", default="Unknown Tines Instance")
-    return f"Tines [{operation}] by [{user}] on [{tines_instance}]"
+    operation = deep_get(event, "operation_name", default="<NO_OPERATION_NAME>")
+    user = deep_get(event, "user_email", default="<NO_USER_EMAIL>")
+    tines_instance = deep_get(event, "p_source_label", default="<NO_SOURCE_LABEL>")
+
+    return f"Tines [{operation}] performed by [{user}] on [{tines_instance}]."
 
 
 def alert_context(event):

--- a/rules/tines_rules/tines_team_destruction.py
+++ b/rules/tines_rules/tines_team_destruction.py
@@ -1,0 +1,8 @@
+def rule(event):
+    return event.get('operation_name') == 'TeamDestruction'
+
+def title(event):
+    operation = event.get('operation_name')
+    user = event.get('user_email')
+    tines_instance = event.get('p_source_label')
+    return f"Tines {operation} by {user} on {tines_instance}"

--- a/rules/tines_rules/tines_team_destruction.py
+++ b/rules/tines_rules/tines_team_destruction.py
@@ -1,4 +1,5 @@
 from panther_base_helpers import deep_get
+from panther_tines_helpers import tines_alert_context
 
 def rule(event):
     return event.get('operation_name') == 'TeamDestruction'
@@ -8,3 +9,6 @@ def title(event):
     user = deep_get(event, 'user_email', default='Unknown User')
     tines_instance = deep_get(event, 'p_source_label', default='Unknown Tines Instance')
     return f"Tines [{operation}] by [{user}] on [{tines_instance}]"
+
+def alert_context(event):
+    return tines_alert_context(event)

--- a/rules/tines_rules/tines_team_destruction.yml
+++ b/rules/tines_rules/tines_team_destruction.yml
@@ -4,18 +4,36 @@ Enabled: true
 Filename: tines_team_destruction.py
 Severity: Low
 Tests:
-    - ExpectedResult: true
+    - Name: Detection Trigger
+      ExpectedResult: true
       Log:
-        created_at: "2023-06-13 15:14:46"
-        operation_name: TeamDestruction
-        p_source_label: tines-log-source-name
-        request_ip: 98.224.225.84
-        request_user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36
-        tenant_id: "1337"
-        user_email: user@email.com
-        user_id: "7331"
-        user_name: Tines User Person
-      Name: Detection Trigger
+          {
+              "created_at": "2023-06-13 15:14:46",
+              "id": 1234,
+              "operation_name": "TeamDestruction",
+              "p_source_label": "tines-log-source-name",
+              "request_ip": "98.224.225.84",
+              "request_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (  KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
+              "tenant_id": "1337",
+              "user_email": "user@email.com",
+              "user_id": "7331",
+              "user_name": "Tines User Person"
+          }
+    - Name: Tines Login
+      ExpectedResult: false
+      Log:
+          {
+              "created_at": "2023-05-17 14:45:19",
+              "id": 7888888,
+              "operation_name": "Login",
+              "p_source_label": "tines-log-source-name",
+              "request_ip": "12.12.12.12",
+              "request_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36",
+              "tenant_id": "8888",
+              "user_email": "user@company.com",
+              "user_id": "17171",
+              "user_name": "user at company dot com"
+          }
 DedupPeriodMinutes: 60
 LogTypes:
     - Tines.Audit

--- a/rules/tines_rules/tines_team_destruction.yml
+++ b/rules/tines_rules/tines_team_destruction.yml
@@ -1,8 +1,17 @@
 AnalysisType: rule
+Filename: tines_team_destruction.py
+RuleID: Tines.Team.Destruction
 DisplayName: "Tines Team Destruction"
 Enabled: true
-Filename: tines_team_destruction.py
+LogTypes:
+    - Tines.Audit
+Tags:
+  - Tines
 Severity: Low
+Description: "A user has destroyed a team"
+Runbook: "Possible data destruction. Please reach out to the user and confirm this was done for valid business reasons."
+DedupPeriodMinutes: 60
+Threshold: 1
 Tests:
     - Name: Detection Trigger
       ExpectedResult: true
@@ -34,8 +43,3 @@ Tests:
               "user_id": "17171",
               "user_name": "user at company dot com"
           }
-DedupPeriodMinutes: 60
-LogTypes:
-    - Tines.Audit
-RuleID: "Tines.Team.Destruction"
-Threshold: 1

--- a/rules/tines_rules/tines_team_destruction.yml
+++ b/rules/tines_rules/tines_team_destruction.yml
@@ -1,0 +1,23 @@
+AnalysisType: rule
+DisplayName: "Tines Team Destruction"
+Enabled: true
+Filename: tines_team_destruction.py
+Severity: Low
+Tests:
+    - ExpectedResult: true
+      Log:
+        created_at: "2023-06-13 15:14:46"
+        operation_name: TeamDestruction
+        p_source_label: tines-log-source-name
+        request_ip: 98.224.225.84
+        request_user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36
+        tenant_id: "1337"
+        user_email: user@email.com
+        user_id: "7331"
+        user_name: Tines User Person
+      Name: Detection Trigger
+DedupPeriodMinutes: 60
+LogTypes:
+    - Tines.Audit
+RuleID: "Tines.Team.Destruction"
+Threshold: 1


### PR DESCRIPTION
### Background

https://www.tines.com/api/audit-logs#:~:text=team%20was%20created-,TeamDestruction,-A%20team%20was

### Changes

* Tines - TeamDestruction rule

### Testing

```
Tines.Team.Destruction
	[PASS] Detection Trigger
		[PASS] [rule] true
		[PASS] [title] Tines [TeamDestruction] performed by [user@email.com] on [tines-log-source-name].
		[PASS] [dedup] Tines [TeamDestruction] performed by [user@email.com] on [tines-log-source-name].
		[PASS] [alertContext] {"actor": "user@email.com", "action": "TeamDestruction", "tenant_id": "1337", "user_email": "user@email.com", "user_id": "7331", "operation_name": "TeamDestruction", "request_ip": "98.224.225.84"}
	[PASS] Tines Login
		[PASS] [rule] false
```


