### PR TITLE
Add detection for GCP firewall rule creations

### DIFF
--- a/rules/gcp_audit_rules/gcp_firewall_rule_created.py
+++ b/rules/gcp_audit_rules/gcp_firewall_rule_created.py
@@ -1,0 +1,36 @@
+import re
+
+from gcp_base_helpers import gcp_alert_context
+from panther_base_helpers import deep_get
+
+
+def rule(event):
+    method_pattern = r"(?:\w+\.)*v1\.(?:Firewall\.Create)|(compute\.firewalls\.insert)"
+    match = re.search(method_pattern, deep_get(event, "protoPayload", "methodName", default=""))
+    return match is not None
+
+
+def title(event):
+    actor = deep_get(
+        event, "protoPayload", "authenticationInfo", "principalEmail", default="<ACTOR_NOT_FOUND>"
+    )
+    resource = deep_get(
+        event,
+        "protoPayload",
+        "resourceName",
+        default="<RESOURCE_NOT_FOUND>",
+    )
+    resource_id = deep_get(
+        event,
+        "resource",
+        "labels",
+        "firewall_rule_id",
+        default="<RESOURCE_ID_NOT_FOUND>",
+    )
+    if resource_id != "<RESOURCE_ID_NOT_FOUND>":
+        return f"[GCP]: [{actor}] created firewall rule with resource ID [{resource_id}]"
+    return f"[GCP]: [{actor}] created firewall rule for resource [{resource}]"
+
+
+def alert_context(event):
+    return gcp_alert_context(event)

--- a/rules/gcp_audit_rules/gcp_firewall_rule_created.yml
+++ b/rules/gcp_audit_rules/gcp_firewall_rule_created.yml
@@ -1,0 +1,190 @@
+---
+AnalysisType: rule
+DedupPeriodMinutes: 60
+DisplayName: GCP Firewall Rule Created
+Enabled: true
+Filename: gcp_firewall_rule_created.py
+RuleID: "GCP.Firewall.Rule.Created"
+Severity: Low
+LogTypes:
+  - GCP.AuditLog
+Tags:
+  - GCP
+  - Firewall
+  - Networking
+  - Infrastructure
+Description: >
+  This rule detects creations of GCP firewall rules.
+Runbook: >
+  Ensure that the rule creation was expected. Firewall rule creations can expose [vulnerable] resoures to the internet.
+Reference: https://cloud.google.com/firewall/docs/about-firewalls
+Tests:
+  - Name: compute.firewalls.create-should-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: true
+    Log:
+      {
+      "insertid": "-xxxxxxxxxxxx",
+      "logname": "projects/test-project-123456/logs/cloudaudit.googleapis.com%2Factivity",
+      "operation": {
+        "first": true,
+        "id": "operation-1684869580331-5fc6144d418a9-e1332ca3-59c615ac",
+        "producer": "compute.googleapis.com"
+      },
+      "protoPayload": {
+        "at_sign_type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "authenticationInfo": {
+          "principalEmail": "user@domain.com"
+        },
+        "authorizationInfo": [
+          {
+            "granted": true,
+            "permission": "compute.firewalls.update",
+            "resourceAttributes": {
+              "name": "projects/test-project-123456/global/firewalls/firewall-create",
+              "service": "compute",
+              "type": "compute.firewalls"
+            }
+          },
+          {
+            "granted": true,
+            "permission": "compute.networks.updatePolicy",
+            "resourceAttributes": {
+              "name": "projects/test-project-123456/global/networks/default",
+              "service": "compute",
+              "type": "compute.networks"
+            }
+          }
+        ],
+        "methodName": "v1.compute.firewalls.insert",
+        "request": {
+          "@type": "type.googleapis.com/compute.firewalls.insert",
+          "denieds": [
+            {
+              "IPProtocol": "all"
+            }
+          ]
+        },
+        "requestMetadata": {
+          "callerIP": "12.12.12.12",
+          "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36,gzip(gfe),gzip(gfe)",
+          "destinationAttributes": {},
+          "requestAttributes": {
+            "auth": {},
+            "reason": "8uSywAYQGg5Db2xpc2V1bSBGbG93cw",
+            "time": "2023-05-23T19:19:41.154751Z"
+          }
+        },
+        "resourceName": "projects/test-project-123456/global/firewalls/firewall-create",
+        "response": {
+          "@type": "type.googleapis.com/operation",
+          "id": "896785227463044899",
+          "insertTime": "2023-05-23T12:19:40.876-07:00",
+          "name": "operation-1684869580331-5fc6144d418a9-e1332ca3-59c615ac",
+          "operationType": "patch",
+          "progress": "0",
+          "selfLink": "https://www.googleapis.com/compute/v1/projects/test-project-123456/global/operations/operation-1684869580331-5fc6144d418a9-e1332ca3-59c615ac",
+          "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/test-project-123456/global/operations/896785227463044899",
+          "startTime": "2023-05-23T12:19:40.888-07:00",
+          "status": "RUNNING",
+          "targetId": "6563507997690081088",
+          "targetLink": "https://www.googleapis.com/compute/v1/projects/test-project-123456/global/firewalls/firewall-create",
+          "user": "user@domain.com"
+        },
+        "serviceName": "compute.googleapis.com"
+      },
+      "receivetimestamp": "2023-05-23 19:19:41.238",
+      "resource": {
+        "labels": {
+          "firewall_rule_id": "6563507997690081088",
+          "project_id": "test-project-123456"
+        },
+        "type": "gce_firewall_rule"
+      },
+      "severity": "NOTICE",
+      "timestamp": "2023-05-23 19:19:40.353"
+    }
+  - Name: appengine.firewall.create-should-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: true
+    Log:
+      {
+      "insertid": "-xxxxxxxxxxxx",
+      "logname": "projects/test-project-123456/logs/cloudaudit.googleapis.com%2Factivity",
+      "protopayload": {
+        "at_sign_type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "authenticationInfo": {
+          "principalEmail": "user@domain.com"
+        },
+        "authorizationInfo": [
+          {
+            "granted": true,
+            "permission": "appengine.applications.update",
+            "resource": "apps/test-project-123456",
+            "resourceAttributes": {}
+          }
+        ],
+        "methodName": "google.appengine.v1.Firewall.CreateIngressRule",
+        "requestMetadata": {
+          "callerIP": "12.12.12.12",
+          "destinationAttributes": {},
+          "requestAttributes": {
+            "auth": {},
+            "time": "2023-05-23T19:28:35.172216Z"
+          }
+        },
+        "resourceName": "apps/test-project-123456",
+        "serviceData": {
+          "@type": "type.googleapis.com/google.appengine.v1beta4.AuditData"
+        },
+        "serviceName": "appengine.googleapis.com",
+        "status": {}
+      },
+      "receivetimestamp": "2023-05-23 19:28:35.479",
+      "resource": {
+        "labels": {
+          "module_id": "",
+          "project_id": "test-project-123456",
+          "version_id": "",
+          "zone": ""
+        },
+        "type": "gae_app"
+      },
+      "severity": "NOTICE",
+      "timestamp": "2023-05-23 19:28:35.049"
+    }
+  - Name: compute.non-create.firewall.method-should-not-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: false
+    Log:
+      {
+        "methodName": "v1.compute.firewalls.patch"
+      }
+  - Name: randomservice.firewall-create.method-should-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: true
+    Log: 
+      {
+        "protoPayload": {
+          "authenticationInfo": {
+            "principalEmail": "user@domain.com"
+          },
+          "methodName": "randomservice.compute.v1.Firewall.CreateIngressRule",
+          "resourceName": "randomservice/test-project-123456/firewall/ingressRules/1000",
+          "requestMetadata": {
+              "callerIP": "12.12.12.12",
+              "destinationAttributes": {},
+              "requestAttributes": {
+                "auth": {},
+                "time": "2023-05-23T19:28:44.663413Z"
+              },
+          },
+        },
+        "resource": {
+            "labels": {
+              "firewall_rule_id": "6563507997690081088",
+              "project_id": "test-project-123456"
+            },
+            "type": "gce_firewall_rule"
+        },
+      }

--- a/rules/gcp_audit_rules/gcp_firewall_rule_created.yml
+++ b/rules/gcp_audit_rules/gcp_firewall_rule_created.yml
@@ -160,6 +160,13 @@ Tests:
       {
         "methodName": "v1.compute.firewalls.patch"
       }
+  - Name: appengine.compute.non-create.firewall.method-should-not-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: false
+    Log:
+      {
+        "methodName": "appengine.compute.v1.Firewall.PatchIngressRule"
+      }
   - Name: randomservice.firewall-create.method-should-alert
     LogType: GCP.AuditLog
     ExpectedResult: true


### PR DESCRIPTION
### Background

Similar to #785, this PR adds a detection for GCP firewall rule creations. The method pattern for this rule specifies `Create` and `insert` for the methods.

I also wanted to point out the distinction between `compute.firewalls.insert` and `compute.firewalls.patch`:
```
Creates a firewall rule in the specified project using the data included in the request...
```

versus:
```
Updates the specified firewall rule with the data included in the request...
```

Given the verbiage, I opted to only include `insert` as part of this PR since `patch` is covered in the aforementioned PR.

The title code for this detection is a little more granular since a Compute Engine firewall rule will return a rule ID whereas an App Engine firewall rule will not return a rule ID, so in those cases the actual resource will be returned instead of the rule ID.

### Changes

* Adds `gcp_firewall_rule_created.py`
* Adds `gcp_firewall_rule_created.yml` with three `True` test cases and two `False` test cases

### Testing

* Tests pass as expected:
```
GCP.Firewall.Rule.Created
        [PASS] compute.firewalls.create-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] created firewall rule with resource ID [6563507997690081088]
                [PASS] [dedup] [GCP]: [user@domain.com] created firewall rule with resource ID [6563507997690081088]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "v1.compute.firewalls.insert", "resourceName": "projects/test-project-123456/global/firewalls/firewall-create", "serviceName": "compute.googleapis.com"}
        [PASS] appengine.firewall.create-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] created firewall rule for resource [apps/test-project-123456]
                [PASS] [dedup] [GCP]: [user@domain.com] created firewall rule for resource [apps/test-project-123456]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "google.appengine.v1.Firewall.CreateIngressRule", "resourceName": "apps/test-project-123456", "serviceName": "appengine.googleapis.com"}
        [PASS] compute.non-create.firewall.method-should-not-alert
                [PASS] [rule] false
        [PASS] randomservice.firewall-create.method-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] created firewall rule with resource ID [6563507997690081088]
                [PASS] [dedup] [GCP]: [user@domain.com] created firewall rule with resource ID [6563507997690081088]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "randomservice.compute.v1.Firewall.CreateIngressRule", "resourceName": "randomservice/test-project-123456/firewall/ingressRules/1000", "serviceName": ""}
```
