### PR TITLE
feat: Notion audit log exported detection

### DIFF
--- a/packs/notion.yml
+++ b/packs/notion.yml
@@ -5,6 +5,7 @@ PackDefinition:
   IDs:
     - Notion.Workspace.Exported
     - Notion.Many.Pages.Exported
+    - Notion.Audit.Log.Exported
     # Globals used in these detections
     - panther_base_helpers
     - panther_notion_helpers

--- a/rules/notion_rules/notion_workspace_audit_log_exported.py
+++ b/rules/notion_rules/notion_workspace_audit_log_exported.py
@@ -1,0 +1,27 @@
+from global_filter_notion import filter_include_event
+from panther_base_helpers import deep_get
+from panther_notion_helpers import notion_alert_context
+
+
+def rule(event):
+    if not filter_include_event(event):
+        return False
+    return (
+        deep_get(event, "type", default="<NO_EVENT_TYPE_FOUND>") == "workspace.audit_log_exported"
+    )
+
+
+def title(event):
+    user = deep_get(event, "actor", "person", "email", default="<NO_USER_FOUND>")
+    workspace_id = deep_get(event, "workspace_id", default="<NO_WORKSPACE_ID_FOUND>")
+    duration_in_days = deep_get(
+        event,
+        "workspace.audit_log_exported",
+        "duration_in_days",
+        default="<NO_DURATION_IN_DAYS_FOUND>",
+    )
+    return f"Notion User [{user}] exported audit logs for the last {duration_in_days} days for workspace id {workspace_id}"
+
+
+def alert_context(event):
+    return notion_alert_context(event)

--- a/rules/notion_rules/notion_workspace_audit_log_exported.py
+++ b/rules/notion_rules/notion_workspace_audit_log_exported.py
@@ -20,7 +20,10 @@ def title(event):
         "duration_in_days",
         default="<NO_DURATION_IN_DAYS_FOUND>",
     )
-    return f"Notion User [{user}] exported audit logs for the last {duration_in_days} days for workspace id {workspace_id}"
+    return (
+        f"Notion User [{user}] exported audit logs for the last "
+        f"{duration_in_days} days for workspace id {workspace_id}"
+    )
 
 
 def alert_context(event):

--- a/rules/notion_rules/notion_workspace_audit_log_exported.yml
+++ b/rules/notion_rules/notion_workspace_audit_log_exported.yml
@@ -1,0 +1,58 @@
+AnalysisType: rule
+Description: A Notion User exported audit logs for your organization’s workspace.
+DisplayName: "Notion Audit Log Exported"
+Enabled: true
+Filename: notion_workspace_audit_log_exported.py
+Runbook: Possible Data Exfiltration. Follow up with the Notion User to determine if this was done for a valid business reason.
+Severity: Medium
+Tags:
+  - Data Security:Data Exfiltration
+Tests:
+    - ExpectedResult: false
+      Log:
+          {
+            "id": "...",
+            "timestamp": "2023-05-15T19:14:21.031Z",
+            "workspace_id": "..",
+            "actor": {
+                "id": "..",
+                "object": "user",
+                "type": "person",
+                "person": {
+                    "email": "homer.simpson@yourcompany.io"
+                }
+            },
+            "ip_address": "...",
+            "platform": "web",
+            "type": "workspace.content_exported",
+            "workspace.content_exported": {}
+         }
+      Name: Other Event
+    - ExpectedResult: true
+      Log:
+          {
+            "id": "...",
+            "timestamp": "2023-05-15T19:14:21.031Z",
+            "workspace_id": "..",
+            "actor": {
+              "object": "user",
+              "id": "..",
+              "type": "person",
+              "person": {
+                "email": "homer.simpson@yourcompany.io"
+              }
+            },
+            "ip_address": "...",
+            "platform": "web",
+            "type": "workspace.audit_log_exported",
+            "workspace.audit_log_exported": {
+              "duration_in_days": 30
+            }
+         }
+
+      Name: Audit Log Exported
+DedupPeriodMinutes: 60
+LogTypes:
+    - Notion.AuditLogs
+RuleID: "Notion.Audit.Log.Exported"
+Threshold: 1


### PR DESCRIPTION
### Background

Detection to alert when the Notion audit log is exported.

### Changes

* Adds `rules/notion_rules/notion_workspace_audit_log_exported.py` and  `rules/notion_rules/notion_workspace_audit_log_exported.yml`

### Testing

* Added tests for not triggering and triggering the detection.
