### PR TITLE
Add detection for GCP firewall rule deletions

### DIFF
--- a/rules/gcp_audit_rules/gcp_firewall_rule_deleted.py
+++ b/rules/gcp_audit_rules/gcp_firewall_rule_deleted.py
@@ -1,0 +1,36 @@
+import re
+
+from gcp_base_helpers import gcp_alert_context
+from panther_base_helpers import deep_get
+
+
+def rule(event):
+    method_pattern = r"(?:\w+\.)*v1\.(?:Firewall\.Delete)|(compute\.firewalls\.delete)"
+    match = re.search(method_pattern, deep_get(event, "protoPayload", "methodName", default=""))
+    return match is not None
+
+
+def title(event):
+    actor = deep_get(
+        event, "protoPayload", "authenticationInfo", "principalEmail", default="<ACTOR_NOT_FOUND>"
+    )
+    resource = deep_get(
+        event,
+        "protoPayload",
+        "resourceName",
+        default="<RESOURCE_NOT_FOUND>",
+    )
+    resource_id = deep_get(
+        event,
+        "resource",
+        "labels",
+        "firewall_rule_id",
+        default="<RESOURCE_ID_NOT_FOUND>",
+    )
+    if resource_id != "<RESOURCE_ID_NOT_FOUND>":
+        return f"[GCP]: [{actor}] deleted firewall rule with resource ID [{resource_id}]"
+    return f"[GCP]: [{actor}] deleted firewall rule for resource [{resource}]"
+
+
+def alert_context(event):
+    return gcp_alert_context(event)

--- a/rules/gcp_audit_rules/gcp_firewall_rule_deleted.yml
+++ b/rules/gcp_audit_rules/gcp_firewall_rule_deleted.yml
@@ -1,0 +1,151 @@
+---
+AnalysisType: rule
+DedupPeriodMinutes: 60
+DisplayName: GCP Firewall Rule Deleted
+Enabled: true
+Filename: gcp_firewall_rule_deleted.py
+RuleID: "GCP.Firewall.Rule.Deleted"
+Severity: Low
+LogTypes:
+  - GCP.AuditLog
+Tags:
+  - GCP
+  - Firewall
+  - Networking
+  - Infrastructure
+Description: >
+  This rule detects deletions of GCP firewall rules.
+Runbook: >
+  Ensure that the rule deletion was expected. Firewall rule deletions can cause service interruptions or outages.
+Reference: https://cloud.google.com/firewall/docs/about-firewalls
+Tests:
+  - Name: compute.firewalls-delete-should-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: true
+    Log:
+      {
+        "insertid": "-xxxxxxxx",
+        "logname": "projects/test-project-123456/logs/cloudaudit.googleapis.com%2Factivity",
+        "operation": {
+          "id": "operation-1684869594486-5fc6145ac17b3-6f92b265-43256266",
+          "last": true,
+          "producer": "compute.googleapis.com"
+        },
+        "protoPayload": {
+          "at_sign_type": "type.googleapis.com/google.cloud.audit.AuditLog",
+          "authenticationInfo": {
+            "principalEmail": "user@domain.com"
+          },
+          "methodName": "v1.compute.firewalls.delete",
+          "request": {
+            "@type": "type.googleapis.com/compute.firewalls.delete"
+          },
+          "requestMetadata": {
+            "callerIP": "12.12.12.12",
+            "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36,gzip(gfe),gzip(gfe)"
+          },
+          "resourceName": "projects/test-project-123456/global/firewalls/firewall-create",
+          "serviceName": "compute.googleapis.com"
+        },
+        "receivetimestamp": "2023-05-23 19:20:00.728",
+        "resource": {
+          "labels": {
+            "firewall_rule_id": "6563507997690081088",
+            "project_id": "test-project-123456"
+          },
+          "type": "gce_firewall_rule"
+        },
+        "severity": "NOTICE",
+        "timestamp": "2023-05-23 19:20:00.396"
+      }
+  - Name: appengine.firewall.delete-should-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: true
+    Log:
+      {
+      "insertid": "-xxxxxxxx",
+      "logname": "projects/test-project-123456/logs/cloudaudit.googleapis.com%2Factivity",
+      "protoPayload": {
+        "at_sign_type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "authenticationInfo": {
+          "principalEmail": "user@domain.com"
+        },
+        "authorizationInfo": [
+          {
+            "granted": true,
+            "permission": "appengine.applications.update",
+            "resource": "apps/test-project-123456/firewall/ingressRules/1000",
+            "resourceAttributes": {}
+          }
+        ],
+        "methodName": "google.appengine.v1.Firewall.DeleteIngressRule",
+        "requestMetadata": {
+          "callerIP": "12.12.12.12",
+          "destinationAttributes": {},
+          "requestAttributes": {
+            "auth": {},
+            "time": "2023-05-23T19:28:48.805823Z"
+          }
+        },
+        "resourceName": "apps/test-project-123456/firewall/ingressRules/1000",
+        "serviceData": {
+          "@type": "type.googleapis.com/google.appengine.v1beta4.AuditData"
+        },
+        "serviceName": "appengine.googleapis.com",
+        "status": {}
+      },
+      "receivetimestamp": "2023-05-23 19:28:49.474",
+      "resource": {
+        "labels": {
+          "module_id": "",
+          "project_id": "test-project-123456",
+          "version_id": "",
+          "zone": ""
+        },
+        "type": "gae_app"
+      },
+      "severity": "NOTICE",
+      "timestamp": "2023-05-23 19:28:48.707"
+    }
+  - Name: compute.non-delete.firewall.method-should-not-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: false
+    Log:
+      {
+        "methodName": "v1.compute.firewalls.insert"
+      }
+  - Name: appengine.non-delete.firewall.method-should-not-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: false
+    Log:
+      {
+        "methodName": "appengine.compute.v1.Firewall.PatchIngressRule"
+      }
+  - Name: randomservice.firewall-delete.method-should-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: true
+    Log: 
+      {
+        "protoPayload": {
+          "authenticationInfo": {
+            "principalEmail": "user@domain.com"
+          },
+          "methodName": "randomservice.compute.v1.Firewall.DeleteIngressRule",
+          "resourceName": "randomservice/test-project-123456/firewall/ingressRules/1000",
+          "requestMetadata": {
+              "callerIP": "12.12.12.12",
+              "destinationAttributes": {},
+              "requestAttributes": {
+                "auth": {},
+                "time": "2023-05-23T19:28:44.663413Z"
+              },
+          },
+        },
+        "resource": {
+            "labels": {
+              "firewall_rule_id": "6563507997690081088",
+              "project_id": "test-project-123456"
+            },
+            "type": "gce_firewall_rule"
+        },
+      }

--- a/rules/gcp_audit_rules/gcp_firewall_rule_modified.yml
+++ b/rules/gcp_audit_rules/gcp_firewall_rule_modified.yml
@@ -153,6 +153,13 @@ Tests:
       "severity": "NOTICE",
       "timestamp": "2023-05-23 19:28:44.562"
     }
+  - Name: compute.non-update.firewall.method-should-not-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: false
+    Log:
+      {
+        "methodName": "v1.compute.firewalls.insert"
+      }
   - Name: appengine.compute.non-update.firewall.method-should-not-alert
     LogType: GCP.AuditLog
     ExpectedResult: false


### PR DESCRIPTION
### Background

This PR is similar to #791 but covers deletions rather than creations. Much of the detection is the same except for the method pattern:
```py
method_pattern = r"(?:\w+\.)*v1\.(?:Firewall\.Delete)|(compute\.firewalls\.delete)"
```

Since this is closely-related to both the above PR and #785, I wanted to create this as a fast follow-up PR.

I also wanted to add another test case for the firewall rule modification detection to cover AppEngine since the original PR only covered Compute Engine.

### Changes

* Adds `gcp_firewall_rule_deleted.py`
* Adds `gcp_firewall_rule_deleted.yml` with three `True` test cases and two `False` test cases
* Adds `compute.non-update.firewall.method-should-not-alert` test to `gcp_firewall_rule_modified.yml`

### Testing

* Tests pass as expected:
```
GCP.Firewall.Rule.Deleted
        [PASS] compute.firewalls-delete-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] deleted firewall rule with resource ID [6563507997690081088]
                [PASS] [dedup] [GCP]: [user@domain.com] deleted firewall rule with resource ID [6563507997690081088]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "v1.compute.firewalls.delete", "resourceName": "projects/test-project-123456/global/firewalls/firewall-create", "serviceName": "compute.googleapis.com"}
        [PASS] appengine.firewall.delete-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] deleted firewall rule for resource [apps/test-project-123456/firewall/ingressRules/1000]
                [PASS] [dedup] [GCP]: [user@domain.com] deleted firewall rule for resource [apps/test-project-123456/firewall/ingressRules/1000]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "google.appengine.v1.Firewall.DeleteIngressRule", "resourceName": "apps/test-project-123456/firewall/ingressRules/1000", "serviceName": "appengine.googleapis.com"}
        [PASS] compute.non-delete.firewall.method-should-not-alert
                [PASS] [rule] false
        [PASS] appengine.non-delete.firewall.method-should-not-alert
                [PASS] [rule] false
        [PASS] randomservice.firewall-delete.method-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] deleted firewall rule with resource ID [6563507997690081088]
                [PASS] [dedup] [GCP]: [user@domain.com] deleted firewall rule with resource ID [6563507997690081088]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "randomservice.compute.v1.Firewall.DeleteIngressRule", "resourceName": "randomservice/test-project-123456/firewall/ingressRules/1000", "serviceName": ""}
```