### PR TITLE
add: notion rule many pages deleted

### DIFF
--- a/packs/notion.yml
+++ b/packs/notion.yml
@@ -5,6 +5,7 @@ PackDefinition:
   IDs:
     - Notion.Workspace.Exported
     - Notion.Many.Pages.Exported
+    - Notion.Many.Pages.Deleted
     # Globals used in these detections
     - panther_base_helpers
     - panther_notion_helpers

--- a/rules/notion_rules/notion_many_pages_deleted.py
+++ b/rules/notion_rules/notion_many_pages_deleted.py
@@ -1,0 +1,19 @@
+from global_filter_notion import filter_include_event
+from panther_base_helpers import deep_get
+from panther_notion_helpers import notion_alert_context
+
+
+def rule(event):
+    if not filter_include_event(event):
+        return False
+    return deep_get(event, "type", default="<NO_EVENT_TYPE_FOUND>") == "page.deleted"
+
+
+def title(event):
+    user = deep_get(event, "actor", "person", "email", default="<NO_USER_FOUND>")
+    page_id = deep_get(event, "details", "target", "page_id", default="<NO_PAGE_ID_FOUND>")
+    return f"Notion User [{user}] deleted multiple pages with page ids [{page_id}]."
+
+
+def alert_context(event):
+    return notion_alert_context(event)

--- a/rules/notion_rules/notion_many_pages_deleted.yml
+++ b/rules/notion_rules/notion_many_pages_deleted.yml
@@ -1,0 +1,66 @@
+AnalysisType: rule
+Description: A Notion User deleted multiple pages.
+DisplayName: "Notion Many Pages Deleted"
+Enabled: true
+Filename: notion_many_pages_deleted.py
+Runbook: Possible Data Destruction. Follow up with the Notion User to determine if this was done for a valid business reason.
+Severity: High
+Tags:
+  - Data Security:Data Destruction
+Tests:
+    - ExpectedResult: false
+      Log:
+          {
+            "id": "...",
+            "timestamp": "2023-06-02T20:16:41.217Z",
+            "workspace_id": "..",
+            "actor": {
+                "id": "..",
+                "object": "user",
+                "type": "person",
+                "person": {
+                    "email": "homer.simpson@yourcompany.io"
+                }
+            },
+            "ip_address": "...",
+            "platform": "mac-desktop",
+            "type": "workspace.content_exported",
+            "workspace.content_exported": {}
+         }
+      Name: Other Event
+    - ExpectedResult: true
+      Log:
+      {
+        "event": {
+          "actor": {
+            "id": "af06b6ff-dd5e-4024-b9ef-78fe77f55884",
+            "object": "user",
+            "person": {
+              "email": "homer.simpson@yourcompany.io"
+            },
+            "type": "person"
+          },
+          "details": {
+            "parent": {
+              "database_id": "543af759-3010-4355-a71e-4sdfs3566a",
+              "type": "database_id"
+            },
+            "target": {
+              "page_id": "93cf05d3-6805-4ddc-abba-adsfjhnlkwje785",
+              "type": "page_id"
+            }
+          },
+          "id": "768873bf-6b2c-40e8-b27c-1c199c4d6ae7",
+          "ip_address": "12.12.12.12",
+          "platform": "web",
+          "timestamp": "2023-05-24 20:17:41.905000000",
+          "type": "page.deleted",
+          "workspace_id": "ea65b016-6abc-4dcf-808b-sdfg445654"
+        }
+      }
+      Name: Many Pages Deleted
+DedupPeriodMinutes: 60
+LogTypes:
+    - Notion.AuditLogs
+RuleID: "Notion.Many.Pages.Deleted"
+Threshold: 10 # Number of pages deleted; please change this value to suit your organization's needs.

--- a/rules/notion_rules/notion_many_pages_deleted.yml
+++ b/rules/notion_rules/notion_many_pages_deleted.yml
@@ -30,34 +30,34 @@ Tests:
       Name: Other Event
     - ExpectedResult: true
       Log:
-      {
-        "event": {
-          "actor": {
-            "id": "af06b6ff-dd5e-4024-b9ef-78fe77f55884",
-            "object": "user",
-            "person": {
-              "email": "homer.simpson@yourcompany.io"
-            },
-            "type": "person"
-          },
-          "details": {
-            "parent": {
-              "database_id": "543af759-3010-4355-a71e-4sdfs3566a",
-              "type": "database_id"
-            },
-            "target": {
-              "page_id": "93cf05d3-6805-4ddc-abba-adsfjhnlkwje785",
-              "type": "page_id"
+          {
+            "event": {
+              "actor": {
+                "id": "af06b6ff-dd5e-4024-b9ef-78fe77f55884",
+                "object": "user",
+                "person": {
+                  "email": "homer.simpson@yourcompany.io"
+                },
+                "type": "person"
+              },
+              "details": {
+                "parent": {
+                  "database_id": "543af759-3010-4355-a71e-4sdfs3566a",
+                  "type": "database_id"
+                },
+                "target": {
+                  "page_id": "93cf05d3-6805-4ddc-abba-adsfjhnlkwje785",
+                  "type": "page_id"
+                }
+              },
+              "id": "768873bf-6b2c-40e8-b27c-1c199c4d6ae7",
+              "ip_address": "12.12.12.12",
+              "platform": "web",
+              "timestamp": "2023-05-24 20:17:41.905000000",
+              "type": "page.deleted",
+              "workspace_id": "ea65b016-6abc-4dcf-808b-sdfg445654"
             }
-          },
-          "id": "768873bf-6b2c-40e8-b27c-1c199c4d6ae7",
-          "ip_address": "12.12.12.12",
-          "platform": "web",
-          "timestamp": "2023-05-24 20:17:41.905000000",
-          "type": "page.deleted",
-          "workspace_id": "ea65b016-6abc-4dcf-808b-sdfg445654"
-        }
-      }
+          }
       Name: Many Pages Deleted
 DedupPeriodMinutes: 60
 LogTypes:

--- a/rules/notion_rules/notion_many_pages_deleted.yml
+++ b/rules/notion_rules/notion_many_pages_deleted.yml
@@ -4,7 +4,7 @@ DisplayName: "Notion Many Pages Deleted"
 Enabled: true
 Filename: notion_many_pages_deleted.py
 Runbook: Possible Data Destruction. Follow up with the Notion User to determine if this was done for a valid business reason.
-Severity: High
+Severity: Medium
 Tags:
   - Data Security:Data Destruction
 Tests:

--- a/rules/notion_rules/notion_many_pages_deleted.yml
+++ b/rules/notion_rules/notion_many_pages_deleted.yml
@@ -31,32 +31,30 @@ Tests:
     - ExpectedResult: true
       Log:
           {
-            "event": {
-              "actor": {
-                "id": "af06b6ff-dd5e-4024-b9ef-78fe77f55884",
-                "object": "user",
-                "person": {
-                  "email": "homer.simpson@yourcompany.io"
-                },
-                "type": "person"
+            "actor": {
+              "id": "af06b6ff-dd5e-4024-b9ef-78fe77f55884",
+              "object": "user",
+              "person": {
+                "email": "homer.simpson@yourcompany.io"
               },
-              "details": {
-                "parent": {
-                  "database_id": "543af759-3010-4355-a71e-4sdfs3566a",
-                  "type": "database_id"
-                },
-                "target": {
-                  "page_id": "93cf05d3-6805-4ddc-abba-adsfjhnlkwje785",
-                  "type": "page_id"
-                }
+              "type": "person"
+            },
+            "details": {
+              "parent": {
+                "database_id": "543af759-3010-4355-a71e-4sdfs3566a",
+                "type": "database_id"
               },
-              "id": "768873bf-6b2c-40e8-b27c-1c199c4d6ae7",
-              "ip_address": "12.12.12.12",
-              "platform": "web",
-              "timestamp": "2023-05-24 20:17:41.905000000",
-              "type": "page.deleted",
-              "workspace_id": "ea65b016-6abc-4dcf-808b-sdfg445654"
-            }
+              "target": {
+                "page_id": "93cf05d3-6805-4ddc-abba-adsfjhnlkwje785",
+                "type": "page_id"
+              }
+            },
+            "id": "768873bf-6b2c-40e8-b27c-1c199c4d6ae7",
+            "ip_address": "12.12.12.12",
+            "platform": "web",
+            "timestamp": "2023-05-24 20:17:41.905000000",
+            "type": "page.deleted",
+            "workspace_id": "ea65b016-6abc-4dcf-808b-sdfg445654"
           }
       Name: Many Pages Deleted
 DedupPeriodMinutes: 60


### PR DESCRIPTION
### Background

[<High level overview here>](https://www.notion.so/pantherlabs/Hackathon-notion-many-pages-deleted-fe435022aa39491a937ae07827327b47)


### Testing

```
  Notion.Many.Pages.Deleted
  	[PASS] Other Event
  		[PASS] [rule] false
  	[PASS] Many Pages Deleted
  		[PASS] [rule] true
  		[PASS] [title] Notion User [homer.simpson@yourcompany.io] deleted multiple pages with page ids [93cf05d3-6805-4ddc-abba-adsfjhnlkwje785].
  		[PASS] [dedup] Notion User [homer.simpson@yourcompany.io] deleted multiple pages with page ids [93cf05d3-6805-4ddc-abba-adsfjhnlkwje785].
  		[PASS] [alertContext] {"actor": {"id": "af06b6ff-dd5e-4024-b9ef-78fe77f55884", "object": "user", "person": {"email": "homer.simpson@yourcompany.io"}, "type": "person"}, "action": "page.deleted"}
```
