### PR TITLE
Add detections for GCP logging bucket or sink deletions

### DIFF
--- a/rules/gcp_audit_rules/gcp_log_bucket_or_sink_deleted.py
+++ b/rules/gcp_audit_rules/gcp_log_bucket_or_sink_deleted.py
@@ -1,0 +1,32 @@
+import re
+
+from gcp_base_helpers import gcp_alert_context
+from panther_base_helpers import deep_get
+
+
+def rule(event):
+    authenticated = deep_get(
+        deep_get(event, "protoPayload", "authorizationInfo", default=[])[0],
+        "granted",
+        default=False,
+    )
+    method_pattern = r"(?:\w+\.)*v\d\.(?:ConfigServiceV\d\.(?:Delete(Bucket|Sink)))"
+    match = re.search(method_pattern, deep_get(event, "protoPayload", "methodName", default=""))
+    return authenticated and match is not None
+
+
+def title(event):
+    actor = deep_get(
+        event, "protoPayload", "authenticationInfo", "principalEmail", default="<ACTOR_NOT_FOUND>"
+    )
+    resource = deep_get(
+        event,
+        "protoPayload",
+        "resourceName",
+        default="<RESOURCE_NOT_FOUND>",
+    )
+    return f"[GCP]: [{actor}] deleted logging bucket or sink [{resource}]"
+
+
+def alert_context(event):
+    return gcp_alert_context(event)

--- a/rules/gcp_audit_rules/gcp_log_bucket_or_sink_deleted.py
+++ b/rules/gcp_audit_rules/gcp_log_bucket_or_sink_deleted.py
@@ -6,7 +6,7 @@ from panther_base_helpers import deep_get
 
 def rule(event):
     authenticated = deep_get(
-        deep_get(event, "protoPayload", "authorizationInfo", default=[])[0],
+        deep_get(event, "protoPayload", "authorizationInfo", default=[{}])[0],
         "granted",
         default=False,
     )

--- a/rules/gcp_audit_rules/gcp_log_bucket_or_sink_deleted.yml
+++ b/rules/gcp_audit_rules/gcp_log_bucket_or_sink_deleted.yml
@@ -1,0 +1,234 @@
+---
+AnalysisType: rule
+DedupPeriodMinutes: 60
+DisplayName: GCP Log Bucket or Sink Deleted
+Enabled: true
+Filename: gcp_log_bucket_or_sink_deleted.py
+RuleID: "GCP.Log.Bucket.Or.Sink.Deleted"
+Severity: Medium
+LogTypes:
+  - GCP.AuditLog
+Tags:
+  - GCP
+  - Logging
+  - Bucket
+  - Sink
+  - Infrastructure
+Description: >
+  This rule detects deletions of GCP Log Buckets or Sinks.
+Runbook: >
+  Ensure that the bucket or sink deletion was expected. Adversaries may do this to cover their tracks.
+Reference: https://cloud.google.com/logging/docs
+Tests:
+  - Name: logging-bucket.deleted-should-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: true
+    Log:
+      {
+        "insertid": "xxxxxxxxxx",
+        "logname": "projects/test-project-123456/logs/cloudaudit.googleapis.com%2Factivity",
+        "protoPayload": {
+          "at_sign_type": "type.googleapis.com/google.cloud.audit.AuditLog",
+          "authenticationInfo": {
+            "principalEmail": "user@domain.com"
+          },
+          "authorizationInfo": [
+            {
+              "granted": true,
+              "permission": "logging.buckets.delete",
+              "resource": "projects/test-project-123456/locations/global/buckets/testloggingbucket",
+              "resourceAttributes": {
+                "name": "projects/test-project-123456/locations/global/buckets/testloggingbucket",
+                "service": "logging.googleapis.com"
+              }
+            }
+          ],
+          "methodName": "google.logging.v2.ConfigServiceV2.DeleteBucket",
+          "request": {
+            "@type": "type.googleapis.com/google.logging.v2.DeleteBucketRequest",
+            "name": "projects/test-project-123456/locations/global/buckets/testloggingbucket"
+          },
+          "requestMetadata": {
+            "callerIP": "12.12.12.12",
+            "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36,gzip(gfe),gzip(gfe)",
+            "destinationAttributes": {},
+            "requestAttributes": {
+              "auth": {},
+              "time": "2023-05-23T19:38:36.846070601Z"
+            }
+          },
+          "resourceName": "projects/test-project-123456/locations/global/buckets/testloggingbucket",
+          "serviceName": "logging.googleapis.com",
+          "status": {}
+        },
+        "receivetimestamp": "2023-05-23 19:38:37.59",
+        "resource": {
+          "labels": {
+            "method": "google.logging.v2.ConfigServiceV2.DeleteBucket",
+            "project_id": "test-project-123456",
+            "service": "logging.googleapis.com"
+          },
+          "type": "audited_resource"
+        },
+        "severity": "NOTICE",
+        "timestamp": "2023-05-23 19:38:36.838"
+      }
+  - Name: logging-sink.deleted-should-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: true
+    Log:
+      {
+        "insertid": "xxxxxxxxxx",
+        "logname": "projects/test-project-123456/logs/cloudaudit.googleapis.com%2Factivity",
+        "protoPayload": {
+          "at_sign_type": "type.googleapis.com/google.cloud.audit.AuditLog",
+          "authenticationInfo": {
+            "principalEmail": "user@domain.com"
+          },
+          "authorizationInfo": [
+            {
+              "granted": true,
+              "permission": "logging.sinks.delete",
+              "resource": "projects/test-project-123456/sinks/test-1",
+              "resourceAttributes": {
+                "name": "projects/test-project-123456/sinks/test-1",
+                "service": "logging.googleapis.com"
+              }
+            }
+          ],
+          "methodName": "google.logging.v2.ConfigServiceV2.DeleteSink",
+          "request": {
+            "@type": "type.googleapis.com/google.logging.v2.DeleteSinkRequest",
+            "sinkName": "projects/test-project-123456/sinks/test-1"
+          },
+          "requestMetadata": {
+            "callerIP": "12.12.12.12",
+            "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36,gzip(gfe),gzip(gfe)",
+            "destinationAttributes": {},
+            "requestAttributes": {
+              "auth": {},
+              "time": "2023-05-23T19:39:15.230304077Z"
+            }
+          },
+          "resourceName": "projects/test-project-123456/sinks/test-1",
+          "serviceName": "logging.googleapis.com",
+          "status": {}
+        },
+        "receivetimestamp": "2023-05-23 19:39:15.565",
+        "resource": {
+          "labels": {
+            "destination": "",
+            "name": "test-1",
+            "project_id": "test-project-123456"
+          },
+          "type": "logging_sink"
+        },
+        "severity": "NOTICE",
+        "timestamp": "2023-05-23 19:39:15.213"
+      }
+  - Name: logging-bucket.non-deletion-should-not-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: false
+    Log:
+      {
+        "insertid": "xxxxxxxxxx",
+        "logname": "projects/test-project-123456/logs/cloudaudit.googleapis.com%2Factivity",
+        "protoPayload": {
+          "at_sign_type": "type.googleapis.com/google.cloud.audit.AuditLog",
+          "authenticationInfo": {
+            "principalEmail": "user@domain.com"
+          },
+          "authorizationInfo": [
+            {
+              "granted": true,
+              "permission": "logging.buckets.get",
+              "resource": "projects/test-project-123456/locations/global/buckets/testloggingbucket",
+              "resourceAttributes": {
+                "name": "projects/test-project-123456/locations/global/buckets/testloggingbucket",
+                "service": "logging.googleapis.com"
+              }
+            }
+          ],
+          "methodName": "google.logging.v2.ConfigServiceV2.GetBucket",
+          "request": {
+            "@type": "type.googleapis.com/google.logging.v2.GetBucketRequest",
+            "name": "projects/test-project-123456/locations/global/buckets/testloggingbucket"
+          },
+          "requestMetadata": {
+            "callerIP": "12.12.12.12",
+            "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36,gzip(gfe),gzip(gfe)",
+            "destinationAttributes": {},
+            "requestAttributes": {
+              "auth": {},
+              "time": "2023-05-23T19:38:36.846070601Z"
+            }
+          },
+          "resourceName": "projects/test-project-123456/locations/global/buckets/testloggingbucket",
+          "serviceName": "logging.googleapis.com",
+          "status": {}
+        },
+        "receivetimestamp": "2023-05-23 19:38:37.59",
+        "resource": {
+          "labels": {
+            "method": "google.logging.v2.ConfigServiceV2.GetBucket",
+            "project_id": "test-project-123456",
+            "service": "logging.googleapis.com"
+          },
+          "type": "audited_resource"
+        },
+        "severity": "NOTICE",
+        "timestamp": "2023-05-23 19:38:36.838"
+      }
+  - Name: logging-sink.non-deletion-should-not-alert
+    LogType: GCP.AuditLog
+    ExpectedResult: false
+    Log:
+      {
+        "insertid": "xxxxxxxxxx",
+        "logname": "projects/test-project-123456/logs/cloudaudit.googleapis.com%2Factivity",
+        "protoPayload": {
+          "at_sign_type": "type.googleapis.com/google.cloud.audit.AuditLog",
+          "authenticationInfo": {
+            "principalEmail": "user@domain.com"
+          },
+          "authorizationInfo": [
+            {
+              "granted": true,
+              "permission": "logging.sinks.get",
+              "resource": "projects/test-project-123456/sinks/test-1",
+              "resourceAttributes": {
+                "name": "projects/test-project-123456/sinks/test-1",
+                "service": "logging.googleapis.com"
+              }
+            }
+          ],
+          "methodName": "google.logging.v2.ConfigServiceV2.GetSink",
+          "request": {
+            "@type": "type.googleapis.com/google.logging.v2.GetSinkRequest",
+            "sinkName": "projects/test-project-123456/sinks/test-1"
+          },
+          "requestMetadata": {
+            "callerIP": "12.12.12.12",
+            "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36,gzip(gfe),gzip(gfe)",
+            "destinationAttributes": {},
+            "requestAttributes": {
+              "auth": {},
+              "time": "2023-05-23T19:39:15.230304077Z"
+            }
+          },
+          "resourceName": "projects/test-project-123456/sinks/test-1",
+          "serviceName": "logging.googleapis.com",
+          "status": {}
+        },
+        "receivetimestamp": "2023-05-23 19:39:15.565",
+        "resource": {
+          "labels": {
+            "destination": "",
+            "name": "test-1",
+            "project_id": "test-project-123456"
+          },
+          "type": "logging_sink"
+        },
+        "severity": "NOTICE",
+        "timestamp": "2023-05-23 19:39:15.213"
+      }


### PR DESCRIPTION
### Background

This PR adds detections around logging bucket and sink deletions. The rule matching follows the regex pattern I have been using in other PRs with the exception of being more broad in matching the API version since this API is `v2` (and given this, I may open a future PR that handles this more gracefully for the other detections I've written recently).

Additionally, I wanted to explicitly alert on authorized requests per the detection spec. To do this, I run a nested `deep_get` on the contents of the `authorizationInfo` list since that list contains an inner dictionary.

### Changes

* Adds `gcp_log_bucket_or_sink_deleted.py`
* Adds `gcp_log_bucket_or_sink_deleted.yml` with two `True` test cases and two `False` test cases

### Testing

* Tests pass as expected:
```
GCP.Log.Bucket.Or.Sink.Deleted
        [PASS] logging-bucket.deleted-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] deleted logging bucket or sink [projects/test-project-123456/locations/global/buckets/testloggingbucket]
                [PASS] [dedup] [GCP]: [user@domain.com] deleted logging bucket or sink [projects/test-project-123456/locations/global/buckets/testloggingbucket]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "google.logging.v2.ConfigServiceV2.DeleteBucket", "resourceName": "projects/test-project-123456/locations/global/buckets/testloggingbucket", "serviceName": "logging.googleapis.com"}
        [PASS] logging-sink.deleted-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] deleted logging bucket or sink [projects/test-project-123456/sinks/test-1]
                [PASS] [dedup] [GCP]: [user@domain.com] deleted logging bucket or sink [projects/test-project-123456/sinks/test-1]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "google.logging.v2.ConfigServiceV2.DeleteSink", "resourceName": "projects/test-project-123456/sinks/test-1", "serviceName": "logging.googleapis.com"}
        [PASS] logging-bucket.non-deletion-should-not-alert
                [PASS] [rule] false
        [PASS] logging-sink.non-deletion-should-not-alert
                [PASS] [rule] false
```
