### PR TITLE
Allow for any API version for certain GCP detections

### DIFF
--- a/rules/gcp_audit_rules/gcp_firewall_rule_created.py
+++ b/rules/gcp_audit_rules/gcp_firewall_rule_created.py
@@ -5,7 +5,7 @@ from panther_base_helpers import deep_get
 
 
 def rule(event):
-    method_pattern = r"(?:\w+\.)*v1\.(?:Firewall\.Create)|(compute\.firewalls\.insert)"
+    method_pattern = r"(?:\w+\.)*v\d\.(?:Firewall\.Create)|(compute\.firewalls\.insert)"
     match = re.search(method_pattern, deep_get(event, "protoPayload", "methodName", default=""))
     return match is not None
 

--- a/rules/gcp_audit_rules/gcp_firewall_rule_deleted.py
+++ b/rules/gcp_audit_rules/gcp_firewall_rule_deleted.py
@@ -5,7 +5,7 @@ from panther_base_helpers import deep_get
 
 
 def rule(event):
-    method_pattern = r"(?:\w+\.)*v1\.(?:Firewall\.Delete)|(compute\.firewalls\.delete)"
+    method_pattern = r"(?:\w+\.)*v\d\.(?:Firewall\.Delete)|(compute\.firewalls\.delete)"
     match = re.search(method_pattern, deep_get(event, "protoPayload", "methodName", default=""))
     return match is not None
 

--- a/rules/gcp_audit_rules/gcp_firewall_rule_modified.py
+++ b/rules/gcp_audit_rules/gcp_firewall_rule_modified.py
@@ -5,7 +5,7 @@ from panther_base_helpers import deep_get
 
 
 def rule(event):
-    method_pattern = r"(?:\w+\.)*v1\.(?:Firewall\.Update)|(compute\.firewalls\.(patch|update))"
+    method_pattern = r"(?:\w+\.)*v\d\.(?:Firewall\.Update)|(compute\.firewalls\.(patch|update))"
     match = re.search(method_pattern, deep_get(event, "protoPayload", "methodName", default=""))
     return match is not None
 


### PR DESCRIPTION
### Background

This is a small PR that allows for any API version to satisfy the pattern checking for a few GCP detections (specifically Firewall Rule creations, deletions, and modifications). 

Originally, this was explicitly `v1`, but this will allow future API versions to work (unless GCP changes the structure around entirely when moving to a new API version which is a separate issue).

### Changes

* Updates the `method_pattern` to allow for `*v\d` rather than just `*v1` for the following detections
    * `gcp_firewall_rule_created.py`
    * `gcp_firewall_rule_deleted.py`
    * `gcp_firewall_rule_modified.py`

### Testing

* Tests for these rules still pass as expected:
```
GCP.Firewall.Rule.Created
        [PASS] compute.firewalls.create-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] created firewall rule with resource ID [6563507997690081088]
                [PASS] [dedup] [GCP]: [user@domain.com] created firewall rule with resource ID [6563507997690081088]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "v1.compute.firewalls.insert", "resourceName": "projects/test-project-123456/global/firewalls/firewall-create", "serviceName": "compute.googleapis.com"}
        [PASS] appengine.firewall.create-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] created firewall rule for resource [apps/test-project-123456]
                [PASS] [dedup] [GCP]: [user@domain.com] created firewall rule for resource [apps/test-project-123456]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "google.appengine.v1.Firewall.CreateIngressRule", "resourceName": "apps/test-project-123456", "serviceName": "appengine.googleapis.com"}
        [PASS] compute.non-create.firewall.method-should-not-alert
                [PASS] [rule] false
        [PASS] appengine.compute.non-create.firewall.method-should-not-alert
                [PASS] [rule] false
        [PASS] randomservice.firewall-create.method-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] created firewall rule with resource ID [6563507997690081088]
                [PASS] [dedup] [GCP]: [user@domain.com] created firewall rule with resource ID [6563507997690081088]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "randomservice.compute.v1.Firewall.CreateIngressRule", "resourceName": "randomservice/test-project-123456/firewall/ingressRules/1000", "serviceName": ""}

GCP.Firewall.Rule.Deleted
        [PASS] compute.firewalls-delete-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] deleted firewall rule with resource ID [6563507997690081088]
                [PASS] [dedup] [GCP]: [user@domain.com] deleted firewall rule with resource ID [6563507997690081088]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "v1.compute.firewalls.delete", "resourceName": "projects/test-project-123456/global/firewalls/firewall-create", "serviceName": "compute.googleapis.com"}
        [PASS] appengine.firewall.delete-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] deleted firewall rule for resource [apps/test-project-123456/firewall/ingressRules/1000]
                [PASS] [dedup] [GCP]: [user@domain.com] deleted firewall rule for resource [apps/test-project-123456/firewall/ingressRules/1000]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "google.appengine.v1.Firewall.DeleteIngressRule", "resourceName": "apps/test-project-123456/firewall/ingressRules/1000", "serviceName": "appengine.googleapis.com"}
        [PASS] compute.non-delete.firewall.method-should-not-alert
                [PASS] [rule] false
        [PASS] appengine.non-delete.firewall.method-should-not-alert
                [PASS] [rule] false
        [PASS] randomservice.firewall-delete.method-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] deleted firewall rule with resource ID [6563507997690081088]
                [PASS] [dedup] [GCP]: [user@domain.com] deleted firewall rule with resource ID [6563507997690081088]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "randomservice.compute.v1.Firewall.DeleteIngressRule", "resourceName": "randomservice/test-project-123456/firewall/ingressRules/1000", "serviceName": ""}

GCP.Firewall.Rule.Modified
        [PASS] compute.firewalls.update-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] modified firewall rule on [projects/test-project-123456/global/firewalls/firewall-create]
                [PASS] [dedup] [GCP]: [user@domain.com] modified firewall rule on [projects/test-project-123456/global/firewalls/firewall-create]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "v1.compute.firewalls.patch", "resourceName": "projects/test-project-123456/global/firewalls/firewall-create", "serviceName": "compute.googleapis.com"}
        [PASS] appengine.firewall.update-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] modified firewall rule on [apps/test-project-123456/firewall/ingressRules/1000]
                [PASS] [dedup] [GCP]: [user@domain.com] modified firewall rule on [apps/test-project-123456/firewall/ingressRules/1000]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "google.appengine.v1.Firewall.UpdateIngressRule", "resourceName": "apps/test-project-123456/firewall/ingressRules/1000", "serviceName": "appengine.googleapis.com"}
        [PASS] compute.non-update.firewall.method-should-not-alert
                [PASS] [rule] false
        [PASS] appengine.compute.non-update.firewall.method-should-not-alert
                [PASS] [rule] false
        [PASS] randomservice.firewall-update.method-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] modified firewall rule on [randomservice/test-project-123456/firewall/ingressRules/1000]
                [PASS] [dedup] [GCP]: [user@domain.com] modified firewall rule on [randomservice/test-project-123456/firewall/ingressRules/1000]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "randomservice.compute.v1.Firewall.UpdateIngressRule", "resourceName": "randomservice/test-project-123456/firewall/ingressRules/1000", "serviceName": ""}
```
