### PR TITLE
Augment deep_get to support Sequence items in dictionaries

### DIFF
--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -1275,7 +1275,8 @@ class TestDeepGet(unittest.TestCase):
             p_b_h.deep_get(event, "key", "requestParameters", "imageId", default=""), "ami1234"
         )
         self.assertEqual(
-            p_b_h.deep_get(event, "key", "requestParameters", "other_key", default=""), "Use Newer Key!"
+            p_b_h.deep_get(event, "key", "requestParameters", "other_key", default=""),
+            "Use Newer Key!",
         )
         self.assertEqual(p_b_h.deep_get(event, "key", "another_key", default=""), "value6")
         self.assertEqual(p_b_h.deep_get(event, "key", "empty_list_key", default=""), "")

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -1228,40 +1228,56 @@ class TestDeepGet(unittest.TestCase):
         self.assertEqual(p_b_h.deep_get(event, "thing", "none_val", default=None), None)
         # If the searched key is not found, and no default kwarg is provided, return None
         self.assertEqual(p_b_h.deep_get(event, "key_does_not_exist"), None)
+
     def test_deep_get_lists(self):
         event = {
             "key": {
-                "inner_key": [{
-                    "nested_key": "value"
-                }],
-                "very_nested": [{
-                    "outer_key": [{
-                        "nested_key": "value",
-                        "nested_key2": [{
-                            "nested_key3": "value2"
-                        }],
-                    }],
-                    "outer_key2": [{
-                        "nested_key4": "value3"
-                    }],
-                }],
+                "inner_key": [{"nested_key": "value"}],
+                "very_nested": [
+                    {
+                        "outer_key": [
+                            {
+                                "nested_key": "value",
+                                "nested_key2": [{"nested_key3": "value2"}],
+                            }
+                        ],
+                        "outer_key2": [{"nested_key4": "value3"}],
+                    }
+                ],
                 "another_key": "value6",
                 "empty_list_key": [],
-                "nested_dict_key": {
-                    "nested_dict_value": "value7"
-                },
+                "nested_dict_key": {"nested_dict_value": "value7"},
                 "none_value": None,
             }
         }
-        self.assertEqual(p_b_h.deep_get(event, "key", "inner_key", "nested_key", default=""), "value")
-        self.assertEqual(p_b_h.deep_get(event, "key", "very_nested", "outer_key", "nested_key", default=""), "value")
-        self.assertEqual(p_b_h.deep_get(event, "key", "very_nested", "outer_key", "nested_key2", "nested_key3", default=""), "value2")
-        self.assertEqual(p_b_h.deep_get(event, "key", "very_nested", "outer_key2", "nested_key4", default=""), "value3")
+        self.assertEqual(
+            p_b_h.deep_get(event, "key", "inner_key", "nested_key", default=""), "value"
+        )
+        self.assertEqual(
+            p_b_h.deep_get(event, "key", "very_nested", "outer_key", "nested_key", default=""),
+            "value",
+        )
+        self.assertEqual(
+            p_b_h.deep_get(
+                event, "key", "very_nested", "outer_key", "nested_key2", "nested_key3", default=""
+            ),
+            "value2",
+        )
+        self.assertEqual(
+            p_b_h.deep_get(event, "key", "very_nested", "outer_key2", "nested_key4", default=""),
+            "value3",
+        )
         self.assertEqual(p_b_h.deep_get(event, "key", "another_key", default=""), "value6")
         self.assertEqual(p_b_h.deep_get(event, "key", "empty_list_key", default=""), "")
-        self.assertEqual(p_b_h.deep_get(event, "key", "empty_list_key", "nonexistent_key", default=""), "")
-        self.assertEqual(p_b_h.deep_get(event, "key", "nested_dict_key", "nested_dict_value", default=""), "value7")
+        self.assertEqual(
+            p_b_h.deep_get(event, "key", "empty_list_key", "nonexistent_key", default=""), ""
+        )
+        self.assertEqual(
+            p_b_h.deep_get(event, "key", "nested_dict_key", "nested_dict_value", default=""),
+            "value7",
+        )
         self.assertEqual(p_b_h.deep_get(event, "key", "none_value", default=""), "")
+
 
 class TestCloudflareHelpers(unittest.TestCase):
     def setUp(self):

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -1228,7 +1228,36 @@ class TestDeepGet(unittest.TestCase):
         self.assertEqual(p_b_h.deep_get(event, "thing", "none_val", default=None), None)
         # If the searched key is not found, and no default kwarg is provided, return None
         self.assertEqual(p_b_h.deep_get(event, "key_does_not_exist"), None)
-
+    def test_deep_get_lists(self):
+        event = {
+            "key": {
+                "inner_key": [{
+                    "nested_key": "value"
+                }],
+                "very_nested": [{
+                    "outer_key": [{
+                        "nested_key": "value",
+                        "nested_key2": [{
+                            "nested_key3": "value2"
+                        }],
+                    }],
+                    "outer_key2": [{
+                        "nested_key4": "value3"
+                    }],
+                }],
+                "another_key": "value6",
+                "empty_list_key": [],
+                "none_value": None,
+            }
+        }
+        self.assertEqual(p_b_h.deep_get(event, "key", "inner_key", "nested_key", default=""), "value")
+        self.assertEqual(p_b_h.deep_get(event, "key", "very_nested", "outer_key", "nested_key", default=""), "value")
+        self.assertEqual(p_b_h.deep_get(event, "key", "very_nested", "outer_key", "nested_key2", "nested_key3", default=""), "value2")
+        self.assertEqual(p_b_h.deep_get(event, "key", "very_nested", "outer_key2", "nested_key4", default=""), "value3")
+        self.assertEqual(p_b_h.deep_get(event, "key", "another_key", default=""), "value6")
+        self.assertEqual(p_b_h.deep_get(event, "key", "empty_list_key", default=""), "")
+        self.assertEqual(p_b_h.deep_get(event, "key", "empty_list_key", "nonexistent_key", default=""), "")
+        self.assertEqual(p_b_h.deep_get(event, "key", "none_value", default=""), "")
 
 class TestCloudflareHelpers(unittest.TestCase):
     def setUp(self):

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -1232,7 +1232,7 @@ class TestDeepGet(unittest.TestCase):
     def test_deep_get_lists(self):
         event = {
             "key": {
-                "inner_key": [{"nested_key": "value"}],
+                "inner_key": [{"nested_key": "nested_value"}, {"nested_key": "nested_value2"}],
                 "very_nested": [
                     {
                         "outer_key": [
@@ -1244,6 +1244,10 @@ class TestDeepGet(unittest.TestCase):
                         "outer_key2": [{"nested_key4": "value3"}],
                     }
                 ],
+                "requestParameters": [
+                    {"imageId": "ami1234", "other_key": None},
+                    {"imageId": "ami1234", "other_key": "Use Newer Key!"},
+                ],
                 "another_key": "value6",
                 "empty_list_key": [],
                 "nested_dict_key": {"nested_dict_value": "value7"},
@@ -1251,7 +1255,7 @@ class TestDeepGet(unittest.TestCase):
             }
         }
         self.assertEqual(
-            p_b_h.deep_get(event, "key", "inner_key", "nested_key", default=""), "value"
+            p_b_h.deep_get(event, "key", "inner_key", "nested_key", default=""), "nested_value2"
         )
         self.assertEqual(
             p_b_h.deep_get(event, "key", "very_nested", "outer_key", "nested_key", default=""),
@@ -1266,6 +1270,12 @@ class TestDeepGet(unittest.TestCase):
         self.assertEqual(
             p_b_h.deep_get(event, "key", "very_nested", "outer_key2", "nested_key4", default=""),
             "value3",
+        )
+        self.assertEqual(
+            p_b_h.deep_get(event, "key", "requestParameters", "imageId", default=""), "ami1234"
+        )
+        self.assertEqual(
+            p_b_h.deep_get(event, "key", "requestParameters", "other_key", default=""), "Use Newer Key!"
         )
         self.assertEqual(p_b_h.deep_get(event, "key", "another_key", default=""), "value6")
         self.assertEqual(p_b_h.deep_get(event, "key", "empty_list_key", default=""), "")

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -1247,6 +1247,9 @@ class TestDeepGet(unittest.TestCase):
                 }],
                 "another_key": "value6",
                 "empty_list_key": [],
+                "nested_dict_key": {
+                    "nested_dict_value": "value7"
+                },
                 "none_value": None,
             }
         }
@@ -1257,6 +1260,7 @@ class TestDeepGet(unittest.TestCase):
         self.assertEqual(p_b_h.deep_get(event, "key", "another_key", default=""), "value6")
         self.assertEqual(p_b_h.deep_get(event, "key", "empty_list_key", default=""), "")
         self.assertEqual(p_b_h.deep_get(event, "key", "empty_list_key", "nonexistent_key", default=""), "")
+        self.assertEqual(p_b_h.deep_get(event, "key", "nested_dict_key", "nested_dict_value", default=""), "value7")
         self.assertEqual(p_b_h.deep_get(event, "key", "none_value", default=""), "")
 
 class TestCloudflareHelpers(unittest.TestCase):

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -331,10 +331,11 @@ def deep_get(dictionary: dict, *keys, default=None):
         if isinstance(obj, Mapping):
             return obj.get(key, default)
         if isinstance(obj, Sequence):
+            result = default
             for item in obj:
                 if isinstance(item, Mapping) and key in item:
-                    return item.get(key, default)
-            return default
+                    result = item.get(key, default)
+            return result
         return default
 
     out = reduce(_type, keys, dictionary) if keys else dictionary

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -299,7 +299,7 @@ def github_alert_context(event: dict):
 def deep_get(dictionary: dict, *keys, default=None):
     """Safely return a value in an arbitrarily nested map
 
-    Also supports nested list elements containing nested dictionaries
+    Also supports nested Sequence items containing nested dictionaries
 
     Usage:
     ```
@@ -323,6 +323,8 @@ def deep_get(dictionary: dict, *keys, default=None):
     print(value, value2, value3)
         value value2 ''
     ```
+
+    Inspired by https://bit.ly/3a0hq9E
     """
 
     def _type(obj, key):

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from fnmatch import fnmatch
 from functools import reduce
 from ipaddress import ip_address, ip_network
-from typing import Any, Sequence
+from typing import Sequence
 
 # # # # # # # # # # # # # #
 #       Exceptions        #

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -324,15 +324,19 @@ def deep_get(dictionary: dict, *keys, default=None):
         value value2 ''
     ```
     """
+
     def _type(obj, key):
         if isinstance(obj, Mapping):
             return obj.get(key, default)
-        if isinstance(obj, Sequence) and not isinstance(obj, str) and (obj is not None and len(obj) > 0):
+        if (
+            isinstance(obj, Sequence)
+            and not isinstance(obj, str)
+            and (obj is not None and len(obj) > 0)
+        ):
             return obj[0].get(key, default)
         return default
-    out = reduce(
-       _type, keys, dictionary
-    )
+
+    out = reduce(_type, keys, dictionary)
     if out is None:
         return default
     return out

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -314,12 +314,14 @@ def deep_get(dictionary: dict, *keys, default=None):
                 "nested_key": "value"
             }],
             "another_key": "value2",
+            "empty_list_key": [],
         }
     }
     value = deep_get(a_dict, "key", "inner_key", "nested_key", default="")
     value2 = deep_get(a_dict, "key", "another_key", default="")
-    print(value, value2)
-        value value2
+    value3 = deep_get(a_dict, "key", "empty_list_key", "nonexistent_key", default="")
+    print(value, value2, value3)
+        value value2 ''
     ```
     """
     def _type(obj, key):

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from fnmatch import fnmatch
 from functools import reduce
 from ipaddress import ip_address, ip_network
-from typing import Sequence
+from typing import Any, Sequence
 
 # # # # # # # # # # # # # #
 #       Exceptions        #
@@ -326,20 +326,17 @@ def deep_get(dictionary: dict, *keys, default=None):
 
     Inspired by https://bit.ly/3a0hq9E
     """
-
     def _type(obj, key):
         if isinstance(obj, Mapping):
             return obj.get(key, default)
-        if (
-            isinstance(obj, Sequence)
-            and not isinstance(obj, str)
-            and (obj is not None and len(obj) > 0)
-        ):
-            return obj[0].get(key, default)
+        if isinstance(obj, Sequence):
+            for item in obj:
+                if isinstance(item, Mapping) and key in item:
+                    return item.get(key, default)
+            return default
         return default
-
-    out = reduce(_type, keys, dictionary)
-    if out is None:
+    out = reduce(_type, keys, dictionary) if keys else dictionary
+    if out is None or out == []:
         return default
     return out
 

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -297,12 +297,39 @@ def github_alert_context(event: dict):
 
 
 def deep_get(dictionary: dict, *keys, default=None):
-    """Safely return the value of an arbitrarily nested map
+    """Safely return a value in an arbitrarily nested map
 
-    Inspired by https://bit.ly/3a0hq9E
+    Also supports nested list elements containing nested dictionaries
+
+    Usage:
+    ```
+    deep_get(a_dict, "key", "another_key", "nth_key", default="")
+    ```
+
+    Example:
+    ```
+    a_dict = {
+        "key": {
+            "inner_key": [{
+                "nested_key": "value"
+            }],
+            "another_key": "value2",
+        }
+    }
+    value = deep_get(a_dict, "key", "inner_key", "nested_key", default="")
+    value2 = deep_get(a_dict, "key", "another_key", default="")
+    print(value, value2)
+        value value2
+    ```
     """
+    def _type(obj, key):
+        if isinstance(obj, Mapping):
+            return obj.get(key, default)
+        if isinstance(obj, Sequence) and not isinstance(obj, str) and (obj is not None and len(obj) > 0):
+            return obj[0].get(key, default)
+        return default
     out = reduce(
-        lambda d, key: d.get(key, default) if isinstance(d, Mapping) else default, keys, dictionary
+       _type, keys, dictionary
     )
     if out is None:
         return default

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -326,6 +326,7 @@ def deep_get(dictionary: dict, *keys, default=None):
 
     Inspired by https://bit.ly/3a0hq9E
     """
+
     def _type(obj, key):
         if isinstance(obj, Mapping):
             return obj.get(key, default)
@@ -335,6 +336,7 @@ def deep_get(dictionary: dict, *keys, default=None):
                     return item.get(key, default)
             return default
         return default
+
     out = reduce(_type, keys, dictionary) if keys else dictionary
     if out is None or out == []:
         return default

--- a/rules/auth0_rules/auth0_mfa_policy_disabled.py
+++ b/rules/auth0_rules/auth0_mfa_policy_disabled.py
@@ -10,7 +10,7 @@ def rule(event):
     request_path = deep_get(
         event, "data", "details", "request", "path", default="<NO_REQUEST_PATH_FOUND>"
     )
-    request_body = deep_get(event, "data", "details", "request", "body", default=[-1])
+    request_body = deep_get(event, "data", "details", "request", "body", default=[])
     return all(
         [
             data_description == "Set the Multi-factor Authentication policies",

--- a/rules/gcp_audit_rules/gcp_destructive_queries.py
+++ b/rules/gcp_audit_rules/gcp_destructive_queries.py
@@ -27,10 +27,10 @@ def rule(event):
     ):
         return True
 
-    if deep_get(event, "protoPayload", "metadata", "tableDeletion"):
+    if deep_get(event, "protoPayload", "metadata", "tableDeletion", default=""):
         return True
 
-    if deep_get(event, "protoPayload", "metadata", "datasetDeletion"):
+    if deep_get(event, "protoPayload", "metadata", "datasetDeletion", default=""):
         return True
 
     return False

--- a/rules/gcp_audit_rules/gcp_destructive_queries.yml
+++ b/rules/gcp_audit_rules/gcp_destructive_queries.yml
@@ -24,7 +24,7 @@ Tests:
         p_schema_version: 0
         p_source_id: 964c7894-9a0d-4ddf-864f-0193438221d6
         p_source_label: gcp-logsource
-        protopayload:
+        protoPayload:
             at_sign_type: type.googleapis.com/google.cloud.audit.AuditLog
             authenticationInfo:
                 principalEmail: user@company.io
@@ -89,7 +89,7 @@ Tests:
         p_schema_version: 0
         p_source_id: 964c7894-9a0d-4ddf-864f-0193438221d6
         p_source_label: gcp-logsource
-        protopayload:
+        protoPayload:
             at_sign_type: type.googleapis.com/google.cloud.audit.AuditLog
             authenticationInfo:
                 principalEmail: user@company.io

--- a/rules/gcp_audit_rules/gcp_service_account_access_denied.py
+++ b/rules/gcp_audit_rules/gcp_service_account_access_denied.py
@@ -3,14 +3,7 @@ from panther_base_helpers import deep_get
 
 
 def rule(event):
-    reason = next(
-        (
-            deep_get(item, "reason", default="")
-            for item in deep_get(event, "protoPayload", "status", "details", default=[{}])
-            if len(item) > 0
-        ),
-        "",
-    )
+    reason = deep_get(event, "protoPayload", "status", "details", "reason", default="")
     return reason == "IAM_PERMISSION_DENIED"
 
 

--- a/rules/gcp_audit_rules/gcp_service_account_access_denied.py
+++ b/rules/gcp_audit_rules/gcp_service_account_access_denied.py
@@ -4,17 +4,16 @@ from gcp_base_helpers import gcp_alert_context
 from panther_base_helpers import deep_get
 
 
-def _get_details(event) -> List[Any]:
-    return deep_get(event, "protoPayload", "status", "details", default=[{}])
-
-
 def rule(event):
-    details = _get_details(event)
-    if len(details) > 0:
-        reason = deep_get(details[0], "reason", default="")
-        if reason == "IAM_PERMISSION_DENIED":
-            return True
-    return False
+    reason = next(
+        (
+            deep_get(item, "reason", default="")
+            for item in deep_get(event, "protoPayload", "status", "details", default=[{}])
+            if len(item) > 0
+        ),
+        "",
+    )
+    return reason == "IAM_PERMISSION_DENIED"
 
 
 def title(event):

--- a/rules/gcp_audit_rules/gcp_service_account_access_denied.py
+++ b/rules/gcp_audit_rules/gcp_service_account_access_denied.py
@@ -1,5 +1,3 @@
-from typing import Any, List
-
 from gcp_base_helpers import gcp_alert_context
 from panther_base_helpers import deep_get
 


### PR DESCRIPTION
### Background

Relates to #801. The retrieval of the `reason` will encounter an `IndexError` when the `details` list is empty or nonexistent.

Originally, this PR focused on fixing that specific implementation, but I spent some time ideating and came up with a solution that augments `deep_get` with the ability to support `Sequence` items in dictionaries.

### Changes

* Updates `deep_get` to support `Sequence` items in dictionaries (with guardrails)
* Updates `gcp_service_account_access_denied.py` to align with the new `deep_get` functionality
* Updates `gcp_destructive_queries.py` and `gcp_destructive_queries.yml`
    * This detection came up while I was testing my changes

### Testing

* Tests still pass as expected:
```
GCP.Service.Account.Access.Denied
        [PASS] service-account.access-denied-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [test-no-perms@test-project-123456.iam.gserviceaccount.com] performed multiple requests resulting in [IAM_PERMISSION_DENIED]
                [PASS] [dedup] [GCP]: [test-no-perms@test-project-123456.iam.gserviceaccount.com] performed multiple requests resulting in [IAM_PERMISSION_DENIED]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "test-no-perms@test-project-123456.iam.gserviceaccount.com", "caller_ip": "12.12.12.12", "methodName": "google.iam.admin.v1.CreateServiceAccount", "resourceName": "projects/test-project-123456", "serviceName": "iam.googleapis.com"}
        [PASS] service-account.access-grated-should-not-alert
                [PASS] [rule] false
```
* All tests pass with the `deep_get` changes:
```
--------------------------
Panther CLI Test Summary
        Path: .
        Passed: 499
        Failed: 0
        Invalid: 0
```

I also verified this functionality using the example stored in the `deep_get` docstring.