### PR TITLE
Rule: Notion public homepage added

### DIFF
--- a/packs/notion.yml
+++ b/packs/notion.yml
@@ -5,6 +5,7 @@ PackDefinition:
   IDs:
     - Notion.Workspace.Exported
     - Notion.Workspace.SCIM.Token.Generated
+    - Notion.Workspace.Public.Page.Added
     - Notion.Many.Pages.Exported
     - Notion.Many.Pages.Deleted
     - Notion.Audit.Log.Exported

--- a/rules/notion_rules/notion_workspace_settings_public_homepage_added.py
+++ b/rules/notion_rules/notion_workspace_settings_public_homepage_added.py
@@ -21,7 +21,7 @@ def title(event):
         "database_id",
         default="<NO_DATABASE_ID_FOUND>",
     )
-    return f"Notion User {[actor]} added a new public page {[db_id]} in workspace {[workspace_id]}"
+    return f"Notion User [{actor}] added a new public page [{db_id}] in workspace [{workspace_id}]"
 
 
 def alert_context(event):

--- a/rules/notion_rules/notion_workspace_settings_public_homepage_added.py
+++ b/rules/notion_rules/notion_workspace_settings_public_homepage_added.py
@@ -1,0 +1,29 @@
+from global_filter_notion import filter_include_event
+from panther_base_helpers import deep_get
+from panther_notion_helpers import notion_alert_context
+
+
+def rule(event):
+    if not filter_include_event(event):
+        return False
+
+    event_type = deep_get(event, "event", "type", default="<NO_EVENT_TYPE_FOUND>")
+    return event_type == "workspace.settings.public_homepage_added"
+
+
+def title(event):
+    actor = deep_get(event, "event", "actor", "person", "email", default="<NO_EMAIL_FOUND>")
+    workspace_id = deep_get(event, "event", "workspace_id", default="<NO_WORKSPACE_ID_FOUND>")
+    public_workspace_database_id = deep_get(
+        event,
+        "event",
+        "workspace.settings.public_homepage_added",
+        "new_public_page",
+        "database_id",
+        default="<NO_DATABASE_ID_FOUND>",
+    )
+    return f"Notion User {actor} added a new public page {public_workspace_database_id} in workspace with workspace id {workspace_id}"
+
+
+def alert_context(event):
+    return notion_alert_context(event)

--- a/rules/notion_rules/notion_workspace_settings_public_homepage_added.py
+++ b/rules/notion_rules/notion_workspace_settings_public_homepage_added.py
@@ -21,7 +21,7 @@ def title(event):
         "database_id",
         default="<NO_DATABASE_ID_FOUND>",
     )
-    return f"Notion User {actor} added a new public page {db_id} in workspace {workspace_id}"
+    return f"Notion User {[actor]} added a new public page {[db_id]} in workspace {[workspace_id]}"
 
 
 def alert_context(event):

--- a/rules/notion_rules/notion_workspace_settings_public_homepage_added.py
+++ b/rules/notion_rules/notion_workspace_settings_public_homepage_added.py
@@ -14,14 +14,14 @@ def rule(event):
 def title(event):
     actor = deep_get(event, "actor", "person", "email", default="<NO_EMAIL_FOUND>")
     workspace_id = deep_get(event, "workspace_id", default="<NO_WORKSPACE_ID_FOUND>")
-    public_workspace_database_id = deep_get(
+    db_id = deep_get(
         event,
         "workspace.settings.public_homepage_added",
         "new_public_page",
         "database_id",
         default="<NO_DATABASE_ID_FOUND>",
     )
-    return f"Notion User {actor} added a new public page {public_workspace_database_id} in workspace with workspace id {workspace_id}"
+    return f"Notion User {actor} added a new public page {db_id} in workspace {workspace_id}"
 
 
 def alert_context(event):

--- a/rules/notion_rules/notion_workspace_settings_public_homepage_added.py
+++ b/rules/notion_rules/notion_workspace_settings_public_homepage_added.py
@@ -7,16 +7,15 @@ def rule(event):
     if not filter_include_event(event):
         return False
 
-    event_type = deep_get(event, "event", "type", default="<NO_EVENT_TYPE_FOUND>")
+    event_type = deep_get(event, "type", default="<NO_EVENT_TYPE_FOUND>")
     return event_type == "workspace.settings.public_homepage_added"
 
 
 def title(event):
-    actor = deep_get(event, "event", "actor", "person", "email", default="<NO_EMAIL_FOUND>")
-    workspace_id = deep_get(event, "event", "workspace_id", default="<NO_WORKSPACE_ID_FOUND>")
+    actor = deep_get(event, "actor", "person", "email", default="<NO_EMAIL_FOUND>")
+    workspace_id = deep_get(event, "workspace_id", default="<NO_WORKSPACE_ID_FOUND>")
     public_workspace_database_id = deep_get(
         event,
-        "event",
         "workspace.settings.public_homepage_added",
         "new_public_page",
         "database_id",

--- a/rules/notion_rules/notion_workspace_settings_public_homepage_added.yml
+++ b/rules/notion_rules/notion_workspace_settings_public_homepage_added.yml
@@ -8,7 +8,7 @@ Severity: Info
 DedupPeriodMinutes: 60
 LogTypes:
     - Notion.AuditLogs
-RuleID: "Notion.Workspace.Settings"
+RuleID: "Notion.Workspace.Public.Page.Added"
 Threshold: 1
 Tags:
   - Data Security:Data Exfiltration

--- a/rules/notion_rules/notion_workspace_settings_public_homepage_added.yml
+++ b/rules/notion_rules/notion_workspace_settings_public_homepage_added.yml
@@ -10,9 +10,6 @@ LogTypes:
     - Notion.AuditLogs
 RuleID: "Notion.Workspace.Public.Page.Added"
 Threshold: 1
-Tags:
-  - Data Security:Data Exfiltration
-  - Data Security:Public Data
 Tests:
   - Name: Public page added
     ExpectedResult: true

--- a/rules/notion_rules/notion_workspace_settings_public_homepage_added.yml
+++ b/rules/notion_rules/notion_workspace_settings_public_homepage_added.yml
@@ -18,26 +18,53 @@ Tests:
     ExpectedResult: true
     Log:
       {
-        "event": {
-          "id": "eeeeeeee-dddd-4444-bbbb-4444444444444",
-          "timestamp": "2023-05-15T19:14:21.031Z",
-          "workspace_id": "vvvvvvvv-dddd-4444-bbbb-666666666666",
-          "actor": {
-            "object": "user",
-            "id": "44444444-cccc-7777-aaaa-666666666666",
-            "type": "person",
-            "person": {
-              "email": "example@personemail.com",
-            },
+        "id": "eeeeeeee-dddd-4444-bbbb-4444444444444",
+        "timestamp": "2023-05-15T19:14:21.031Z",
+        "workspace_id": "vvvvvvvv-dddd-4444-bbbb-666666666666",
+        "actor": {
+          "object": "user",
+          "id": "44444444-cccc-7777-aaaa-666666666666",
+          "type": "person",
+          "person": {
+            "email": "example@personemail.com",
           },
-          "ip_address": "00.000.00.000",
-          "platform": "web",
-          "type": "workspace.settings.public_homepage_added",
-          "workspace.settings.public_homepage_added": {
-            "new_public_page": {
-              "type": "database_id",
-              "database_id": "4b801dc7-d724-4fbb-afd0-9885cbc12405",
-            },
+        },
+        "ip_address": "00.000.00.000",
+        "platform": "web",
+        "type": "workspace.settings.public_homepage_added",
+        "workspace.settings.public_homepage_added": {
+          "new_public_page": {
+            "type": "database_id",
+            "database_id": "4b801dc7-d724-4fbb-afd0-9885cbc12405",
           },
         },
       }
+  - Name: Workspace Exported
+    ExpectedResult: false
+    Log:
+      {
+        "actor": {
+              "id": "bd37477c-869d-418b-abdb-0fc727b38b5e",
+              "object": "user",
+              "person": {
+                "email": "homer.simpson@yourcompany.io"
+              },
+              "type": "person"
+            },
+            "details": {
+              "parent": {
+                "type": "workspace_id",
+                "workspace_id": "ab99as87-6abc-4dcf-808b-111999882299"
+              },
+              "target": {
+                "page_id": "3cd2c560-d1b9-474e-b46e-gh8899002763",
+                "type": "page_id"
+              }
+            },
+            "id": "d4b9963f-12a8-4b01-b597-233a140abf5e",
+            "ip_address": "12.12.12.12",
+            "platform": "web",
+            "timestamp": "2023-06-01 18:57:07.486000000",
+            "type": "page.exported",
+            "workspace_id": "ea65b016-6abc-4dcf-808b-e119617b55d1"
+        }

--- a/rules/notion_rules/notion_workspace_settings_public_homepage_added.yml
+++ b/rules/notion_rules/notion_workspace_settings_public_homepage_added.yml
@@ -1,0 +1,43 @@
+AnalysisType: rule
+Description: A Notion page was set to public in your worksace.
+DisplayName: "Notion Workspace public page added"
+Enabled: true
+Filename: notion_workspace_settings_public_homepage_added.py
+Runbook: A Notion page was made public. Check with the author to determine why this page was made public.
+Severity: Info
+DedupPeriodMinutes: 60
+LogTypes:
+    - Notion.AuditLogs
+RuleID: "Notion.Workspace.Settings"
+Threshold: 1
+Tags:
+  - Data Security:Data Exfiltration
+  - Data Security:Public Data
+Tests:
+  - Name: Public page added
+    ExpectedResult: true
+    Log:
+      {
+        "event": {
+          "id": "eeeeeeee-dddd-4444-bbbb-4444444444444",
+          "timestamp": "2023-05-15T19:14:21.031Z",
+          "workspace_id": "vvvvvvvv-dddd-4444-bbbb-666666666666",
+          "actor": {
+            "object": "user",
+            "id": "44444444-cccc-7777-aaaa-666666666666",
+            "type": "person",
+            "person": {
+              "email": "example@personemail.com",
+            },
+          },
+          "ip_address": "00.000.00.000",
+          "platform": "web",
+          "type": "workspace.settings.public_homepage_added",
+          "workspace.settings.public_homepage_added": {
+            "new_public_page": {
+              "type": "database_id",
+              "database_id": "4b801dc7-d724-4fbb-afd0-9885cbc12405",
+            },
+          },
+        },
+      }


### PR DESCRIPTION
### Background

Adds a new rule to detect when a Notion workspace page is made public.

### Testing

```
Notion.Workspace.Public.Page.Added
	[PASS] Public page added
		[PASS] [rule] true
		[PASS] [title] Notion User example@personemail.com added a new public page 4b801dc7-d724-4fbb-afd0-9885cbc12405 in workspace vvvvvvvv-dddd-4444-bbbb-666666666666
		[PASS] [dedup] Notion User example@personemail.com added a new public page 4b801dc7-d724-4fbb-afd0-9885cbc12405 in workspace vvvvvvvv-dddd-4444-bbbb-666666666666
		[PASS] [alertContext] {"actor": {"object": "user", "id": "44444444-cccc-7777-aaaa-666666666666", "type": "person", "person": {"email": "example@personemail.com"}}, "action": "workspace.settings.public_homepage_added"}
	[PASS] Workspace Exported
		[PASS] [rule] false

--------------------------
Panther CLI Test Summary
	Path: .
	Passed: 1
	Failed: 0
	Invalid: 0
```
