### PR TITLE
feat: find enrichments by value leveraging p_match field

### DIFF
--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -1801,7 +1801,10 @@ class TestLookupTableHelpers(unittest.TestCase):
         }
         self.simple_event = {
             "p_enrichment": {
-                "tor_exit_nodes": {"foo": {"ip": "1.2.3.4", "p_match": "1.2.3.4"}},
+                "tor_exit_nodes": {
+                   "foo": {"ip": "1.2.3.4", "p_match": "1.2.3.4"},
+                   "bar": {"ip": "1.2.3.5", "p_match": "1.2.3.5"}
+                  },
                 "ipinfo_asn": {
                     "foo": {
                         "asn": "AS99999",

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -21,6 +21,7 @@ import panther_base_helpers as p_b_h  # pylint: disable=C0413
 import panther_cloudflare_helpers as p_cf_h  # pylint: disable=C0413
 import panther_greynoise_helpers as p_greynoise_h  # pylint: disable=C0413
 import panther_ipinfo_helpers as p_i_h  # pylint: disable=C0413
+import panther_lookuptable_helpers as p_l_h  # pylint: disable=C0413
 import panther_notion_helpers as p_notion_h  # pylint: disable=C0413
 import panther_oss_helpers as p_o_h  # pylint: disable=C0413
 import panther_snyk_helpers as p_snyk_h  # pylint: disable=C0413
@@ -190,28 +191,16 @@ class TestTorExitNodes(unittest.TestCase):
     def setUp(self):
 
         self.event = {
-            "p_enrichment": {
-                "tor_exit_nodes": {
-                    "foo": {"ip": "1.2.3.4"},
-                    "p_match": "1.2.3.4"
-                }
-            }
+            "p_enrichment": {"tor_exit_nodes": {"foo": {"ip": "1.2.3.4"}, "p_match": "1.2.3.4"}}
         }
-
 
         # match against array field
         self.event_list = {
             "p_enrichment": {
                 "tor_exit_nodes": {
                     "p_any_ip_addresses": [
-                        {
-                            "ip": "1.2.3.4",
-                            "p_match": "1.2.3.4"
-                        }, 
-                        {
-                            "ip": "1.2.3.5",
-                            "p_match": "1.2.3.5"
-                        }
+                        {"ip": "1.2.3.4", "p_match": "1.2.3.4"},
+                        {"ip": "1.2.3.5", "p_match": "1.2.3.5"},
                     ]
                 }
             }
@@ -1802,6 +1791,72 @@ class TestNotionHelpers(unittest.TestCase):
         returns = p_notion_h.notion_alert_context({})
         self.assertEqual(returns.get("actor", ""), "<NO_ACTOR_FOUND>")
         self.assertEqual(returns.get("action", ""), "<NO_ACTION_FOUND>")
+
+
+class TestLookupTableHelpers(unittest.TestCase):
+    # pylint: disable=protected-access
+    def setUp(self):
+        self.simple_event_no_pmatch = {
+            "p_enrichment": {"tor_exit_nodes": {"foo": {"ip": "1.2.3.4"}}}
+        }
+        self.simple_event = {
+            "p_enrichment": {
+                "tor_exit_nodes": {"foo": {"ip": "1.2.3.4", "p_match": "1.2.3.4"}},
+                "ipinfo_asn": {
+                    "foo": {
+                        "asn": "AS99999",
+                        "domain": "verytrusty.com",
+                        "name": "Super Trustworthy, LLC",
+                        "p_match": "1.2.3.4",
+                        "route": "1.0.0.0/8",
+                        "type": "isp",
+                    }
+                },
+            }
+        }
+        # match against array field
+        self.list_event = {
+            "p_enrichment": {
+                "tor_exit_nodes": {
+                    "p_any_ip_addresses": [
+                        {"ip": "1.2.3.4", "p_match": "1.2.3.4"},
+                        {"ip": "1.2.3.5", "p_match": "1.2.3.5"},
+                    ]
+                }
+            }
+        }
+
+    def test_register(self):
+        lut = p_l_h.LookupTableMatches()
+        lut._register(self.simple_event, "tor_exit_nodes")
+        self.assertEqual(lut.lut_matches, {"foo": {"ip": "1.2.3.4", "p_match": "1.2.3.4"}})
+        # call lut._register with non-extant key
+        lut._register(self.simple_event, "not_exists_enrichment")
+        self.assertEqual(lut.lut_matches, None)
+
+    def test_enrichments_by_pmatch(self):
+        lut = p_l_h.LookupTableMatches()
+        matches = lut.enrichments_by_pmatch(self.simple_event_no_pmatch, "1.2.3.4")
+        self.assertEqual(matches, [])
+        matches = lut.enrichments_by_pmatch(self.simple_event, "1.2.3.4")
+        self.assertEqual(
+            matches,
+            [
+                {"tor_exit_nodes": {"ip": "1.2.3.4", "p_match": "1.2.3.4"}},
+                {
+                    "ipinfo_asn": {
+                        "asn": "AS99999",
+                        "domain": "verytrusty.com",
+                        "name": "Super Trustworthy, LLC",
+                        "p_match": "1.2.3.4",
+                        "route": "1.0.0.0/8",
+                        "type": "isp",
+                    }
+                },
+            ],
+        )
+        matches = lut.enrichments_by_pmatch(self.list_event, "1.2.3.4")
+        self.assertEqual(matches, [{"tor_exit_nodes": {"ip": "1.2.3.4", "p_match": "1.2.3.4"}}])
 
 
 if __name__ == "__main__":

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -1841,17 +1841,17 @@ class TestLookupTableHelpers(unittest.TestCase):
         matches = lut.enrichments_by_pmatch(self.simple_event, "1.2.3.4")
         self.assertEqual(
             matches,
-            { 
+            {
                 "tor_exit_nodes": {"ip": "1.2.3.4", "p_match": "1.2.3.4"},
                 "ipinfo_asn": {
-                        "asn": "AS99999",
-                        "domain": "verytrusty.com",
-                        "name": "Super Trustworthy, LLC",
-                        "p_match": "1.2.3.4",
-                        "route": "1.0.0.0/8",
-                        "type": "isp",
-                    }
-            }
+                    "asn": "AS99999",
+                    "domain": "verytrusty.com",
+                    "name": "Super Trustworthy, LLC",
+                    "p_match": "1.2.3.4",
+                    "route": "1.0.0.0/8",
+                    "type": "isp",
+                },
+            },
         )
         matches = lut.enrichments_by_pmatch(self.list_event, "1.2.3.4")
         self.assertEqual(matches, {"tor_exit_nodes": {"ip": "1.2.3.4", "p_match": "1.2.3.4"}})

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -1837,14 +1837,13 @@ class TestLookupTableHelpers(unittest.TestCase):
     def test_enrichments_by_pmatch(self):
         lut = p_l_h.LookupTableMatches()
         matches = lut.enrichments_by_pmatch(self.simple_event_no_pmatch, "1.2.3.4")
-        self.assertEqual(matches, [])
+        self.assertEqual(matches, {})
         matches = lut.enrichments_by_pmatch(self.simple_event, "1.2.3.4")
         self.assertEqual(
             matches,
-            [
-                {"tor_exit_nodes": {"ip": "1.2.3.4", "p_match": "1.2.3.4"}},
-                {
-                    "ipinfo_asn": {
+            { 
+                "tor_exit_nodes": {"ip": "1.2.3.4", "p_match": "1.2.3.4"},
+                "ipinfo_asn": {
                         "asn": "AS99999",
                         "domain": "verytrusty.com",
                         "name": "Super Trustworthy, LLC",
@@ -1852,11 +1851,10 @@ class TestLookupTableHelpers(unittest.TestCase):
                         "route": "1.0.0.0/8",
                         "type": "isp",
                     }
-                },
-            ],
+            }
         )
         matches = lut.enrichments_by_pmatch(self.list_event, "1.2.3.4")
-        self.assertEqual(matches, [{"tor_exit_nodes": {"ip": "1.2.3.4", "p_match": "1.2.3.4"}}])
+        self.assertEqual(matches, {"tor_exit_nodes": {"ip": "1.2.3.4", "p_match": "1.2.3.4"}})
 
 
 if __name__ == "__main__":

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -1802,9 +1802,9 @@ class TestLookupTableHelpers(unittest.TestCase):
         self.simple_event = {
             "p_enrichment": {
                 "tor_exit_nodes": {
-                   "foo": {"ip": "1.2.3.4", "p_match": "1.2.3.4"},
-                   "bar": {"ip": "1.2.3.5", "p_match": "1.2.3.5"}
-                  },
+                    "foo": {"ip": "1.2.3.4", "p_match": "1.2.3.4"},
+                    "bar": {"ip": "1.2.3.5", "p_match": "1.2.3.5"},
+                },
                 "ipinfo_asn": {
                     "foo": {
                         "asn": "AS99999",
@@ -1832,18 +1832,26 @@ class TestLookupTableHelpers(unittest.TestCase):
     def test_register(self):
         lut = p_l_h.LookupTableMatches()
         lut._register(self.simple_event, "tor_exit_nodes")
-        self.assertEqual(lut.lut_matches, {"foo": {"ip": "1.2.3.4", "p_match": "1.2.3.4"}})
+        self.assertEqual(
+            lut.lut_matches,
+            {
+                "foo": {"ip": "1.2.3.4", "p_match": "1.2.3.4"},
+                "bar": {"ip": "1.2.3.5", "p_match": "1.2.3.5"},
+            },
+        )
         # call lut._register with non-extant key
         lut._register(self.simple_event, "not_exists_enrichment")
         self.assertEqual(lut.lut_matches, None)
 
     def test_enrichments_by_pmatch(self):
         lut = p_l_h.LookupTableMatches()
-        matches = lut.enrichments_by_pmatch(self.simple_event_no_pmatch, "1.2.3.4")
-        self.assertEqual(matches, {})
-        matches = lut.enrichments_by_pmatch(self.simple_event, "1.2.3.4")
+        self.assertEqual(lut.p_matches(None, None), {})
+        self.assertEqual(lut.p_matches({}), {})
+        self.assertEqual(lut.p_matches(self.simple_event_no_pmatch, "1.2.3.4"), {})
+        self.assertEqual(lut.p_matched, {})
+
         self.assertEqual(
-            matches,
+            lut.p_matches(self.simple_event, "1.2.3.4"),
             {
                 "tor_exit_nodes": {"ip": "1.2.3.4", "p_match": "1.2.3.4"},
                 "ipinfo_asn": {
@@ -1856,8 +1864,11 @@ class TestLookupTableHelpers(unittest.TestCase):
                 },
             },
         )
-        matches = lut.enrichments_by_pmatch(self.list_event, "1.2.3.4")
-        self.assertEqual(matches, {"tor_exit_nodes": {"ip": "1.2.3.4", "p_match": "1.2.3.4"}})
+        self.assertEqual(
+            lut.p_matches(self.list_event, "1.2.3.4"),
+            {"tor_exit_nodes": {"ip": "1.2.3.4", "p_match": "1.2.3.4"}},
+        )
+        self.assertEqual(lut.p_matched, {"tor_exit_nodes": {"ip": "1.2.3.4", "p_match": "1.2.3.4"}})
 
 
 if __name__ == "__main__":

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -189,12 +189,31 @@ class TestBoxParseAdditionalDetails(unittest.TestCase):
 class TestTorExitNodes(unittest.TestCase):
     def setUp(self):
 
-        self.event = {"p_enrichment": {"tor_exit_nodes": {"foo": {"ip": "1.2.3.4"}}}}
+        self.event = {
+            "p_enrichment": {
+                "tor_exit_nodes": {
+                    "foo": {"ip": "1.2.3.4"},
+                    "p_match": "1.2.3.4"
+                }
+            }
+        }
+
 
         # match against array field
         self.event_list = {
             "p_enrichment": {
-                "tor_exit_nodes": {"p_any_ip_addresses": [{"ip": "1.2.3.4"}, {"ip": "1.2.3.5"}]}
+                "tor_exit_nodes": {
+                    "p_any_ip_addresses": [
+                        {
+                            "ip": "1.2.3.4",
+                            "p_match": "1.2.3.4"
+                        }, 
+                        {
+                            "ip": "1.2.3.5",
+                            "p_match": "1.2.3.5"
+                        }
+                    ]
+                }
             }
         }
 
@@ -266,6 +285,7 @@ class TestGreyNoiseBasic(unittest.TestCase):
                         "actor": "unknown",
                         "classification": "malicious",
                         "ip": "142.93.204.250",
+                        "p_match": "142.93.204.250",
                     }
                 }
             }
@@ -339,6 +359,7 @@ class TestGreyNoiseAdvanced(unittest.TestCase):
             "p_enrichment": {
                 "greynoise_noise_advanced": {
                     "ClientIP": {
+                        "p_match": "142.93.204.250",
                         "actor": "unknown",
                         "bot": False,
                         "classification": "malicious",
@@ -379,6 +400,7 @@ class TestGreyNoiseAdvanced(unittest.TestCase):
                 "greynoise_noise_advanced": {
                     "p_any_ip_addresses": [
                         {
+                            "p_match": "142.93.204.250",
                             "actor": "unknown",
                             "bot": False,
                             "classification": "malicious",
@@ -411,6 +433,7 @@ class TestGreyNoiseAdvanced(unittest.TestCase):
                             "vpn_service": "N/A",
                         },
                         {
+                            "p_match": "100.93.204.250",
                             "actor": "stinky rat",
                             "bot": True,
                             "classification": "malicious",
@@ -678,6 +701,7 @@ class TestRIOTBasic(unittest.TestCase):
             "p_enrichment": {
                 "greynoise_riot_basic": {
                     "ClientIP": {
+                        "p_match": "142.93.204.250",
                         "ip_cidr": "142.93.204.250/32",
                         "provider": {"name": "foo"},
                         "scan_time": "2023-05-12 05:11:04.679962983",
@@ -753,6 +777,7 @@ class TestRIOTAdvanced(unittest.TestCase):
             "p_enrichment": {
                 "greynoise_riot_advanced": {
                     "ClientIP": {
+                        "p_match": "142.93.204.250",
                         "ip_cidr": "142.93.204.250/32",
                         "provider": {
                             "name": "foo",
@@ -774,6 +799,7 @@ class TestRIOTAdvanced(unittest.TestCase):
                 "greynoise_riot_advanced": {
                     "p_any_ip_addresses": [
                         {
+                            "p_match": "142.93.204.250",
                             "ip_cidr": "142.93.204.250/32",
                             "provider": {
                                 "name": "foo",
@@ -786,6 +812,7 @@ class TestRIOTAdvanced(unittest.TestCase):
                             "scan_time": "2023-05-12 05:11:04.679962983",
                         },
                         {
+                            "p_match": "142.93.204.128",
                             "ip_cidr": "142.93.204.128/32",
                             "provider": {
                                 "name": "bar",
@@ -919,6 +946,7 @@ class TestIpInfoHelpersLocation(unittest.TestCase):
             "p_enrichment": {
                 p_i_h.IPINFO_LOCATION_LUT_NAME: {
                     self.match_field: {
+                        "p_match": "12.12.12.12",
                         "city": "Constantinople",
                         "country": "Byzantium",
                         "lat": "41.008610",
@@ -989,6 +1017,7 @@ class TestIpInfoHelpersASN(unittest.TestCase):
             "p_enrichment": {
                 p_i_h.IPINFO_ASN_LUT_NAME: {
                     self.match_field: {
+                        "p_match": "1.2.3.15",
                         "asn": "AS00000",
                         "domain": "byzantineempire.com",
                         "name": "Byzantine Empire",
@@ -1103,6 +1132,7 @@ class TestIpInfoHelpersPrivacy(unittest.TestCase):
             "p_enrichment": {
                 p_i_h.IPINFO_PRIVACY_LUT_NAME: {
                     self.match_field: {
+                        "p_match": "1.2.3.4",
                         "hosting": False,
                         "proxy": False,
                         "tor": False,
@@ -1161,6 +1191,7 @@ class TestGeoInfoFromIP(unittest.TestCase):
             "p_enrichment": {
                 p_i_h.IPINFO_ASN_LUT_NAME: {
                     self.match_field: {
+                        "p_match": "1.2.3.12",
                         "asn": "AS00000",
                         "domain": "byzantineempire.com",
                         "name": "Byzantine Empire",
@@ -1170,6 +1201,7 @@ class TestGeoInfoFromIP(unittest.TestCase):
                 },
                 p_i_h.IPINFO_LOCATION_LUT_NAME: {
                     self.match_field: {
+                        "p_match": "2.2.2.2",
                         "city": "Constantinople",
                         "country": "Byzantium",
                         "lat": "41.008610",

--- a/global_helpers/panther_greynoise_helpers.py
+++ b/global_helpers/panther_greynoise_helpers.py
@@ -26,6 +26,7 @@ class PantherGreyNoiseException(Exception):
 
 class GreyNoiseBasic(LookupTableMatches):
     def __init__(self, event):
+        super().__init__()
         super()._register(event, "greynoise_noise_basic")
         self.sublevel = "basic"
 
@@ -76,6 +77,7 @@ class GreyNoiseBasic(LookupTableMatches):
 class GreyNoiseAdvanced(GreyNoiseBasic):
     # pylint: disable=W0231
     def __init__(self, event):
+        super().__init__(event)
         super()._register(event, "greynoise_noise_advanced")
         self.sublevel = "advanced"
 
@@ -183,6 +185,7 @@ class GreyNoiseAdvanced(GreyNoiseBasic):
 
 class GreyNoiseRIOTBasic(LookupTableMatches):
     def __init__(self, event):
+        super().__init__()
         super()._register(event, "greynoise_riot_basic")
         self.sublevel = "basic"
 

--- a/global_helpers/panther_ipinfo_helpers.py
+++ b/global_helpers/panther_ipinfo_helpers.py
@@ -16,6 +16,7 @@ class IPInfoLocation(LookupTableMatches):
     """Helper to get IPInfo location information for enriched fields"""
 
     def __init__(self, event):
+        super().__init__()
         super()._register(event, IPINFO_LOCATION_LUT_NAME)
 
     def city(self, match_field: str) -> Union[list[str], str]:
@@ -59,6 +60,7 @@ class IPInfoASN(LookupTableMatches):
     """Helper to get IPInfo ASN information for enriched fields"""
 
     def __init__(self, event):
+        super().__init__()
         super()._register(event, IPINFO_ASN_LUT_NAME)
 
     def asn(self, match_field: str) -> Union[list[str], str]:
@@ -90,6 +92,7 @@ class IPInfoPrivacy(LookupTableMatches):
     """Helper to get IPInfo Privacy information for enriched fields"""
 
     def __init__(self, event):
+        super().__init__()
         super()._register(event, IPINFO_PRIVACY_LUT_NAME)
 
     def hosting(self, match_field: str) -> bool or list:

--- a/global_helpers/panther_lookuptable_helpers.py
+++ b/global_helpers/panther_lookuptable_helpers.py
@@ -23,8 +23,8 @@ class LookupTableMatches:
                 if isinstance(en_values, list):
                     for val in en_values:
                         if deep_get(val, "p_match", default="") == p_match:
-                            matched_items[enrichment_type]= val
+                            matched_items[enrichment_type] = val
                 if isinstance(en_values, dict):
                     if deep_get(en_values, "p_match", default="") == p_match:
-                        matched_items[enrichment_type]= en_values
+                        matched_items[enrichment_type] = en_values
         return matched_items

--- a/global_helpers/panther_lookuptable_helpers.py
+++ b/global_helpers/panther_lookuptable_helpers.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from panther_base_helpers import deep_get
 
 ENRICHMENT_KEY = "p_enrichment"
@@ -18,34 +16,15 @@ class LookupTableMatches:
             return [deep_get(match_value, *keys) if match_value else None for match_value in match]
         return deep_get(match, *keys)
 
-    def enrichments_by_pmatch(self, event, p_match: str) -> List[dict]:
-        """
-        {
-          p_enrichment: {
-              tor_exit: {
-                  client_ip: {
-                      "p_match": 122
-                  },
-                  p_any_ip_addresses: [
-                    {
-                      "p_match": 2345
-                    },
-                    {
-                      "p_match": 5432
-                    },
-                  ]
-              }
-          }
-        }
-        """
-        matched_items = []
+    def enrichments_by_pmatch(self, event, p_match: str) -> dict:
+        matched_items = {}
         for enrichment_type in deep_get(event, ENRICHMENT_KEY, default={}).keys():
             for en_values in deep_get(event, ENRICHMENT_KEY, enrichment_type, default={}).values():
                 if isinstance(en_values, list):
                     for val in en_values:
                         if deep_get(val, "p_match", default="") == p_match:
-                            matched_items.append({enrichment_type: val})
+                            matched_items[enrichment_type]= val
                 if isinstance(en_values, dict):
                     if deep_get(en_values, "p_match", default="") == p_match:
-                        matched_items.append({enrichment_type: en_values})
+                        matched_items[enrichment_type]= en_values
         return matched_items

--- a/global_helpers/panther_lookuptable_helpers.py
+++ b/global_helpers/panther_lookuptable_helpers.py
@@ -1,11 +1,14 @@
+from typing import List
+
 from panther_base_helpers import deep_get
 
+ENRICHMENT_KEY = "p_enrichment"
 
 # pylint: disable=too-few-public-methods
 class LookupTableMatches:
     def _register(self, event, lookuptable_name: str):
         # pylint: disable=attribute-defined-outside-init
-        self.lut_matches = deep_get(event, "p_enrichment", lookuptable_name)
+        self.lut_matches = deep_get(event, ENRICHMENT_KEY, lookuptable_name)
 
     def _lookup(self, match_field: str, *keys) -> list or str:
         match = deep_get(self.lut_matches, match_field)
@@ -14,3 +17,35 @@ class LookupTableMatches:
         if isinstance(match, list):
             return [deep_get(match_value, *keys) if match_value else None for match_value in match]
         return deep_get(match, *keys)
+
+    def enrichments_by_pmatch(self, event, p_match: str) -> List[dict]:
+        """
+        {
+          p_enrichment: {
+              tor_exit: {
+                  client_ip: {
+                      "p_match": 122
+                  },
+                  p_any_ip_addresses: [
+                    {
+                      "p_match": 2345
+                    },
+                    {
+                      "p_match": 5432
+                    },
+                  ]
+              }
+          }
+        }
+        """
+        matched_items = []
+        for enrichment_type in deep_get(event, ENRICHMENT_KEY, default={}).keys():
+            for en_values in deep_get(event, ENRICHMENT_KEY, enrichment_type, default={}).values():
+                if isinstance(en_values, list):
+                    for val in en_values:
+                        if deep_get(val, "p_match", default="") == p_match:
+                            matched_items.append({enrichment_type: val})
+                if isinstance(en_values, dict):
+                    if deep_get(en_values, "p_match", default="") == p_match:
+                        matched_items.append({enrichment_type: en_values})
+        return matched_items

--- a/global_helpers/panther_lookuptable_helpers.py
+++ b/global_helpers/panther_lookuptable_helpers.py
@@ -4,8 +4,11 @@ ENRICHMENT_KEY = "p_enrichment"
 
 # pylint: disable=too-few-public-methods
 class LookupTableMatches:
+    def __init__(self):
+        self.lut_matches = None
+        self._p_matched = {}
+
     def _register(self, event, lookuptable_name: str):
-        # pylint: disable=attribute-defined-outside-init
         self.lut_matches = deep_get(event, ENRICHMENT_KEY, lookuptable_name)
 
     def _lookup(self, match_field: str, *keys) -> list or str:
@@ -16,15 +19,31 @@ class LookupTableMatches:
             return [deep_get(match_value, *keys) if match_value else None for match_value in match]
         return deep_get(match, *keys)
 
-    def enrichments_by_pmatch(self, event, p_match: str) -> dict:
+    @property
+    def p_matched(self):
+        return self._p_matched
+
+    def p_matches(self, event: dict, p_match: str = "") -> dict:
+        """Collect enrichments by searching for a value match in the p_match field
+
+        Parameters:
+        event (dict): the original log event, as passed to rule(event)
+        p_match (str): the value to match on in a p_match field
+
+        Returns:
+        dict: All enrichments that hold the searched value in the p_match field
+
+        """
+        event = event or {}
         matched_items = {}
         for lut_name in deep_get(event, ENRICHMENT_KEY, default={}).keys():
-            for en_values in deep_get(event, ENRICHMENT_KEY, enrichment_type, default={}).values():
+            for en_values in deep_get(event, ENRICHMENT_KEY, lut_name, default={}).values():
                 if isinstance(en_values, list):
                     for val in en_values:
                         if deep_get(val, "p_match", default="") == p_match:
-                            matched_items[enrichment_type] = val
+                            matched_items[lut_name] = val
                 if isinstance(en_values, dict):
                     if deep_get(en_values, "p_match", default="") == p_match:
-                        matched_items[enrichment_type] = en_values
+                        matched_items[lut_name] = en_values
+        self._p_matched = matched_items
         return matched_items

--- a/global_helpers/panther_lookuptable_helpers.py
+++ b/global_helpers/panther_lookuptable_helpers.py
@@ -18,7 +18,7 @@ class LookupTableMatches:
 
     def enrichments_by_pmatch(self, event, p_match: str) -> dict:
         matched_items = {}
-        for enrichment_type in deep_get(event, ENRICHMENT_KEY, default={}).keys():
+        for lut_name in deep_get(event, ENRICHMENT_KEY, default={}).keys():
             for en_values in deep_get(event, ENRICHMENT_KEY, enrichment_type, default={}).values():
                 if isinstance(en_values, list):
                     for val in en_values:

--- a/global_helpers/panther_tor_helpers.py
+++ b/global_helpers/panther_tor_helpers.py
@@ -5,6 +5,7 @@ from panther_lookuptable_helpers import LookupTableMatches
 
 class TorExitNodes(LookupTableMatches):
     def __init__(self, event):
+        super().__init__()
         super()._register(event, "tor_exit_nodes")
 
     def ip_address(self, match_field) -> list or str:


### PR DESCRIPTION
### Background

p_match has rolled out as part of enrichment, and that allows us to traverse enrichments by value.

### Changes

extends the base class for lookup tables to walk all lookup tables on the event, collecting matches based on p_match value

### Testing

added global helper unit tests
