### PR TITLE
fix: restore the has_exit_nodes() method to TorExitNodes class

### DIFF
--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -203,18 +203,21 @@ class TestTorExitNodes(unittest.TestCase):
         tor_exit_nodes = p_tor_h.TorExitNodes({})
         ip_address = tor_exit_nodes.ip_address("foo")
         self.assertEqual(ip_address, None)
+        self.assertEqual(tor_exit_nodes.has_exit_nodes(), False)
 
     def test_ip_address_found(self):
         """Should find enrichment"""
         tor_exit_nodes = p_tor_h.TorExitNodes(self.event)
         ip_address = tor_exit_nodes.ip_address("foo")
         self.assertEqual(ip_address, "1.2.3.4")
+        self.assertEqual(tor_exit_nodes.has_exit_nodes(), True)
 
     def test_ip_address_found_list(self):
         """Should find enrichment list"""
         tor_exit_nodes = p_tor_h.TorExitNodes(self.event_list)
         ip_address_list = tor_exit_nodes.ip_address("p_any_ip_addresses")
         self.assertEqual(ip_address_list, ["1.2.3.4", "1.2.3.5"])
+        self.assertEqual(tor_exit_nodes.has_exit_nodes(), True)
 
     def test_url(self):
         """url generation"""

--- a/global_helpers/panther_tor_helpers.py
+++ b/global_helpers/panther_tor_helpers.py
@@ -7,6 +7,9 @@ class TorExitNodes(LookupTableMatches):
     def __init__(self, event):
         super()._register(event, "tor_exit_nodes")
 
+    def has_exit_nodes(self):
+        return bool(self.lut_matches)
+
     def ip_address(self, match_field) -> list or str:
         """Enrich an ip address"""
         return self._lookup(match_field, "ip")


### PR DESCRIPTION
### Background
TorExitNodes.has_exit_nodes() method was recently lost. 

This PR adds unit tests covering the method and restores the method. This relates to #759 


### Changes



### Testing
```text
(panther-analysis) user@computer:~/Developer/PAN/panther-analysis $ make global-helpers-unit-test
pipenv run python global_helpers/*_test.py
.......................................................................................................................................
----------------------------------------------------------------------
Ran 135 tests in 0.596s

OK
```

