### PR TITLE
Add detection for user invitations to tenants and organizations

### DIFF
--- a/packs/auth0.yml
+++ b/packs/auth0.yml
@@ -5,6 +5,7 @@ PackDefinition:
   IDs:
     - Auth0.MFA.Policy.Disabled
     - Auth0.MFA.Risk.Assessment.Disabled
+    - Auth0.User.Invitation.Created
     # Globals used in these detections
     - panther_base_helpers
     - panther_auth0_helpers

--- a/packs/auth0.yml
+++ b/packs/auth0.yml
@@ -7,7 +7,6 @@ PackDefinition:
     - Auth0.MFA.Factor.Setting.Enabled
     - Auth0.MFA.Policy.Disabled
     - Auth0.MFA.Risk.Assessment.Disabled
-    - Auth0.MFA.Factor.Setting.Enabled
     - Auth0.User.Invitation.Created
     - Auth0.User.Joined.Tenant
     # Globals used in these detections

--- a/packs/auth0.yml
+++ b/packs/auth0.yml
@@ -5,8 +5,8 @@ PackDefinition:
   IDs:
     - Auth0.MFA.Policy.Disabled
     - Auth0.MFA.Risk.Assessment.Disabled
-    - Auth0.User.Invitation.Created
     - Auth0.MFA.Factor.Setting.Enabled
+    - Auth0.User.Invitation.Created
     - Auth0.User.Joined.Tenant
     # Globals used in these detections
     - panther_base_helpers

--- a/rules/auth0_rules/auth0_user_invitation_created.py
+++ b/rules/auth0_rules/auth0_user_invitation_created.py
@@ -1,0 +1,39 @@
+import re
+
+from global_filter_auth0 import filter_include_event
+from panther_auth0_helpers import auth0_alert_context, is_auth0_config_event
+from panther_base_helpers import deep_get
+
+org_re = re.compile(r"^/api/v2/organizations/[^/\s]+/invitations$")
+
+def rule(event):
+    if not filter_include_event(event) or not is_auth0_config_event(event):
+        return False
+    
+    return invitation_type(event) is not None
+
+def title(event):
+    inv_type = invitation_type(event)
+    if inv_type == "tenant":
+        invitee = deep_get(event, "data", "details", "request", "body", "owners")[0]
+    elif inv_type == "organization":
+        invitee = deep_get(event, "data", "details", "request", "body", "invitee", "email")
+    else:
+        raise Exception(f"Unexpected invitation type {inv_type}")
+
+    inviter = deep_get(event, "data", "details", "request", "auth", "user", "email")
+    source = deep_get(event, "p_source_label", default="unknown")
+    return f"Auth0 User [{inviter}] invited [{invitee}] to {inv_type.title()} [{source}]]"
+
+def invitation_type(event):
+    path = deep_get(event, "data", "details", "request", "path")
+
+    if path == "/api/v2/tenants/invitations":
+        return "tenant"
+    elif org_re.match(path):
+        return "organization"
+    
+    return None
+
+def alert_context(event):
+    return auth0_alert_context(event)

--- a/rules/auth0_rules/auth0_user_invitation_created.py
+++ b/rules/auth0_rules/auth0_user_invitation_created.py
@@ -8,10 +8,7 @@ org_re = re.compile(r"^/api/v2/organizations/[^/\s]+/invitations$")
 
 
 def rule(event):
-    if not any([
-       filter_include_event(event),
-       is_auth0_config_event(event)
-       ]):
+    if not any([filter_include_event(event), is_auth0_config_event(event)]):
         return False
 
     return invitation_type(event) is not None
@@ -29,7 +26,9 @@ def title(event):
     else:
         invitee = "<NO_INVITEE>"
 
-    inviter = deep_get(event, "data", "details", "request", "auth", "user", "email", default="<NO_INVITER>")
+    inviter = deep_get(
+        event, "data", "details", "request", "auth", "user", "email", default="<NO_INVITER>"
+    )
     source = deep_get(event, "p_source_label", default="<NO_PSOURCE>")
     return f"Auth0 User [{inviter}] invited [{invitee}] to {inv_type.title()} [{source}]]"
 

--- a/rules/auth0_rules/auth0_user_invitation_created.py
+++ b/rules/auth0_rules/auth0_user_invitation_created.py
@@ -20,11 +20,15 @@ def rule(event):
 def title(event):
     inv_type = invitation_type(event)
     if inv_type == "tenant":
-        invitee = deep_get(event, "data", "details", "request", "body", "owners")[0]
+        invitees = deep_get(event, "data", "details", "request", "body", "owners", default=[])
+        if not invitees:
+            invitee = "<NO_INVITEE>"
+        else:
+            invitee = invitees[0]
     elif inv_type == "organization":
         invitee = deep_get(event, "data", "details", "request", "body", "invitee", "email")
     else:
-        raise Exception(f"Unexpected invitation type {inv_type}")
+        invitee = "<NO_INVITEE>"
 
     inviter = deep_get(event, "data", "details", "request", "auth", "user", "email", default="<NO_INVITER>")
     source = deep_get(event, "p_source_label", default="<NO_PSOURCE>")

--- a/rules/auth0_rules/auth0_user_invitation_created.py
+++ b/rules/auth0_rules/auth0_user_invitation_created.py
@@ -8,7 +8,10 @@ org_re = re.compile(r"^/api/v2/organizations/[^/\s]+/invitations$")
 
 
 def rule(event):
-    if not filter_include_event(event) or not is_auth0_config_event(event):
+    if not any([
+       filter_include_event(event),
+       is_auth0_config_event(event)
+       ]):
         return False
 
     return invitation_type(event) is not None
@@ -23,13 +26,13 @@ def title(event):
     else:
         raise Exception(f"Unexpected invitation type {inv_type}")
 
-    inviter = deep_get(event, "data", "details", "request", "auth", "user", "email")
-    source = deep_get(event, "p_source_label", default="unknown")
+    inviter = deep_get(event, "data", "details", "request", "auth", "user", "email", default="<NO_INVITER>")
+    source = deep_get(event, "p_source_label", default="<NO_PSOURCE>")
     return f"Auth0 User [{inviter}] invited [{invitee}] to {inv_type.title()} [{source}]]"
 
 
 def invitation_type(event):
-    path = deep_get(event, "data", "details", "request", "path")
+    path = deep_get(event, "data", "details", "request", "path", default="")
 
     if path == "/api/v2/tenants/invitations":
         return "tenant"

--- a/rules/auth0_rules/auth0_user_invitation_created.py
+++ b/rules/auth0_rules/auth0_user_invitation_created.py
@@ -20,11 +20,10 @@ def rule(event):
 def title(event):
     inv_type = invitation_type(event)
     if inv_type == "tenant":
-        invitees = deep_get(event, "data", "details", "request", "body", "owners", default=[])
-        if not invitees:
+        try:
+            invitee = deep_get(event, "data", "details", "request", "body", "owners", default=[])[0]
+        except IndexError:
             invitee = "<NO_INVITEE>"
-        else:
-            invitee = invitees[0]
     elif inv_type == "organization":
         invitee = deep_get(event, "data", "details", "request", "body", "invitee", "email")
     else:

--- a/rules/auth0_rules/auth0_user_invitation_created.py
+++ b/rules/auth0_rules/auth0_user_invitation_created.py
@@ -6,11 +6,13 @@ from panther_base_helpers import deep_get
 
 org_re = re.compile(r"^/api/v2/organizations/[^/\s]+/invitations$")
 
+
 def rule(event):
     if not filter_include_event(event) or not is_auth0_config_event(event):
         return False
-    
+
     return invitation_type(event) is not None
+
 
 def title(event):
     inv_type = invitation_type(event)
@@ -25,15 +27,17 @@ def title(event):
     source = deep_get(event, "p_source_label", default="unknown")
     return f"Auth0 User [{inviter}] invited [{invitee}] to {inv_type.title()} [{source}]]"
 
+
 def invitation_type(event):
     path = deep_get(event, "data", "details", "request", "path")
 
     if path == "/api/v2/tenants/invitations":
         return "tenant"
-    elif org_re.match(path):
+    if org_re.match(path):
         return "organization"
-    
+
     return None
+
 
 def alert_context(event):
     return auth0_alert_context(event)

--- a/rules/auth0_rules/auth0_user_invitation_created.yml
+++ b/rules/auth0_rules/auth0_user_invitation_created.yml
@@ -60,7 +60,7 @@ Tests:
         p_row_id: e20ac28001d19ac6df97b99618d4a207
         p_schema_version: 0
         p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
-        p_source_label: Org Auth0 Tenant Label
+        p_source_label: Auth0 Org Label
       Name: Test-org
     - ExpectedResult: false
       Log:
@@ -118,7 +118,7 @@ Tests:
         p_row_id: e20ac28001d19ac6df97b99618d4a207
         p_schema_version: 0
         p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
-        p_source_label: Org Auth0 Tenant Label
+        p_source_label: Auth0 Tenant Label
       Name: Test-org-regex-fail
     - ExpectedResult: false
       Log:
@@ -492,7 +492,7 @@ Tests:
         p_row_id: e20ac28001d19ac6df97b99618d4a207
         p_schema_version: 0
         p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
-        p_source_label: Org Auth0 Tenant Label
+        p_source_label: Auth0 Tenant Label
       Name: Test-tenant
 DedupPeriodMinutes: 60
 LogTypes:

--- a/rules/auth0_rules/auth0_user_invitation_created.yml
+++ b/rules/auth0_rules/auth0_user_invitation_created.yml
@@ -1,0 +1,501 @@
+AnalysisType: rule
+DisplayName: "Auth0 User Invitation Created"
+Enabled: true
+Filename: auth0_user_invitation_created.py
+Severity: Info
+Tests:
+    - ExpectedResult: true
+      Log:
+        data:
+            _id: "90020230616045255729813000000000000001223372038324184656"
+            client_id: 6xNLmMWZMYvMO3ZjQoN8siUWAbg3pnpA
+            client_name: ""
+            date: "2023-06-16T04:52:50.663Z"
+            description: Create invitations to organization
+            details:
+                request:
+                    auth:
+                        credentials:
+                            jti: 81a67a5a3b2c4fb5cc2fcf38349456dd
+                        strategy: jwt
+                        user:
+                            email: bob@panther.com
+                            name: Bob
+                            user_id: google-oauth2|115547599209686809398
+                    body:
+                        client_id: KwJItGFu62zryEc4c8t5BQuwB1qdeDFa
+                        invitee:
+                            email: larry@example.com
+                        inviter:
+                            name: Larry Jones
+                    channel: https://manage.auth0.com/
+                    ip: 123.123.123.123
+                    method: post
+                    path: /api/v2/organizations/org_tFmw9RlOUjoSkOf1/invitations
+                    query: {}
+                    userAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36
+                response:
+                    body:
+                        client_id: KwJItGFu62zryEc4c8t5BQuwB1qdeDFa
+                        id: uinv_DeLuEdgf3hjxRd0z
+                        invitee:
+                            email: frank@example.com
+                        inviter:
+                            name: Bob Jones
+                    statusCode: 201
+            id: "90020230616045255729813000000000000001223372038324184656"
+            ip: 123.123.123.123
+            isMobile: false
+            log_id: "90020230616045255729813000000000000001223372038324184656"
+            type: sapi
+            user_agent: Chrome 114.0.0 / Mac OS X 10.15.7
+            user_id: google-oauth2|115547599209686809398
+        p_any_ip_addresses:
+            - 12.12.12.12
+        p_any_usernames:
+            - auth0|6459776e974703f3a65dc258
+        p_event_time: "2023-05-15 16:13:53.609"
+        p_log_type: Auth0.Events
+        p_parse_time: "2023-05-15 16:15:28.555"
+        p_row_id: e20ac28001d19ac6df97b99618d4a207
+        p_schema_version: 0
+        p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+        p_source_label: Org Auth0 Tenant Label
+      Name: Test-org
+    - ExpectedResult: false
+      Log:
+        data:
+            _id: "90020230616045255729813000000000000001223372038324184656"
+            client_id: 6xNLmMWZMYvMO3ZjQoN8siUWAbg3pnpA
+            client_name: ""
+            date: "2023-06-16T04:52:50.663Z"
+            description: Create invitations to organization
+            details:
+                request:
+                    auth:
+                        credentials:
+                            jti: 81a67a5a3b2c4fb5cc2fcf38349456dd
+                        strategy: jwt
+                        user:
+                            email: bob@panther.com
+                            name: Bob
+                            user_id: google-oauth2|115547599209686809398
+                    body:
+                        client_id: KwJItGFu62zryEc4c8t5BQuwB1qdeDFa
+                        invitee:
+                            email: larry@example.com
+                        inviter:
+                            name: Larry Jones
+                    channel: https://manage.auth0.com/
+                    ip: 123.123.123.123
+                    method: post
+                    path: /api/v2/organizations/more/org_tFmw9RlOUjoSkOf1/invitations
+                    query: {}
+                    userAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36
+                response:
+                    body:
+                        client_id: KwJItGFu62zryEc4c8t5BQuwB1qdeDFa
+                        id: uinv_DeLuEdgf3hjxRd0z
+                        invitee:
+                            email: frank@example.com
+                        inviter:
+                            name: Bob Jones
+                    statusCode: 201
+            id: "90020230616045255729813000000000000001223372038324184656"
+            ip: 35.167.74.121
+            isMobile: false
+            log_id: "90020230616045255729813000000000000001223372038324184656"
+            type: sapi
+            user_agent: Chrome 114.0.0 / Mac OS X 10.15.7
+            user_id: google-oauth2|115547599209686809398
+        p_any_ip_addresses:
+            - 12.12.12.12
+        p_any_usernames:
+            - auth0|6459776e974703f3a65dc258
+        p_event_time: "2023-05-15 16:13:53.609"
+        p_log_type: Auth0.Events
+        p_parse_time: "2023-05-15 16:15:28.555"
+        p_row_id: e20ac28001d19ac6df97b99618d4a207
+        p_schema_version: 0
+        p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+        p_source_label: Org Auth0 Tenant Label
+      Name: Test-org-regex-fail
+    - ExpectedResult: false
+      Log:
+        data:
+            client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+            client_name: ""
+            date: "2023-05-15 16:13:53.609000000"
+            description: Create tenant invitations for a given client
+            details:
+                request:
+                    auth:
+                        credentials:
+                            jti: dc1843dbe925a1ed2e707452c2123913
+                            scopes:
+                                - create:actions
+                                - create:actions_log_sessions
+                                - create:authentication_methods
+                                - create:client_credentials
+                                - create:client_grants
+                                - create:clients
+                                - create:connections
+                                - create:custom_domains
+                                - create:email_provider
+                                - create:email_templates
+                                - create:guardian_enrollment_tickets
+                                - create:integrations
+                                - create:log_streams
+                                - create:organization_connections
+                                - create:organization_invitations
+                                - create:organization_member_roles
+                                - create:organization_members
+                                - create:organizations
+                                - create:requested_scopes
+                                - create:resource_servers
+                                - create:roles
+                                - create:rules
+                                - create:shields
+                                - create:signing_keys
+                                - create:tenant_invitations
+                                - create:test_email_dispatch
+                                - create:users
+                                - delete:actions
+                                - delete:anomaly_blocks
+                                - delete:authentication_methods
+                                - delete:branding
+                                - delete:client_credentials
+                                - delete:client_grants
+                                - delete:clients
+                                - delete:connections
+                                - delete:custom_domains
+                                - delete:device_credentials
+                                - delete:email_provider
+                                - delete:email_templates
+                                - delete:grants
+                                - delete:guardian_enrollments
+                                - delete:integrations
+                                - delete:log_streams
+                                - delete:organization_connections
+                                - delete:organization_invitations
+                                - delete:organization_member_roles
+                                - delete:organization_members
+                                - delete:organizations
+                                - delete:owners
+                                - delete:requested_scopes
+                                - delete:resource_servers
+                                - delete:roles
+                                - delete:rules
+                                - delete:rules_configs
+                                - delete:shields
+                                - delete:tenant_invitations
+                                - delete:tenant_members
+                                - delete:tenants
+                                - delete:users
+                                - read:actions
+                                - read:anomaly_blocks
+                                - read:attack_protection
+                                - read:authentication_methods
+                                - read:branding
+                                - read:checks
+                                - read:client_credentials
+                                - read:client_grants
+                                - read:client_keys
+                                - read:clients
+                                - read:connections
+                                - read:custom_domains
+                                - read:device_credentials
+                                - read:email_provider
+                                - read:email_templates
+                                - read:email_triggers
+                                - read:entity_counts
+                                - read:grants
+                                - read:guardian_factors
+                                - read:insights
+                                - read:integrations
+                                - read:log_streams
+                                - read:logs
+                                - read:mfa_policies
+                                - read:organization_connections
+                                - read:organization_invitations
+                                - read:organization_member_roles
+                                - read:organization_members
+                                - read:organizations
+                                - read:prompts
+                                - read:requested_scopes
+                                - read:resource_servers
+                                - read:roles
+                                - read:rules
+                                - read:rules_configs
+                                - read:shields
+                                - read:signing_keys
+                                - read:stats
+                                - read:tenant_invitations
+                                - read:tenant_members
+                                - read:tenant_settings
+                                - read:triggers
+                                - read:users
+                                - run:checks
+                                - update:actions
+                                - update:attack_protection
+                                - update:authentication_methods
+                                - update:branding
+                                - update:client_credentials
+                                - update:client_grants
+                                - update:client_keys
+                                - update:clients
+                                - update:connections
+                                - update:custom_domains
+                                - update:email_provider
+                                - update:email_templates
+                                - update:email_triggers
+                                - update:guardian_factors
+                                - update:integrations
+                                - update:log_streams
+                                - update:mfa_policies
+                                - update:organization_connections
+                                - update:organizations
+                                - update:prompts
+                                - update:requested_scopes
+                                - update:resource_servers
+                                - update:roles
+                                - update:rules
+                                - update:rules_configs
+                                - update:shields
+                                - update:signing_keys
+                                - update:tenant_members
+                                - update:tenant_settings
+                                - update:triggers
+                                - update:users
+                        strategy: jwt
+                        user:
+                            email: homer.simpson@yourcompany.io
+                            name: homer.simpson@yourcompany.io
+                            user_id: auth0|6459776e974703f3a65dc258
+                    body:
+                        owners:
+                            - marge.simpson@yourcompany.io
+                        roles:
+                            - owner
+                    channel: https://manage.auth0.com/
+                    ip: 12.12.12.12
+                    method: post
+                    path: /api/v2/some-other-endpoint
+                    query: {}
+                    userAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36
+                response:
+                    body:
+                        - email: marge.simpson@yourcompany.io
+                          expires_at: "2023-05-18T16:13:53.600Z"
+                          invitation_id: inv_TEyzbreI336AHrfU
+                    statusCode: 201
+            ip: 12.12.12.12
+            log_id: "90020230515161358744602000000000000001223372037485092159"
+            type: sapi
+            user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36
+            user_id: auth0|6459776e974703f3a65dc258
+        log_id: "90020230515161358744602000000000000001223372037485092159"
+        p_any_ip_addresses:
+            - 12.12.12.12
+        p_any_usernames:
+            - auth0|6459776e974703f3a65dc258
+        p_event_time: "2023-05-15 16:13:53.609"
+        p_log_type: Auth0.Events
+        p_parse_time: "2023-05-15 16:15:28.555"
+        p_row_id: e20ac28001d19ac6df97b99618d4a207
+        p_schema_version: 0
+        p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+        p_source_label: Org Auth0 Tenant Label
+      Name: Test-other-endpoint
+    - ExpectedResult: true
+      Log:
+        data:
+            client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+            client_name: ""
+            date: "2023-05-15 16:13:53.609000000"
+            description: Create tenant invitations for a given client
+            details:
+                request:
+                    auth:
+                        credentials:
+                            jti: dc1843dbe925a1ed2e707452c2123913
+                            scopes:
+                                - create:actions
+                                - create:actions_log_sessions
+                                - create:authentication_methods
+                                - create:client_credentials
+                                - create:client_grants
+                                - create:clients
+                                - create:connections
+                                - create:custom_domains
+                                - create:email_provider
+                                - create:email_templates
+                                - create:guardian_enrollment_tickets
+                                - create:integrations
+                                - create:log_streams
+                                - create:organization_connections
+                                - create:organization_invitations
+                                - create:organization_member_roles
+                                - create:organization_members
+                                - create:organizations
+                                - create:requested_scopes
+                                - create:resource_servers
+                                - create:roles
+                                - create:rules
+                                - create:shields
+                                - create:signing_keys
+                                - create:tenant_invitations
+                                - create:test_email_dispatch
+                                - create:users
+                                - delete:actions
+                                - delete:anomaly_blocks
+                                - delete:authentication_methods
+                                - delete:branding
+                                - delete:client_credentials
+                                - delete:client_grants
+                                - delete:clients
+                                - delete:connections
+                                - delete:custom_domains
+                                - delete:device_credentials
+                                - delete:email_provider
+                                - delete:email_templates
+                                - delete:grants
+                                - delete:guardian_enrollments
+                                - delete:integrations
+                                - delete:log_streams
+                                - delete:organization_connections
+                                - delete:organization_invitations
+                                - delete:organization_member_roles
+                                - delete:organization_members
+                                - delete:organizations
+                                - delete:owners
+                                - delete:requested_scopes
+                                - delete:resource_servers
+                                - delete:roles
+                                - delete:rules
+                                - delete:rules_configs
+                                - delete:shields
+                                - delete:tenant_invitations
+                                - delete:tenant_members
+                                - delete:tenants
+                                - delete:users
+                                - read:actions
+                                - read:anomaly_blocks
+                                - read:attack_protection
+                                - read:authentication_methods
+                                - read:branding
+                                - read:checks
+                                - read:client_credentials
+                                - read:client_grants
+                                - read:client_keys
+                                - read:clients
+                                - read:connections
+                                - read:custom_domains
+                                - read:device_credentials
+                                - read:email_provider
+                                - read:email_templates
+                                - read:email_triggers
+                                - read:entity_counts
+                                - read:grants
+                                - read:guardian_factors
+                                - read:insights
+                                - read:integrations
+                                - read:log_streams
+                                - read:logs
+                                - read:mfa_policies
+                                - read:organization_connections
+                                - read:organization_invitations
+                                - read:organization_member_roles
+                                - read:organization_members
+                                - read:organizations
+                                - read:prompts
+                                - read:requested_scopes
+                                - read:resource_servers
+                                - read:roles
+                                - read:rules
+                                - read:rules_configs
+                                - read:shields
+                                - read:signing_keys
+                                - read:stats
+                                - read:tenant_invitations
+                                - read:tenant_members
+                                - read:tenant_settings
+                                - read:triggers
+                                - read:users
+                                - run:checks
+                                - update:actions
+                                - update:attack_protection
+                                - update:authentication_methods
+                                - update:branding
+                                - update:client_credentials
+                                - update:client_grants
+                                - update:client_keys
+                                - update:clients
+                                - update:connections
+                                - update:custom_domains
+                                - update:email_provider
+                                - update:email_templates
+                                - update:email_triggers
+                                - update:guardian_factors
+                                - update:integrations
+                                - update:log_streams
+                                - update:mfa_policies
+                                - update:organization_connections
+                                - update:organizations
+                                - update:prompts
+                                - update:requested_scopes
+                                - update:resource_servers
+                                - update:roles
+                                - update:rules
+                                - update:rules_configs
+                                - update:shields
+                                - update:signing_keys
+                                - update:tenant_members
+                                - update:tenant_settings
+                                - update:triggers
+                                - update:users
+                        strategy: jwt
+                        user:
+                            email: homer.simpson@yourcompany.io
+                            name: homer.simpson@yourcompany.io
+                            user_id: auth0|6459776e974703f3a65dc258
+                    body:
+                        owners:
+                            - marge.simpson@yourcompany.io
+                        roles:
+                            - owner
+                    channel: https://manage.auth0.com/
+                    ip: 12.12.12.12
+                    method: post
+                    path: /api/v2/tenants/invitations
+                    query: {}
+                    userAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36
+                response:
+                    body:
+                        - email: marge.simpson@yourcompany.io
+                          expires_at: "2023-05-18T16:13:53.600Z"
+                          invitation_id: inv_TEyzbreI336AHrfU
+                    statusCode: 201
+            ip: 12.12.12.12
+            log_id: "90020230515161358744602000000000000001223372037485092159"
+            type: sapi
+            user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36
+            user_id: auth0|6459776e974703f3a65dc258
+        log_id: "90020230515161358744602000000000000001223372037485092159"
+        p_any_ip_addresses:
+            - 12.12.12.12
+        p_any_usernames:
+            - auth0|6459776e974703f3a65dc258
+        p_event_time: "2023-05-15 16:13:53.609"
+        p_log_type: Auth0.Events
+        p_parse_time: "2023-05-15 16:15:28.555"
+        p_row_id: e20ac28001d19ac6df97b99618d4a207
+        p_schema_version: 0
+        p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+        p_source_label: Org Auth0 Tenant Label
+      Name: Test-tenant
+DedupPeriodMinutes: 60
+LogTypes:
+    - Auth0.Events
+RuleID: "Auth0.User.Invitation.Created"
+Threshold: 1

--- a/rules/auth0_rules/auth0_user_invitation_created.yml
+++ b/rules/auth0_rules/auth0_user_invitation_created.yml
@@ -135,138 +135,6 @@ Tests:
                             scopes:
                                 - create:actions
                                 - create:actions_log_sessions
-                                - create:authentication_methods
-                                - create:client_credentials
-                                - create:client_grants
-                                - create:clients
-                                - create:connections
-                                - create:custom_domains
-                                - create:email_provider
-                                - create:email_templates
-                                - create:guardian_enrollment_tickets
-                                - create:integrations
-                                - create:log_streams
-                                - create:organization_connections
-                                - create:organization_invitations
-                                - create:organization_member_roles
-                                - create:organization_members
-                                - create:organizations
-                                - create:requested_scopes
-                                - create:resource_servers
-                                - create:roles
-                                - create:rules
-                                - create:shields
-                                - create:signing_keys
-                                - create:tenant_invitations
-                                - create:test_email_dispatch
-                                - create:users
-                                - delete:actions
-                                - delete:anomaly_blocks
-                                - delete:authentication_methods
-                                - delete:branding
-                                - delete:client_credentials
-                                - delete:client_grants
-                                - delete:clients
-                                - delete:connections
-                                - delete:custom_domains
-                                - delete:device_credentials
-                                - delete:email_provider
-                                - delete:email_templates
-                                - delete:grants
-                                - delete:guardian_enrollments
-                                - delete:integrations
-                                - delete:log_streams
-                                - delete:organization_connections
-                                - delete:organization_invitations
-                                - delete:organization_member_roles
-                                - delete:organization_members
-                                - delete:organizations
-                                - delete:owners
-                                - delete:requested_scopes
-                                - delete:resource_servers
-                                - delete:roles
-                                - delete:rules
-                                - delete:rules_configs
-                                - delete:shields
-                                - delete:tenant_invitations
-                                - delete:tenant_members
-                                - delete:tenants
-                                - delete:users
-                                - read:actions
-                                - read:anomaly_blocks
-                                - read:attack_protection
-                                - read:authentication_methods
-                                - read:branding
-                                - read:checks
-                                - read:client_credentials
-                                - read:client_grants
-                                - read:client_keys
-                                - read:clients
-                                - read:connections
-                                - read:custom_domains
-                                - read:device_credentials
-                                - read:email_provider
-                                - read:email_templates
-                                - read:email_triggers
-                                - read:entity_counts
-                                - read:grants
-                                - read:guardian_factors
-                                - read:insights
-                                - read:integrations
-                                - read:log_streams
-                                - read:logs
-                                - read:mfa_policies
-                                - read:organization_connections
-                                - read:organization_invitations
-                                - read:organization_member_roles
-                                - read:organization_members
-                                - read:organizations
-                                - read:prompts
-                                - read:requested_scopes
-                                - read:resource_servers
-                                - read:roles
-                                - read:rules
-                                - read:rules_configs
-                                - read:shields
-                                - read:signing_keys
-                                - read:stats
-                                - read:tenant_invitations
-                                - read:tenant_members
-                                - read:tenant_settings
-                                - read:triggers
-                                - read:users
-                                - run:checks
-                                - update:actions
-                                - update:attack_protection
-                                - update:authentication_methods
-                                - update:branding
-                                - update:client_credentials
-                                - update:client_grants
-                                - update:client_keys
-                                - update:clients
-                                - update:connections
-                                - update:custom_domains
-                                - update:email_provider
-                                - update:email_templates
-                                - update:email_triggers
-                                - update:guardian_factors
-                                - update:integrations
-                                - update:log_streams
-                                - update:mfa_policies
-                                - update:organization_connections
-                                - update:organizations
-                                - update:prompts
-                                - update:requested_scopes
-                                - update:resource_servers
-                                - update:roles
-                                - update:rules
-                                - update:rules_configs
-                                - update:shields
-                                - update:signing_keys
-                                - update:tenant_members
-                                - update:tenant_settings
-                                - update:triggers
-                                - update:users
                         strategy: jwt
                         user:
                             email: homer.simpson@yourcompany.io
@@ -322,138 +190,57 @@ Tests:
                             scopes:
                                 - create:actions
                                 - create:actions_log_sessions
-                                - create:authentication_methods
-                                - create:client_credentials
-                                - create:client_grants
-                                - create:clients
-                                - create:connections
-                                - create:custom_domains
-                                - create:email_provider
-                                - create:email_templates
-                                - create:guardian_enrollment_tickets
-                                - create:integrations
-                                - create:log_streams
-                                - create:organization_connections
-                                - create:organization_invitations
-                                - create:organization_member_roles
-                                - create:organization_members
-                                - create:organizations
-                                - create:requested_scopes
-                                - create:resource_servers
-                                - create:roles
-                                - create:rules
-                                - create:shields
-                                - create:signing_keys
-                                - create:tenant_invitations
-                                - create:test_email_dispatch
-                                - create:users
-                                - delete:actions
-                                - delete:anomaly_blocks
-                                - delete:authentication_methods
-                                - delete:branding
-                                - delete:client_credentials
-                                - delete:client_grants
-                                - delete:clients
-                                - delete:connections
-                                - delete:custom_domains
-                                - delete:device_credentials
-                                - delete:email_provider
-                                - delete:email_templates
-                                - delete:grants
-                                - delete:guardian_enrollments
-                                - delete:integrations
-                                - delete:log_streams
-                                - delete:organization_connections
-                                - delete:organization_invitations
-                                - delete:organization_member_roles
-                                - delete:organization_members
-                                - delete:organizations
-                                - delete:owners
-                                - delete:requested_scopes
-                                - delete:resource_servers
-                                - delete:roles
-                                - delete:rules
-                                - delete:rules_configs
-                                - delete:shields
-                                - delete:tenant_invitations
-                                - delete:tenant_members
-                                - delete:tenants
-                                - delete:users
-                                - read:actions
-                                - read:anomaly_blocks
-                                - read:attack_protection
-                                - read:authentication_methods
-                                - read:branding
-                                - read:checks
-                                - read:client_credentials
-                                - read:client_grants
-                                - read:client_keys
-                                - read:clients
-                                - read:connections
-                                - read:custom_domains
-                                - read:device_credentials
-                                - read:email_provider
-                                - read:email_templates
-                                - read:email_triggers
-                                - read:entity_counts
-                                - read:grants
-                                - read:guardian_factors
-                                - read:insights
-                                - read:integrations
-                                - read:log_streams
-                                - read:logs
-                                - read:mfa_policies
-                                - read:organization_connections
-                                - read:organization_invitations
-                                - read:organization_member_roles
-                                - read:organization_members
-                                - read:organizations
-                                - read:prompts
-                                - read:requested_scopes
-                                - read:resource_servers
-                                - read:roles
-                                - read:rules
-                                - read:rules_configs
-                                - read:shields
-                                - read:signing_keys
-                                - read:stats
-                                - read:tenant_invitations
-                                - read:tenant_members
-                                - read:tenant_settings
-                                - read:triggers
-                                - read:users
-                                - run:checks
-                                - update:actions
-                                - update:attack_protection
-                                - update:authentication_methods
-                                - update:branding
-                                - update:client_credentials
-                                - update:client_grants
-                                - update:client_keys
-                                - update:clients
-                                - update:connections
-                                - update:custom_domains
-                                - update:email_provider
-                                - update:email_templates
-                                - update:email_triggers
-                                - update:guardian_factors
-                                - update:integrations
-                                - update:log_streams
-                                - update:mfa_policies
-                                - update:organization_connections
-                                - update:organizations
-                                - update:prompts
-                                - update:requested_scopes
-                                - update:resource_servers
-                                - update:roles
-                                - update:rules
-                                - update:rules_configs
-                                - update:shields
-                                - update:signing_keys
-                                - update:tenant_members
-                                - update:tenant_settings
-                                - update:triggers
-                                - update:users
+                        strategy: jwt
+                        user:
+                            email: homer.simpson@yourcompany.io
+                            name: homer.simpson@yourcompany.io
+                            user_id: auth0|6459776e974703f3a65dc258
+                    body:
+                    channel: https://manage.auth0.com/
+                    ip: 12.12.12.12
+                    method: post
+                    path: /api/v2/tenants/invitations
+                    query: {}
+                    userAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36
+                response:
+                    body:
+                        - email: marge.simpson@yourcompany.io
+                          expires_at: "2023-05-18T16:13:53.600Z"
+                          invitation_id: inv_TEyzbreI336AHrfU
+                    statusCode: 201
+            ip: 12.12.12.12
+            log_id: "90020230515161358744602000000000000001223372037485092159"
+            type: sapi
+            user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36
+            user_id: auth0|6459776e974703f3a65dc258
+        log_id: "90020230515161358744602000000000000001223372037485092159"
+        p_any_ip_addresses:
+            - 12.12.12.12
+        p_any_usernames:
+            - auth0|6459776e974703f3a65dc258
+        p_event_time: "2023-05-15 16:13:53.609"
+        p_log_type: Auth0.Events
+        p_parse_time: "2023-05-15 16:15:28.555"
+        p_row_id: e20ac28001d19ac6df97b99618d4a207
+        p_schema_version: 0
+        p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+        p_source_label: Auth0 Tenant Label
+      Name: Test-no-invitee
+    - ExpectedResult: true
+      Log:
+        data:
+            client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+            client_name: ""
+            date: "2023-05-15 16:13:53.609000000"
+            description: Create tenant invitations for a given client
+            details:
+                request:
+                    auth:
+                        credentials:
+                            jti: dc1843dbe925a1ed2e707452c2123913
+                            scopes:
+                                - create:actions
+                                - create:actions_log_sessions
                         strategy: jwt
                         user:
                             email: homer.simpson@yourcompany.io


### PR DESCRIPTION
### Background

Adds  Auth0 user invitation detection for both Tenants and Organizations.

### Changes

* add `auth0_user_invitation_created.py` and `auth0_user_invitation_created.yml`
* update `auth0.yml`

### Testing

Unit test results:

```
Auth0.User.Invitation.Created
	[PASS] Test-org
		[PASS] [rule] true
		[PASS] [title] Auth0 User [bob@panther.com] invited [larry@example.com] to Organization [Auth0 Org Label]]
		[PASS] [dedup] Auth0 User [bob@panther.com] invited [larry@example.com] to Organization [Auth0 Org Label]]
		[PASS] [alertContext] {"actor": {"email": "bob@panther.com", "name": "Bob", "user_id": "google-oauth2|115547599209686809398"}, "action": "Create invitations to organization"}
	[PASS] Test-org-regex-fail
		[PASS] [rule] false
	[PASS] Test-other-endpoint
		[PASS] [rule] false
	[PASS] Test-no-invitee
		[PASS] [rule] true
		[PASS] [title] Auth0 User [homer.simpson@yourcompany.io] invited [<NO_INVITEE>] to Tenant [Auth0 Tenant Label]]
		[PASS] [dedup] Auth0 User [homer.simpson@yourcompany.io] invited [<NO_INVITEE>] to Tenant [Auth0 Tenant Label]]
		[PASS] [alertContext] {"actor": {"email": "homer.simpson@yourcompany.io", "name": "homer.simpson@yourcompany.io", "user_id": "auth0|6459776e974703f3a65dc258"}, "action": "Create tenant invitations for a given client"}
	[PASS] Test-tenant
		[PASS] [rule] true
		[PASS] [title] Auth0 User [homer.simpson@yourcompany.io] invited [marge.simpson@yourcompany.io] to Tenant [Auth0 Tenant Label]]
		[PASS] [dedup] Auth0 User [homer.simpson@yourcompany.io] invited [marge.simpson@yourcompany.io] to Tenant [Auth0 Tenant Label]]
		[PASS] [alertContext] {"actor": {"email": "homer.simpson@yourcompany.io", "name": "homer.simpson@yourcompany.io", "user_id": "auth0|6459776e974703f3a65dc258"}, "action": "Create tenant invitations for a given client"}
```

I'll be attempting real integration testing and will follow up.
