### PR TITLE
Add Auth0 MFA Risk Assessment Enabled

### DIFF
--- a/packs/auth0.yml
+++ b/packs/auth0.yml
@@ -7,6 +7,7 @@ PackDefinition:
     - Auth0.MFA.Factor.Setting.Enabled
     - Auth0.MFA.Policy.Disabled
     - Auth0.MFA.Risk.Assessment.Disabled
+    - Auth0.MFA.Risk.Assessment.Enabled
     - Auth0.User.Invitation.Created
     - Auth0.User.Joined.Tenant
     # Globals used in these detections

--- a/rules/auth0_rules/auth0_mfa_risk_assessment_enabled.py
+++ b/rules/auth0_rules/auth0_mfa_risk_assessment_enabled.py
@@ -1,0 +1,38 @@
+from global_filter_auth0 import filter_include_event
+from panther_auth0_helpers import auth0_alert_context, is_auth0_config_event
+from panther_base_helpers import deep_get
+
+
+def rule(event):
+    if not filter_include_event(event):
+        return False
+    data_description = deep_get(event, "data", "description", default="<NO_DATA_DESCRIPTION_FOUND>")
+    request_path = deep_get(
+        event, "data", "details", "request", "path", default="<NO_REQUEST_PATH_FOUND>"
+    )
+    request_body = deep_get(
+        event, "data", "details", "request", "body", "AfterAuthentication", default=[]
+    )
+    return all(
+        [
+            data_description == "Updates risk assessment configs",
+            request_path == "/api/v2/risk-assessment/config",
+            request_body is True,
+            is_auth0_config_event(event),
+        ]
+    )
+
+
+def title(event):
+    user = deep_get(
+        event, "data", "details", "request", "auth", "user", "email", default="<NO_USER_FOUND>"
+    )
+    p_source_label = deep_get(event, "p_source_label", default="<NO_P_SOURCE_LABEL_FOUND>")
+    return (
+        f"Auth0 User [{user}] enabled mfa risk assessment settings for your "
+        f"organization’s tenant [{p_source_label}]."
+    )
+
+
+def alert_context(event):
+    return auth0_alert_context(event)

--- a/rules/auth0_rules/auth0_mfa_risk_assessment_enabled.yml
+++ b/rules/auth0_rules/auth0_mfa_risk_assessment_enabled.yml
@@ -4,7 +4,7 @@ DisplayName: "Auth0 MFA Risk Assessment Enabled"
 Enabled: true
 Filename: auth0_mfa_risk_assessment_enabled.py
 Runbook: Assess if this was done by the user for a valid business reason. Be vigilant when enabling this setting as it's in the best security interest for your organization's security posture.
-Severity: High
+Severity: Info
 Tests:
     - ExpectedResult: false
       Log:

--- a/rules/auth0_rules/auth0_mfa_risk_assessment_enabled.yml
+++ b/rules/auth0_rules/auth0_mfa_risk_assessment_enabled.yml
@@ -1,0 +1,355 @@
+AnalysisType: rule
+Description: An Auth0 User enabled the mfa risk assessment setting for your organization's tenant.
+DisplayName: "Auth0 MFA Risk Assessment Enabled"
+Enabled: true
+Filename: auth0_mfa_risk_assessment_enabled.py
+Runbook: Assess if this was done by the user for a valid business reason. Be vigilant when enabling this setting as it's in the best security interest for your organization's security posture.
+Severity: High
+Tests:
+    - ExpectedResult: false
+      Log:
+        data:
+            client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+            client_name: ""
+            date: "2023-05-16 17:28:11.165000000"
+            description: Set the Multi-factor Authentication policies
+            details:
+                request:
+                    auth:
+                        credentials:
+                            jti: 0107c849078d8d889af711840197ba7c
+                            scopes:
+                                - create:actions
+                                - create:actions_log_sessions
+                                - create:authentication_methods
+                                - create:client_credentials
+                                - create:client_grants
+                                - create:clients
+                                - create:connections
+                                - create:custom_domains
+                                - create:email_provider
+                                - create:email_templates
+                                - create:guardian_enrollment_tickets
+                                - create:integrations
+                                - create:log_streams
+                                - create:organization_connections
+                                - create:organization_invitations
+                                - create:organization_member_roles
+                                - create:organization_members
+                                - create:organizations
+                                - create:requested_scopes
+                                - create:resource_servers
+                                - create:roles
+                                - create:rules
+                                - create:shields
+                                - create:signing_keys
+                                - create:tenant_invitations
+                                - create:test_email_dispatch
+                                - create:users
+                                - delete:actions
+                                - delete:anomaly_blocks
+                                - delete:authentication_methods
+                                - delete:branding
+                                - delete:client_credentials
+                                - delete:client_grants
+                                - delete:clients
+                                - delete:connections
+                                - delete:custom_domains
+                                - delete:device_credentials
+                                - delete:email_provider
+                                - delete:email_templates
+                                - delete:grants
+                                - delete:guardian_enrollments
+                                - delete:integrations
+                                - delete:log_streams
+                                - delete:organization_connections
+                                - delete:organization_invitations
+                                - delete:organization_member_roles
+                                - delete:organization_members
+                                - delete:organizations
+                                - delete:owners
+                                - delete:requested_scopes
+                                - delete:resource_servers
+                                - delete:roles
+                                - delete:rules
+                                - delete:rules_configs
+                                - delete:shields
+                                - delete:tenant_invitations
+                                - delete:tenant_members
+                                - delete:tenants
+                                - delete:users
+                                - read:actions
+                                - read:anomaly_blocks
+                                - read:attack_protection
+                                - read:authentication_methods
+                                - read:branding
+                                - read:checks
+                                - read:client_credentials
+                                - read:client_grants
+                                - read:client_keys
+                                - read:clients
+                                - read:connections
+                                - read:custom_domains
+                                - read:device_credentials
+                                - read:email_provider
+                                - read:email_templates
+                                - read:email_triggers
+                                - read:entity_counts
+                                - read:grants
+                                - read:guardian_factors
+                                - read:insights
+                                - read:integrations
+                                - read:log_streams
+                                - read:logs
+                                - read:mfa_policies
+                                - read:organization_connections
+                                - read:organization_invitations
+                                - read:organization_member_roles
+                                - read:organization_members
+                                - read:organizations
+                                - read:prompts
+                                - read:requested_scopes
+                                - read:resource_servers
+                                - read:roles
+                                - read:rules
+                                - read:rules_configs
+                                - read:shields
+                                - read:signing_keys
+                                - read:stats
+                                - read:tenant_invitations
+                                - read:tenant_members
+                                - read:tenant_settings
+                                - read:triggers
+                                - read:users
+                                - run:checks
+                                - update:actions
+                                - update:attack_protection
+                                - update:authentication_methods
+                                - update:branding
+                                - update:client_credentials
+                                - update:client_grants
+                                - update:client_keys
+                                - update:clients
+                                - update:connections
+                                - update:custom_domains
+                                - update:email_provider
+                                - update:email_templates
+                                - update:email_triggers
+                                - update:guardian_factors
+                                - update:integrations
+                                - update:log_streams
+                                - update:mfa_policies
+                                - update:organization_connections
+                                - update:organizations
+                                - update:prompts
+                                - update:requested_scopes
+                                - update:resource_servers
+                                - update:roles
+                                - update:rules
+                                - update:rules_configs
+                                - update:shields
+                                - update:signing_keys
+                                - update:tenant_members
+                                - update:tenant_settings
+                                - update:triggers
+                                - update:users
+                        strategy: jwt
+                        user:
+                            email: user.name@yourcompany.io
+                            name: User Name
+                            user_id: google-oauth2|105261262156475850461
+                    body: []
+                    channel: https://manage.auth0.com/
+                    ip: 12.12.12.12
+                    method: put
+                    path: /api/v2/guardian/policies
+                    query: {}
+                    userAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36
+                response:
+                    body: []
+                    statusCode: 200
+            ip: 12.12.12.12
+            log_id: "90020230516172812328948000000000000001223372037498448373"
+            type: sapi
+            user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36
+            user_id: google-oauth2|105261262156475850461
+        log_id: "90020230516172812328948000000000000001223372037498448373"
+      Name: Other Event
+    - ExpectedResult: true
+      Log:
+        data:
+            client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+            client_name: ""
+            date: "2023-05-15 21:55:18.060000000"
+            description: Updates risk assessment configs
+            details:
+                request:
+                    auth:
+                        credentials:
+                            jti: 949869e066205b5076e6df203fdd7b9b
+                            scopes:
+                                - create:actions
+                                - create:actions_log_sessions
+                                - create:authentication_methods
+                                - create:client_credentials
+                                - create:client_grants
+                                - create:clients
+                                - create:connections
+                                - create:custom_domains
+                                - create:email_provider
+                                - create:email_templates
+                                - create:guardian_enrollment_tickets
+                                - create:integrations
+                                - create:log_streams
+                                - create:organization_connections
+                                - create:organization_invitations
+                                - create:organization_member_roles
+                                - create:organization_members
+                                - create:organizations
+                                - create:requested_scopes
+                                - create:resource_servers
+                                - create:roles
+                                - create:rules
+                                - create:shields
+                                - create:signing_keys
+                                - create:tenant_invitations
+                                - create:test_email_dispatch
+                                - create:users
+                                - delete:actions
+                                - delete:anomaly_blocks
+                                - delete:authentication_methods
+                                - delete:branding
+                                - delete:client_credentials
+                                - delete:client_grants
+                                - delete:clients
+                                - delete:connections
+                                - delete:custom_domains
+                                - delete:device_credentials
+                                - delete:email_provider
+                                - delete:email_templates
+                                - delete:grants
+                                - delete:guardian_enrollments
+                                - delete:integrations
+                                - delete:log_streams
+                                - delete:organization_connections
+                                - delete:organization_invitations
+                                - delete:organization_member_roles
+                                - delete:organization_members
+                                - delete:organizations
+                                - delete:owners
+                                - delete:requested_scopes
+                                - delete:resource_servers
+                                - delete:roles
+                                - delete:rules
+                                - delete:rules_configs
+                                - delete:shields
+                                - delete:tenant_invitations
+                                - delete:tenant_members
+                                - delete:tenants
+                                - delete:users
+                                - read:actions
+                                - read:anomaly_blocks
+                                - read:attack_protection
+                                - read:authentication_methods
+                                - read:branding
+                                - read:checks
+                                - read:client_credentials
+                                - read:client_grants
+                                - read:client_keys
+                                - read:clients
+                                - read:connections
+                                - read:custom_domains
+                                - read:device_credentials
+                                - read:email_provider
+                                - read:email_templates
+                                - read:email_triggers
+                                - read:entity_counts
+                                - read:grants
+                                - read:guardian_factors
+                                - read:insights
+                                - read:integrations
+                                - read:log_streams
+                                - read:logs
+                                - read:mfa_policies
+                                - read:organization_connections
+                                - read:organization_invitations
+                                - read:organization_member_roles
+                                - read:organization_members
+                                - read:organizations
+                                - read:prompts
+                                - read:requested_scopes
+                                - read:resource_servers
+                                - read:roles
+                                - read:rules
+                                - read:rules_configs
+                                - read:shields
+                                - read:signing_keys
+                                - read:stats
+                                - read:tenant_invitations
+                                - read:tenant_members
+                                - read:tenant_settings
+                                - read:triggers
+                                - read:users
+                                - run:checks
+                                - update:actions
+                                - update:attack_protection
+                                - update:authentication_methods
+                                - update:branding
+                                - update:client_credentials
+                                - update:client_grants
+                                - update:client_keys
+                                - update:clients
+                                - update:connections
+                                - update:custom_domains
+                                - update:email_provider
+                                - update:email_templates
+                                - update:email_triggers
+                                - update:guardian_factors
+                                - update:integrations
+                                - update:log_streams
+                                - update:mfa_policies
+                                - update:organization_connections
+                                - update:organizations
+                                - update:prompts
+                                - update:requested_scopes
+                                - update:resource_servers
+                                - update:roles
+                                - update:rules
+                                - update:rules_configs
+                                - update:shields
+                                - update:signing_keys
+                                - update:tenant_members
+                                - update:tenant_settings
+                                - update:triggers
+                                - update:users
+                        strategy: jwt
+                        user:
+                            email: user.name@yourcompany.io
+                            name: User Name
+                            user_id: google-oauth2|105261262156475850461
+                    body:
+                        AfterAuthentication: true
+                    channel: https://manage.auth0.com/
+                    ip: 12.12.12.12
+                    method: patch
+                    path: /api/v2/risk-assessment/config
+                    query: {}
+                    userAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36
+                response:
+                    body:
+                        AfterAuthentication: true
+                        BeforeLoginPrompt: false
+                        BeforeLoginPromptMonitoring: false
+                    statusCode: 200
+            ip: 12.12.12.12
+            log_id: "90020230515215719063964000000000000001223372037488829643"
+            type: sapi
+            user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36
+            user_id: google-oauth2|105261262156475850461
+        log_id: "90020230515215719063964000000000000001223372037488829643"
+      Name: Risk Assessment Enabled
+DedupPeriodMinutes: 60
+LogTypes:
+    - Auth0.Events
+RuleID: "Auth0.MFA.Risk.Assessment.Enabled"
+Threshold: 1


### PR DESCRIPTION
### Background

Detection for Auth0 MFA Policies
Fires an `HIGH` severity alert

### Changes

* Adds `rules/auth0_rules/auth0_mfa_risk_assessment_enabled.py` & `rules/auth0_rules/auth0_mfa_risk_assessment_enabled.yaml` files and udpates the pack.

### Testing

Test with
```
pipenv run panther_analysis_tool test --filter RuleID=Auth0.MFA.Risk.Assessment.Enabled
```

and got:
```
Auth0.MFA.Risk.Assessment.Enabled
	[PASS] Other Event
		[PASS] [rule] false
	[PASS] Risk Assessment Enabled
		[PASS] [rule] true
		[PASS] [title] Auth0 User [user.name@yourcompany.io] enabled mfa risk assessment settings for your organization’s tenant [<NO_P_SOURCE_LABEL_FOUND>].
		[PASS] [dedup] Auth0 User [user.name@yourcompany.io] enabled mfa risk assessment settings for your organization’s tenant [<NO_P_SOURCE_LABEL_FOUND>].
		[PASS] [alertContext] {"actor": {"email": "user.name@yourcompany.io", "name": "User Name", "user_id": "google-oauth2|105261262156475850461"}, "action": "Updates risk assessment configs"}

--------------------------
Panther CLI Test Summary
	Path: .
	Passed: 1
	Failed: 0
	Invalid: 0
```
