### PR TITLE
Rule: CrowdStrike MacOS Added Trusted Cert

### DIFF
--- a/packs/crowdstrike.yml
+++ b/packs/crowdstrike.yml
@@ -16,6 +16,7 @@ PackDefinition:
     - Crowdstrike.Base64EncodedArgs
     - Crowdstrike.FDR.LOLBAS
     - Standard.DNSBase64
+    - Crowdstrike.Macos.Add.Trusted.Cert
     # Globals used in these detections
     - panther_base_helpers
     # Data models

--- a/rules/crowdstrike_rules/crowdstrike_macos_add_trusted_cert.py
+++ b/rules/crowdstrike_rules/crowdstrike_macos_add_trusted_cert.py
@@ -1,0 +1,25 @@
+from panther_base_helpers import crowdstrike_process_alert_context, deep_get
+
+
+def rule(event):
+    event_platform = deep_get(event, "event_platform", default="<UNKNOWN_PLATFORM>")
+    fdr_event_type = deep_get(event, "fdr_event_type", default="<UNKNOWN_FDR_EVENT_TYPE>")
+    image_filename = deep_get(event, "event", "ImageFileName", default="<UNKNOWN_IMAGE_FILE_NAME>")
+    command_line = deep_get(event, "event", "CommandLine", default="<UNKNOWN_COMMAND_LINE>")
+    return all(
+        [
+            event_platform == "Mac",
+            fdr_event_type == "ProcessRollup2",
+            image_filename == "/usr/bin/security",
+            "add-trusted-cert" in command_line,
+        ]
+    )
+
+
+def title(event):
+    aid = event.get("aid", "<UNKNOWN_AID>")
+    return f"Crowdstrike: New trusted cert added on device [{aid}]"
+
+
+def alert_context(event):
+    return crowdstrike_process_alert_context(event)

--- a/rules/crowdstrike_rules/crowdstrike_macos_add_trusted_cert.yml
+++ b/rules/crowdstrike_rules/crowdstrike_macos_add_trusted_cert.yml
@@ -1,0 +1,420 @@
+AnalysisType: rule
+DisplayName: CrowdStrike MacOS Added Trusted Cert
+Description: Detects attempt to install a root certificate on MacOS
+Enabled: true
+Filename: crowdstrike_macos_add_trusted_cert.py
+RuleID: Crowdstrike.Macos.Add.Trusted.Cert
+Severity: Medium
+LogTypes:
+    - Crowdstrike.FDREvent
+Tests:
+  - Name: Added root cert
+    ExpectedResult: true
+    Log:
+      {
+        "aid": "1234abcdefghijklmnop",
+        "aip": "1.2.3.4",
+        "cid": "abcde098654321xyz",
+        "configbuild": "1007.4.0016804.11",
+        "configstatehash": "1260279761",
+        "entitlements": "15",
+        "event": {
+          "CodeSigningFlags": "570506001",
+          "CommandLine": "security add-trusted-cert -d -r trusted",
+          "ConfigBuild": "1007.4.0016804.11",
+          "ConfigStateHash": "1260279761",
+          "EffectiveTransmissionClass": "2",
+          "Entitlements": "15",
+          "GID": "20",
+          "ImageFileName": "/usr/bin/security",
+          "MD5HashData": "5a29b1ee210395604829dafd744a8039",
+          "MachOSubType": "1",
+          "ParentBaseFileName": "zsh",
+          "ParentProcessId": "488592041865603507",
+          "ProcessEndTime": "",
+          "ProcessGroupId": "488638905187012012",
+          "ProcessStartTime": "1685123957.068",
+          "RGID": "501",
+          "RUID": "501",
+          "RawProcessId": "51673",
+          "SHA1HashData": "0000000000000000000000000000000000000000",
+          "SHA256HashData": "fc708414b7e7c0df8d7711d0362b4dbd79a45fba65bdc646848fa8f50e9035de",
+          "SVGID": "20",
+          "SVUID": "501",
+          "SessionProcessId": "488592041748162994",
+          "SigningId": "com.apple.Foundation.plutil",
+          "SourceProcessId": "488592041865603507",
+          "SourceThreadId": "0",
+          "Tags": "316",
+          "TargetProcessId": "488638905187012012",
+          "TeamId": "-",
+          "UID": "501",
+          "aid": "1234abcdefghijklmnop",
+          "aip": "1.2.3.4",
+          "cid": "abcde098654321xyz",
+          "event_platform": "Mac",
+          "event_simpleName": "ProcessRollup2",
+          "id": "59c9d5fb-b9b7-43a3-913f-6df72d9e1969",
+          "name": "ProcessRollup2MacV9",
+          "timestamp": "1685123957235"
+        },
+        "event_platform": "Mac",
+        "event_simplename": "ProcessRollup2",
+        "fdr_event_type": "ProcessRollup2",
+        "id": "59c9d5fb-b9b7-43a3-913f-6df72d9e1969",
+        "name": "ProcessRollup2MacV9",
+        "p_any_ip_addresses": [
+          "1.2.3.4"
+        ],
+        "p_any_md5_hashes": [
+          "1234abcdefghijklmnop",
+          "5a29b1ee210395604829dafd744a8039",
+          "abcde098654321xyz"
+        ],
+        "p_any_sha1_hashes": [
+          "0000000000000000000000000000000000000000"
+        ],
+        "p_any_sha256_hashes": [
+          "fc708414b7e7c0df8d7711d0362b4dbd79a45fba65bdc646848fa8f50e9035de"
+        ],
+        "p_any_trace_ids": [
+          "1234abcdefghijklmnop",
+          "abcde098654321xyz"
+        ],
+        "p_event_time": "2023-05-26 17:59:17.235",
+        "p_log_type": "Crowdstrike.FDREvent",
+        "p_parse_time": "2023-05-26 18:11:03.404",
+        "p_row_id": "d6ff1555b3f6e785b3e2bbb218abf524",
+        "p_schema_version": 0,
+        "p_source_id": "e4962678-a986-44af-a757-18163a2bc963",
+        "p_source_label": "Crowdstrike",
+        "timestamp": "2023-05-26 17:59:17.235"
+      }
+  - Name: Windows log
+    ExpectedResult: false
+    Log:
+      {
+        "aid": "1234abcdefghijklmnop",
+        "aip": "1.2.3.4",
+        "cid": "abcde098654321xyz",
+        "configbuild": "1007.4.0016804.11",
+        "configstatehash": "1260279761",
+        "entitlements": "15",
+        "event": {
+          "CodeSigningFlags": "570506001",
+          "CommandLine": "security add-trusted-cert -d -r trusted",
+          "ConfigBuild": "1007.4.0016804.11",
+          "ConfigStateHash": "1260279761",
+          "EffectiveTransmissionClass": "2",
+          "Entitlements": "15",
+          "GID": "20",
+          "ImageFileName": "/usr/bin/security",
+          "MD5HashData": "5a29b1ee210395604829dafd744a8039",
+          "MachOSubType": "1",
+          "ParentBaseFileName": "zsh",
+          "ParentProcessId": "488592041865603507",
+          "ProcessEndTime": "",
+          "ProcessGroupId": "488638905187012012",
+          "ProcessStartTime": "1685123957.068",
+          "RGID": "501",
+          "RUID": "501",
+          "RawProcessId": "51673",
+          "SHA1HashData": "0000000000000000000000000000000000000000",
+          "SHA256HashData": "fc708414b7e7c0df8d7711d0362b4dbd79a45fba65bdc646848fa8f50e9035de",
+          "SVGID": "20",
+          "SVUID": "501",
+          "SessionProcessId": "488592041748162994",
+          "SigningId": "com.apple.Foundation.plutil",
+          "SourceProcessId": "488592041865603507",
+          "SourceThreadId": "0",
+          "Tags": "316",
+          "TargetProcessId": "488638905187012012",
+          "TeamId": "-",
+          "UID": "501",
+          "aid": "1234abcdefghijklmnop",
+          "aip": "1.2.3.4",
+          "cid": "abcde098654321xyz",
+          "event_platform": "Mac",
+          "event_simpleName": "ProcessRollup2",
+          "id": "59c9d5fb-b9b7-43a3-913f-6df72d9e1969",
+          "name": "ProcessRollup2MacV9",
+          "timestamp": "1685123957235"
+        },
+        "event_platform": "Win",
+        "event_simplename": "ProcessRollup2",
+        "fdr_event_type": "ProcessRollup2",
+        "id": "59c9d5fb-b9b7-43a3-913f-6df72d9e1969",
+        "name": "ProcessRollup2MacV9",
+        "p_any_ip_addresses": [
+          "1.2.3.4"
+        ],
+        "p_any_md5_hashes": [
+          "1234abcdefghijklmnop",
+          "5a29b1ee210395604829dafd744a8039",
+          "abcde098654321xyz"
+        ],
+        "p_any_sha1_hashes": [
+          "0000000000000000000000000000000000000000"
+        ],
+        "p_any_sha256_hashes": [
+          "fc708414b7e7c0df8d7711d0362b4dbd79a45fba65bdc646848fa8f50e9035de"
+        ],
+        "p_any_trace_ids": [
+          "1234abcdefghijklmnop",
+          "abcde098654321xyz"
+        ],
+        "p_event_time": "2023-05-26 17:59:17.235",
+        "p_log_type": "Crowdstrike.FDREvent",
+        "p_parse_time": "2023-05-26 18:11:03.404",
+        "p_row_id": "d6ff1555b3f6e785b3e2bbb218abf524",
+        "p_schema_version": 0,
+        "p_source_id": "e4962678-a986-44af-a757-18163a2bc963",
+        "p_source_label": "Crowdstrike",
+        "timestamp": "2023-05-26 17:59:17.235"
+      }
+  - Name: Wrong FDR event type
+    ExpectedResult: false
+    Log:
+      {
+        "aid": "1234abcdefghijklmnop",
+        "aip": "1.2.3.4",
+        "cid": "abcde098654321xyz",
+        "configbuild": "1007.4.0016804.11",
+        "configstatehash": "1260279761",
+        "entitlements": "15",
+        "event": {
+          "CodeSigningFlags": "570506001",
+          "CommandLine": "security add-trusted-cert -d -r trusted",
+          "ConfigBuild": "1007.4.0016804.11",
+          "ConfigStateHash": "1260279761",
+          "EffectiveTransmissionClass": "2",
+          "Entitlements": "15",
+          "GID": "20",
+          "ImageFileName": "/usr/bin/security",
+          "MD5HashData": "5a29b1ee210395604829dafd744a8039",
+          "MachOSubType": "1",
+          "ParentBaseFileName": "zsh",
+          "ParentProcessId": "488592041865603507",
+          "ProcessEndTime": "",
+          "ProcessGroupId": "488638905187012012",
+          "ProcessStartTime": "1685123957.068",
+          "RGID": "501",
+          "RUID": "501",
+          "RawProcessId": "51673",
+          "SHA1HashData": "0000000000000000000000000000000000000000",
+          "SHA256HashData": "fc708414b7e7c0df8d7711d0362b4dbd79a45fba65bdc646848fa8f50e9035de",
+          "SVGID": "20",
+          "SVUID": "501",
+          "SessionProcessId": "488592041748162994",
+          "SigningId": "com.apple.Foundation.plutil",
+          "SourceProcessId": "488592041865603507",
+          "SourceThreadId": "0",
+          "Tags": "316",
+          "TargetProcessId": "488638905187012012",
+          "TeamId": "-",
+          "UID": "501",
+          "aid": "1234abcdefghijklmnop",
+          "aip": "1.2.3.4",
+          "cid": "abcde098654321xyz",
+          "event_platform": "Mac",
+          "event_simpleName": "ProcessRollup2",
+          "id": "59c9d5fb-b9b7-43a3-913f-6df72d9e1969",
+          "name": "ProcessRollup2MacV9",
+          "timestamp": "1685123957235"
+        },
+        "event_platform": "Mac",
+        "event_simplename": "DnsRequest",
+        "fdr_event_type": "DnsRequest",
+        "id": "59c9d5fb-b9b7-43a3-913f-6df72d9e1969",
+        "name": "ProcessRollup2MacV9",
+        "p_any_ip_addresses": [
+          "1.2.3.4"
+        ],
+        "p_any_md5_hashes": [
+          "1234abcdefghijklmnop",
+          "5a29b1ee210395604829dafd744a8039",
+          "abcde098654321xyz"
+        ],
+        "p_any_sha1_hashes": [
+          "0000000000000000000000000000000000000000"
+        ],
+        "p_any_sha256_hashes": [
+          "fc708414b7e7c0df8d7711d0362b4dbd79a45fba65bdc646848fa8f50e9035de"
+        ],
+        "p_any_trace_ids": [
+          "1234abcdefghijklmnop",
+          "abcde098654321xyz"
+        ],
+        "p_event_time": "2023-05-26 17:59:17.235",
+        "p_log_type": "Crowdstrike.FDREvent",
+        "p_parse_time": "2023-05-26 18:11:03.404",
+        "p_row_id": "d6ff1555b3f6e785b3e2bbb218abf524",
+        "p_schema_version": 0,
+        "p_source_id": "e4962678-a986-44af-a757-18163a2bc963",
+        "p_source_label": "Crowdstrike",
+        "timestamp": "2023-05-26 17:59:17.235"
+      }
+  - Name: Wrong executable path
+    ExpectedResult: false
+    Log:
+      {
+        "aid": "1234abcdefghijklmnop",
+        "aip": "1.2.3.4",
+        "cid": "abcde098654321xyz",
+        "configbuild": "1007.4.0016804.11",
+        "configstatehash": "1260279761",
+        "entitlements": "15",
+        "event": {
+          "CodeSigningFlags": "570506001",
+          "CommandLine": "security add-trusted-cert -d -r trusted",
+          "ConfigBuild": "1007.4.0016804.11",
+          "ConfigStateHash": "1260279761",
+          "EffectiveTransmissionClass": "2",
+          "Entitlements": "15",
+          "GID": "20",
+          "ImageFileName": "/home/test/bin/security",
+          "MD5HashData": "5a29b1ee210395604829dafd744a8039",
+          "MachOSubType": "1",
+          "ParentBaseFileName": "zsh",
+          "ParentProcessId": "488592041865603507",
+          "ProcessEndTime": "",
+          "ProcessGroupId": "488638905187012012",
+          "ProcessStartTime": "1685123957.068",
+          "RGID": "501",
+          "RUID": "501",
+          "RawProcessId": "51673",
+          "SHA1HashData": "0000000000000000000000000000000000000000",
+          "SHA256HashData": "fc708414b7e7c0df8d7711d0362b4dbd79a45fba65bdc646848fa8f50e9035de",
+          "SVGID": "20",
+          "SVUID": "501",
+          "SessionProcessId": "488592041748162994",
+          "SigningId": "com.apple.Foundation.plutil",
+          "SourceProcessId": "488592041865603507",
+          "SourceThreadId": "0",
+          "Tags": "316",
+          "TargetProcessId": "488638905187012012",
+          "TeamId": "-",
+          "UID": "501",
+          "aid": "1234abcdefghijklmnop",
+          "aip": "1.2.3.4",
+          "cid": "abcde098654321xyz",
+          "event_platform": "Mac",
+          "event_simpleName": "ProcessRollup2",
+          "id": "59c9d5fb-b9b7-43a3-913f-6df72d9e1969",
+          "name": "ProcessRollup2MacV9",
+          "timestamp": "1685123957235"
+        },
+        "event_platform": "Mac",
+        "event_simplename": "ProcessRollup2",
+        "fdr_event_type": "ProcessRollup2",
+        "id": "59c9d5fb-b9b7-43a3-913f-6df72d9e1969",
+        "name": "ProcessRollup2MacV9",
+        "p_any_ip_addresses": [
+          "1.2.3.4"
+        ],
+        "p_any_md5_hashes": [
+          "1234abcdefghijklmnop",
+          "5a29b1ee210395604829dafd744a8039",
+          "abcde098654321xyz"
+        ],
+        "p_any_sha1_hashes": [
+          "0000000000000000000000000000000000000000"
+        ],
+        "p_any_sha256_hashes": [
+          "fc708414b7e7c0df8d7711d0362b4dbd79a45fba65bdc646848fa8f50e9035de"
+        ],
+        "p_any_trace_ids": [
+          "1234abcdefghijklmnop",
+          "abcde098654321xyz"
+        ],
+        "p_event_time": "2023-05-26 17:59:17.235",
+        "p_log_type": "Crowdstrike.FDREvent",
+        "p_parse_time": "2023-05-26 18:11:03.404",
+        "p_row_id": "d6ff1555b3f6e785b3e2bbb218abf524",
+        "p_schema_version": 0,
+        "p_source_id": "e4962678-a986-44af-a757-18163a2bc963",
+        "p_source_label": "Crowdstrike",
+        "timestamp": "2023-05-26 17:59:17.235"
+      }
+  - Name: Help command
+    ExpectedResult: false
+    Log:
+      {
+        "aid": "1234abcdefghijklmnop",
+        "aip": "1.2.3.4",
+        "cid": "abcde098654321xyz",
+        "configbuild": "1007.4.0016804.11",
+        "configstatehash": "1260279761",
+        "entitlements": "15",
+        "event": {
+          "CodeSigningFlags": "570506001",
+          "CommandLine": "security help",
+          "ConfigBuild": "1007.4.0016804.11",
+          "ConfigStateHash": "1260279761",
+          "EffectiveTransmissionClass": "2",
+          "Entitlements": "15",
+          "GID": "20",
+          "ImageFileName": "/usr/bin/security",
+          "MD5HashData": "5a29b1ee210395604829dafd744a8039",
+          "MachOSubType": "1",
+          "ParentBaseFileName": "zsh",
+          "ParentProcessId": "488592041865603507",
+          "ProcessEndTime": "",
+          "ProcessGroupId": "488638905187012012",
+          "ProcessStartTime": "1685123957.068",
+          "RGID": "501",
+          "RUID": "501",
+          "RawProcessId": "51673",
+          "SHA1HashData": "0000000000000000000000000000000000000000",
+          "SHA256HashData": "fc708414b7e7c0df8d7711d0362b4dbd79a45fba65bdc646848fa8f50e9035de",
+          "SVGID": "20",
+          "SVUID": "501",
+          "SessionProcessId": "488592041748162994",
+          "SigningId": "com.apple.Foundation.plutil",
+          "SourceProcessId": "488592041865603507",
+          "SourceThreadId": "0",
+          "Tags": "316",
+          "TargetProcessId": "488638905187012012",
+          "TeamId": "-",
+          "UID": "501",
+          "aid": "1234abcdefghijklmnop",
+          "aip": "1.2.3.4",
+          "cid": "abcde098654321xyz",
+          "event_platform": "Mac",
+          "event_simpleName": "ProcessRollup2",
+          "id": "59c9d5fb-b9b7-43a3-913f-6df72d9e1969",
+          "name": "ProcessRollup2MacV9",
+          "timestamp": "1685123957235"
+        },
+        "event_platform": "Mac",
+        "event_simplename": "ProcessRollup2",
+        "fdr_event_type": "ProcessRollup2",
+        "id": "59c9d5fb-b9b7-43a3-913f-6df72d9e1969",
+        "name": "ProcessRollup2MacV9",
+        "p_any_ip_addresses": [
+          "1.2.3.4"
+        ],
+        "p_any_md5_hashes": [
+          "1234abcdefghijklmnop",
+          "5a29b1ee210395604829dafd744a8039",
+          "abcde098654321xyz"
+        ],
+        "p_any_sha1_hashes": [
+          "0000000000000000000000000000000000000000"
+        ],
+        "p_any_sha256_hashes": [
+          "fc708414b7e7c0df8d7711d0362b4dbd79a45fba65bdc646848fa8f50e9035de"
+        ],
+        "p_any_trace_ids": [
+          "1234abcdefghijklmnop",
+          "abcde098654321xyz"
+        ],
+        "p_event_time": "2023-05-26 17:59:17.235",
+        "p_log_type": "Crowdstrike.FDREvent",
+        "p_parse_time": "2023-05-26 18:11:03.404",
+        "p_row_id": "d6ff1555b3f6e785b3e2bbb218abf524",
+        "p_schema_version": 0,
+        "p_source_id": "e4962678-a986-44af-a757-18163a2bc963",
+        "p_source_label": "Crowdstrike",
+        "timestamp": "2023-05-26 17:59:17.235"
+      }


### PR DESCRIPTION
### Changes

* Adds a medium severity rule for CrowdStrike logs that alerts when a user attempts to add a new trusted root certificate on a Mac.

### Testing

```
Crowdstrike.Macos.Add.Trusted.Cert
        [PASS] Added root cert
                [PASS] [rule] true
                [PASS] [title] Crowdstrike: New trusted cert added on device [1234abcdefghijklmnop]
                [PASS] [dedup] Crowdstrike: New trusted cert added on device [1234abcdefghijklmnop]
                [PASS] [alertContext] {"aid": "1234abcdefghijklmnop", "CommandLine": "security add-trusted-cert -d -r trusted", "TargetProcessId": "488638905187012012", "RawProcessId": "51673", "ParentBaseFileName": "zsh", "ParentProcessId": "488592041865603507", "ImageFileName": "/usr/bin/security", "SHA256Hash": "fc708414b7e7c0df8d7711d0362b4dbd79a45fba65bdc646848fa8f50e9035de", "platform": "Mac"}
        [PASS] Windows log
                [PASS] [rule] false
        [PASS] Wrong FDR event type
                [PASS] [rule] false
        [PASS] Wrong executable path
                [PASS] [rule] false
        [PASS] Help command
                [PASS] [rule] false
```
