### PR TITLE
docs: Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,12 @@ Global helper functions are defined in the `global_helpers` folder. This is a ha
 
 Additionally, groups of detections may be linked to multiple "Reports", which is a system for tracking frameworks like CIS, PCI, MITRE ATT&CK, or more.
 
-### Using [Visual Studio Code](https://code.visualstudio.com/)
+## Using [Visual Studio Code](https://code.visualstudio.com/)
 If you are comfortable using the Visual Studio Code IDE, the `make vscode-config` command can configure VSCode to work with this repo. 
+
+In addition to this command, you will need to install these vscode add-ons:
+1. [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
+1. [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
 
 `make vscode-config` will configure:
 1. Configure VSCode to use the python virtual environment for this repository.
@@ -115,7 +119,7 @@ user@computer:panther-analysis: make vscode-config
 
 ```
 
-### Using Docker
+## Using Docker
 
 To use Docker, you can run some of the `make` commands provided to run common panther-analysis workflows. Start by building the container, then you can run any command you want from the image created. If you would like to run a different command, follow the pattern in the Makefile.
 ```
@@ -126,7 +130,7 @@ make docker-lint
 
 Please note that you only need to rebuild the container if you update your `Pipfile.lock` changes, because the dependencies are install when the image is built. The subsequent test and lint commands are run in the image by mounting the current file system directory, so it is using your local file system. 
 
-### Using Windows
+## Using Windows
 
 If you are on a Windows machine, you can use the following instructions to perform the standard panther-analysis workflow. 
 
@@ -208,11 +212,14 @@ Customizing detections-as-code is one of the most powerful capabilities Panther 
 
 Upon [tagged releases](https://github.com/panther-labs/panther-analysis/releases), you can pull upstream changes from this public repo.
 
-Follow the instructions [here](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) to learn how to get started with forks.
+Follow the instructions [here](https://docs.panther.com/panther-developer-workflows/ci-cd/detections-repo) to get started with either a public fork or a private cloned repo to host your custom detection content.
+
 
 ## Getting Updates
 
-When you want to pull in the latest changes from this repository, perform the following steps from your private repo:
+When you want to pull in the latest changes from this repository, we recommend leveraging the [included GitHub Action](https://docs.panther.com/panther-developer-workflows/ci-cd/detections-repo/public-fork#keeping-in-sync-with-upstream).
+
+If you wish to sync manually, the process below can be run from a terminal.
 
 ```bash
 # add the public repository as a remote


### PR DESCRIPTION
### Background
I wanted to bring some additional information about how to get VSCode up and going for maximum effect based on some feedback. 

While I was in the README, I noticed a few other places where the sectioning seemed off, or linked docs could be updated. 

### Changes

* Notes and Links for needed VSCode Extensions
* Tweaks some `h3` into `h2` for clarity in sectioning
* Updated instructions around how to get updates
* Updated instructions about how to get started with either of a public fork or a private cloned repo

### Testing

