### PR TITLE
docs: add unit test to ensure that GetGreyNoiseObject({}).lut_matches is None

### DIFF
--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -290,8 +290,9 @@ class TestGreyNoiseBasic(unittest.TestCase):
         self.assertEqual(noise.subscription_level(), "basic")
         # Ensure that noise.lut_matches is None if there is no enrichment
         # some users want to test if any greynoise enrichment exists
+        self.assertIsNotNone(noise.lut_matches)
         noise_none = p_greynoise_h.GetGreyNoiseObject({})
-        self.assertEqual(noise_none.lut_matches, None)
+        self.assertIsNone(noise_none.lut_matches)
 
     def test_greynoise_severity(self):
         """Should be CRITICAL"""

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -288,6 +288,10 @@ class TestGreyNoiseBasic(unittest.TestCase):
         """Should be basic"""
         noise = p_greynoise_h.GetGreyNoiseObject(self.event)
         self.assertEqual(noise.subscription_level(), "basic")
+        # Ensure that noise.lut_matches is None if there is no enrichment
+        # some users want to test if any greynoise enrichment exists
+        noise_none = p_greynoise_h.GetGreyNoiseObject({})
+        self.assertEqual(noise_none.lut_matches, None)
 
     def test_greynoise_severity(self):
         """Should be CRITICAL"""


### PR DESCRIPTION
### Background

Sometimes users want to know if there is any GreyNoise enrichment or not, without inspecting any of the details about the enrichment's content. 

This had been a behavior in the now absent `GetGreyNoiseObject().noise` attribute. 

`GetGreyNoiseObject().lut_matches` serves this same purpose, and as such this adds a unit test to contract the behavior. 


### Testing

```text
(panther-analysis) user@computer:~/Developer/PAN/panther-analysis $ make global-helpers-unit-test
pipenv run python global_helpers/*_test.py
............................................................................................................................................
----------------------------------------------------------------------
Ran 140 tests in 5.781s

OK
```
