### PR TITLE
Update deep_walk type hints

### DIFF
--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -312,22 +312,24 @@ def deep_get(dictionary: dict, *keys, default=None):
 
 # pylint: disable=too-complex,too-many-return-statements
 def deep_walk(
-    obj: dict, *keys: str, default: str = None, return_val: str = "all"
-) -> Union[Optional[str], Optional[List[str]]]:
+    obj: Optional[Any], *keys: str, default: str = None, return_val: str = "all"
+) -> Union[Optional[Any], Optional[List[Any]]]:
     """Safely retrieve a value stored in complex dictionary structure
 
     Similar to deep_get but supports accessing dictionary keys within nested lists as well
 
     Parameters:
-    obj (dict): the original log event, as passed to rule(event)
+    obj (any): the original log event passed to rule(event)
+                and nested objects retrieved recursively
     keys (str): comma-separated list of keys used to traverse the event object
     default (str): the default value to return if the desired key's value is not present
     return_val (str): string specifying which value to return
                       possible values are "first", "last", or "all"
 
     Returns:
-    str | list[str]: A string value if return_val is "first", "last",
-                     or if "all" returns a single value, otherwise a list of [string] values
+    any | list[any]: A single value if return_val is "first", "last",
+                     or if "all" is a list containing one element, 
+                     otherwise a list of values
     """
 
     def _empty_list(sub_obj: Any):

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -328,7 +328,7 @@ def deep_walk(
 
     Returns:
     any | list[any]: A single value if return_val is "first", "last",
-                     or if "all" is a list containing one element, 
+                     or if "all" is a list containing one element,
                      otherwise a list of values
     """
 


### PR DESCRIPTION
### Background

The original `deep_walk` parameter types and type hints were explicitly expecting `dict` objects to be passed in for the `obj` parameter and only strings or a list of strings to be returned by `deep_walk`, respectively.

This PR updates the type hints to be more accurate (i.e., not just `dict` or `str`).

### Changes

* Updates the `obj` parameter type hint to `Optional[Any]`
  * The initial object will be a dictionary, but recursive calls may provide a value that is another dictionary, a list, or other type
* Updates the return type hints to `Optional[Any], Optional[List[Any]]` since the value type could also be something like an integer or boolean in addition to a string.

### Testing

* Tests still pass as expected
