### PR TITLE
docs: Test+Lint queries directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-dirs := $(shell ls | egrep 'policies|rules|helpers|models|templates' | xargs)
+dirs := $(shell ls | egrep 'policies|rules|helpers|models|templates|queries' | xargs)
 UNAME := $(shell uname)
 
 ifeq ($(UNAME), Darwin)

--- a/queries/aws_queries/scheduled_rule_default.py
+++ b/queries/aws_queries/scheduled_rule_default.py
@@ -1,3 +1,2 @@
 def rule(_):
     return True
- 

--- a/queries/snowflake_queries/snowflake_account_admin_assigned.py
+++ b/queries/snowflake_queries/snowflake_account_admin_assigned.py
@@ -1,7 +1,7 @@
 def rule(_):
     return True
 
+
 def title(event):
-    target = " ".join(event.get("query_text","").split(" ")[-2:])
+    target = " ".join(event.get("query_text", "").split(" ")[-2:])
     return f"Snowflake AccountAdmin granted to {target}"
- 

--- a/queries/snowflake_queries/snowflake_brute_force_ip.py
+++ b/queries/snowflake_queries/snowflake_brute_force_ip.py
@@ -1,6 +1,10 @@
 def rule(_):
     return True
 
+
 def title(event):
-    return f"Login attempts from IP [{event.get('client_ip','<UNKNOWN_USER>')}] have exceeded the failed logins threshold"
- 
+    return (
+        "Login attempts from IP "
+        f"[{event.get('client_ip','<UNKNOWN_USER>')}] "
+        "have exceeded the failed logins threshold"
+    )

--- a/queries/snowflake_queries/snowflake_brute_force_username.py
+++ b/queries/snowflake_queries/snowflake_brute_force_username.py
@@ -3,5 +3,6 @@ def rule(_):
 
 
 def title(event):
-    return f"User [{event.get('user_name','<UNKNOWN_USER>')}] has exceeded the failed logins threshold"
- 
+    return (
+        f"User [{event.get('user_name','<UNKNOWN_USER>')}] has exceeded the failed logins threshold"
+    )

--- a/queries/snowflake_queries/snowflake_external_shares.py
+++ b/queries/snowflake_queries/snowflake_external_shares.py
@@ -1,13 +1,14 @@
 def rule(_):
     return True
 
+
 def title(event):
     return (
-        f"A data export has been initiated from source cloud [{event.get('source_cloud','<SOURCE_CLOUD_NOT_FOUND>')}] "
+        "A data export has been initiated from source cloud "
+        f"[{event.get('source_cloud','<SOURCE_CLOUD_NOT_FOUND>')}] "
         f"in source region [{event.get('source_region','<SOURCE_REGION_NOT_FOUND>')}] "
         f"to target cloud [{event.get('target_cloud','<TARGET_CLOUD_NOT_FOUND>')}] "
         f"in target region [{event.get('target_region','<TARGET_REGION_NOT_FOUND>')}] "
         f"with transfer type [{event.get('transfer_type','<TRANSFER_TYPE_NOT_FOUND>')}] "
         f"for [{event.get('bytes_transferred','<BYTES_NOT_FOUND>')}] bytes."
     )
- 

--- a/queries/snowflake_queries/snowflake_key_user_password_login.py
+++ b/queries/snowflake_queries/snowflake_key_user_password_login.py
@@ -1,6 +1,6 @@
 def rule(_):
     return True
 
+
 def title(event):
     return f"User {event.get('name')} logged in with Password instead of RSA key"
- 

--- a/queries/snowflake_queries/snowflake_login_without_mfa.py
+++ b/queries/snowflake_queries/snowflake_login_without_mfa.py
@@ -1,8 +1,5 @@
-MFA_EXCEPTIONS = {
-    "PANTHER_READONLY",
-    "PANTHER_ADMIN"
-}
+MFA_EXCEPTIONS = {"PANTHER_READONLY", "PANTHER_ADMIN"}
+
 
 def rule(event):
     return event.get("user_name", "") not in MFA_EXCEPTIONS
- 

--- a/queries/snowflake_queries/snowflake_multiple_failed_logins_followed_by_success.py
+++ b/queries/snowflake_queries/snowflake_multiple_failed_logins_followed_by_success.py
@@ -1,7 +1,9 @@
 def rule(_):
     return True
 
+
 def title(event):
+    # pylint: disable=line-too-long
     return (
         f"Username [{event.get('user_name','<USER_NOT_FOUND>')}] from clientIP "
         f"[{event.get('client_ip','<CLIENT_IP_NOT_FOUND>')}] "
@@ -10,4 +12,3 @@ def title(event):
         f"followed by a successful login which occurred at "
         f"[{event.get('successful_login_time','<SUCCESS_LOGIN_TIME_NOT_FOUND>')}]."
     )
- 

--- a/queries/snowflake_queries/snowflake_public_role_grant.py
+++ b/queries/snowflake_queries/snowflake_public_role_grant.py
@@ -1,3 +1,2 @@
 def rule(_):
     return True
- 

--- a/queries/snowflake_queries/snowflake_user_created.py
+++ b/queries/snowflake_queries/snowflake_user_created.py
@@ -1,9 +1,14 @@
 def rule(_):
     return True
 
+
 def title(event):
-    query_text = event.get('query_text', '').split(' ')
+    query_text = event.get("query_text", "").split(" ")
     if len(query_text) > 2:
-        return f"Snowflake user [{query_text[2]}] created by [{event.get('user_name','<UNKNOWN_ADMIN>')}]"
-    return f"Snowflake user [<UNKNOWN_USER>] created by [{event.get('user_name','<UNKNOWN_ADMIN>')}]"
- 
+        return (
+            f"Snowflake user [{query_text[2]}] created by "
+            f"[{event.get('user_name','<UNKNOWN_ADMIN>')}]"
+        )
+    return (
+        f"Snowflake user [<UNKNOWN_USER>] created by [{event.get('user_name','<UNKNOWN_ADMIN>')}]"
+    )

--- a/queries/snowflake_queries/snowflake_user_enabled.py
+++ b/queries/snowflake_queries/snowflake_user_enabled.py
@@ -1,9 +1,14 @@
 def rule(_):
     return True
 
+
 def title(event):
-    query_text = event.get('query_text', '').split(' ')
+    query_text = event.get("query_text", "").split(" ")
     if len(query_text) > 2:
-        return f"Snowflake user [{query_text[2]}] enabled by [{event.get('user_name','<UNKNOWN_ADMIN>')}]"
-    return f"Snowflake user [<UNKNOWN_USER>] enabled by [{event.get('user_name','<UNKNOWN_ADMIN>')}]"
- 
+        return (
+            f"Snowflake user [{query_text[2]}] "
+            f"enabled by [{event.get('user_name','<UNKNOWN_ADMIN>')}]"
+        )
+    return (
+        f"Snowflake user [<UNKNOWN_USER>] enabled by [{event.get('user_name','<UNKNOWN_ADMIN>')}]"
+    )


### PR DESCRIPTION
### Background

The queries directory was excluded from lint and test expectations. This PR updates the default lint and test targets to include the queries directory.

### Changes

some reformatting of `queries/*/*.py` where the files did not comply with the expectations of the linter. 

### Testing

#### AFTER 

```text
user@computer:~/Developer/PAN/panther-analysis $ make lint
pipenv run bandit -r data_models global_helpers policies queries rules templates --skip B101  # allow assert statements in tests
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: B101
[main]  INFO    running on Python 3.9.16
Working... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:01
Run started:2023-06-26 16:47:45.188757

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 13510
        Total lines skipped (#nosec): 5

Run metrics:
        Total issues (by severity):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
        Total issues (by confidence):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
Files skipped (0):
pipenv run pylint data_models global_helpers policies queries rules templates \
          --disable=missing-docstring,duplicate-code,import-error,fixme,consider-iterating-dictionary,global-variable-not-assigned \
          --load-plugins=pylint.extensions.mccabe,pylint_print \
          --max-line-length=100

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

Checking python file formatting with the black code style checker
pipenv run black --line-length=100 --check data_models global_helpers policies queries rules templates
All done! ✨ 🍰 ✨
560 files would be left unchanged.
```

#### Before

```text
user@computer:~/Developer/PAN/panther-analysis $ make lint
pipenv run bandit -r data_models global_helpers policies queries rules templates --skip B101  # allow assert statements in tests
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: B101
[main]  INFO    running on Python 3.9.16
Working... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:01
Run started:2023-06-26 16:48:58.427851

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 13496
        Total lines skipped (#nosec): 5

Run metrics:
        Total issues (by severity):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
        Total issues (by confidence):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
Files skipped (0):
pipenv run pylint data_models global_helpers policies queries rules templates \
          --disable=missing-docstring,duplicate-code,import-error,fixme,consider-iterating-dictionary,global-variable-not-assigned \
          --load-plugins=pylint.extensions.mccabe,pylint_print \
          --max-line-length=100
************* Module snowflake_queries.snowflake_account_admin_assigned
queries/snowflake_queries/snowflake_account_admin_assigned.py:7:0: C0303: Trailing whitespace (trailing-whitespace)
************* Module snowflake_queries.snowflake_login_without_mfa
queries/snowflake_queries/snowflake_login_without_mfa.py:8:0: C0303: Trailing whitespace (trailing-whitespace)
************* Module snowflake_queries.snowflake_brute_force_username
queries/snowflake_queries/snowflake_brute_force_username.py:6:0: C0301: Line too long (103/100) (line-too-long)
queries/snowflake_queries/snowflake_brute_force_username.py:7:0: C0303: Trailing whitespace (trailing-whitespace)
************* Module snowflake_queries.snowflake_external_shares
queries/snowflake_queries/snowflake_external_shares.py:6:0: C0301: Line too long (119/100) (line-too-long)
************* Module snowflake_queries.snowflake_multiple_failed_logins_followed_by_success
queries/snowflake_queries/snowflake_multiple_failed_logins_followed_by_success.py:9:0: C0301: Line too long (123/100) (line-too-long)
************* Module snowflake_queries.snowflake_brute_force_ip
queries/snowflake_queries/snowflake_brute_force_ip.py:5:0: C0301: Line too long (122/100) (line-too-long)
queries/snowflake_queries/snowflake_brute_force_ip.py:6:0: C0303: Trailing whitespace (trailing-whitespace)
************* Module snowflake_queries.snowflake_user_enabled
queries/snowflake_queries/snowflake_user_enabled.py:7:0: C0301: Line too long (106/100) (line-too-long)
queries/snowflake_queries/snowflake_user_enabled.py:8:0: C0301: Line too long (101/100) (line-too-long)
queries/snowflake_queries/snowflake_user_enabled.py:9:0: C0303: Trailing whitespace (trailing-whitespace)
************* Module snowflake_queries.snowflake_key_user_password_login
queries/snowflake_queries/snowflake_key_user_password_login.py:6:0: C0303: Trailing whitespace (trailing-whitespace)
************* Module snowflake_queries.snowflake_user_created
queries/snowflake_queries/snowflake_user_created.py:7:0: C0301: Line too long (106/100) (line-too-long)
queries/snowflake_queries/snowflake_user_created.py:8:0: C0301: Line too long (101/100) (line-too-long)
queries/snowflake_queries/snowflake_user_created.py:9:0: C0303: Trailing whitespace (trailing-whitespace)
************* Module snowflake_queries.snowflake_public_role_grant
queries/snowflake_queries/snowflake_public_role_grant.py:3:0: C0303: Trailing whitespace (trailing-whitespace)
************* Module aws_queries.scheduled_rule_default
queries/aws_queries/scheduled_rule_default.py:3:0: C0303: Trailing whitespace (trailing-whitespace)

-------------------------------------------------------------------
Your code has been rated at 9.98/10 (previous run: 10.00/10, -0.02)

make: *** [lint-pylint] Error 16
```
