### PR TITLE
fix: update spacing in deep_walk docstring

### DIFF
--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -320,7 +320,7 @@ def deep_walk(
 
     Parameters:
     obj (any): the original log event passed to rule(event)
-                and nested objects retrieved recursively
+               and nested objects retrieved recursively
     keys (str): comma-separated list of keys used to traverse the event object
     default (str): the default value to return if the desired key's value is not present
     return_val (str): string specifying which value to return


### PR DESCRIPTION
### Background

When I was updating the documentation for this function yesterday I noticed that I left in an extra space.

This is a very small change for the sake of consistency.

### Changes

* Removes an extra space in the `deep_walk` docstring

### Testing

N/A