### PR TITLE
fix: when a global is used as a state machine, it is preferable to define it in rule()

### DIFF
--- a/rules/standard_rules/impossible_travel_login.py
+++ b/rules/standard_rules/impossible_travel_login.py
@@ -11,10 +11,7 @@ from panther_oss_helpers import (
     resolve_timestamp_string,
 )
 
-EVENT_CITY_TRACKING = {}
-CACHE_KEY = None
-IS_VPN = False
-IS_APPLE_PRIVATE_RELAY = False
+# pylint: disable=global-variable-undefined
 
 
 def gen_key(event):
@@ -38,6 +35,11 @@ def rule(event):
     global CACHE_KEY
     global IS_VPN
     global IS_APPLE_PRIVATE_RELAY
+
+    EVENT_CITY_TRACKING = {}
+    CACHE_KEY = None
+    IS_VPN = False
+    IS_APPLE_PRIVATE_RELAY = False
 
     # Only evaluate successful logins
     if event.udm("event_type") != event_type.SUCCESSFUL_LOGIN:

--- a/rules/standard_rules/impossible_travel_login.yml
+++ b/rules/standard_rules/impossible_travel_login.yml
@@ -436,6 +436,7 @@ Tests:
           "ipinfo_privacy": {
             "client.ipAddress": {
               "hosting": false,
+              "p_match": "12.12.12.12",
               "proxy": false,
               "relay": false,
               "service": "Private Internet Access",


### PR DESCRIPTION
### Background
There was a vestigial tail of sorts in **Standard.ImpossibleTravel.Login** test case `Okta sign-in with history and impossible travel, VPN with service` where the alert_context attribute `"is_apple_priv_relay"` was set to true, though it shouldn't have been. 

To my ability to validate it, this nit wouldn't cause things to alert that otherwise shouldn't. 

This ultimately seems to be a side effect of how globals work inside the unit testing framework. By moving the definition of the global variable into `rule()`, we ensure that the global gets reset for each test case. 

I checked detections using globals ( ignoring the rules that have global-filters:  auth0_rule, tines_rule,  snyk_rule,  github_rules,  notion_rules,  cloudflare_rules ) and I didn't identify any enabled rules that had this specific configuration. 

In this same test case, the p_match field hadn't been backfilled into the ipinfo_privacy enrichment. 

### Testing

```text
Standard.ImpossibleTravel.Login
	[PASS] CloudTrail not ConsoleLogin
		[PASS] [rule] false
	[PASS] CloudTrail ConsoleLogin no history
		[PASS] [rule] false
	[PASS] CloudTrail ConsoleLogin with history
		[PASS] [rule] true
		[PASS] [title] Impossible Travel: [tester] in [LogSource Name] went [7098] km/h for [14197] km between [New York City] and [Auckland]
		[PASS] [dedup] LogSourceName..tester
		[PASS] [alertContext] {"actor_user": "tester", "previous": {"p_event_time": "2023-05-26 18:14:51", "city": "New York City", "country": "US", "lat": "40.71427", "lng": "-74.00597", "postal_code": "10004", "region": "New York", "region_code": "NY", "timezone": "America/New_York"}, "current": {"p_event_time": "2023-05-26T20:14:51", "source_ip": "12.12.12.12", "city": "Auckland", "country": "NZ", "lat": "-36.84853", "lng": "174.76349", "p_match": "12.12.12.12", "postal_code": "1010", "region": "Auckland", "region_code": "AUK", "timezone": "Pacific/Auckland"}, "speed": 7098, "speed_units": "km/h", "distance": 14197, "distance_units": "km"}
		[PASS] [severity] HIGH
	[PASS] Okta Not sign-in
		[PASS] [rule] false
	[PASS] Okta sign-in with history and impossible travel
		[PASS] [rule] true
		[PASS] [title] Impossible Travel: [Homer Simpson] in [Okta Logs] went [6869] km/h for [14197] km between [New York City] and [Auckland]
		[PASS] [dedup] OktaLogs..Homer Simpson
		[PASS] [alertContext] {"actor_user": "Homer Simpson", "previous": {"p_event_time": "2023-05-26 18:14:51", "city": "New York City", "country": "US", "lat": "40.71427", "lng": "-74.00597", "postal_code": "10004", "region": "New York", "region_code": "NY", "timezone": "America/New_York"}, "current": {"p_event_time": "2023-05-26T20:18:51", "source_ip": "12.12.12.12", "city": "Auckland", "country": "NZ", "lat": "-36.84853", "lng": "174.76349", "p_match": "12.12.12.12", "postal_code": "1010", "region": "Auckland", "region_code": "AUK", "timezone": "Pacific/Auckland"}, "speed": 6869, "speed_units": "km/h", "distance": 14197, "distance_units": "km"}
		[PASS] [severity] HIGH
	[PASS] Okta sign-in with history and impossible travel, Apple Private Relay
		[PASS] [rule] true
		[PASS] [title] Impossible Travel: [Homer Simpson] in [Okta Logs] went [1904] km/h for [3936] km between [New York City] and [Los Angeles]
		[PASS] [dedup] OktaLogs..Homer Simpson
		[PASS] [alertContext] {"actor_user": "Homer Simpson", "previous": {"p_event_time": "2023-05-26 18:14:51", "city": "New York City", "country": "US", "lat": "40.71427", "lng": "-74.00597", "postal_code": "10004", "region": "New York", "region_code": "NY", "timezone": "America/New_York"}, "current": {"p_event_time": "2023-05-26T20:18:51", "source_ip": "12.12.12.12", "city": "Los Angeles", "country": "US", "lat": "34.05223", "lng": "-118.24368", "p_match": "12.12.12.12", "postal_code": "90009", "region": "California", "region_code": "CA", "timezone": "America/Los_Angeles", "is_vpn": "False", "is_apple_priv_relay": "True", "service_name": "Apple Private Relay", "NOTE": "APPLE PRIVATE RELAY AND VPN LOGINS ARE NOT CACHED FOR COMPARISON"}, "speed": 1904, "speed_units": "km/h", "distance": 3936, "distance_units": "km"}
		[PASS] [severity] INFO
	[PASS] Okta sign-in with history and impossible travel, VPN with service
		[PASS] [rule] true
		[PASS] [title] Impossible Travel: [Homer Simpson] in [Okta Logs] went [1904] km/h for [3936] km between [New York City] and [Los Angeles]
		[PASS] [dedup] OktaLogs..Homer Simpson
		[PASS] [alertContext] {"actor_user": "Homer Simpson", "previous": {"p_event_time": "2023-05-26 18:14:51", "city": "New York City", "country": "US", "lat": "40.71427", "lng": "-74.00597", "postal_code": "10004", "region": "New York", "region_code": "NY", "timezone": "America/New_York"}, "current": {"p_event_time": "2023-05-26T20:18:51", "source_ip": "12.12.12.12", "city": "Los Angeles", "country": "US", "lat": "34.05223", "lng": "-118.24368", "p_match": "12.12.12.12", "postal_code": "90009", "region": "California", "region_code": "CA", "timezone": "America/Los_Angeles", "is_vpn": "True", "is_apple_priv_relay": "False", "service_name": "Private Internet Access", "NOTE": "APPLE PRIVATE RELAY AND VPN LOGINS ARE NOT CACHED FOR COMPARISON"}, "speed": 1904, "speed_units": "km/h", "distance": 3936, "distance_units": "km"}
		[PASS] [severity] INFO
	[PASS] Okta sign-in with history and impossible travel, VPN with no service
		[PASS] [rule] true
		[PASS] [title] Impossible Travel: [Homer Simpson] in [Okta Logs] went [1904] km/h for [3936] km between [New York City] and [Los Angeles]
		[PASS] [dedup] OktaLogs..Homer Simpson
		[PASS] [alertContext] {"actor_user": "Homer Simpson", "previous": {"p_event_time": "2023-05-26 18:14:51", "city": "New York City", "country": "US", "lat": "40.71427", "lng": "-74.00597", "postal_code": "10004", "region": "New York", "region_code": "NY", "timezone": "America/New_York"}, "current": {"p_event_time": "2023-05-26T20:18:51", "source_ip": "12.12.12.12", "city": "Los Angeles", "country": "US", "lat": "34.05223", "lng": "-118.24368", "p_match": "12.12.12.12", "postal_code": "90009", "region": "California", "region_code": "CA", "timezone": "America/Los_Angeles"}, "speed": 1904, "speed_units": "km/h", "distance": 3936, "distance_units": "km"}
		[PASS] [severity] HIGH
	[PASS] Short Distances and Short Timedeltas
		[PASS] [rule] true
		[PASS] [title] Impossible Travel: [Homer Simpson] in [Okta Logs] went [1111] km/h for [40] km between [Los Angeles] and [Anaheim]
		[PASS] [dedup] OktaLogs..Homer Simpson
		[PASS] [alertContext] {"actor_user": "Homer Simpson", "previous": {"city": "Los Angeles", "country": "US", "lat": "34.05223", "lng": "-118.24368", "p_event_time": "2023-06-12T22:23:51.964000", "postal_code": "90009", "region": "California", "region_code": "CA", "timezone": "America/Los_Angeles"}, "current": {"p_event_time": "2023-06-12T22:26:01.951000", "source_ip": "12.12.12.11", "p_match": "12.12.12.11", "city": "Anaheim", "country": "US", "lat": "33.8085", "lng": "-117.9228", "postal_code": "92802", "region": "California", "region_code": "CA", "timezone": "America/Los_Angeles"}, "speed": 1111, "speed_units": "km/h", "distance": 40, "distance_units": "km"}
		[PASS] [severity] LOW
	[PASS] Asana ImpossibleTravel
		[PASS] [rule] true
		[PASS] [title] Impossible Travel: [Homer Simpson] in [Asana Logs] went [3920] km/h for [3920] km between [New York City] and [Anaheim]
		[PASS] [dedup] AsanaLogs..Homer Simpson
		[PASS] [alertContext] {"actor_user": "Homer Simpson", "previous": {"p_event_time": "2023-06-12T21:26:01.951000", "city": "New York City", "country": "US", "lat": "40.71427", "lng": "-74.00597", "postal_code": "10004", "region": "New York", "region_code": "NY", "timezone": "America/New_York"}, "current": {"p_event_time": "2023-06-12T22:26:01.951000", "source_ip": "1.2.3.4", "p_match": "1.2.3.4", "city": "Anaheim", "country": "US", "lat": "33.8085", "lng": "-117.9228", "postal_code": "92802", "region": "California", "region_code": "CA", "timezone": "America/Los_Angeles"}, "speed": 3920, "speed_units": "km/h", "distance": 3920, "distance_units": "km"}
		[PASS] [severity] HIGH

--------------------------
Panther CLI Test Summary
	Path: .
	Passed: 1
	Failed: 0
	Invalid: 0


```