### PR TITLE
Rework a few GCP detections to use deep_walk

### DIFF
--- a/global_helpers/gcp_environment.py
+++ b/global_helpers/gcp_environment.py
@@ -9,9 +9,9 @@ rule_exceptions = {
                     "system:serviceaccount:example-namespace:example-namespace-service-account"
                 ],
                 # If empty, then all namespaces
-                "namespaces": [],
+                "namespaces": ["example"],
                 # If projects empty then all projects
-                "projects": [],
+                "projects": ["rigup-production"],
             },
             {
                 "principals": ["example-allowed-user@example.com"],

--- a/global_helpers/gcp_environment.py
+++ b/global_helpers/gcp_environment.py
@@ -9,9 +9,9 @@ rule_exceptions = {
                     "system:serviceaccount:example-namespace:example-namespace-service-account"
                 ],
                 # If empty, then all namespaces
-                "namespaces": ["example"],
+                "namespaces": [],
                 # If projects empty then all projects
-                "projects": ["rigup-production"],
+                "projects": [],
             },
             {
                 "principals": ["example-allowed-user@example.com"],

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -312,7 +312,7 @@ def deep_get(dictionary: dict, *keys, default=None):
 
 # pylint: disable=too-complex,too-many-return-statements
 def deep_walk(
-    obj: Optional[Any], *keys: str, default: str = None, return_val: str = "all"
+    obj: Optional[Any], *keys: str, default: Optional[str] = None, return_val: str = "all"
 ) -> Union[Optional[Any], Optional[List[Any]]]:
     """Safely retrieve a value stored in complex dictionary structure
 
@@ -343,7 +343,7 @@ def deep_walk(
         return default if _empty_list(obj) else obj
 
     current_key = keys[0]
-    found = OrderedDict()
+    found: OrderedDict = OrderedDict()
 
     if isinstance(obj, Mapping):
         next_key = obj.get(current_key, None)
@@ -362,13 +362,13 @@ def deep_walk(
                 else:
                     found[value] = None
 
-    found = list(found.keys())
-    if not found:
+    found_list: list[Any] = list(found.keys())
+    if not found_list:
         return default
     return {
-        "first": found[0],
-        "last": found[-1],
-        "all": found[0] if len(found) == 1 else found,
+        "first": found_list[0],
+        "last": found_list[-1],
+        "all": found_list[0] if len(found_list) == 1 else found_list,
     }.get(return_val, "all")
 
 

--- a/rules/gcp_audit_rules/gcp_access_attempts_violating_vpc_service_controls.py
+++ b/rules/gcp_audit_rules/gcp_access_attempts_violating_vpc_service_controls.py
@@ -7,9 +7,14 @@ def rule(event):
     violation_types = deep_walk(
         event, "protoPayload", "status", "details", "violations", "type", default=""
     )
-    if severity == "ERROR" and status_code == 7:
-        if "VPC_SERVICE_CONTROLS" in violation_types:
-            return True
+    if all(
+        [
+            severity == "ERROR",
+            status_code == 7,
+            "VPC_SERVICE_CONTROLS" in violation_types,
+        ]
+    ):
+        return True
     return False
 
 

--- a/rules/gcp_audit_rules/gcp_access_attempts_violating_vpc_service_controls.py
+++ b/rules/gcp_audit_rules/gcp_access_attempts_violating_vpc_service_controls.py
@@ -4,11 +4,11 @@ from panther_base_helpers import deep_get, deep_walk
 def rule(event):
     severity = deep_get(event, "severity", default="")
     status_code = deep_get(event, "protoPayload", "status", "code", default="")
-    violations = deep_walk(
+    violation_types = deep_walk(
         event, "protoPayload", "status", "details", "violations", "type", default=""
     )
     if severity == "ERROR" and status_code == 7:
-        if "VPC_SERVICE_CONTROLS" in violations:
+        if "VPC_SERVICE_CONTROLS" in violation_types:
             return True
     return False
 

--- a/rules/gcp_audit_rules/gcp_access_attempts_violating_vpc_service_controls.py
+++ b/rules/gcp_audit_rules/gcp_access_attempts_violating_vpc_service_controls.py
@@ -5,7 +5,7 @@ def rule(event):
     severity = deep_get(event, "severity", default="")
     status_code = deep_get(event, "protoPayload", "status", "code", default="")
     violation_types = deep_walk(
-        event, "protoPayload", "status", "details", "violations", "type", default=""
+        event, "protoPayload", "status", "details", "violations", "type", default=[]
     )
     if all(
         [

--- a/rules/gcp_audit_rules/gcp_access_attempts_violating_vpc_service_controls.py
+++ b/rules/gcp_audit_rules/gcp_access_attempts_violating_vpc_service_controls.py
@@ -4,7 +4,9 @@ from panther_base_helpers import deep_get, deep_walk
 def rule(event):
     severity = deep_get(event, "severity", default="")
     status_code = deep_get(event, "protoPayload", "status", "code", default="")
-    violations = deep_walk(event, "protoPayload", "status", "details", "violations", "type", default="")
+    violations = deep_walk(
+        event, "protoPayload", "status", "details", "violations", "type", default=""
+    )
     if severity == "ERROR" and status_code == 7:
         if "VPC_SERVICE_CONTROLS" in violations:
             return True

--- a/rules/gcp_audit_rules/gcp_access_attempts_violating_vpc_service_controls.py
+++ b/rules/gcp_audit_rules/gcp_access_attempts_violating_vpc_service_controls.py
@@ -2,12 +2,12 @@ from panther_base_helpers import deep_get, deep_walk
 
 
 def rule(event):
-    if event.get("severity", "") == "ERROR":
-        if deep_get(event, "protoPayload", "status", "code") == 7:
-            return (
-                deep_walk(event, "protoPayload", "status", "details", "violations", "type")
-                == "VPC_SERVICE_CONTROLS"
-            )
+    severity = deep_get(event, "severity", default="")
+    status_code = deep_get(event, "protoPayload", "status", "code", default="")
+    violations = deep_walk(event, "protoPayload", "status", "details", "violations", "type", default="")
+    if severity == "ERROR" and status_code == 7:
+        if "VPC_SERVICE_CONTROLS" in violations:
+            return True
     return False
 
 

--- a/rules/gcp_audit_rules/gcp_access_attempts_violating_vpc_service_controls.py
+++ b/rules/gcp_audit_rules/gcp_access_attempts_violating_vpc_service_controls.py
@@ -1,15 +1,13 @@
-from panther_base_helpers import deep_get
+from panther_base_helpers import deep_get, deep_walk
 
 
 def rule(event):
     if event.get("severity", "") == "ERROR":
         if deep_get(event, "protoPayload", "status", "code") == 7:
-            details = deep_get(event, "protoPayload", "status", "details", default=[])
-            for detail in details:
-                violations = deep_get(detail, "violations", default=[])
-                for violation in violations:
-                    if violation.get("type", "") == "VPC_SERVICE_CONTROLS":
-                        return True
+            return (
+                deep_walk(event, "protoPayload", "status", "details", "violations", "type")
+                == "VPC_SERVICE_CONTROLS"
+            )
     return False
 
 

--- a/rules/gcp_audit_rules/gcp_access_attempts_violating_vpc_service_controls.yml
+++ b/rules/gcp_audit_rules/gcp_access_attempts_violating_vpc_service_controls.yml
@@ -123,6 +123,8 @@ Tests:
                       violations:
                         - description: gBc-wuGVCapNMnTUePoHos_VyJmr3CsMKlr48kVa4b6XpsT_OWKRng
                           type: VPC_SERVICE_CONTROLS
+                        - description: gCc-wuJa334DJ9940ssdiw_V8400skgjj3912500sldgjzh_LGJANr
+                          type: OTHER_CONTROL_VIOLATION
                 message: 'Request is prohibited by organization''s policy. vpcServiceControlsUniqueIdentifier: gBc-wuGVCapNMnTUePoHos_VyJmr3CsMKlr48kVa4b6XpsT_OWKRng'
         receiveTimestamp: "2023-03-09T16:28:42.567340480Z"
         resource:

--- a/rules/gcp_audit_rules/gcp_log_bucket_or_sink_deleted.py
+++ b/rules/gcp_audit_rules/gcp_log_bucket_or_sink_deleted.py
@@ -1,15 +1,11 @@
 import re
 
 from gcp_base_helpers import gcp_alert_context
-from panther_base_helpers import deep_get
+from panther_base_helpers import deep_get, deep_walk
 
 
 def rule(event):
-    authenticated = deep_get(
-        deep_get(event, "protoPayload", "authorizationInfo", default=[{}])[0],
-        "granted",
-        default=False,
-    )
+    authenticated = deep_walk(event, "protoPayload", "authorizationInfo", "granted", default=False)
     method_pattern = r"(?:\w+\.)*v\d\.(?:ConfigServiceV\d\.(?:Delete(Bucket|Sink)))"
     match = re.search(method_pattern, deep_get(event, "protoPayload", "methodName", default=""))
     return authenticated and match is not None

--- a/rules/gcp_k8s_rules/gcp_k8s_exec_into_pod.py
+++ b/rules/gcp_k8s_rules/gcp_k8s_exec_into_pod.py
@@ -36,7 +36,7 @@ def rule(event):
 
 
 def severity(event):
-    project_id = deep_walk(get_k8s_info(event), "project_id", default="")
+    project_id = deep_walk(get_k8s_info(event), "project_id", default="", return_val="last")
     if project_id in PRODUCTION_PROJECT_IDS:
         return "high"
     return "info"

--- a/rules/gcp_k8s_rules/gcp_k8s_exec_into_pod.py
+++ b/rules/gcp_k8s_rules/gcp_k8s_exec_into_pod.py
@@ -1,37 +1,42 @@
 from gcp_base_helpers import get_k8s_info
 from gcp_environment import PRODUCTION_PROJECT_IDS, rule_exceptions
-from panther_base_helpers import deep_get
+from panther_base_helpers import deep_walk
 
 
 def rule(event):
     # Defaults to False (no alert) unless method is exec and principal not allowed
-    if not deep_get(
+    if not deep_walk(
         event, "protoPayload", "methodName"
-    ) == "io.k8s.core.v1.pods.exec.create" or not deep_get(event, "protoPayload", "resourceName"):
+    ) == "io.k8s.core.v1.pods.exec.create" or not deep_walk(event, "protoPayload", "resourceName"):
         return False
 
     k8s_info = get_k8s_info(event)
-    principal = k8s_info["principal"]
-    namespace = k8s_info["namespace"]
-    project_id = k8s_info["project_id"]
+    principal = deep_walk(k8s_info, "principal", default="", return_val="last")
+    namespace = deep_walk(k8s_info, "namespace", default="", return_val="last")
+    project_id = deep_walk(k8s_info, "project_id", default="", return_val="last")
     # rule_exceptions that are allowed temporarily are defined in gcp_environment.py
     # Some execs have principal which is long numerical UUID, appears to be k8s internals
-    for allowed_principal in rule_exceptions["gcp_k8s_exec_into_pod"]["allowed_principals"]:
+    for allowed_principal in deep_walk(
+        rule_exceptions, "gcp_k8s_exec_into_pod", "allowed_principals", default=""
+    ):
         if (
-            principal in allowed_principal["principals"]
+            principal in deep_walk(allowed_principal, "principals", default="")
             and (
-                not allowed_principal["namespaces"] or namespace in allowed_principal["namespaces"]
+                not deep_walk(allowed_principal, "namespaces", default="")
+                or namespace in deep_walk(allowed_principal, "namespaces", default="")
             )
-            and (not allowed_principal["projects"] or project_id in allowed_principal["projects"])
+            and (
+                not deep_walk(allowed_principal, "projects", default="")
+                or project_id in deep_walk(allowed_principal, "projects", default="")
+            )
         ):
-            # nested if since without we get linting error R0916
             if principal.find("@") == -1:
                 return False
     return True
 
 
 def severity(event):
-    project_id = get_k8s_info(event)["project_id"]
+    project_id = deep_walk(get_k8s_info(event), "project_id", default="")
     if project_id in PRODUCTION_PROJECT_IDS:
         return "high"
     return "info"
@@ -40,10 +45,10 @@ def severity(event):
 def title(event):
     # TODO: use unified data model field in title for actor
     k8s_info = get_k8s_info(event)
-    principal = k8s_info["principal"]
-    project_id = k8s_info["project_id"]
-    pod = k8s_info["pod"]
-    namespace = k8s_info["namespace"]
+    principal = deep_walk(k8s_info, "principal", default="", return_val="last")
+    project_id = deep_walk(k8s_info, "project_id", default="", return_val="last")
+    pod = deep_walk(k8s_info, "pod", default="", return_val="last")
+    namespace = deep_walk(k8s_info, "namespace", default="", return_val="last")
     return f"Exec into pod namespace/{namespace}/pod/{pod} by {principal} in {project_id}"
 
 

--- a/rules/gcp_k8s_rules/gcp_k8s_exec_into_pod.py
+++ b/rules/gcp_k8s_rules/gcp_k8s_exec_into_pod.py
@@ -11,9 +11,9 @@ def rule(event):
         return False
 
     k8s_info = get_k8s_info(event)
-    principal = deep_walk(k8s_info, "principal", default="", return_val="last")
-    namespace = deep_walk(k8s_info, "namespace", default="", return_val="last")
-    project_id = deep_walk(k8s_info, "project_id", default="", return_val="last")
+    principal = deep_walk(k8s_info, "principal", default="")
+    namespace = deep_walk(k8s_info, "namespace", default="")
+    project_id = deep_walk(k8s_info, "project_id", default="")
     # rule_exceptions that are allowed temporarily are defined in gcp_environment.py
     # Some execs have principal which is long numerical UUID, appears to be k8s internals
     for allowed_principal in deep_walk(
@@ -36,7 +36,7 @@ def rule(event):
 
 
 def severity(event):
-    project_id = deep_walk(get_k8s_info(event), "project_id", default="", return_val="last")
+    project_id = deep_walk(get_k8s_info(event), "project_id", default="")
     if project_id in PRODUCTION_PROJECT_IDS:
         return "high"
     return "info"
@@ -45,10 +45,14 @@ def severity(event):
 def title(event):
     # TODO: use unified data model field in title for actor
     k8s_info = get_k8s_info(event)
-    principal = deep_walk(k8s_info, "principal", default="", return_val="last")
-    project_id = deep_walk(k8s_info, "project_id", default="", return_val="last")
-    pod = deep_walk(k8s_info, "pod", default="", return_val="last")
-    namespace = deep_walk(k8s_info, "namespace", default="", return_val="last")
+    principal = deep_walk(k8s_info, "principal", default="")
+    project_id = deep_walk(
+        k8s_info,
+        "project_id",
+        default="",
+    )
+    pod = deep_walk(k8s_info, "pod", default="")
+    namespace = deep_walk(k8s_info, "namespace", default="")
     return f"Exec into pod namespace/{namespace}/pod/{pod} by {principal} in {project_id}"
 
 

--- a/rules/gcp_k8s_rules/gcp_k8s_exec_into_pod.py
+++ b/rules/gcp_k8s_rules/gcp_k8s_exec_into_pod.py
@@ -22,10 +22,15 @@ def rule(event):
     for allowed_principal in deep_walk(
         rule_exceptions, "gcp_k8s_exec_into_pod", "allowed_principals", default=[]
     ):
+        allowed_principals = deep_walk(allowed_principal, "principals", default=[])
+        allowed_namespaces = deep_walk(allowed_principal, "namespaces", default=[])
+        allowed_project_ids = deep_walk(allowed_principal, "projects", default=[])
         if (
-            principal in deep_walk(allowed_principal, "principals", default=[])
-            and namespace in deep_walk(allowed_principal, "namespaces", default=[])
-            and project_id in deep_walk(allowed_principal, "projects", default=[])
+            principal in allowed_principals
+            and namespace in allowed_namespaces
+            or allowed_namespaces == []
+            and project_id in allowed_project_ids
+            or allowed_project_ids == []
         ):
             if "@" not in principal:
                 return False

--- a/rules/gcp_k8s_rules/gcp_k8s_exec_into_pod.py
+++ b/rules/gcp_k8s_rules/gcp_k8s_exec_into_pod.py
@@ -27,10 +27,8 @@ def rule(event):
         allowed_project_ids = deep_walk(allowed_principal, "projects", default=[])
         if (
             principal in allowed_principals
-            and namespace in allowed_namespaces
-            or allowed_namespaces == []
-            and project_id in allowed_project_ids
-            or allowed_project_ids == []
+            and (namespace in allowed_namespaces or allowed_namespaces == [])
+            and (project_id in allowed_project_ids or allowed_project_ids == [])
         ):
             if "@" not in principal:
                 return False


### PR DESCRIPTION
### Background

@edyesed mentioned that some GCP detections could benefit from using `deep_walk`, so this PR implements that.

### Changes

* Updates the following detections to use `deep_walk`:
  * `gcp_access_attempts_violating_vpc_service_controls.py`
  * `gcp_log_bucket_or_sink_deleted.py`
  * `gcp_permissions_granted_to_create_or_manage_service_account_key.py`
  * `gcp_k8s_exec_into_pod.py`

### Testing

* Tests still pass as expected
