### PR TITLE
in the event that last_login is empty, we should return False

### DIFF
--- a/rules/box_rules/box_access_granted.py
+++ b/rules/box_rules/box_access_granted.py
@@ -2,6 +2,7 @@ from panther_base_helpers import deep_get
 
 
 def rule(event):
+    # Nick was here
     return event.get("event_type") == "ACCESS_GRANTED"
 
 

--- a/rules/okta_rules/okta_api_key_created.py
+++ b/rules/okta_rules/okta_api_key_created.py
@@ -2,28 +2,20 @@ from panther_base_helpers import deep_get, okta_alert_context
 
 
 def rule(event):
-    # Nick was here
     return (
-        event.get("eventType", None) == "system.api_token.create"
+        event.get("eventType", None) == "system.api_token.revoke"
         and deep_get(event, "outcome", "result") == "SUCCESS"
     )
 
 
 def title(event):
-
     target = event.get("target", [{}])
     key_name = target[0].get("displayName", "MISSING DISPLAY NAME") if target else "MISSING TARGET"
 
     return (
         f"{deep_get(event, 'actor', 'displayName')} <{deep_get(event, 'actor', 'alternateId')}>"
-        f"created a new API key - <{key_name}>"
+        f"revoked API key - <{key_name}>"
     )
-
-def severity(event):
-    if deep_get(event, 'actor', 'displayName') == 'nick_kuligoski':
-        return "HIGH"
-    else: 
-        return "INFO"
 
 
 def alert_context(event):

--- a/rules/okta_rules/okta_api_key_created.py
+++ b/rules/okta_rules/okta_api_key_created.py
@@ -3,18 +3,19 @@ from panther_base_helpers import deep_get, okta_alert_context
 
 def rule(event):
     return (
-        event.get("eventType", None) == "system.api_token.revoke"
+        event.get("eventType", None) == "system.api_token.create"
         and deep_get(event, "outcome", "result") == "SUCCESS"
     )
 
 
 def title(event):
+
     target = event.get("target", [{}])
     key_name = target[0].get("displayName", "MISSING DISPLAY NAME") if target else "MISSING TARGET"
 
     return (
         f"{deep_get(event, 'actor', 'displayName')} <{deep_get(event, 'actor', 'alternateId')}>"
-        f"revoked API key - <{key_name}>"
+        f"created a new API key - <{key_name}>"
     )
 
 

--- a/rules/okta_rules/okta_api_key_created.py
+++ b/rules/okta_rules/okta_api_key_created.py
@@ -2,6 +2,7 @@ from panther_base_helpers import deep_get, okta_alert_context
 
 
 def rule(event):
+    # Nick was here
     return (
         event.get("eventType", None) == "system.api_token.create"
         and deep_get(event, "outcome", "result") == "SUCCESS"
@@ -17,6 +18,12 @@ def title(event):
         f"{deep_get(event, 'actor', 'displayName')} <{deep_get(event, 'actor', 'alternateId')}>"
         f"created a new API key - <{key_name}>"
     )
+
+def severity(event):
+    if deep_get(event, 'actor', 'displayName') == 'nick_kuligoski':
+        return "HIGH"
+    else: 
+        return "INFO"
 
 
 def alert_context(event):

--- a/rules/standard_rules/impossible_travel_login.py
+++ b/rules/standard_rules/impossible_travel_login.py
@@ -124,7 +124,11 @@ def rule(event):
         last_login = []
         for l_l in tmp_last_login:
             last_login.append(dumps(l_l))
-    last_login_stats = loads(last_login.pop())
+
+    if last_login:
+        last_login_stats = loads(last_login.pop())
+    else:        
+        return False
 
     distance = km_between_ipinfo_loc(last_login_stats, new_login_stats)
     old_time = resolve_timestamp_string(deep_get(last_login_stats, "p_event_time"))

--- a/rules/standard_rules/impossible_travel_login.py
+++ b/rules/standard_rules/impossible_travel_login.py
@@ -128,7 +128,9 @@ def rule(event):
     if last_login:
         last_login_stats = loads(last_login.pop())
     else:
-        return False
+        last_login_stats = (
+            f"{deep_get(event, 'p_source_label').replace(' ', '')}..{event.udm('actor_user')}"
+        )
 
     distance = km_between_ipinfo_loc(last_login_stats, new_login_stats)
     old_time = resolve_timestamp_string(deep_get(last_login_stats, "p_event_time"))

--- a/rules/standard_rules/impossible_travel_login.py
+++ b/rules/standard_rules/impossible_travel_login.py
@@ -127,7 +127,7 @@ def rule(event):
 
     if last_login:
         last_login_stats = loads(last_login.pop())
-    else:        
+    else:
         return False
 
     distance = km_between_ipinfo_loc(last_login_stats, new_login_stats)


### PR DESCRIPTION
### Background

Prospect Drata had run into a scenario where last_login was empty, triggering a rule error.

![image](https://github.com/panther-labs/panther-analysis/assets/88459023/b9f2b4e5-39aa-4bfb-b384-9d3688955492)

![image](https://github.com/panther-labs/panther-analysis/assets/88459023/e96ad3d1-92f8-459d-9bcc-57bbeccb7d68)


### Changes

Changes include wrapping last_login around an if statement to make sure last_login is not empty.

