### PR TITLE
Fixes misnaming of github_repo_collaborator_change

### DIFF
--- a/indexes/github.md
+++ b/indexes/github.md
@@ -22,7 +22,7 @@
 
 [ GitHub Repository Created](../rules/github_rules/github_repo_created.py)
 
-[ GitHub Repository Visibility Change](../rules/github_rules/github_repo_collaborator_change.py)
+[ GitHub Repository Collaborator Change](../rules/github_rules/github_repo_collaborator_change.py)
 
 [ GitHub Web Hook Modified](../rules/github_rules/github_repo_hook_modified.py)
 

--- a/rules/github_rules/github_repo_collaborator_change.yml
+++ b/rules/github_rules/github_repo_collaborator_change.yml
@@ -1,7 +1,7 @@
 AnalysisType: rule
 Filename: github_repo_collaborator_change.py
 RuleID: "Github.Repo.CollaboratorChange"
-DisplayName: "GitHub Repository Visibility Change"
+DisplayName: "GitHub Repository Collaborator Change"
 Enabled: true
 LogTypes:
   - GitHub.Audit


### PR DESCRIPTION
Currently, two rules are named `GitHub Repository Visibility Change`

This PR fixes that