### PR TITLE
fix: typechecking fixes for isinstance(whatever,list)

### DIFF
--- a/global_helpers/panther_greynoise_helpers.py
+++ b/global_helpers/panther_greynoise_helpers.py
@@ -1,5 +1,6 @@
 # pylint: disable=too-many-public-methods
 import datetime
+from collections.abc import Sequence
 from typing import Union
 
 from dateutil import parser
@@ -58,7 +59,7 @@ class GreyNoiseBasic(LookupTableMatches):
         ip_address = self._lookup(match_field, "ip")
         if not ip_address:
             return None
-        if isinstance(ip_address, list):
+        if isinstance(ip_address, Sequence) and not isinstance(ip_address, str):
             return [
                 f"https://www.greynoise.io/viz/ip/{list_ip_address}"
                 for list_ip_address in ip_address
@@ -86,7 +87,7 @@ class GreyNoiseAdvanced(GreyNoiseBasic):
 
     def cve_string(self, match_field: str, limit: int = 10) -> str:
         cve_raw = self._lookup(match_field, "cve")
-        if isinstance(cve_raw, list):
+        if isinstance(cve_raw, Sequence) and not isinstance(cve_raw, str):
             return " ".join(cve_raw[:limit])
         return cve_raw
 
@@ -100,7 +101,7 @@ class GreyNoiseAdvanced(GreyNoiseBasic):
         time = self._lookup(match_field, "first_seen")
         if not time:
             return None
-        if isinstance(time, list):
+        if isinstance(time, Sequence) and not isinstance(time, str):
             if len(time) == 0:
                 return None
             return min(parser.parse(t) for t in time)
@@ -110,7 +111,7 @@ class GreyNoiseAdvanced(GreyNoiseBasic):
         time = self._lookup(match_field, "last_seen_timestamp")
         if not time:
             return None
-        if isinstance(time, list):
+        if isinstance(time, Sequence) and not isinstance(time, str):
             if len(time) == 0:
                 return None
             return max(parser.parse(t) for t in time)
@@ -157,7 +158,7 @@ class GreyNoiseAdvanced(GreyNoiseBasic):
 
     def tags_string(self, match_field: str, limit: int = 10) -> str:
         tags_raw = self._lookup(match_field, "tags")
-        if isinstance(tags_raw, list):
+        if isinstance(tags_raw, Sequence) and not isinstance(tags_raw, str):
             return " ".join(tags_raw[:limit])
         return tags_raw
 
@@ -208,7 +209,7 @@ class GreyNoiseRIOTBasic(LookupTableMatches):
         is_riot = self._lookup(match_field, "ip_cidr")
         if not is_riot:
             return False
-        if isinstance(is_riot, list):  # at least 1
+        if isinstance(is_riot, Sequence) and not isinstance(is_riot, str):  # at least 1
             for list_is_riot in is_riot:
                 if list_is_riot:
                     return True
@@ -225,7 +226,7 @@ class GreyNoiseRIOTBasic(LookupTableMatches):
         ip_stripped = self._lookup(match_field, "ip_cidr")
         if not ip_stripped:
             return None
-        if isinstance(ip_stripped, list):
+        if isinstance(ip_stripped, Sequence) and not isinstance(ip_stripped, str):
             return [
                 f"https://www.greynoise.io/viz/ip/{list_ip_stripped}"
                 for list_ip_stripped in ip_stripped
@@ -236,7 +237,7 @@ class GreyNoiseRIOTBasic(LookupTableMatches):
         time = self._lookup(match_field, "scan_time")
         if not time:
             return None
-        if isinstance(time, list):
+        if isinstance(time, Sequence) and not isinstance(time, str):
             if len(time) == 0:
                 return None
             return max(parser.parse(t) for t in time)
@@ -306,7 +307,7 @@ def GreyNoiseSeverity(event, field, default="MEDIUM"):
         return "INFO"
 
     classification = noise.classification(field)
-    if isinstance(classification, list):
+    if isinstance(classification, Sequence) and not isinstance(classification, str):
         highest_severity = "INFO"
         for list_classification in classification:
             severity = GreyNoiseSeverityDecode(list_classification, default)

--- a/global_helpers/panther_lookuptable_helpers.py
+++ b/global_helpers/panther_lookuptable_helpers.py
@@ -17,7 +17,7 @@ class LookupTableMatches:
         match = deep_get(self.lut_matches, match_field)
         if not match:
             return None
-        if isinstance(match, list):
+        if isinstance(match, Sequence) and not isinstance(match, str):
             return [deep_get(match_value, *keys) if match_value else None for match_value in match]
         return deep_get(match, *keys)
 

--- a/global_helpers/panther_tor_helpers.py
+++ b/global_helpers/panther_tor_helpers.py
@@ -1,4 +1,5 @@
 import datetime
+from collections.abc import Sequence
 
 from panther_lookuptable_helpers import LookupTableMatches
 
@@ -19,7 +20,7 @@ class TorExitNodes(LookupTableMatches):
         """Return link to Tor database"""
         today = datetime.datetime.today().strftime("%Y-%m-%d")
         ip_address = self.ip_address(match_field)
-        if isinstance(ip_address, list):
+        if isinstance(ip_address, Sequence) and not isinstance(ip_address, str):
             return [
                 # pylint: disable=C0301 (line-too-long)
                 f"https://metrics.torproject.org/exonerator.html?ip={list_ip_address}&timestamp={today}&lang=en"

--- a/policies/aws_ec2_policies/aws_ec2_instance_approved_vpc.py
+++ b/policies/aws_ec2_policies/aws_ec2_instance_approved_vpc.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 # Tags: ['AWS Managed Rules - Compute']
 # This is a list of approved VPC IDs. All EC2 instances must exist in one of these VPCs.
 APPROVED_VPCS = {
@@ -21,7 +23,7 @@ def policy(resource):
                 if isinstance(IGNORED_INSTANCE_TAGS[tag], str):
                     if tags[tag] == IGNORED_INSTANCE_TAGS[tag]:
                         return True
-                elif isinstance(IGNORED_INSTANCE_TAGS[tag], list):
+                elif isinstance(IGNORED_INSTANCE_TAGS[tag], Sequence):
                     if tags[tag] in IGNORED_INSTANCE_TAGS[tag]:
                         return True
 

--- a/policies/aws_iam_policies/aws_iam_role_external_permission.py
+++ b/policies/aws_iam_policies/aws_iam_role_external_permission.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Sequence
 
 from botocore.exceptions import NoCredentialsError
 from panther_oss_helpers import BadLookup, resource_lookup
@@ -67,7 +68,7 @@ def check_account(resource):
         content_assumerole = json.loads(content_assumerole)
     principal = content_assumerole["Statement"][0]["Principal"]
     if "AWS" in principal.keys():
-        if isinstance(principal["AWS"], list):
+        if isinstance(principal["AWS"], Sequence) and not isinstance(principal["AWS"], str):
             for principal_aws in principal["AWS"]:
                 if not check_account_number(principal_aws):
                     return False


### PR DESCRIPTION
### Background

When python global-unit-tests run, python base types ( `str`, `list`, `dict`) are generally used. 

When `panther_analysis_tool test` tests are run, and when the detections-engine is processing events, the base classes of events do not answer to `isinstance(whatever, list)` or `isinstance(whatever, dict)`. Instead objects answer to `isinstance(whatever, collections.abc.Sequence)` or `collections.abc.Mapping` in the case of dicts.  

This can lead to scenarios where behavior that is codified in python unit tests do not have the expected result. 

There had been a PR  in the past ( #435 )  to excise direct references to panther_core, which provides the PantherEvent types that subclass collections.abc.Mapping & Sequence. 



### Changes

Look for callers of isinstance(..., list) and isinstance(..., dict) and evaluate if they need updates or not. 

No detections or unit tests needed changes as a result of this changeset. Ideally, this is due to `isinstance(..., collections.abc.Sequence)` being truthy everywhere that `isinstance(..., list)` is truthy. 

### Testing

make global-helpers-unit-test 
and 
make test 