### PR TITLE
fix: unit testing suite should test by using the panther_analysis_tool.immutable types

### DIFF
--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -165,50 +165,49 @@ class TestBoxParseAdditionalDetails(unittest.TestCase):
         self.initial_str_list_json = "[1, 2, 3, 4]"
 
     def test_additional_details_string(self):
-        event = {"additional_details": self.initial_str}
+        event = ImmutableCaseInsensitiveDict({"additional_details": self.initial_str})
         returns = p_b_h.box_parse_additional_details(event)
         self.assertEqual(returns.get("t", 0), 10)
 
     # in the case of a byte array, we expect the empty dict
     def test_additional_details_bytes(self):
-        event = {"additional_details": self.initial_bytes}
+        event = ImmutableCaseInsensitiveDict({"additional_details": self.initial_bytes})
         returns = p_b_h.box_parse_additional_details(event)
         self.assertEqual(len(returns), 0)
 
     # In the case of a list ( not a string or bytes array ), expect un-altered return
     def test_additional_details_list(self):
-        event = {"additional_details": self.initial_list}
+        event = ImmutableCaseInsensitiveDict({"additional_details": self.initial_list})
         returns = p_b_h.box_parse_additional_details(event)
         self.assertEqual(len(returns), 4)
 
     # in the case of a dict or similar, we expect it to be returned un-altered
     def test_additional_details_dict(self):
-        event = {"additional_details": self.initial_dict}
+        event = ImmutableCaseInsensitiveDict({"additional_details": self.initial_dict})
         returns = p_b_h.box_parse_additional_details(event)
         self.assertEqual(returns.get("t", 0), 10)
 
     # If it's a string with no json object to be decoded, we expect an empty dict back
     def test_additional_details_plain_str(self):
-        event = {"additional_details": self.initial_str_no_json}
+        event = ImmutableCaseInsensitiveDict({"additional_details": self.initial_str_no_json})
         returns = p_b_h.box_parse_additional_details(event)
         self.assertEqual(len(returns), 0)
 
     # If it's a string with a json list, we expect the list
     def test_additional_details_str_list_json(self):
-        event = {"additional_details": self.initial_str_list_json}
+        event = ImmutableCaseInsensitiveDict({"additional_details": self.initial_str_list_json})
         returns = p_b_h.box_parse_additional_details(event)
         self.assertEqual(len(returns), 4)
 
 
 class TestTorExitNodes(unittest.TestCase):
     def setUp(self):
-
-        self.event = {
+        self.event = ImmutableCaseInsensitiveDict({
             "p_enrichment": {"tor_exit_nodes": {"foo": {"ip": "1.2.3.4"}, "p_match": "1.2.3.4"}}
-        }
+        })
 
         # match against array field
-        self.event_list = {
+        self.event_list = ImmutableCaseInsensitiveDict({
             "p_enrichment": {
                 "tor_exit_nodes": {
                     "p_any_ip_addresses": [
@@ -217,7 +216,7 @@ class TestTorExitNodes(unittest.TestCase):
                     ]
                 }
             }
-        }
+        })
 
     def test_ip_address_not_found(self):
         """Should not find anything"""
@@ -282,7 +281,7 @@ class TestTorExitNodes(unittest.TestCase):
 
 class TestGreyNoiseBasic(unittest.TestCase):
     def setUp(self):
-        self.event = {
+        self.event = ImmutableCaseInsensitiveDict({
             "p_enrichment": {
                 "greynoise_noise_basic": {
                     "ClientIP": {
@@ -293,7 +292,7 @@ class TestGreyNoiseBasic(unittest.TestCase):
                     }
                 }
             }
-        }
+        })
 
     def test_greynoise_object(self):
         """Should be basic"""
@@ -363,7 +362,7 @@ class TestGreyNoiseBasic(unittest.TestCase):
 # pylint: disable=too-many-public-methods
 class TestGreyNoiseAdvanced(unittest.TestCase):
     def setUp(self):
-        self.event = {
+        self.event = ImmutableCaseInsensitiveDict({
             "p_enrichment": {
                 "greynoise_noise_advanced": {
                     "ClientIP": {
@@ -401,9 +400,9 @@ class TestGreyNoiseAdvanced(unittest.TestCase):
                     }
                 }
             }
-        }
+        })
 
-        self.event_list = {
+        self.event_list = ImmutableCaseInsensitiveDict({
             "p_enrichment": {
                 "greynoise_noise_advanced": {
                     "p_any_ip_addresses": [
@@ -468,7 +467,7 @@ class TestGreyNoiseAdvanced(unittest.TestCase):
                     ]
                 }
             }
-        }
+        })
 
     def test_greynoise_object(self):
         """Should be advanced"""
@@ -704,7 +703,7 @@ class TestGreyNoiseAdvanced(unittest.TestCase):
 
 class TestRIOTBasic(unittest.TestCase):
     def setUp(self):
-        self.event = {
+        self.event = ImmutableCaseInsensitiveDict({
             "p_enrichment": {
                 "greynoise_riot_basic": {
                     "ClientIP": {
@@ -715,7 +714,7 @@ class TestRIOTBasic(unittest.TestCase):
                     }
                 }
             }
-        }
+        })
 
     def test_greynoise_object(self):
         """Should be basic"""
@@ -779,7 +778,7 @@ class TestRIOTBasic(unittest.TestCase):
 
 class TestRIOTAdvanced(unittest.TestCase):
     def setUp(self):
-        self.event = {
+        self.event = ImmutableCaseInsensitiveDict({
             "p_enrichment": {
                 "greynoise_riot_advanced": {
                     "ClientIP": {
@@ -797,10 +796,10 @@ class TestRIOTAdvanced(unittest.TestCase):
                     }
                 }
             }
-        }
+        })
 
         # for testing array matches
-        self.event_list = {
+        self.event_list = ImmutableCaseInsensitiveDict({
             "p_enrichment": {
                 "greynoise_riot_advanced": {
                     "p_any_ip_addresses": [
@@ -833,7 +832,7 @@ class TestRIOTAdvanced(unittest.TestCase):
                     ]
                 }
             }
-        }
+        })
 
     def test_greynoise_object(self):
         """Should be advanced"""
@@ -948,7 +947,7 @@ class TestRIOTAdvanced(unittest.TestCase):
 class TestIpInfoHelpersLocation(unittest.TestCase):
     def setUp(self):
         self.match_field = "clientIp"
-        self.event = {
+        self.event = ImmutableCaseInsensitiveDict({
             "p_enrichment": {
                 p_i_h.IPINFO_LOCATION_LUT_NAME: {
                     self.match_field: {
@@ -964,7 +963,7 @@ class TestIpInfoHelpersLocation(unittest.TestCase):
                     }
                 }
             }
-        }
+        })
         self.ip_info = p_i_h.get_ipinfo_location(self.event)
 
     def test_city(self):
@@ -1019,7 +1018,7 @@ class TestIpInfoHelpersLocation(unittest.TestCase):
 class TestIpInfoHelpersASN(unittest.TestCase):
     def setUp(self):
         self.match_field = "clientIp"
-        self.event = {
+        self.event = ImmutableCaseInsensitiveDict({
             "p_enrichment": {
                 p_i_h.IPINFO_ASN_LUT_NAME: {
                     self.match_field: {
@@ -1032,7 +1031,7 @@ class TestIpInfoHelpersASN(unittest.TestCase):
                     }
                 }
             }
-        }
+        })
         self.ip_info = p_i_h.get_ipinfo_asn(self.event)
 
     def test_asn(self):
@@ -1142,7 +1141,7 @@ class TestGetCrowdstrikeField(unittest.TestCase):
 class TestIpInfoHelpersPrivacy(unittest.TestCase):
     def setUp(self):
         self.match_field = "clientIp"
-        self.event = {
+        self.event = ImmutableCaseInsensitiveDict({
             "p_enrichment": {
                 p_i_h.IPINFO_PRIVACY_LUT_NAME: {
                     self.match_field: {
@@ -1156,7 +1155,7 @@ class TestIpInfoHelpersPrivacy(unittest.TestCase):
                     }
                 }
             }
-        }
+        })
         self.ip_info = p_i_h.get_ipinfo_privacy(self.event)
 
     def test_hosting(self):
@@ -1201,7 +1200,7 @@ class TestIpInfoHelpersPrivacy(unittest.TestCase):
 class TestGeoInfoFromIP(unittest.TestCase):
     def setUp(self):
         self.match_field = "clientIp"
-        self.event = {
+        self.event = ImmutableCaseInsensitiveDict({
             "p_enrichment": {
                 p_i_h.IPINFO_ASN_LUT_NAME: {
                     self.match_field: {
@@ -1228,7 +1227,7 @@ class TestGeoInfoFromIP(unittest.TestCase):
                 },
             },
             self.match_field: "1.2.3.4",
-        }
+        })
 
     def test_geoinfo(self):
         geoinfo = p_i_h.geoinfo_from_ip(self.event, self.match_field)
@@ -1245,7 +1244,7 @@ class TestGeoInfoFromIP(unittest.TestCase):
         self.assertEqual(expected, geoinfo)
 
     def test_ipinfo_not_enabled_exception(self):
-        event = {"p_enrichment": {}}
+        event = ImmutableCaseInsensitiveDict({"p_enrichment": {}})
         with self.assertRaises(p_i_h.PantherIPInfoException) as exc:
             p_i_h.geoinfo_from_ip(event, "fake_field")
 
@@ -2078,10 +2077,10 @@ class TestNotionHelpers(unittest.TestCase):
 class TestLookupTableHelpers(unittest.TestCase):
     # pylint: disable=protected-access
     def setUp(self):
-        self.simple_event_no_pmatch = {
+        self.simple_event_no_pmatch = ImmutableCaseInsensitiveDict({
             "p_enrichment": {"tor_exit_nodes": {"foo": {"ip": "1.2.3.4"}}}
-        }
-        self.simple_event = {
+        })
+        self.simple_event = ImmutableCaseInsensitiveDict({
             "p_enrichment": {
                 "tor_exit_nodes": {
                     "foo": {"ip": "1.2.3.4", "p_match": "1.2.3.4"},
@@ -2098,9 +2097,9 @@ class TestLookupTableHelpers(unittest.TestCase):
                     }
                 },
             }
-        }
+        })
         # match against array field
-        self.list_event = {
+        self.list_event = ImmutableCaseInsensitiveDict({
             "p_enrichment": {
                 "tor_exit_nodes": {
                     "p_any_ip_addresses": [
@@ -2109,7 +2108,7 @@ class TestLookupTableHelpers(unittest.TestCase):
                     ]
                 }
             }
-        }
+        })
 
     def test_register(self):
         lut = p_l_h.LookupTableMatches()

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -1476,15 +1476,13 @@ class TestDeepWalk(unittest.TestCase):
             "value3",
         )
         self.assertEqual(p_b_h.deep_walk(event, "key", "another_key", default=""), "value6")
-        # XXX self.assertEqual(p_b_h.deep_walk(event, "key", "empty_list_key", default=""), "")
+        self.assertEqual(p_b_h.deep_walk(event, "key", "empty_list_key", default=""), "")
         self.assertEqual(
             p_b_h.deep_walk(event, "key", "empty_list_key", "nonexistent_key", default=""), ""
         )
-        # XXX Disabled due to failing test 
-        # self.assertEqual(p_b_h.deep_walk(event, "key", "multiple_empty_lists_key1", default=""), "")
-        # self.assertEqual(p_b_h.deep_walk(event, "key", "multiple_empty_lists_key2", default=""), "")
-        # self.assertEqual(p_b_h.deep_walk(event, "key", "multiple_empty_lists_key3", default=""), "")
-        # XXX /Disabled due to failing test 
+        self.assertEqual(p_b_h.deep_walk(event, "key", "multiple_empty_lists_key1", default=""), "")
+        self.assertEqual(p_b_h.deep_walk(event, "key", "multiple_empty_lists_key2", default=""), "")
+        self.assertEqual(p_b_h.deep_walk(event, "key", "multiple_empty_lists_key3", default=""), "")
         self.assertEqual(
             p_b_h.deep_walk(
                 event, "key", "multiple_nested_lists_with_dict", "very_nested_key", default=""

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -12,6 +12,7 @@ import unittest
 
 import boto3
 from moto import mock_dynamodb
+from panther_analysis_tool.immutable import ImmutableCaseInsensitiveDict, ImmutableList
 
 # pipenv run does the right thing, but IDE based debuggers may fail to import
 #   so noting, we append this directory to sys.path
@@ -36,57 +37,59 @@ import panther_tor_helpers as p_tor_h  # pylint: disable=C0413
 class TestEksPantherObjRef(unittest.TestCase):
     def setUp(self):
         # pylint: disable=C0301
-        self.event = {
-            "annotations": {
-                "authorization.k8s.io/decision": "allow",
-                "authorization.k8s.io/reason": "",
-            },
-            "apiVersion": "audit.k8s.io/v1",
-            "auditID": "35506555-dffc-4337-b2b1-c4af52b88e18",
-            "kind": "Event",
-            "level": "Request",
-            "objectRef": {
-                "apiVersion": "v1",
-                "name": "some-job-xxx1y",
-                "namespace": "default",
-                "resource": "pods",
-                "subresource": "log",
-            },
-            "p_any_aws_account_ids": ["123412341234"],
-            "p_any_aws_arns": [
-                "arn:aws:iam::123412341234:role/KubeAdministrator",
-                "arn:aws:sts::123412341234:assumed-role/KubeAdministrator/1669660343296132000",
-            ],
-            "p_any_ip_addresses": ["5.5.5.5"],
-            "p_any_usernames": ["kubernetes-admin"],
-            "p_event_time": "2022-11-29 00:09:04.38",
-            "p_log_type": "Amazon.EKS.Audit",
-            "p_parse_time": "2022-11-29 00:10:25.067",
-            "p_row_id": "2e4ab474b0f0f7a4a8fff4f014aab32a",
-            "p_source_id": "4c859cd4-9406-469b-9e0e-c2dc1bee24fa",
-            "p_source_label": "example-cluster-eks-logs",
-            "requestReceivedTimestamp": "2022-11-29 00:09:04.38",
-            "requestURI": "/api/v1/namespaces/default/pods/kube-bench-drn4j/log?container=kube-bench",
-            "responseStatus": {"code": 200},
-            "sourceIPs": ["5.5.5.5"],
-            "stage": "ResponseComplete",
-            "stageTimestamp": "2022-11-29 00:09:04.394",
-            "user": {
-                "extra": {
-                    "accessKeyId": ["ASIARLIVEKVNNXXXXXXX"],
-                    "arn": [
-                        "arn:aws:sts::123412341234:assumed-role/KubeAdministrator/1669660343296132000"
-                    ],
-                    "canonicalArn": ["arn:aws:iam::123412341234:role/KubeAdministrator"],
-                    "sessionName": ["1669660343296132000"],
+        self.event = ImmutableCaseInsensitiveDict(
+            {
+                "annotations": {
+                    "authorization.k8s.io/decision": "allow",
+                    "authorization.k8s.io/reason": "",
                 },
-                "groups": ["system:masters", "system:authenticated"],
-                "uid": "aws-iam-authenticator:123412341234:AROARLIVEXXXXXXXXXXXX",
-                "username": "kubernetes-admin",
-            },
-            "userAgent": "kubectl/v1.25.4 (darwin/arm64) kubernetes/872a965",
-            "verb": "get",
-        }
+                "apiVersion": "audit.k8s.io/v1",
+                "auditID": "35506555-dffc-4337-b2b1-c4af52b88e18",
+                "kind": "Event",
+                "level": "Request",
+                "objectRef": {
+                    "apiVersion": "v1",
+                    "name": "some-job-xxx1y",
+                    "namespace": "default",
+                    "resource": "pods",
+                    "subresource": "log",
+                },
+                "p_any_aws_account_ids": ["123412341234"],
+                "p_any_aws_arns": [
+                    "arn:aws:iam::123412341234:role/KubeAdministrator",
+                    "arn:aws:sts::123412341234:assumed-role/KubeAdministrator/1669660343296132000",
+                ],
+                "p_any_ip_addresses": ["5.5.5.5"],
+                "p_any_usernames": ["kubernetes-admin"],
+                "p_event_time": "2022-11-29 00:09:04.38",
+                "p_log_type": "Amazon.EKS.Audit",
+                "p_parse_time": "2022-11-29 00:10:25.067",
+                "p_row_id": "2e4ab474b0f0f7a4a8fff4f014aab32a",
+                "p_source_id": "4c859cd4-9406-469b-9e0e-c2dc1bee24fa",
+                "p_source_label": "example-cluster-eks-logs",
+                "requestReceivedTimestamp": "2022-11-29 00:09:04.38",
+                "requestURI": "/api/v1/namespaces/default/pods/kube-bench-drn4j/log?container=kube-bench",
+                "responseStatus": {"code": 200},
+                "sourceIPs": ["5.5.5.5"],
+                "stage": "ResponseComplete",
+                "stageTimestamp": "2022-11-29 00:09:04.394",
+                "user": {
+                    "extra": {
+                        "accessKeyId": ["ASIARLIVEKVNNXXXXXXX"],
+                        "arn": [
+                            "arn:aws:sts::123412341234:assumed-role/KubeAdministrator/1669660343296132000"
+                        ],
+                        "canonicalArn": ["arn:aws:iam::123412341234:role/KubeAdministrator"],
+                        "sessionName": ["1669660343296132000"],
+                    },
+                    "groups": ["system:masters", "system:authenticated"],
+                    "uid": "aws-iam-authenticator:123412341234:AROARLIVEXXXXXXXXXXXX",
+                    "username": "kubernetes-admin",
+                },
+                "userAgent": "kubectl/v1.25.4 (darwin/arm64) kubernetes/872a965",
+                "verb": "get",
+            }
+        )
 
     def test_complete_event(self):
         response = p_b_h.eks_panther_obj_ref(self.event)
@@ -100,12 +103,14 @@ class TestEksPantherObjRef(unittest.TestCase):
         self.assertEqual(response.get("p_source_label", ""), "example-cluster-eks-logs")
 
     def test_all_missing_event(self):
-        del self.event["user"]["username"]
-        del self.event["objectRef"]
-        del self.event["sourceIPs"]
-        del self.event["verb"]
-        del self.event["p_source_label"]
-        response = p_b_h.eks_panther_obj_ref(self.event)
+        temp_event = self.event.to_dict()
+        del temp_event["user"]["username"]
+        del temp_event["objectRef"]
+        del temp_event["sourceIPs"]
+        del temp_event["verb"]
+        del temp_event["p_source_label"]
+        temp_event = ImmutableCaseInsensitiveDict(temp_event)
+        response = p_b_h.eks_panther_obj_ref(temp_event)
         self.assertEqual(response.get("actor", ""), "<NO_USERNAME>")
         self.assertEqual(response.get("object", ""), "<NO_OBJECT_NAME>")
         self.assertEqual(response.get("ns", ""), "<NO_OBJECT_NAMESPACE>")
@@ -116,18 +121,22 @@ class TestEksPantherObjRef(unittest.TestCase):
         self.assertEqual(response.get("p_source_label", ""), "<NO_P_SOURCE_LABEL>")
 
     def test_missing_subresource_event(self):
-        del self.event["objectRef"]["subresource"]
-        response = p_b_h.eks_panther_obj_ref(self.event)
+        temp_event = self.event.to_dict()
+        del temp_event["objectRef"]["subresource"]
+        temp_event = ImmutableCaseInsensitiveDict(temp_event)
+        response = p_b_h.eks_panther_obj_ref(temp_event)
         self.assertEqual(response.get("resource", ""), "pods")
 
 
 class TestGetValFromList(unittest.TestCase):
     def setUp(self):
-        self.input = [
-            {"actor": 1, "one": 1, "select": "me"},
-            {"actor": 2, "two": 2, "select": "me"},
-            {"actor": 3, "three": 3, "select": "not_me"},
-        ]
+        self.input = ImmutableList(
+            [
+                {"actor": 1, "one": 1, "select": "me"},
+                {"actor": 2, "two": 2, "select": "me"},
+                {"actor": 3, "three": 3, "select": "not_me"},
+            ]
+        )
 
     def test_input_key_exists(self):
         response = p_b_h.get_val_from_list(self.input, "actor", "select", "me")
@@ -146,8 +155,10 @@ class TestGetValFromList(unittest.TestCase):
 
 class TestBoxParseAdditionalDetails(unittest.TestCase):
     def setUp(self):
-        self.initial_dict = {"t": 10, "a": [{"b": 1, "c": 2}], "d": {"e": {"f": True}}}
-        self.initial_list = ["1", 2, True, False]
+        self.initial_dict = ImmutableCaseInsensitiveDict(
+            {"t": 10, "a": [{"b": 1, "c": 2}], "d": {"e": {"f": True}}}
+        )
+        self.initial_list = ImmutableList(["1", 2, True, False])
         self.initial_bytes = b'{"t": 10, "a": [{"b": 1, "c": 2}], "d": {"e": {"f": True}}}'
         self.initial_str = '{"t": 10, "a": [{"b": 1, "c": 2}], "d": {"e": {"f": true}}}'
         self.initial_str_no_json = "this is a plain string"
@@ -1060,12 +1071,14 @@ class TestIpInfoHelpersASN(unittest.TestCase):
 
 class TestFilterCrowdStrikeFdrEventType(unittest.TestCase):
     def setUp(self):
-        self.input = {
-            "p_log_type": "Crowdstrike.FDREvent",
-            "aid": "else",
-            "event": {"foo": "bar"},
-            "fdr_event_type": "DnsRequest",
-        }
+        self.input = ImmutableCaseInsensitiveDict(
+            {
+                "p_log_type": "Crowdstrike.FDREvent",
+                "aid": "else",
+                "event": {"foo": "bar"},
+                "fdr_event_type": "DnsRequest",
+            }
+        )
 
     def test_is_different_with_fdr_event_type_provided(self):
         response = p_b_h.filter_crowdstrike_fdr_event_type(self.input, "SomethingElse")
@@ -1076,23 +1089,27 @@ class TestFilterCrowdStrikeFdrEventType(unittest.TestCase):
         self.assertEqual(response, False)
 
     def test_is_entirely_different_type(self):
-        self.input = {
-            "p_log_type": "Crowdstrike.DnsRequest",
-            "aid": "else",
-            "event": {"foo": "bar"},
-        }
+        self.input = ImmutableCaseInsensitiveDict(
+            {
+                "p_log_type": "Crowdstrike.DnsRequest",
+                "aid": "else",
+                "event": {"foo": "bar"},
+            }
+        )
         response = p_b_h.filter_crowdstrike_fdr_event_type(self.input, "DnsRequest")
         self.assertEqual(response, False)
 
 
 class TestGetCrowdstrikeField(unittest.TestCase):
     def setUp(self):
-        self.input = {
-            "cid": "something",
-            "aid": "else",
-            "event": {"foo": "bar"},
-            "unknown_payload": {"field": "is"},
-        }
+        self.input = ImmutableCaseInsensitiveDict(
+            {
+                "cid": "something",
+                "aid": "else",
+                "event": {"foo": "bar"},
+                "unknown_payload": {"field": "is"},
+            }
+        )
 
     def test_input_key_default_works(self):
         response = p_b_h.get_crowdstrike_field(self.input, "zee", default="hello")
@@ -1115,8 +1132,10 @@ class TestGetCrowdstrikeField(unittest.TestCase):
         self.assertEqual(response, "is")
 
     def test_precedence(self):
-        self.input["event"]["field"] = "found"
-        response = p_b_h.get_crowdstrike_field(self.input, "field")
+        temp_event = self.input.to_dict()
+        temp_event["event"]["field"] = "found"
+        temp_event = ImmutableCaseInsensitiveDict(temp_event)
+        response = p_b_h.get_crowdstrike_field(temp_event, "field")
         self.assertEqual(response, "found")
 
 
@@ -1246,10 +1265,12 @@ class TestGeoInfoFromIP(unittest.TestCase):
 
 class TestDeepGet(unittest.TestCase):
     def test_deep_get(self):
-        event = {"thing": {"value": "one"}}
+        event = ImmutableCaseInsensitiveDict({"thing": {"value": "one"}})
         self.assertEqual(p_b_h.deep_get(event, "thing", "value"), "one")
         self.assertEqual(p_b_h.deep_get(event, "thing", "not_exist", default="ok"), "ok")
-        event["thing"]["none_val"] = None
+        temp_event = event.to_dict()
+        temp_event["thing"]["none_val"] = None
+        event = ImmutableCaseInsensitiveDict(temp_event)
         self.assertEqual(p_b_h.deep_get(event, "thing", "none_val", default="ok"), "ok")
         # If the value and the default kwarg are both None, then return None
         self.assertEqual(p_b_h.deep_get(event, "thing", "none_val", default=None), None)
@@ -1395,34 +1416,38 @@ class TestDeepWalk(unittest.TestCase):
 
         :return:
         """
-        event = {
-            "key": {
-                "inner_key": [{"nested_key": "nested_value"}, {"nested_key": "nested_value2"}],
-                "very_nested": [
-                    {
-                        "outer_key": [
-                            {
-                                "nested_key": "value",
-                                "nested_key2": [{"nested_key3": "value2"}],
-                            },
-                            {
-                                "nested_key": "value4",
-                                "nested_key2": [{"nested_key3": "value2"}],
-                            },
-                        ],
-                        "outer_key2": [{"nested_key4": "value3"}],
-                    }
-                ],
-                "another_key": "value6",
-                "empty_list_key": [],
-                "multiple_empty_lists_key1": [[]],
-                "multiple_empty_lists_key2": [[[]]],
-                "multiple_empty_lists_key3": [[[[[[]]]]]],
-                "multiple_nested_lists_with_dict": [[[{"very_nested_key": "very_nested_value"}]]],
-                "nested_dict_key": {"nested_dict_value": "value7"},
-                "none_value": None,
+        event = ImmutableCaseInsensitiveDict(
+            {
+                "key": {
+                    "inner_key": [{"nested_key": "nested_value"}, {"nested_key": "nested_value2"}],
+                    "very_nested": [
+                        {
+                            "outer_key": [
+                                {
+                                    "nested_key": "value",
+                                    "nested_key2": [{"nested_key3": "value2"}],
+                                },
+                                {
+                                    "nested_key": "value4",
+                                    "nested_key2": [{"nested_key3": "value2"}],
+                                },
+                            ],
+                            "outer_key2": [{"nested_key4": "value3"}],
+                        }
+                    ],
+                    "another_key": "value6",
+                    "empty_list_key": [],
+                    "multiple_empty_lists_key1": [[]],
+                    "multiple_empty_lists_key2": [[[]]],
+                    "multiple_empty_lists_key3": [[[[[[]]]]]],
+                    "multiple_nested_lists_with_dict": [
+                        [[{"very_nested_key": "very_nested_value"}]]
+                    ],
+                    "nested_dict_key": {"nested_dict_value": "value7"},
+                    "none_value": None,
+                }
             }
-        }
+        )
         self.assertEqual(
             p_b_h.deep_walk(event, "key", "inner_key", "nested_key", default=""),
             ["nested_value", "nested_value2"],
@@ -1452,13 +1477,15 @@ class TestDeepWalk(unittest.TestCase):
             "value3",
         )
         self.assertEqual(p_b_h.deep_walk(event, "key", "another_key", default=""), "value6")
-        self.assertEqual(p_b_h.deep_walk(event, "key", "empty_list_key", default=""), "")
+        # XXX self.assertEqual(p_b_h.deep_walk(event, "key", "empty_list_key", default=""), "")
         self.assertEqual(
             p_b_h.deep_walk(event, "key", "empty_list_key", "nonexistent_key", default=""), ""
         )
-        self.assertEqual(p_b_h.deep_walk(event, "key", "multiple_empty_lists_key1", default=""), "")
-        self.assertEqual(p_b_h.deep_walk(event, "key", "multiple_empty_lists_key2", default=""), "")
-        self.assertEqual(p_b_h.deep_walk(event, "key", "multiple_empty_lists_key3", default=""), "")
+        # XXX Disabled due to failing test 
+        # self.assertEqual(p_b_h.deep_walk(event, "key", "multiple_empty_lists_key1", default=""), "")
+        # self.assertEqual(p_b_h.deep_walk(event, "key", "multiple_empty_lists_key2", default=""), "")
+        # self.assertEqual(p_b_h.deep_walk(event, "key", "multiple_empty_lists_key3", default=""), "")
+        # XXX /Disabled due to failing test 
         self.assertEqual(
             p_b_h.deep_walk(
                 event, "key", "multiple_nested_lists_with_dict", "very_nested_key", default=""
@@ -1474,86 +1501,90 @@ class TestDeepWalk(unittest.TestCase):
 
 class TestCloudflareHelpers(unittest.TestCase):
     def setUp(self):
-        self.event = {
-            "Source": "firewallrules",
-            "ClientIP": "12.12.12.12",
-            "BotScore": 0,
-            "Action": "block",
-        }
+        self.event = ImmutableCaseInsensitiveDict(
+            {
+                "Source": "firewallrules",
+                "ClientIP": "12.12.12.12",
+                "BotScore": 0,
+                "Action": "block",
+            }
+        )
         self.possible_sources = p_cf_h.FIREWALL_SOURCE_MAPPING.keys()
-        self.http_event = {
-            # pylint: disable=line-too-long
-            # ClientUserAgent line is too long
-            "CacheCacheStatus": "hit",
-            "CacheResponseBytes": 21213,
-            "CacheResponseStatus": 200,
-            "CacheTieredFill": True,
-            "ClientASN": 15169,
-            "ClientCountry": "us",
-            "ClientDeviceType": "desktop",
-            "ClientIP": "12.12.12.12",
-            "ClientIPClass": "searchEngine",
-            "ClientMTLSAuthCertFingerprint": "",
-            "ClientMTLSAuthStatus": "unknown",
-            "ClientRequestBytes": 5460,
-            "ClientRequestHost": "panther.com",
-            "ClientRequestMethod": "GET",
-            "ClientRequestPath": "/blog/",
-            "ClientRequestProtocol": "HTTP/1.1",
-            "ClientRequestReferer": "",
-            "ClientRequestScheme": "https",
-            "ClientRequestSource": "edgeWorkerFetch",
-            "ClientRequestURI": "/blog/",
-            "ClientRequestUserAgent": "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
-            "ClientSSLCipher": "NONE",
-            "ClientSSLProtocol": "none",
-            "ClientSrcPort": 0,
-            "ClientTCPRTTMs": 0,
-            "ClientXRequestedWith": "",
-            "EdgeCFConnectingO2O": False,
-            "EdgeColoCode": "ABC",
-            "EdgeColoID": 111,
-            "EdgeEndTimestamp": "2022-08-27 22:00:10",
-            "EdgePathingOp": "wl",
-            "EdgePathingSrc": "macro",
-            "EdgePathingStatus": "se",
-            "EdgeRateLimitAction": "",
-            "EdgeRateLimitID": "0",
-            "EdgeRequestHost": "panther.com",
-            "EdgeResponseBodyBytes": 76074,
-            "EdgeResponseBytes": 77454,
-            "EdgeResponseCompressionRatio": 1,
-            "EdgeResponseContentType": "text/html",
-            "EdgeResponseStatus": 200,
-            "EdgeServerIP": "",
-            "EdgeStartTimestamp": "2022-08-27 22:00:10",
-            "EdgeTimeToFirstByteMs": 82,
-            "OriginDNSResponseTimeMs": 0,
-            "OriginIP": "",
-            "OriginRequestHeaderSendDurationMs": 0,
-            "OriginResponseBytes": 0,
-            "OriginResponseDurationMs": 70,
-            "OriginResponseStatus": 0,
-            "OriginResponseTime": 0,
-            "OriginSSLProtocol": "unknown",
-            "ParentRayID": "7000000000000000",
-            "RayID": "7000000000000001",
-            "SecurityLevel": "off",
-            "SmartRouteColoID": 0,
-            "UpperTierColoID": 1,
-            "WAFAction": "unknown",
-            "WAFFlags": "0",
-            "WAFMatchedVar": "xx",
-            "WAFProfile": "unknown",
-            "WAFRuleID": "xx",
-            "WAFRuleMessage": "xx",
-            "WorkerCPUTime": 0,
-            "WorkerStatus": "unknown",
-            "WorkerSubrequest": True,
-            "WorkerSubrequestCount": 0,
-            "ZoneID": 500000000,
-            "ZoneName": "panther.com",
-        }
+        self.http_event = ImmutableCaseInsensitiveDict(
+            {
+                # pylint: disable=line-too-long
+                # ClientUserAgent line is too long
+                "CacheCacheStatus": "hit",
+                "CacheResponseBytes": 21213,
+                "CacheResponseStatus": 200,
+                "CacheTieredFill": True,
+                "ClientASN": 15169,
+                "ClientCountry": "us",
+                "ClientDeviceType": "desktop",
+                "ClientIP": "12.12.12.12",
+                "ClientIPClass": "searchEngine",
+                "ClientMTLSAuthCertFingerprint": "",
+                "ClientMTLSAuthStatus": "unknown",
+                "ClientRequestBytes": 5460,
+                "ClientRequestHost": "panther.com",
+                "ClientRequestMethod": "GET",
+                "ClientRequestPath": "/blog/",
+                "ClientRequestProtocol": "HTTP/1.1",
+                "ClientRequestReferer": "",
+                "ClientRequestScheme": "https",
+                "ClientRequestSource": "edgeWorkerFetch",
+                "ClientRequestURI": "/blog/",
+                "ClientRequestUserAgent": "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+                "ClientSSLCipher": "NONE",
+                "ClientSSLProtocol": "none",
+                "ClientSrcPort": 0,
+                "ClientTCPRTTMs": 0,
+                "ClientXRequestedWith": "",
+                "EdgeCFConnectingO2O": False,
+                "EdgeColoCode": "ABC",
+                "EdgeColoID": 111,
+                "EdgeEndTimestamp": "2022-08-27 22:00:10",
+                "EdgePathingOp": "wl",
+                "EdgePathingSrc": "macro",
+                "EdgePathingStatus": "se",
+                "EdgeRateLimitAction": "",
+                "EdgeRateLimitID": "0",
+                "EdgeRequestHost": "panther.com",
+                "EdgeResponseBodyBytes": 76074,
+                "EdgeResponseBytes": 77454,
+                "EdgeResponseCompressionRatio": 1,
+                "EdgeResponseContentType": "text/html",
+                "EdgeResponseStatus": 200,
+                "EdgeServerIP": "",
+                "EdgeStartTimestamp": "2022-08-27 22:00:10",
+                "EdgeTimeToFirstByteMs": 82,
+                "OriginDNSResponseTimeMs": 0,
+                "OriginIP": "",
+                "OriginRequestHeaderSendDurationMs": 0,
+                "OriginResponseBytes": 0,
+                "OriginResponseDurationMs": 70,
+                "OriginResponseStatus": 0,
+                "OriginResponseTime": 0,
+                "OriginSSLProtocol": "unknown",
+                "ParentRayID": "7000000000000000",
+                "RayID": "7000000000000001",
+                "SecurityLevel": "off",
+                "SmartRouteColoID": 0,
+                "UpperTierColoID": 1,
+                "WAFAction": "unknown",
+                "WAFFlags": "0",
+                "WAFMatchedVar": "xx",
+                "WAFProfile": "unknown",
+                "WAFRuleID": "xx",
+                "WAFRuleMessage": "xx",
+                "WorkerCPUTime": 0,
+                "WorkerStatus": "unknown",
+                "WorkerSubrequest": True,
+                "WorkerSubrequestCount": 0,
+                "ZoneID": 500000000,
+                "ZoneName": "panther.com",
+            }
+        )
 
     def test_map_source_to_name(self):
         self.assertEqual(p_cf_h.map_source_to_name(self.event.get("Source")), "Firewall Rules")
@@ -1564,8 +1595,10 @@ class TestCloudflareHelpers(unittest.TestCase):
     def test_fw_context_helper(self):
         context = p_cf_h.cloudflare_fw_alert_context(self.event)
         self.assertEqual("Firewall Rules", context.get("pan_cf_source"))
-        self.event.pop("Source")
-        context = p_cf_h.cloudflare_fw_alert_context(self.event)
+        tmp_event = self.event.to_dict()
+        tmp_event.pop("Source")
+        tmp_event = ImmutableCaseInsensitiveDict(tmp_event)
+        context = p_cf_h.cloudflare_fw_alert_context(tmp_event)
         self.assertEqual("<Source_NOT_IN_EVENT>", context.get("Source"))
         self.assertEqual("block", context.get("Action"))
         self.assertEqual("12.12.12.12", context.get("ClientIP"))
@@ -1580,83 +1613,95 @@ class TestCloudflareHelpers(unittest.TestCase):
 
 class TestAsanaHelpers(unittest.TestCase):
     def setUp(self):
-        self.event = {
-            "actor": {
-                "actor_type": "user",
-                "email": "user@domain.com",
-                "gid": "11111111111111111111",
-                "name": "Users Name",
-            },
-            "context": {
-                "client_ip_address": "209.6.224.22",
-                "context_type": "web",
-                "user_agent": "AsanaDesktopOfficial darwin_arm64/1.12.0 Chrome/108.0.5359.62",
-            },
-            "created_at": "2023-02-08 19:00:14.355",
-            "details": {},
-            "event_category": "deletion",
-            "event_type": "task_deleted",
-            "gid": "1222222222222222",
-            "p_event_time": "2023-02-08 19:00:14.355",
-            "resource": {
-                "gid": "133333333333333",
-                "name": "Task Name Goes Here",
-                "resource_subtype": "task",
-                "resource_type": "task",
-            },
-        }
+        self.event = ImmutableCaseInsensitiveDict(
+            {
+                "actor": {
+                    "actor_type": "user",
+                    "email": "user@domain.com",
+                    "gid": "11111111111111111111",
+                    "name": "Users Name",
+                },
+                "context": {
+                    "client_ip_address": "209.6.224.22",
+                    "context_type": "web",
+                    "user_agent": "AsanaDesktopOfficial darwin_arm64/1.12.0 Chrome/108.0.5359.62",
+                },
+                "created_at": "2023-02-08 19:00:14.355",
+                "details": {},
+                "event_category": "deletion",
+                "event_type": "task_deleted",
+                "gid": "1222222222222222",
+                "p_event_time": "2023-02-08 19:00:14.355",
+                "resource": {
+                    "gid": "133333333333333",
+                    "name": "Task Name Goes Here",
+                    "resource_subtype": "task",
+                    "resource_type": "task",
+                },
+            }
+        )
 
     def test_alert_context(self):
         returns = p_a_h.asana_alert_context(self.event)
         self.assertEqual(returns.get("actor", ""), "user@domain.com")
         self.assertEqual(returns.get("event_type", ""), "task_deleted")
         # Remove the user's email attribute
-        self.event["actor"].pop("email")
-        returns = p_a_h.asana_alert_context(self.event)
+        tmp_event = self.event.to_dict()
+        tmp_event["actor"].pop("email")
+        tmp_event = ImmutableCaseInsensitiveDict(tmp_event)
+        returns = p_a_h.asana_alert_context(tmp_event)
         self.assertEqual(returns.get("actor", ""), "<NO_ACTOR_EMAIL>")
         self.assertEqual(returns.get("resource_type", ""), "task")
-        self.event["resource"] = {"resource_type": "story", "resource_subtype": "added_to_project"}
-        returns = p_a_h.asana_alert_context(self.event)
+        tmp_event = tmp_event.to_dict()
+        tmp_event["resource"] = {"resource_type": "story", "resource_subtype": "added_to_project"}
+        tmp_event = ImmutableCaseInsensitiveDict(tmp_event)
+        returns = p_a_h.asana_alert_context(tmp_event)
         self.assertEqual(returns.get("resource_type", ""), "story__added_to_project")
         # resource with no resource subtype
-        self.event["resource"] = {
+        tmp_event = tmp_event.to_dict()
+        tmp_event["resource"] = {
             "email": "user@email.com",
             "gid": "1111111111111111",
             "name": "Users Name",
             "resource_type": "user",
         }
-        returns = p_a_h.asana_alert_context(self.event)
+        tmp_event = ImmutableCaseInsensitiveDict(tmp_event)
+        returns = p_a_h.asana_alert_context(tmp_event)
         self.assertEqual(returns.get("resource_type", ""), "user")
         self.assertEqual(returns.get("resource_name", ""), "Users Name")
         self.assertEqual(returns.get("resource_gid", ""), "1111111111111111")
 
     def test_safe_ac_missing_entries(self):
-        returns = p_a_h.asana_alert_context({})
+        returns = p_a_h.asana_alert_context(ImmutableCaseInsensitiveDict({}))
         self.assertEqual(returns.get("actor"), "<NO_ACTOR>")
         self.assertEqual(returns.get("event_type"), "<NO_EVENT_TYPE>")
         self.assertEqual(returns.get("resource_type"), "<NO_RESOURCE_TYPE>")
         self.assertEqual(returns.get("resource_name"), "<NO_RESOURCE_NAME>")
         self.assertEqual(returns.get("resource_gid"), "<NO_RESOURCE_GID>")
-        self.event["resource"]["resource_type"] = None
-        returns = p_a_h.asana_alert_context(self.event)
+        tmp_event = self.event.to_dict()
+        tmp_event["resource"]["resource_type"] = None
+        tmp_event = ImmutableCaseInsensitiveDict(tmp_event)
+        returns = p_a_h.asana_alert_context(tmp_event)
         self.assertEqual(returns.get("resource_type"), "<NO_RESOURCE_TYPE>")
 
     def test_external_admin(self):
-        event = {
-            "actor": {"actor_type": "external_administrator"},
-            "context": {"context_type": "api"},
-            "created_at": "2023-02-13 18:41:02.759",
-            "details": {},
-            "event_category": "logins",
-            "event_type": "user_logged_out",
-            "gid": "1222222222222222",
-            "resource": {
-                "email": "user@email.com",
-                "gid": "1201201201201201",
-                "name": "User Name",
-                "resource_type": "user",
-            },
-        }
+        event = ImmutableCaseInsensitiveDict(
+            {
+                "actor": {"actor_type": "external_administrator"},
+                "context": {"context_type": "api"},
+                "created_at": "2023-02-13 18:41:02.759",
+                "details": {},
+                "event_category": "logins",
+                "event_type": "user_logged_out",
+                "gid": "1222222222222222",
+                "resource": {
+                    "email": "user@email.com",
+                    "gid": "1201201201201201",
+                    "name": "User Name",
+                    "resource_type": "user",
+                },
+            }
+        )
         returns = p_a_h.asana_alert_context(event)
         self.assertEqual(returns.get("context"), "api")
         self.assertEqual(returns.get("actor"), "external_administrator")
@@ -1664,14 +1709,16 @@ class TestAsanaHelpers(unittest.TestCase):
 
 class TestSnykHelpers(unittest.TestCase):
     def setUp(self):
-        self.event = {
-            "content": {"url": "/api/v1/user/me"},
-            "created": "2022-12-27 16:50:46.959",
-            "event": "api.access",
-            "groupId": "8fffffff-1555-4444-b000-b55555555555",
-            "orgId": "21111111-a222-4eee-8ddd-a99999999999",
-            "userId": "05555555-3333-4ddd-8ccc-755555555555",
-        }
+        self.event = ImmutableCaseInsensitiveDict(
+            {
+                "content": {"url": "/api/v1/user/me"},
+                "created": "2022-12-27 16:50:46.959",
+                "event": "api.access",
+                "groupId": "8fffffff-1555-4444-b000-b55555555555",
+                "orgId": "21111111-a222-4eee-8ddd-a99999999999",
+                "userId": "05555555-3333-4ddd-8ccc-755555555555",
+            }
+        )
 
     def test_alert_context(self):
         returns = p_snyk_h.snyk_alert_context(self.event)
@@ -1686,7 +1733,7 @@ class TestSnykHelpers(unittest.TestCase):
                 "actor_link": "https://app.snyk.io/group/8fffffff-1555-4444-b000-b55555555555/manage/member/05555555-3333-4ddd-8ccc-755555555555",
             },
         )
-        returns = p_snyk_h.snyk_alert_context({})
+        returns = p_snyk_h.snyk_alert_context(ImmutableCaseInsensitiveDict({}))
         self.assertEqual(
             returns,
             {
@@ -1700,17 +1747,19 @@ class TestSnykHelpers(unittest.TestCase):
 
 class TestTinesHelpers(unittest.TestCase):
     def setUp(self):
-        self.event = {
-            "created_at": "2023-05-01 01:02:03",
-            "id": 7206820,
-            "operation_name": "Login",
-            "request_ip": "12.12.12.12",
-            "request_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) UserAgent",
-            "tenant_id": "1234",
-            "user_email": "user@domain.com",
-            "user_id": "17171",
-            "user_name": "user at domain dot com",
-        }
+        self.event = ImmutableCaseInsensitiveDict(
+            {
+                "created_at": "2023-05-01 01:02:03",
+                "id": 7206820,
+                "operation_name": "Login",
+                "request_ip": "12.12.12.12",
+                "request_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) UserAgent",
+                "tenant_id": "1234",
+                "user_email": "user@domain.com",
+                "user_id": "17171",
+                "user_name": "user at domain dot com",
+            }
+        )
 
     def test_alert_context(self):
         returns = p_tines_h.tines_alert_context(self.event)
@@ -1726,7 +1775,7 @@ class TestTinesHelpers(unittest.TestCase):
                 "request_ip": "12.12.12.12",
             },
         )
-        returns = p_tines_h.tines_alert_context({})
+        returns = p_tines_h.tines_alert_context(ImmutableCaseInsensitiveDict({}))
         self.assertEqual(
             returns,
             {
@@ -1743,46 +1792,48 @@ class TestTinesHelpers(unittest.TestCase):
 
 class TestAuth0Helpers(unittest.TestCase):
     def setUp(self):
-        self.event = {
-            "data": {
-                "client_id": "1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr",
-                "client_name": "",
-                "date": "2023-05-15 17:41:31.451000000",
-                "description": "Create a role",
-                "details": {
-                    "request": {
-                        "auth": {
-                            "credentials": {"jti": "949869e066205b5076e6df203fdd7b9b"},
-                            "strategy": "jwt",
-                            "user": {
-                                "email": "user.name@yourcompany.io",
-                                "name": "User Name",
-                                "user_id": "google-oauth2|20839745023748560278",
+        self.event = ImmutableCaseInsensitiveDict(
+            {
+                "data": {
+                    "client_id": "1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr",
+                    "client_name": "",
+                    "date": "2023-05-15 17:41:31.451000000",
+                    "description": "Create a role",
+                    "details": {
+                        "request": {
+                            "auth": {
+                                "credentials": {"jti": "949869e066205b5076e6df203fdd7b9b"},
+                                "strategy": "jwt",
+                                "user": {
+                                    "email": "user.name@yourcompany.io",
+                                    "name": "User Name",
+                                    "user_id": "google-oauth2|20839745023748560278",
+                                },
                             },
+                            "body": {"description": "custom_role", "name": "custom_role"},
+                            "channel": "https://manage.auth0.com/",
+                            "ip": "12.12.12.12",
+                            "method": "post",
+                            "path": "/api/v2/roles",
+                            "query": {},
                         },
-                        "body": {"description": "custom_role", "name": "custom_role"},
-                        "channel": "https://manage.auth0.com/",
-                        "ip": "12.12.12.12",
-                        "method": "post",
-                        "path": "/api/v2/roles",
-                        "query": {},
-                    },
-                    "response": {
-                        "body": {
-                            "description": "custom_role",
-                            "id": "rol_AmvLkz7vhswmWJhJ",
-                            "name": "custom_role",
+                        "response": {
+                            "body": {
+                                "description": "custom_role",
+                                "id": "rol_AmvLkz7vhswmWJhJ",
+                                "name": "custom_role",
+                            },
+                            "statusCode": 200,
                         },
-                        "statusCode": 200,
                     },
+                    "ip": "12.12.12.12",
+                    "log_id": "90020230515174135349782000000000000001223372037486042970",
+                    "type": "sapi",
+                    "user_id": "google-oauth2|105261262156475850461",
                 },
-                "ip": "12.12.12.12",
                 "log_id": "90020230515174135349782000000000000001223372037486042970",
-                "type": "sapi",
-                "user_id": "google-oauth2|105261262156475850461",
-            },
-            "log_id": "90020230515174135349782000000000000001223372037486042970",
-        }
+            }
+        )
 
     def test_alert_context(self):
         returns = p_auth0_h.auth0_alert_context(self.event)
@@ -1797,7 +1848,7 @@ class TestAuth0Helpers(unittest.TestCase):
         )
         self.assertEqual(returns.get("action", ""), "Create a role")
         self.assertEqual(auth0_config_event, True)
-        returns = p_auth0_h.auth0_alert_context({})
+        returns = p_auth0_h.auth0_alert_context(ImmutableCaseInsensitiveDict({}))
         auth0_config_event = p_auth0_h.is_auth0_config_event({})
         self.assertEqual(returns.get("actor", ""), "<NO_ACTOR_FOUND>")
         self.assertEqual(returns.get("action", ""), "<NO_ACTION_FOUND>")
@@ -1923,46 +1974,54 @@ class TestOssHelpers(unittest.TestCase):
 
 class TestKmBetweenTwoIPInfoLocs(unittest.TestCase):
     def setUp(self):
-        self.loc_nyc = {
-            "city": "New York City",
-            "country": "US",
-            "lat": "40.71427",
-            "lng": "-74.00597",
-            "postal_code": "10004",
-            "region": "New York",
-            "region_code": "NY",
-            "timezone": "America/New_York",
-        }
-        self.loc_sfo = {
-            "city": "San Francisco",
-            "country": "US",
-            "lat": "37.77493",
-            "lng": "-122.41942",
-            "postal_code": "94102",
-            "region": "California",
-            "region_code": "CA",
-            "timezone": "America/Los_Angeles",
-        }
-        self.loc_athens = {
-            "city": "Athens",
-            "country": "GR",
-            "lat": "37.98376",
-            "lng": "23.72784",
-            "postal_code": "",
-            "region": "Attica",
-            "region_code": "I",
-            "timezone": "Europe/Athens",
-        }
-        self.loc_aukland = {
-            "city": "Auckland",
-            "country": "NZ",
-            "lat": "-36.84853",
-            "lng": "174.76349",
-            "postal_code": "1010",
-            "region": "Auckland",
-            "region_code": "AUK",
-            "timezone": "Pacific/Auckland",
-        }
+        self.loc_nyc = ImmutableCaseInsensitiveDict(
+            {
+                "city": "New York City",
+                "country": "US",
+                "lat": "40.71427",
+                "lng": "-74.00597",
+                "postal_code": "10004",
+                "region": "New York",
+                "region_code": "NY",
+                "timezone": "America/New_York",
+            }
+        )
+        self.loc_sfo = ImmutableCaseInsensitiveDict(
+            {
+                "city": "San Francisco",
+                "country": "US",
+                "lat": "37.77493",
+                "lng": "-122.41942",
+                "postal_code": "94102",
+                "region": "California",
+                "region_code": "CA",
+                "timezone": "America/Los_Angeles",
+            }
+        )
+        self.loc_athens = ImmutableCaseInsensitiveDict(
+            {
+                "city": "Athens",
+                "country": "GR",
+                "lat": "37.98376",
+                "lng": "23.72784",
+                "postal_code": "",
+                "region": "Attica",
+                "region_code": "I",
+                "timezone": "Europe/Athens",
+            }
+        )
+        self.loc_aukland = ImmutableCaseInsensitiveDict(
+            {
+                "city": "Auckland",
+                "country": "NZ",
+                "lat": "-36.84853",
+                "lng": "174.76349",
+                "postal_code": "1010",
+                "region": "Auckland",
+                "region_code": "AUK",
+                "timezone": "Pacific/Auckland",
+            }
+        )
 
     def test_distances(self):
         nyc_to_sfo = p_o_h.km_between_ipinfo_loc(self.loc_nyc, self.loc_sfo)
@@ -1981,21 +2040,23 @@ class TestKmBetweenTwoIPInfoLocs(unittest.TestCase):
 
 class TestNotionHelpers(unittest.TestCase):
     def setUp(self):
-        self.event = {
-            "id": "...",
-            "timestamp": "2023-06-02T20:16:41.217Z",
-            "workspace_id": "..",
-            "actor": {
-                "id": "..",
-                "object": "user",
-                "type": "person",
-                "person": {"email": "user.name@yourcompany.io"},
-            },
-            "ip_address": "...",
-            "platform": "mac-desktop",
-            "type": "workspace.content_exported",
-            "workspace.content_exported": {},
-        }
+        self.event = ImmutableCaseInsensitiveDict(
+            {
+                "id": "...",
+                "timestamp": "2023-06-02T20:16:41.217Z",
+                "workspace_id": "..",
+                "actor": {
+                    "id": "..",
+                    "object": "user",
+                    "type": "person",
+                    "person": {"email": "user.name@yourcompany.io"},
+                },
+                "ip_address": "...",
+                "platform": "mac-desktop",
+                "type": "workspace.content_exported",
+                "workspace.content_exported": {},
+            }
+        )
 
     def test_alert_context(self):
         returns = p_notion_h.notion_alert_context(self.event)
@@ -2009,7 +2070,7 @@ class TestNotionHelpers(unittest.TestCase):
             },
         )
         self.assertEqual(returns.get("action", ""), "workspace.content_exported")
-        returns = p_notion_h.notion_alert_context({})
+        returns = p_notion_h.notion_alert_context(ImmutableCaseInsensitiveDict({}))
         self.assertEqual(returns.get("actor", ""), "<NO_ACTOR_FOUND>")
         self.assertEqual(returns.get("action", ""), "<NO_ACTION_FOUND>")
 

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -335,7 +335,7 @@ def deep_walk(
     def _empty_list(sub_obj: Any):
         return (
             all(_empty_list(next_obj) for next_obj in sub_obj)
-            if isinstance(sub_obj, list)
+            if isinstance(sub_obj, Sequence) and not isinstance(sub_obj, str)
             else False
         )
 
@@ -356,7 +356,7 @@ def deep_walk(
         for item in obj:
             value = deep_walk(item, *keys, default=default, return_val=return_val)
             if value is not None:
-                if isinstance(value, list):
+                if isinstance(value, Sequence) and not isinstance(value, str):
                     for sub_item in value:
                         found[sub_item] = None
                 else:

--- a/global_helpers/panther_greynoise_helpers.py
+++ b/global_helpers/panther_greynoise_helpers.py
@@ -1,5 +1,6 @@
 # pylint: disable=too-many-public-methods
 import datetime
+from collections.abc import Sequence
 from typing import Union
 
 from dateutil import parser
@@ -58,7 +59,7 @@ class GreyNoiseBasic(LookupTableMatches):
         ip_address = self._lookup(match_field, "ip")
         if not ip_address:
             return None
-        if isinstance(ip_address, list):
+        if isinstance(ip_address, Sequence) and not isinstance(ip_address, str):
             return [
                 f"https://www.greynoise.io/viz/ip/{list_ip_address}"
                 for list_ip_address in ip_address
@@ -86,7 +87,7 @@ class GreyNoiseAdvanced(GreyNoiseBasic):
 
     def cve_string(self, match_field: str, limit: int = 10) -> str:
         cve_raw = self._lookup(match_field, "cve")
-        if isinstance(cve_raw, list):
+        if isinstance(cve_raw, Sequence) and not isinstance(cve_raw, str):
             return " ".join(cve_raw[:limit])
         return cve_raw
 
@@ -100,7 +101,7 @@ class GreyNoiseAdvanced(GreyNoiseBasic):
         time = self._lookup(match_field, "first_seen")
         if not time:
             return None
-        if isinstance(time, list):
+        if isinstance(time, Sequence) and not isinstance(time, str):
             if len(time) == 0:
                 return None
             return min(parser.parse(t) for t in time)
@@ -110,7 +111,7 @@ class GreyNoiseAdvanced(GreyNoiseBasic):
         time = self._lookup(match_field, "last_seen_timestamp")
         if not time:
             return None
-        if isinstance(time, list):
+        if isinstance(time, Sequence) and not isinstance(time, str):
             if len(time) == 0:
                 return None
             return max(parser.parse(t) for t in time)
@@ -157,7 +158,7 @@ class GreyNoiseAdvanced(GreyNoiseBasic):
 
     def tags_string(self, match_field: str, limit: int = 10) -> str:
         tags_raw = self._lookup(match_field, "tags")
-        if isinstance(tags_raw, list):
+        if isinstance(tags_raw, Sequence) and not isinstance(tags_raw, str):
             return " ".join(tags_raw[:limit])
         return tags_raw
 
@@ -208,7 +209,7 @@ class GreyNoiseRIOTBasic(LookupTableMatches):
         is_riot = self._lookup(match_field, "ip_cidr")
         if not is_riot:
             return False
-        if isinstance(is_riot, list):  # at least 1
+        if isinstance(is_riot, Sequence) and not isinstance(is_riot, str):  # at least 1
             for list_is_riot in is_riot:
                 if list_is_riot:
                     return True
@@ -225,7 +226,7 @@ class GreyNoiseRIOTBasic(LookupTableMatches):
         ip_stripped = self._lookup(match_field, "ip_cidr")
         if not ip_stripped:
             return None
-        if isinstance(ip_stripped, list):
+        if isinstance(ip_stripped, Sequence) and not isinstance(ip_stripped, str):
             return [
                 f"https://www.greynoise.io/viz/ip/{list_ip_stripped}"
                 for list_ip_stripped in ip_stripped
@@ -236,7 +237,7 @@ class GreyNoiseRIOTBasic(LookupTableMatches):
         time = self._lookup(match_field, "scan_time")
         if not time:
             return None
-        if isinstance(time, list):
+        if isinstance(time, Sequence) and not isinstance(time, str):
             if len(time) == 0:
                 return None
             return max(parser.parse(t) for t in time)
@@ -306,7 +307,7 @@ def GreyNoiseSeverity(event, field, default="MEDIUM"):
         return "INFO"
 
     classification = noise.classification(field)
-    if isinstance(classification, list):
+    if isinstance(classification, Sequence) and not isinstance(classification, str):
         highest_severity = "INFO"
         for list_classification in classification:
             severity = GreyNoiseSeverityDecode(list_classification, default)

--- a/global_helpers/panther_lookuptable_helpers.py
+++ b/global_helpers/panther_lookuptable_helpers.py
@@ -17,7 +17,7 @@ class LookupTableMatches:
         match = deep_get(self.lut_matches, match_field)
         if not match:
             return None
-        if isinstance(match, list):
+        if isinstance(match, Sequence) and not isinstance(match, str):
             return [deep_get(match_value, *keys) if match_value else None for match_value in match]
         return deep_get(match, *keys)
 

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import time
+from collections.abc import Mapping
 from datetime import datetime
 from ipaddress import ip_address
 from math import atan2, cos, radians, sin, sqrt
@@ -274,7 +275,7 @@ def put_dictionary(key: str, val: dict, epoch_seconds: int = None):
         val: A Python dictionary
         epoch_seconds: (Optional) Set string expiration time
     """
-    if not isinstance(val, dict):
+    if not isinstance(val, (dict, Mapping)):
         raise Exception("panther_oss_helpers.put_dictionary: value is not a dictionary")
 
     try:

--- a/global_helpers/panther_tor_helpers.py
+++ b/global_helpers/panther_tor_helpers.py
@@ -1,4 +1,5 @@
 import datetime
+from collections.abc import Sequence
 
 from panther_lookuptable_helpers import LookupTableMatches
 
@@ -19,7 +20,7 @@ class TorExitNodes(LookupTableMatches):
         """Return link to Tor database"""
         today = datetime.datetime.today().strftime("%Y-%m-%d")
         ip_address = self.ip_address(match_field)
-        if isinstance(ip_address, list):
+        if isinstance(ip_address, Sequence) and not isinstance(ip_address, str):
             return [
                 # pylint: disable=C0301 (line-too-long)
                 f"https://metrics.torproject.org/exonerator.html?ip={list_ip_address}&timestamp={today}&lang=en"


### PR DESCRIPTION
### Background

`isinstance(thing, list)` can be problematic due to `panther_analysis_tool.immutable.ImmutableList` returning falsey for that isinstance check and local unit tests returning truthy. 

This PR updates the global helper unit test cases to use `panther_analysis_tool.immutable.ImmutableCaseInsensitiveDict`  as a wrapping type for test events. 

This PR also updates the underlying global helper functions to typecheck against `collections.abc.Sequence` or `collections.abc.Mapping` as necessary.  

Note: no detections should need to be updated as a result of this.

This update is expected to be fully backwards compatible, should a `dict` or `list` make it into any of the updated python functions. 

Truth Table for `isinstance(object, type)` 
| object |  type | truthy | 
| --- | --- | --- | 
| str | collections.abc.Sequence | true | 
| list | collections.abc.Sequence | true | 
| dict | collections.abc.Sequence | false | 
| ImmutableList | collections.abc.Sequence  | true |
| ImmutableList | collections.abc.Mapping | false |
| ImmutableList |  list  | false | 
| ImmutableDict | collections.abc.Sequence | false |
| ImmutableDict | collections.abc.Mapping | true |
| ImmutableDict | dict | false |



### Testing

make test 
