### PR TITLE
fix: Update list of "safe" TLS ciphers in AWS ALB SSL/TLS policy

### DIFF
--- a/policies/aws_load_balancer_policies/aws_alb_ssl_policy.py
+++ b/policies/aws_load_balancer_policies/aws_alb_ssl_policy.py
@@ -1,12 +1,13 @@
-# Generated with the AWS CLI with the following command:
-#   aws elbv2 describe-ssl-policies --query 'SslPolicies[?SslProtocols==[`TLSv1.2`]].Name'
-TLS_1_2_POLICIES = {
-    "ELBSecurityPolicy-TLS-1-2-2017-01",
-    "ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
-    "ELBSecurityPolicy-FS-1-2-Res-2019-08",
+# https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies
+# Requirements to be "safe": 1) TLSv1.2+ only; 2) Forward Secrecy
+
+TLS_SAFE_POLICIES = {
     "ELBSecurityPolicy-FS-1-2-2019-08",
+    "ELBSecurityPolicy-FS-1-2-Res-2019-08",
     "ELBSecurityPolicy-FS-1-2-Res-2020-10",
     "ELBSecurityPolicy-TLS13-1-2-2021-06",
+    "ELBSecurityPolicy-TLS13-1-2-Res-2021-06",
+    "ELBSecurityPolicy-TLS13-1-3-2021-06",
 }
 
 
@@ -16,5 +17,5 @@ def policy(resource):
         return True
 
     return len(resource.get("Listeners") if resource.get("Listeners") else []) >= 1 and all(
-        (each_policy in TLS_1_2_POLICIES for each_policy in resource.get("SSLPolicies", {}).keys())
+        (each_policy in TLS_SAFE_POLICIES for each_policy in resource.get("SSLPolicies", {}).keys())
     )

--- a/policies/aws_load_balancer_policies/aws_alb_ssl_policy.yml
+++ b/policies/aws_load_balancer_policies/aws_alb_ssl_policy.yml
@@ -19,7 +19,7 @@ Severity: Medium
 Description: Ensures that deprecated TLS versions are not supported in internet-facing load balancers
 Runbook: >
   Update your load balancer's SSLPolicies to only support modern TLS versions
-Reference: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html
+Reference: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html
 Tests:
   -
     Name: Strong Ciphers Internet Facing
@@ -92,7 +92,7 @@ Tests:
         },
         "Name": "web",
         "SSLPolicies": {
-          "ELBSecurityPolicy-TLS-1-2-Ext-2018-06": {
+          "ELBSecurityPolicy-FS-1-2-2019-08": {
             "SslProtocols": [
                 "TLSv1.2"
             ],
@@ -144,33 +144,9 @@ Tests:
                 {
                     "Name": "ECDHE-ECDSA-AES256-SHA",
                     "Priority": 12
-                },
-                {
-                    "Name": "AES128-GCM-SHA256",
-                    "Priority": 13
-                },
-                {
-                    "Name": "AES128-SHA256",
-                    "Priority": 14
-                },
-                {
-                    "Name": "AES128-SHA",
-                    "Priority": 15
-                },
-                {
-                    "Name": "AES256-GCM-SHA384",
-                    "Priority": 16
-                },
-                {
-                    "Name": "AES256-SHA256",
-                    "Priority": 17
-                },
-                {
-                    "Name": "AES256-SHA",
-                    "Priority": 18
                 }
             ],
-            "Name": "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+            "Name": "ELBSecurityPolicy-FS-1-2-2019-08"
           }
         },
         "Arn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/3ff2fab33a993e0c",


### PR DESCRIPTION
### Background

Several "safe" TLS cipher selections were missing from the approved list of ciphers, while non-safe ciphers were being included. Requirements to be "safe": 1) TLSv1.2+ only; 2) Forward Secrecy.

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies

### Changes

* Add ciphers `ELBSecurityPolicy-TLS13-1-2-Res-2021-06` and `ELBSecurityPolicy-TLS13-1-3-2021-06`.
* Remove ciphers `ELBSecurityPolicy-TLS-1-2-2017-01` and `ELBSecurityPolicy-TLS-1-2-Ext-2018-06`, as they do not support forward secrecy.

### Testing

* Updated existing test to account for the removal of a previously approved cipher.