### PR TITLE
fix: explicitly ignore top level enrichments that start with 'p_any_' in the key name

### DIFF
--- a/global_helpers/panther_lookuptable_helpers.py
+++ b/global_helpers/panther_lookuptable_helpers.py
@@ -3,6 +3,7 @@ from collections.abc import Mapping, Sequence
 from panther_base_helpers import deep_get
 
 ENRICHMENT_KEY = "p_enrichment"
+IGNORE_ENRICHMENTS = "p_any_"
 
 # pylint: disable=too-few-public-methods
 class LookupTableMatches:
@@ -39,6 +40,8 @@ class LookupTableMatches:
         event = event or {}
         matched_items = {}
         for lut_name in deep_get(event, ENRICHMENT_KEY, default={}).keys():
+            if lut_name.startswith(IGNORE_ENRICHMENTS):
+                continue
             for en_values in deep_get(event, ENRICHMENT_KEY, lut_name, default={}).values():
                 if isinstance(en_values, Sequence):
                     for val in en_values:


### PR DESCRIPTION
### Background
There are keys at the top level under `p_enrichment` that begin with `p_any_`. These `p_enrichment.p_any*` keys are sometimes (always?) arrays. 

### Changes

* adds an explicit `ignore all keys under p_enrichment that begin with p_any_` to the base lookuptable helper. 

### Testing

global helper unit tests and detection unit tests needed no updates with this change. 
