### PR TITLE
fix: CS base64 rule fails for some event types

### DIFF
--- a/data_models/crowdstrike_fdr_data_model.py
+++ b/data_models/crowdstrike_fdr_data_model.py
@@ -18,7 +18,7 @@ def get_process_name(event):
     # Mac = /usr/libexec/xpcproxy
     image_fn = deep_get(event, "event", "ImageFileName")
     if not image_fn:
-        return None # Explicitly return None if the key DNE
+        return None  # Explicitly return None if the key DNE
     if platform == "Win":
         return image_fn.split("\\")[-1]
     return image_fn.split("/")[-1]

--- a/data_models/crowdstrike_fdr_data_model.py
+++ b/data_models/crowdstrike_fdr_data_model.py
@@ -18,7 +18,7 @@ def get_process_name(event):
     # Mac = /usr/libexec/xpcproxy
     image_fn = deep_get(event, "event", "ImageFileName")
     if not image_fn:
-        return None # Explicitly return an empty string if the key DNE
+        return None # Explicitly return None if the key DNE
     if platform == "Win":
         return image_fn.split("\\")[-1]
     return image_fn.split("/")[-1]

--- a/data_models/crowdstrike_fdr_data_model.py
+++ b/data_models/crowdstrike_fdr_data_model.py
@@ -18,7 +18,7 @@ def get_process_name(event):
     # Mac = /usr/libexec/xpcproxy
     image_fn = deep_get(event, "event", "ImageFileName")
     if not image_fn:
-        return "" # Explicitly return an empty string if the key DNE
+        return None # Explicitly return an empty string if the key DNE
     if platform == "Win":
         return image_fn.split("\\")[-1]
     return image_fn.split("/")[-1]

--- a/data_models/crowdstrike_fdr_data_model.py
+++ b/data_models/crowdstrike_fdr_data_model.py
@@ -16,6 +16,9 @@ def get_process_name(event):
     # Win = \Device\HarddiskVolume2\Windows\System32\winlogon.exe
     # Lin = /usr/bin/run-parts
     # Mac = /usr/libexec/xpcproxy
+    image_fn = deep_get(event, "event", "ImageFileName")
+    if not image_fn:
+        return "" # Explicitly return an empty string if the key DNE
     if platform == "Win":
-        return deep_get(event, "event", "ImageFileName").split("\\")[-1]
-    return deep_get(event, "event", "ImageFileName").split("/")[-1]
+        return image_fn.split("\\")[-1]
+    return image_fn.split("/")[-1]

--- a/rules/crowdstrike_rules/crowdstrike_base64_encoded_args.py
+++ b/rules/crowdstrike_rules/crowdstrike_base64_encoded_args.py
@@ -13,6 +13,10 @@ def rule(event):
         "rundll32.exe",
     }
 
+    # Filter by CS event type
+    if event.get("fdr_event_type") != "ProcessRollup2":
+        return False
+
     # Define a regular expression pattern to match Base64 encoded strings
 
     if event.get("event_platform") == "Win":


### PR DESCRIPTION
### Background

The current `Crowdstrike.Base64EncodedArgs` detection runs into issues for FDR event types which aren't `ProcessRollup2`. This PR fixes that.

### Changes

* Allow CS-FDR UDM function `get_process_name` to return an empty string for cases where the `ImageFileName` field isn't present
* Add a check in the detection to pass on event types other than `ProcessRollup`

### Testing
```
Crowdstrike.Base64EncodedArgs
        [PASS] Command Line Tool Execution with Base64 Argument (Positive)
                [PASS] [rule] true
                [PASS] [title] Crowdstrike: Execution with base64 encoded args: [powershell.exe] - ["c:\windows\system32\windowspowershell\v1.0\powershell.exe" -encodedcommand "agvsbg93b3jsza==" -someextracommand "helloworld"]
                [PASS] [dedup] Crowdstrike: Execution with base64 encoded args: [powershell.exe] - ["c:\windows\system32\windowspowershell\v1.0\powershell.exe" -encodedcommand "agvsbg93b3jsza==" -someextracommand "helloworld"]
                [PASS] [alertContext] {"aid": "877761efa8db44d792ddc2redacted", "CommandLine": "\"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\" -EncodedCommand \"aGVsbG93b3JsZA==\" -SomeExtraCommand \"HelloWorld\"", "TargetProcessId": "10413665481", "RawProcessId": "3120", "ParentBaseFileName": "pwsh.exe", "ParentProcessId": "4370948876", "ImageFileName": "\\Device\\HarddiskVolume2\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "SHA256Hash": "840e1f9dc5a29bebf01626822d7390251e9cf05bb3560ba7b68bdb8a41cf08e3", "platform": "Win"}
        [PASS] Command Line Tool Execution with Base64 Argument 2 (Positive)
                [PASS] [rule] true
                [PASS] [title] Crowdstrike: Execution with base64 encoded args: [powershell.exe] - ["c:\windows\system32\windowspowershell\v1.0\powershell.exe" -encodedcommand agvsbg93b3jsza== -someextracommand "helloworld"]
                [PASS] [dedup] Crowdstrike: Execution with base64 encoded args: [powershell.exe] - ["c:\windows\system32\windowspowershell\v1.0\powershell.exe" -encodedcommand agvsbg93b3jsza== -someextracommand "helloworld"]
                [PASS] [alertContext] {"aid": "877761efa8db44d792ddc2redacted", "CommandLine": "\"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\" -EncodedCommand aGVsbG93b3JsZA== -SomeExtraCommand \"HelloWorld\"", "TargetProcessId": "10413665481", "RawProcessId": "3120", "ParentBaseFileName": "pwsh.exe", "ParentProcessId": "4370948876", "ImageFileName": "\\Device\\HarddiskVolume2\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "SHA256Hash": "840e1f9dc5a29bebf01626822d7390251e9cf05bb3560ba7b68bdb8a41cf08e3", "platform": "Win"}
        [PASS] Command Line Tool Execution without Base64 Argument (Negative)
                [PASS] [rule] false
        [PASS] Mac - Git
                [PASS] [rule] false
```