### PR TITLE
New: Global helpers and filters for tailscale

### DIFF
--- a/global_helpers/global_filter_notion.py
+++ b/global_helpers/global_filter_notion.py
@@ -3,7 +3,7 @@ from panther_base_helpers import deep_get  # pylint: disable=unused-import
 
 def filter_include_event(event) -> bool:  # pylint: disable=unused-argument
     """
-    filter_include_event provides a global include filter for all Auth0 detections
+    filter_include_event provides a global include filter for all Notion detections
     Panther will not update this filter, and you can edit it without creating
     merge conflicts in the future.
 

--- a/global_helpers/global_filter_tailscale.py
+++ b/global_helpers/global_filter_tailscale.py
@@ -1,0 +1,23 @@
+from panther_base_helpers import deep_get  # pylint: disable=unused-import
+
+
+def filter_include_event(event) -> bool:  # pylint: disable=unused-argument
+    """
+    filter_include_event provides a global include filter for all Tailscale detections
+    Panther will not update this filter, and you can edit it without creating
+    merge conflicts in the future.
+
+    return True to include events, and False to exclude events
+    """
+    # This commented-out example would have the effect of
+    #  including event origin based actions:
+    #    1. actions that originate from the admin console.
+    #    2. events where events origin is undefined.
+    #
+    #
+    # # example: event.origin
+    # # if we don't know the event_origin, we want default behavior to be to alert on this event.
+    # event_origin = deep_get(event, "origin", default="")
+    # return event_origin in ["ADMIN_CONSOLE", ""]
+    #
+    return True

--- a/global_helpers/global_filter_tailscale.yml
+++ b/global_helpers/global_filter_tailscale.yml
@@ -1,0 +1,11 @@
+AnalysisType: global
+Filename: global_filter_tailscale.py
+GlobalID: "global_filter_tailscale"
+Description: >
+  This module provides one filter that is included in all Tailscale detections.
+  
+  This filter defines if events should be included or excluded.
+
+  You can change the definition of this filter to work in your own environment. 
+  Panther will not change the filter definition, and should not create 
+  merge conflicts.

--- a/global_helpers/panther_tailscale_helpers.py
+++ b/global_helpers/panther_tailscale_helpers.py
@@ -1,0 +1,13 @@
+from panther_base_helpers import deep_get
+
+
+def tailscale_alert_context(event) -> dict:
+    a_c = {}
+    a_c["actor"] = deep_get(event, "actor", default="<NO_ACTOR_FOUND>")
+    a_c["action"] = deep_get(event, "action", default="<NO_ACTION_FOUND>")
+    return a_c
+
+
+def is_tailscale_admin_console_event(event):
+    origin = deep_get(event, "origin", default="")
+    return origin == "ADMIN_CONSOLE"

--- a/global_helpers/panther_tailscale_helpers.yml
+++ b/global_helpers/panther_tailscale_helpers.yml
@@ -1,0 +1,5 @@
+AnalysisType: global
+Filename: panther_tailscale_helpers.py
+GlobalID: "panther_tailscale_helpers"
+Description: >
+  Global helpers for Tailscale detections


### PR DESCRIPTION
### Background

- Pre dev work needed to reference alert context and add customizable global filters for tailscale

### Changes

* added global filters and panther helpers for tailscale along with tests 
* also fixed comment in notion global filter referencing another integration to reference notion only 

### Testing

* all tests passing 
