### PR TITLE
fix: tailscale log events seem to have an 'event' attribute that wraps everything other than 'fields'…

### DIFF
--- a/global_helpers/global_filter_tailscale.py
+++ b/global_helpers/global_filter_tailscale.py
@@ -17,7 +17,7 @@ def filter_include_event(event) -> bool:  # pylint: disable=unused-argument
     #
     # # example: event.origin
     # # if we don't know the event_origin, we want default behavior to be to alert on this event.
-    # event_origin = deep_get(event, "origin", default="")
+    # event_origin = deep_get(event, "event", "origin", default="")
     # return event_origin in ["ADMIN_CONSOLE", ""]
     #
     return True

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -1879,17 +1879,20 @@ class TestTailscaleHelpers(unittest.TestCase):
     def setUp(self):
         self.event = ImmutableCaseInsensitiveDict(
             {
-                "action": "CREATE",
-                "actor": {
-                    "displayName": "Homer Simpson",
-                    "id": "uodc9f3CNTRL",
-                    "loginName": "homer.simpson@yourcompany.io",
-                    "type": "USER",
+                "event": {
+                    "action": "CREATE",
+                    "actor": {
+                        "displayName": "Homer Simpson",
+                        "id": "uodc9f3CNTRL",
+                        "loginName": "homer.simpson@yourcompany.io",
+                        "type": "USER",
+                    },
+                    "eventGroupID": "9f880e02981e341447958344b7b4071f",
+                    "new": {},
+                    "origin": "ADMIN_CONSOLE",
+                    "target": {"id": "k6r3fm3CNTRL", "name": "API key", "type": "API_KEY"},
                 },
-                "eventGroupID": "9f880e02981e341447958344b7b4071f",
-                "new": {},
-                "origin": "ADMIN_CONSOLE",
-                "target": {"id": "k6r3fm3CNTRL", "name": "API key", "type": "API_KEY"},
+                "fields": {"recorded": "2023-07-19 16:10:48.385283827"},
             }
         )
 

--- a/global_helpers/panther_tailscale_helpers.py
+++ b/global_helpers/panther_tailscale_helpers.py
@@ -3,11 +3,11 @@ from panther_base_helpers import deep_get
 
 def tailscale_alert_context(event) -> dict:
     a_c = {}
-    a_c["actor"] = deep_get(event, "actor", default="<NO_ACTOR_FOUND>")
-    a_c["action"] = deep_get(event, "action", default="<NO_ACTION_FOUND>")
+    a_c["actor"] = deep_get(event, "event", "actor", default="<NO_ACTOR_FOUND>")
+    a_c["action"] = deep_get(event, "event", "action", default="<NO_ACTION_FOUND>")
     return a_c
 
 
 def is_tailscale_admin_console_event(event):
-    origin = deep_get(event, "origin", default="")
+    origin = deep_get(event, "event", "origin", default="")
     return origin == "ADMIN_CONSOLE"

--- a/rules/tailscale_rules/tailscale_https_disabled.py
+++ b/rules/tailscale_rules/tailscale_https_disabled.py
@@ -9,8 +9,10 @@ from panther_tailscale_helpers import (
 def rule(event):
     if not filter_include_event(event):
         return False
-    action = deep_get(event, "action", default="<NO_ACTION_FOUND>")
-    target_property = deep_get(event, "target", "property", default="<NO_TARGET_PROPERTY_FOUND>")
+    action = deep_get(event, "event", "action", default="<NO_ACTION_FOUND>")
+    target_property = deep_get(
+        event, "event", "target", "property", default="<NO_TARGET_PROPERTY_FOUND>"
+    )
     return all(
         [
             action == "DISABLE",
@@ -21,8 +23,8 @@ def rule(event):
 
 
 def title(event):
-    user = deep_get(event, "actor", "loginName", default="<NO_USER_FOUND>")
-    target_id = deep_get(event, "target", "id", default="<NO_TARGET_ID_FOUND>")
+    user = deep_get(event, "event", "actor", "loginName", default="<NO_USER_FOUND>")
+    target_id = deep_get(event, "event", "target", "id", default="<NO_TARGET_ID_FOUND>")
     return (
         f"Tailscale user [{user}] disabled HTTPS for "
         f"[{target_id}] in your organization’s tenant."

--- a/rules/tailscale_rules/tailscale_https_disabled.yml
+++ b/rules/tailscale_rules/tailscale_https_disabled.yml
@@ -9,6 +9,7 @@ Tests:
     - ExpectedResult: true
       Log:
         {
+          "event": {
             "action": "DISABLE",
             "actor": {
               "displayName": "Homer Simpson",
@@ -24,6 +25,7 @@ Tests:
               "property": "HTTPS",
               "type": "TAILNET"
             },
+          },
           "fields": {
             "recorded": "2023-07-19 16:10:48.385283827"
           },
@@ -50,6 +52,7 @@ Tests:
     - ExpectedResult: false
       Log:
         {
+          "event": {
             "action": "CREATE",
             "actor": {
               "displayName": "Homer Simpson",
@@ -65,6 +68,7 @@ Tests:
               "name": "API key",
               "type": "API_KEY"
             },
+          },
           "fields": {
             "recorded": "2023-07-19 16:11:41.778839718"
           },

--- a/rules/tailscale_rules/tailscale_machine_approval_requirements_disabled.py
+++ b/rules/tailscale_rules/tailscale_machine_approval_requirements_disabled.py
@@ -9,8 +9,10 @@ from panther_tailscale_helpers import (
 def rule(event):
     if not filter_include_event(event):
         return False
-    action = deep_get(event, "action", default="<NO_ACTION_FOUND>")
-    target_property = deep_get(event, "target", "property", default="<NO_TARGET_PROPERTY_FOUND>")
+    action = deep_get(event, "event", "action", default="<NO_ACTION_FOUND>")
+    target_property = deep_get(
+        event, "event", "target", "property", default="<NO_TARGET_PROPERTY_FOUND>"
+    )
     return all(
         [
             action == "DISABLE",
@@ -21,10 +23,10 @@ def rule(event):
 
 
 def title(event):
-    user = deep_get(event, "actor", "loginName", default="<NO_USER_FOUND>")
+    user = deep_get(event, "event", "actor", "loginName", default="<NO_USER_FOUND>")
     return (
         f"Tailscale user [{user}] disabled device approval requirements "
-        f"for new devices before accessing your organization’s network."
+        f"for new devices accessing your organization’s network."
     )
 
 

--- a/rules/tailscale_rules/tailscale_machine_approval_requirements_disabled.yml
+++ b/rules/tailscale_rules/tailscale_machine_approval_requirements_disabled.yml
@@ -9,6 +9,7 @@ Tests:
     - ExpectedResult: true
       Log:
         {
+          "event": {
             "action": "DISABLE",
             "actor": {
               "displayName": "Homer Simpson",
@@ -24,6 +25,7 @@ Tests:
               "property": "MACHINE_APPROVAL_NEEDED",
               "type": "TAILNET"
             },
+          },
           "fields": {
             "recorded": "2023-06-27 22:58:15.824694387"
           },
@@ -51,6 +53,7 @@ Tests:
     - ExpectedResult: false
       Log:
         {
+          "event": {
             "action": "CREATE",
             "actor": {
               "displayName": "Homer Simpson",
@@ -66,6 +69,7 @@ Tests:
               "name": "API key",
               "type": "API_KEY"
             },
+          },
           "fields": {
             "recorded": "2023-07-19 16:11:41.778839718"
           },

--- a/rules/tailscale_rules/tailscale_magicdns_disabled.py
+++ b/rules/tailscale_rules/tailscale_magicdns_disabled.py
@@ -9,8 +9,10 @@ from panther_tailscale_helpers import (
 def rule(event):
     if not filter_include_event(event):
         return False
-    action = deep_get(event, "action", default="<NO_ACTION_FOUND>")
-    target_property = deep_get(event, "target", "property", default="<NO_TARGET_PROPERTY_FOUND>")
+    action = deep_get(event, "event", "action", default="<NO_ACTION_FOUND>")
+    target_property = deep_get(
+        event, "event", "target", "property", default="<NO_TARGET_PROPERTY_FOUND>"
+    )
     return all(
         [
             action == "DISABLE",
@@ -21,8 +23,8 @@ def rule(event):
 
 
 def title(event):
-    user = deep_get(event, "actor", "loginName", default="<NO_USER_FOUND>")
-    target_id = deep_get(event, "target", "id", default="<NO_TARGET_ID_FOUND>")
+    user = deep_get(event, "event", "actor", "loginName", default="<NO_USER_FOUND>")
+    target_id = deep_get(event, "event", "target", "id", default="<NO_TARGET_ID_FOUND>")
     return (
         f"Tailscale user [{user}] disabled Magic DNS for "
         f"[{target_id}] in your organization’s tenant."

--- a/rules/tailscale_rules/tailscale_magicdns_disabled.yml
+++ b/rules/tailscale_rules/tailscale_magicdns_disabled.yml
@@ -9,6 +9,7 @@ Tests:
     - ExpectedResult: true
       Log:
         {
+          "event": {
             "action": "DISABLE",
             "actor": {
               "displayName": "Homer Simpson",
@@ -24,6 +25,7 @@ Tests:
               "property": "MAGIC_DNS",
               "type": "TAILNET"
             },
+          },
           "fields": {
             "recorded": "2023-07-19 16:10:38.825360311"
           },
@@ -50,6 +52,7 @@ Tests:
     - ExpectedResult: false
       Log:
         {
+          "event": {
             "action": "CREATE",
             "actor": {
               "displayName": "Homer Simpson",
@@ -65,6 +68,7 @@ Tests:
               "name": "API key",
               "type": "API_KEY"
             },
+          },
           "fields": {
             "recorded": "2023-07-19 16:11:41.778839718"
           },


### PR DESCRIPTION
### Background
In reviewing #852, it looks like there's an `event` json attribute that exists in these log entries

### Changes

* tweaks to insert the `event` attribute and update callers

### Testing


