### PR TITLE
Adding Github.Audit Actor IP to lookup tables

### DIFF
--- a/lookup_tables/greynoise/advanced/noise_advanced.yml
+++ b/lookup_tables/greynoise/advanced/noise_advanced.yml
@@ -117,6 +117,9 @@ LogTypeMap:
         - "$.protoPayload.requestMetadata.callerIP"
         - "$.httpRequest.remoteIP"
         - "$.httpRequest.serverIP"
+    - LogType: Github.Audit
+      Selectors:
+        - 'actor_ip'
     - LogType: GitLab.API
       Selectors:
         - "remote_ip"

--- a/lookup_tables/greynoise/advanced/noise_advanced.yml
+++ b/lookup_tables/greynoise/advanced/noise_advanced.yml
@@ -117,7 +117,7 @@ LogTypeMap:
         - "$.protoPayload.requestMetadata.callerIP"
         - "$.httpRequest.remoteIP"
         - "$.httpRequest.serverIP"
-    - LogType: Github.Audit
+    - LogType: GitHub.Audit
       Selectors:
         - 'actor_ip'
     - LogType: GitLab.API

--- a/lookup_tables/greynoise/advanced/riot_advanced.yml
+++ b/lookup_tables/greynoise/advanced/riot_advanced.yml
@@ -117,6 +117,9 @@ LogTypeMap:
         - "$.protoPayload.requestMetadata.callerIP"
         - "$.httpRequest.remoteIP"
         - "$.httpRequest.serverIP"
+    - LogType: Github.Audit
+      Selectors:
+        - 'actor_ip'
     - LogType: GitLab.API
       Selectors:
         - "remote_ip"

--- a/lookup_tables/greynoise/advanced/riot_advanced.yml
+++ b/lookup_tables/greynoise/advanced/riot_advanced.yml
@@ -117,7 +117,7 @@ LogTypeMap:
         - "$.protoPayload.requestMetadata.callerIP"
         - "$.httpRequest.remoteIP"
         - "$.httpRequest.serverIP"
-    - LogType: Github.Audit
+    - LogType: GitHub.Audit
       Selectors:
         - 'actor_ip'
     - LogType: GitLab.API

--- a/lookup_tables/greynoise/basic/noise_basic.yml
+++ b/lookup_tables/greynoise/basic/noise_basic.yml
@@ -117,6 +117,9 @@ LogTypeMap:
         - "$.protoPayload.requestMetadata.callerIP"
         - "$.httpRequest.remoteIP"
         - "$.httpRequest.serverIP"
+    - LogType: Github.Audit
+      Selectors:
+        - 'actor_ip'
     - LogType: GitLab.API
       Selectors:
         - "remote_ip"

--- a/lookup_tables/greynoise/basic/noise_basic.yml
+++ b/lookup_tables/greynoise/basic/noise_basic.yml
@@ -117,7 +117,7 @@ LogTypeMap:
         - "$.protoPayload.requestMetadata.callerIP"
         - "$.httpRequest.remoteIP"
         - "$.httpRequest.serverIP"
-    - LogType: Github.Audit
+    - LogType: GitHub.Audit
       Selectors:
         - 'actor_ip'
     - LogType: GitLab.API

--- a/lookup_tables/greynoise/basic/riot_basic.yml
+++ b/lookup_tables/greynoise/basic/riot_basic.yml
@@ -117,6 +117,9 @@ LogTypeMap:
         - "$.protoPayload.requestMetadata.callerIP"
         - "$.httpRequest.remoteIP"
         - "$.httpRequest.serverIP"
+    - LogType: Github.Audit
+      Selectors:
+        - 'actor_ip'
     - LogType: GitLab.API
       Selectors:
         - "remote_ip"

--- a/lookup_tables/greynoise/basic/riot_basic.yml
+++ b/lookup_tables/greynoise/basic/riot_basic.yml
@@ -117,7 +117,7 @@ LogTypeMap:
         - "$.protoPayload.requestMetadata.callerIP"
         - "$.httpRequest.remoteIP"
         - "$.httpRequest.serverIP"
-    - LogType: Github.Audit
+    - LogType: GitHub.Audit
       Selectors:
         - 'actor_ip'
     - LogType: GitLab.API

--- a/lookup_tables/ipinfo/ipinfo_asn.yml
+++ b/lookup_tables/ipinfo/ipinfo_asn.yml
@@ -152,7 +152,7 @@ LogTypeMap:
         - '$.jsonPayload.removeIp'
         - '$.httpRequest.remoteIp'
         - '$.httpRequest.serverIp'
-    - LogType: Github.Audit
+    - LogType: GitHub.Audit
       Selectors:
         - 'actor_ip'
     - LogType: GitLab.API

--- a/lookup_tables/ipinfo/ipinfo_asn.yml
+++ b/lookup_tables/ipinfo/ipinfo_asn.yml
@@ -152,6 +152,9 @@ LogTypeMap:
         - '$.jsonPayload.removeIp'
         - '$.httpRequest.remoteIp'
         - '$.httpRequest.serverIp'
+    - LogType: Github.Audit
+      Selectors:
+        - 'actor_ip'
     - LogType: GitLab.API
       Selectors:
         - 'remote_ip'

--- a/lookup_tables/ipinfo/ipinfo_asn_datalake.yml
+++ b/lookup_tables/ipinfo/ipinfo_asn_datalake.yml
@@ -152,7 +152,7 @@ LogTypeMap:
         - '$.jsonPayload.removeIp'
         - '$.httpRequest.remoteIp'
         - '$.httpRequest.serverIp'
-    - LogType: Github.Audit
+    - LogType: GitHub.Audit
       Selectors:
         - 'actor_ip'
     - LogType: GitLab.API

--- a/lookup_tables/ipinfo/ipinfo_asn_datalake.yml
+++ b/lookup_tables/ipinfo/ipinfo_asn_datalake.yml
@@ -152,6 +152,9 @@ LogTypeMap:
         - '$.jsonPayload.removeIp'
         - '$.httpRequest.remoteIp'
         - '$.httpRequest.serverIp'
+    - LogType: Github.Audit
+      Selectors:
+        - 'actor_ip'
     - LogType: GitLab.API
       Selectors:
         - 'remote_ip'

--- a/lookup_tables/ipinfo/ipinfo_location.yml
+++ b/lookup_tables/ipinfo/ipinfo_location.yml
@@ -152,7 +152,7 @@ LogTypeMap:
         - '$.jsonPayload.removeIp'
         - '$.httpRequest.remoteIp'
         - '$.httpRequest.serverIp'
-    - LogType: Github.Audit
+    - LogType: GitHub.Audit
       Selectors:
         - 'actor_ip'
     - LogType: GitLab.API

--- a/lookup_tables/ipinfo/ipinfo_location.yml
+++ b/lookup_tables/ipinfo/ipinfo_location.yml
@@ -152,6 +152,9 @@ LogTypeMap:
         - '$.jsonPayload.removeIp'
         - '$.httpRequest.remoteIp'
         - '$.httpRequest.serverIp'
+    - LogType: Github.Audit
+      Selectors:
+        - 'actor_ip'
     - LogType: GitLab.API
       Selectors:
         - 'remote_ip'

--- a/lookup_tables/ipinfo/ipinfo_location_datalake.yml
+++ b/lookup_tables/ipinfo/ipinfo_location_datalake.yml
@@ -152,7 +152,7 @@ LogTypeMap:
         - '$.jsonPayload.removeIp'
         - '$.httpRequest.remoteIp'
         - '$.httpRequest.serverIp'
-    - LogType: Github.Audit
+    - LogType: GitHub.Audit
       Selectors:
         - 'actor_ip'
     - LogType: GitLab.API

--- a/lookup_tables/ipinfo/ipinfo_location_datalake.yml
+++ b/lookup_tables/ipinfo/ipinfo_location_datalake.yml
@@ -152,6 +152,9 @@ LogTypeMap:
         - '$.jsonPayload.removeIp'
         - '$.httpRequest.remoteIp'
         - '$.httpRequest.serverIp'
+    - LogType: Github.Audit
+      Selectors:
+        - 'actor_ip'
     - LogType: GitLab.API
       Selectors:
         - 'remote_ip'

--- a/lookup_tables/ipinfo/ipinfo_privacy.yml
+++ b/lookup_tables/ipinfo/ipinfo_privacy.yml
@@ -168,6 +168,9 @@ LogTypeMap:
     - LogType: GSuite.Reports
       Selectors:
         - 'ipAddress'
+    - LogType: Github.Audit
+      Selectors:
+        - 'actor_ip'
     - LogType: Jamfpro.Login
       Selectors:
         - 'ipAddress'

--- a/lookup_tables/ipinfo/ipinfo_privacy.yml
+++ b/lookup_tables/ipinfo/ipinfo_privacy.yml
@@ -168,7 +168,7 @@ LogTypeMap:
     - LogType: GSuite.Reports
       Selectors:
         - 'ipAddress'
-    - LogType: Github.Audit
+    - LogType: GitHub.Audit
       Selectors:
         - 'actor_ip'
     - LogType: Jamfpro.Login

--- a/lookup_tables/ipinfo/ipinfo_privacy_datalake.yml
+++ b/lookup_tables/ipinfo/ipinfo_privacy_datalake.yml
@@ -152,7 +152,7 @@ LogTypeMap:
         - '$.jsonPayload.removeIp'
         - '$.httpRequest.remoteIp'
         - '$.httpRequest.serverIp'
-    - LogType: Github.Audit
+    - LogType: GitHub.Audit
       Selectors:
         - 'actor_ip'
     - LogType: GitLab.API

--- a/lookup_tables/ipinfo/ipinfo_privacy_datalake.yml
+++ b/lookup_tables/ipinfo/ipinfo_privacy_datalake.yml
@@ -152,6 +152,9 @@ LogTypeMap:
         - '$.jsonPayload.removeIp'
         - '$.httpRequest.remoteIp'
         - '$.httpRequest.serverIp'
+    - LogType: Github.Audit
+      Selectors:
+        - 'actor_ip'
     - LogType: GitLab.API
       Selectors:
         - 'remote_ip'

--- a/lookup_tables/tor/tor_exit_nodes.yml
+++ b/lookup_tables/tor/tor_exit_nodes.yml
@@ -155,7 +155,7 @@ LogTypeMap:
         - '$.jsonPayload.removeIp'
         - '$.httpRequest.remoteIp'
         - '$.httpRequest.serverIp'
-    - LogType: Github.Audit
+    - LogType: GitHub.Audit
       Selectors:
         - 'actor_ip'
     - LogType: GitLab.API

--- a/lookup_tables/tor/tor_exit_nodes.yml
+++ b/lookup_tables/tor/tor_exit_nodes.yml
@@ -155,6 +155,9 @@ LogTypeMap:
         - '$.jsonPayload.removeIp'
         - '$.httpRequest.remoteIp'
         - '$.httpRequest.serverIp'
+    - LogType: Github.Audit
+      Selectors:
+        - 'actor_ip'
     - LogType: GitLab.API
       Selectors:
         - 'remote_ip'


### PR DESCRIPTION
### Background

We added `actor_ip` to `Github.Audit` recently. Updating Lookup tables to use it as well.

### Changes

* Adding `actor_ip` to all enrichment LUTs

### Testing

* Not yet tested
