### PR TITLE
make vscode-config instruction improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ We welcome all contributions! Please read the [contributing guidelines](https://
 # Quick Start
 
 ## Clone the repository
+
 ```bash
 git clone git@github.com:panther-labs/panther-analysis.git
 cd panther-analysis
@@ -53,6 +54,7 @@ pipenv run panther_analysis_tool test --path rules/aws_cloudtrail_rules/
 ```
 
 ### Run detection tests
+
 ```bash
 pipenv run panther_analysis_tool test [-h] [--path PATH]
                                 [--filter KEY=VALUE [KEY=VALUE ...]
@@ -60,20 +62,25 @@ pipenv run panther_analysis_tool test [-h] [--path PATH]
 ```
 
 ### Test with a specific path
+
 ```bash
 pipenv run panther_analysis_tool test --path rules/cisco_umbrella_dns_rules
 ```
+
 ### Test by severity
+
 ```bash
 pipenv run panther_analysis_tool test --filter Severity=Critical
 ```
 
 ### Test by log type
+
 ```bash
 pipenv run panther_analysis_tool test --filter LogTypes=AWS.GuardDuty
 ```
 
 ### Create a zip file of detections
+
 ```bash
 pipenv run panther_analysis_tool zip [-h] [--path PATH] [--out OUT]
                                [--filter KEY=VALUE [KEY=VALUE ...]]
@@ -81,11 +88,13 @@ pipenv run panther_analysis_tool zip [-h] [--path PATH] [--out OUT]
 ```
 
 ### Zip all Critical severity detections
+
 ```bash
 pipenv run panther_analysis_tool zip --filter Severity=Critical
 ````
 
 ### Upload detections to your Panther instance
+
 ```bash
 # Note: Set your AWS access keys and region env variables before running the `upload` command
 
@@ -100,48 +109,53 @@ Global helper functions are defined in the `global_helpers` folder. This is a ha
 Additionally, groups of detections may be linked to multiple "Reports", which is a system for tracking frameworks like CIS, PCI, MITRE ATT&CK, or more.
 
 ## Using [Visual Studio Code](https://code.visualstudio.com/)
+
 If you are comfortable using the Visual Studio Code IDE, the `make vscode-config` command can configure VSCode to work with this repo. 
 
 In addition to this command, you will need to install these vscode add-ons:
+
 1. [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
-1. [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
+2. [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
+
+You will also need Visual Studio's [code](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line) configured to open Visual Studio from your CLI.
 
 `make vscode-config` will configure:
+
 1. Configure VSCode to use the python virtual environment for this repository.
 1. Resolve local imports like global_helpers, which permits code completion via Intellisense/Pylance
 1. Creates two debugging targets, which will give you single-button push support for running `panther_analysis_tool test` through the debugger.
 1. Installs JSONSchema support for your custom panther-analysis schemas in the `schemas/` directory. This brings IDE hints about which fields are necessary for schemas/custom-schema.yml files.
 1. Installs JSONSchema support for panther-analysis rules in the `rules/` directory. This brings IDE hints about which fields are necessary for rules/my-rule.yml files.
 
-
 ```shell
 user@computer:panther-analysis: make vscode-config
-
 ```
 
 ## Using Docker
 
 To use Docker, you can run some of the `make` commands provided to run common panther-analysis workflows. Start by building the container, then you can run any command you want from the image created. If you would like to run a different command, follow the pattern in the Makefile.
-```
-make docker-build
-make docker-test
-make docker-lint
-```
 
-Please note that you only need to rebuild the container if you update your `Pipfile.lock` changes, because the dependencies are install when the image is built. The subsequent test and lint commands are run in the image by mounting the current file system directory, so it is using your local file system. 
+  ``` bash
+  make docker-build
+  make docker-test
+  make docker-lint
+  ```
+
+Please note that you only need to rebuild the container if you update your `Pipfile.lock` changes, because the dependencies are install when the image is built. The subsequent test and lint commands are run in the image by mounting the current file system directory, so it is using your local file system.
 
 ## Using Windows
 
-If you are on a Windows machine, you can use the following instructions to perform the standard panther-analysis workflow. 
+If you are on a Windows machine, you can use the following instructions to perform the standard panther-analysis workflow.
 
 1. Install [docker desktop](https://docs.docker.com/desktop/install/windows-install/) for Windows.
 2. Using `make` is recommended. If you would like to use `make`, first install [chocolately](https://chocolatey.org/install), a standard Windows packaging manager.
 3. With chocolately, install the make command:
-```shell
-choco install make
-```
-4. `make` should now be installed and added to your PATH. Try running a `make docker-build` to get started. 
 
+    ```shell
+    choco install make
+    ```
+
+4. `make` should now be installed and added to your PATH. Try running a `make docker-build` to get started.
 
 # Writing Detections
 
@@ -213,7 +227,6 @@ Customizing detections-as-code is one of the most powerful capabilities Panther 
 Upon [tagged releases](https://github.com/panther-labs/panther-analysis/releases), you can pull upstream changes from this public repo.
 
 Follow the instructions [here](https://docs.panther.com/panther-developer-workflows/ci-cd/detections-repo) to get started with either a public fork or a private cloned repo to host your custom detection content.
-
 
 ## Getting Updates
 


### PR DESCRIPTION
### Background

`make vscode-config` is helpful! First-time users may not have the `code` cli tool configured properly, though. This improvement adds those instructions. 

### Changes

* Added a line highlighting `code` cli is needed
* Also cleaned up markdown syntax. 
