### PR TITLE
fix: Add missing CrowdStrike aid context to global helper

### DIFF
--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -218,6 +218,7 @@ def okta_alert_context(event: dict):
 def crowdstrike_detection_alert_context(event: dict):
     """Returns common context for Crowdstrike detections"""
     return {
+        "aid": get_crowdstrike_field(event, "aid", default=""),
         "user": get_crowdstrike_field(event, "UserName", default=""),
         "console-link": get_crowdstrike_field(event, "FalconHostLink", default=""),
         "commandline": get_crowdstrike_field(event, "CommandLine", default=""),


### PR DESCRIPTION
### Background

The current `crowdstrike_detection_alert_context()` global helper doesn't provide `aid` context similar to how `crowdstrike_network_detection_alert_context()` and `crowdstrike_process_alert_context()` do. I'm not sure if there's a specific reason why it was omitted, but it would be really useful to have vs. extracting the value from the rules that have it in their titles.

### Changes

* Adds `aid` context to `crowdstrike_detection_alert_context()` global helper

### Testing
Tested using `panther_analysis_tool test --path /rules/crowdstrike_rules`