### PR TITLE
Altered 4 rules to return dict, not PantherEvent

### DIFF
--- a/rules/dropbox_rules/dropbox_many_deletes.py
+++ b/rules/dropbox_rules/dropbox_many_deletes.py
@@ -11,4 +11,4 @@ def title(event):
 
 
 def alert_context(event):
-    return event
+    return event.to_dict()

--- a/rules/dropbox_rules/dropbox_many_downloads.py
+++ b/rules/dropbox_rules/dropbox_many_downloads.py
@@ -11,4 +11,4 @@ def title(event):
 
 
 def alert_context(event):
-    return event
+    return event.to_dict()

--- a/rules/gsuite_activityevent_rules/gsuite_drive_many_docs_deleted.py
+++ b/rules/gsuite_activityevent_rules/gsuite_drive_many_docs_deleted.py
@@ -11,4 +11,4 @@ def title(event):
 
 
 def alert_context(event):
-    return event
+    return event.to_dict()

--- a/rules/gsuite_activityevent_rules/gsuite_drive_many_docs_downloaded.py
+++ b/rules/gsuite_activityevent_rules/gsuite_drive_many_docs_downloaded.py
@@ -11,4 +11,4 @@ def title(event):
 
 
 def alert_context(event):
-    return event
+    return event.to_dict()


### PR DESCRIPTION
### Background

Customer pointed out that some of the `alert_context` functions return a `PantherEvent` object instead of a regular Python `dict`, which threw them for a loop in their workflow. Since `alert_context` is expected to return a `dict` anyway, I changed those functions to accommodate the customer. 

### Changes

* Changed 4 `alert_context` functions from `return event` to `return event.to_dict()`

### Testing

* Ran `make test`, all tests returned successful.
