### PR TITLE
Migrate Azure.SignIn rules to Azure.Audit

### DIFF
--- a/data_models/azure_signin_data_model.py
+++ b/data_models/azure_signin_data_model.py
@@ -1,16 +1,16 @@
 import panther_event_type_helpers as event_type
-from panther_azuresignin_helpers import actor_user
+from panther_azuresignin_helpers import actor_user, is_signin_event
 from panther_base_helpers import deep_get
 
 
 def get_event_type(event):
-    operation = deep_get(event, "operationName", default="")
+    if not is_signin_event(event):
+        return None
+
     error_code = deep_get(event, "properties", "status", "errorCode", default=0)
-    if operation == "Sign-in activity":
-        if error_code == 0:
-            return event_type.SUCCESSFUL_LOGIN
-        return event_type.FAILED_LOGIN
-    return None
+    if error_code == 0:
+        return event_type.SUCCESSFUL_LOGIN
+    return event_type.FAILED_LOGIN
 
 
 def get_actor_user(event):

--- a/data_models/azure_signin_data_model.py
+++ b/data_models/azure_signin_data_model.py
@@ -1,10 +1,10 @@
 import panther_event_type_helpers as event_type
-from panther_azuresignin_helpers import actor_user, is_signin_event
+from panther_azuresignin_helpers import actor_user, is_sign_in_event
 from panther_base_helpers import deep_get
 
 
 def get_event_type(event):
-    if not is_signin_event(event):
+    if not is_sign_in_event(event):
         return None
 
     error_code = deep_get(event, "properties", "status", "errorCode", default=0)

--- a/data_models/azure_signin_data_model.yml
+++ b/data_models/azure_signin_data_model.yml
@@ -1,7 +1,7 @@
 AnalysisType: datamodel
 LogTypes:
-  - Azure.SignIn
-DataModelID: "Standard.Azure.SignIn"
+  - Azure.Audit
+DataModelID: "Standard.Azure.Audit.SignIn"
 DisplayName: "Azure SignIn Logs DataModel"
 Filename: azure_signin_data_model.py
 Enabled: true

--- a/global_helpers/panther_azuresignin_helpers.py
+++ b/global_helpers/panther_azuresignin_helpers.py
@@ -10,6 +10,10 @@ def actor_user(event):
     return None
 
 
+def is_sign_in_event(event):
+    return deep_get(event, "operationName", default="") == "Sign-in activity"
+
+
 def azure_signin_alert_context(event) -> dict:
     ac_actor_user = actor_user(event)
     if ac_actor_user is None:

--- a/packs/azure_signin.yml
+++ b/packs/azure_signin.yml
@@ -1,13 +1,13 @@
 AnalysisType: pack
-PackID: PantherManaged.AzureSignin
-Description: Group of Azure.SignIn detections
+PackID: PantherManaged.AzureAudit.Signin
+Description: Group of Azure.Audit detections
 PackDefinition:
   IDs:
-    - Azure.SignIn.LegacyAuth
-    - Azure.SignIn.ManyFailedSignIns
-    - Azure.SignIn.RiskLevelPassthrough
+    - Azure.Audit.LegacyAuth
+    - Azure.Audit.ManyFailedSignIns
+    - Azure.Audit.RiskLevelPassthrough
     # Globals used in these detections
     - global_filter_azuresignin
     - panther_azuresignin_helpers
     - panther_base_helpers
-DisplayName: "Panther Azure.SignIn Pack"
+DisplayName: "Panther Azure.Audit SignIn Pack"

--- a/rules/azure_signin_rules/azure_failed_signins.py
+++ b/rules/azure_signin_rules/azure_failed_signins.py
@@ -1,9 +1,12 @@
 from global_filter_azuresignin import filter_include_event
-from panther_azuresignin_helpers import actor_user, azure_signin_alert_context
+from panther_azuresignin_helpers import actor_user, azure_signin_alert_context, is_sign_in_event
 from panther_base_helpers import deep_get
 
 
 def rule(event):
+    if not is_sign_in_event(event):
+        return False
+
     if not filter_include_event(event):
         return False
     error_code = deep_get(event, "properties", "status", "errorCode", default=0)

--- a/rules/azure_signin_rules/azure_failed_signins.yml
+++ b/rules/azure_signin_rules/azure_failed_signins.yml
@@ -1,13 +1,13 @@
 AnalysisType: rule
 Filename: azure_failed_signins.py
-RuleID: "Azure.SignIn.ManyFailedSignIns"
+RuleID: "Azure.Audit.ManyFailedSignIns"
 DisplayName: "Azure Many Failed SignIns"
 Enabled: true
 # Ten Failed Sign-Ins(Threshold) in Ten Minutes(DedupPeriodMinutes)
 Threshold: 10
 DedupPeriodMinutes: 10
 LogTypes:
-  - Azure.SignIn
+  - Azure.Audit
 Severity: Medium
 Description: >
   This detection looks for a number of failed sign-ins for the same

--- a/rules/azure_signin_rules/azure_failed_signins_deprecated.yml
+++ b/rules/azure_signin_rules/azure_failed_signins_deprecated.yml
@@ -1,0 +1,8 @@
+AnalysisType: rule
+RuleID: "Azure.SignIn.ManyFailedSignIns"
+DisplayName: "--DEPRECATED-- Many Failed SignIns"
+Enabled: false
+LogTypes:
+  - Azure.SignIn
+Severity: Low
+Filename: azure_failed_signins.py

--- a/rules/azure_signin_rules/azure_legacyauth.py
+++ b/rules/azure_signin_rules/azure_legacyauth.py
@@ -2,7 +2,7 @@ import json
 from unittest.mock import MagicMock
 
 from global_filter_azuresignin import filter_include_event
-from panther_azuresignin_helpers import actor_user, azure_signin_alert_context
+from panther_azuresignin_helpers import actor_user, azure_signin_alert_context, is_sign_in_event
 from panther_base_helpers import deep_get
 
 LEGACY_AUTH_USERAGENTS = ["BAV2ROPC", "CBAInPROD"]  # CBAInPROD is reported to be IMAP
@@ -13,6 +13,9 @@ KNOWN_EXCEPTIONS = []
 
 
 def rule(event):
+    if not is_sign_in_event(event):
+        return False
+
     global KNOWN_EXCEPTIONS  # pylint: disable=global-statement
     if isinstance(KNOWN_EXCEPTIONS, MagicMock):
         KNOWN_EXCEPTIONS = json.loads(KNOWN_EXCEPTIONS())  # pylint: disable=not-callable

--- a/rules/azure_signin_rules/azure_legacyauth.yml
+++ b/rules/azure_signin_rules/azure_legacyauth.yml
@@ -1,12 +1,12 @@
 AnalysisType: rule
 Filename: azure_legacyauth.py
-RuleID: "Azure.SignIn.LegacyAuth"
+RuleID: "Azure.Audit.LegacyAuth"
 DisplayName: "Azure SignIn via Legacy Authentication Protocol"
 Enabled: true
 Threshold: 1
 DedupPeriodMinutes: 10
 LogTypes:
-  - Azure.SignIn
+  - Azure.Audit
 Severity: Medium
 Description: >
   This detection looks for Successful Logins that have used legacy authentication protocols

--- a/rules/azure_signin_rules/azure_legacyauth_deprecated.yml
+++ b/rules/azure_signin_rules/azure_legacyauth_deprecated.yml
@@ -1,0 +1,8 @@
+AnalysisType: rule
+RuleID: "Azure.SignIn.LegacyAuth"
+DisplayName: "--DEPRECATED-- SignIn via Legacy Authentication Protocol"
+Enabled: false
+LogTypes:
+  - Azure.SignIn
+Severity: Low
+Filename: azure_legacyauth.py

--- a/rules/azure_signin_rules/azure_risklevel_passthrough.py
+++ b/rules/azure_signin_rules/azure_risklevel_passthrough.py
@@ -1,11 +1,14 @@
 from global_filter_azuresignin import filter_include_event
-from panther_azuresignin_helpers import actor_user, azure_signin_alert_context
+from panther_azuresignin_helpers import actor_user, azure_signin_alert_context, is_sign_in_event
 from panther_base_helpers import deep_get
 
 PASSTHROUGH_SEVERITIES = {"low", "medium", "high"}
 
 
 def rule(event):
+    if not is_sign_in_event(event):
+        return False
+
     if not filter_include_event(event):
         return False
     global IDENTIFIED_RISK_LEVEL  # pylint: disable=global-variable-undefined

--- a/rules/azure_signin_rules/azure_risklevel_passthrough.yml
+++ b/rules/azure_signin_rules/azure_risklevel_passthrough.yml
@@ -1,12 +1,12 @@
 AnalysisType: rule
 Filename: azure_risklevel_passthrough.py
-RuleID: "Azure.SignIn.RiskLevelPassthrough"
+RuleID: "Azure.Audit.RiskLevelPassthrough"
 DisplayName: "Azure RiskLevel Passthrough"
 Enabled: true
 Threshold: 1
 DedupPeriodMinutes: 10
 LogTypes:
-  - Azure.SignIn
+  - Azure.Audit
 Severity: Medium
 Description: >
   This detection surfaces an alert based on 

--- a/rules/azure_signin_rules/azure_risklevel_passthrough.yml
+++ b/rules/azure_signin_rules/azure_risklevel_passthrough.yml
@@ -112,7 +112,7 @@ Tests:
         "operationname": "Sign-in activity",
         "operationversion": 1,
         "p_event_time": "2023-07-26 23:00:20.889",
-        "p_log_type": "Azure.SignIn",
+        "p_log_type": "Azure.Audit",
         "properties": {
           "appId": "cfceb902-8fab-4f8c-88ba-374d3c975c3a",
           "authenticationProcessingDetails": [
@@ -179,7 +179,7 @@ Tests:
         "operationname": "Sign-in activity",
         "operationversion": 1,
         "p_event_time": "2023-07-26 23:00:20.889",
-        "p_log_type": "Azure.SignIn",
+        "p_log_type": "Azure.Audit",
         "properties": {
           "appId": "cfceb902-8fab-4f8c-88ba-374d3c975c3a",
           "authenticationProcessingDetails": [

--- a/rules/azure_signin_rules/azure_risklevel_passthrough_deprecated.yml
+++ b/rules/azure_signin_rules/azure_risklevel_passthrough_deprecated.yml
@@ -1,0 +1,8 @@
+AnalysisType: rule
+RuleID: "Azure.SignIn.RiskLevelPassthrough"
+DisplayName: "--DEPRECATED-- Azure RiskLevel Passthrough"
+Enabled: false
+LogTypes:
+  - Azure.SignIn
+Severity: Low
+Filename: azure_risklevel_passthrough.py


### PR DESCRIPTION
### Background

Due to classification issues, we are merging the `Azure.Audit` and `Azure.SignIn` schemas into one (the former: `Azure.Audit`).
We need to migtea

Relates to https://app.asana.com/0/1205441909782364/1205232760343992/f

### Changes

* Move the old rules to new files with `Enabled: false` and deprecated notices
* Duplicate the rules into the new schema and add a new guard `is_signin_event` in the rule function

### Testing

CLI tests:
![image](https://github.com/panther-labs/panther-analysis/assets/777619/775d8bfe-e583-4801-b061-f9258b6b25d7)

