### PR TITLE
Fixed invalid summary attributes

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_ecr_crud.yml
+++ b/rules/aws_cloudtrail_rules/aws_ecr_crud.yml
@@ -20,7 +20,7 @@ Reference: reference.link
 SummaryAttributes:
   - eventSource
   - eventName
-  - accountId
+  - recipientAccountId
   - awsRegion
   - p_any_aws_arns
 Tests:

--- a/rules/aws_cloudtrail_rules/aws_ecr_events.yml
+++ b/rules/aws_cloudtrail_rules/aws_ecr_events.yml
@@ -17,7 +17,7 @@ Runbook: https://docs.aws.amazon.com/AmazonECR/latest/userguide/logging-using-cl
 Reference: reference.link
 SummaryAttributes:
   - eventSource
-  - accountId
+  - recipientAccountId
   - awsRegion
   - p_any_aws_arns
 Tests:

--- a/rules/aws_cloudtrail_rules/aws_lambda_crud.yml
+++ b/rules/aws_cloudtrail_rules/aws_lambda_crud.yml
@@ -20,7 +20,7 @@ Reference: reference.link
 SummaryAttributes:
   - eventSource
   - eventName
-  - accountId
+  - recipientAccountId
   - awsRegion
   - p_any_aws_arns
 Tests:

--- a/rules/aws_cloudtrail_rules/aws_s3_activity_greynoise.yml
+++ b/rules/aws_cloudtrail_rules/aws_s3_activity_greynoise.yml
@@ -16,10 +16,8 @@ SummaryAttributes:
   - eventName
   - p_any_aws_arns
   - recipientAccountId
-  - sourceIpAddress
+  - sourceIPAddress
   - userAgent
-  - p_alert_context
-  - p_enrichment
 LogTypes:
   - AWS.CloudTrail
 RuleID: "AWS.S3.GreyNoiseActivity"

--- a/rules/aws_cloudtrail_rules/aws_unused_region.yml
+++ b/rules/aws_cloudtrail_rules/aws_unused_region.yml
@@ -18,7 +18,7 @@ Reference: https://attack.mitre.org/techniques/T1535/
 SummaryAttributes:
   - eventSource
   - eventName
-  - accountId
+  - recipientAccountId
   - awsRegion
   - p_any_aws_arns
 Tests:

--- a/rules/cloudflare_rules/cloudflare_firewall_high_volume_events_blocked_greynoise.yml
+++ b/rules/cloudflare_rules/cloudflare_firewall_high_volume_events_blocked_greynoise.yml
@@ -19,8 +19,6 @@ SummaryAttributes:
   - Action
   - EdgeResponseStatus
   - OriginResponseStatus
-  - p_alert_context
-  - p_enrichment
 Tests:
   -
     Name: Blocked Event - Malicious

--- a/rules/gcp_audit_rules/gcp_iam_org_folder_changes.yml
+++ b/rules/gcp_audit_rules/gcp_iam_org_folder_changes.yml
@@ -26,10 +26,7 @@ Runbook: >
   put your new policy bindings. 
 SummaryAttributes:
   - severity
-  - actor
-  - policy_change
-  - caller_ip
-  - user_agent
+  - p_any_ip_addresses
 Tests:
   - Name: Terraform User Agent
     ExpectedResult: true

--- a/rules/gcp_k8s_rules/gcp_k8s_exec_into_pod.yml
+++ b/rules/gcp_k8s_rules/gcp_k8s_exec_into_pod.yml
@@ -14,10 +14,6 @@ Description: >
   Alerts when users exec into pod. Possible to specify specific projects and allowed users.
 Runbook: >
   Investigate the user and determine why. Advise that it is discouraged practice. Create ticket if appropriate. 
-SummaryAttributes:
-  - actor_user
-  - project_id
-  - pod
 Tests:
   -
     Name: Allowed User

--- a/rules/github_rules/github_organization_app_integration_installed.yml
+++ b/rules/github_rules/github_organization_app_integration_installed.yml
@@ -52,5 +52,4 @@ RuleID: "Github.Organization.App.Integration.Installed"
 SummaryAttributes:
     - actor
     - name
-    - org
 Threshold: 1

--- a/rules/github_rules/github_public_repository_created.yml
+++ b/rules/github_rules/github_public_repository_created.yml
@@ -42,6 +42,6 @@ LogTypes:
 RuleID: "Github.Public.Repository.Created"
 SummaryAttributes:
     - actor
-    - repo
+    - repository
     - visibility
 Threshold: 1

--- a/rules/gsuite_activityevent_rules/google_workspace_admin_custom_role.yml
+++ b/rules/gsuite_activityevent_rules/google_workspace_admin_custom_role.yml
@@ -92,7 +92,6 @@ LogTypes:
     - GSuite.ActivityEvent
 RuleID: "Google.Workspace.Admin.Custom.Role"
 SummaryAttributes:
-    - actor.email
     - name
     - type
 Threshold: 1

--- a/rules/okta_rules/okta_password_accessed.yml
+++ b/rules/okta_rules/okta_password_accessed.yml
@@ -17,10 +17,6 @@ Description: >
 Reference: https://developer.okta.com/docs/reference/api/event-types/#catalog
 Runbook: >
   Investigate whether this was authorized access.
-SummaryAttributes:
-  - account_id
-  - user_name
-  - user_id
 Tests:
   - Name: User accessed their own password
     ExpectedResult: false

--- a/rules/standard_rules/impossible_travel_login.yml
+++ b/rules/standard_rules/impossible_travel_login.yml
@@ -21,7 +21,7 @@ Runbook: >
   If the user responds that the geolocation on the new location is incorrect, you can directly
   report the inaccuracy via  https://ipinfo.io/corrections
 SummaryAttributes:
-  - p_any_user_names
+  - p_any_usernames
   - p_any_ip_addresses
   - p_any_domain_names
 # All test cases for this detection will need to include:

--- a/rules/zendesk_rules/zendesk_user_assumption.yml
+++ b/rules/zendesk_rules/zendesk_user_assumption.yml
@@ -16,7 +16,7 @@ Description: User enabled or disabled zendesk support user assumption.
 Runbook: >
   Investigate whether allowing zendesk support to assume users is necessary. If not, disable the feature.
 SummaryAttributes:
-  - p_any_addresses
+  - p_any_ip_addresses
 Tests:
   - 
     Name: User assumption settings changed


### PR DESCRIPTION
### Background

We are adding some new functionality to uploads to validate the `SummaryAttributes` field, and found that some of our managed detections have invalid `SummaryAttributes` values.

### Changes

* Changed invalid summary attributes to be valid

### Testing

* `pat validate` in an instance with the enforce valid summary attributes feature enabled
