### PR TITLE
replacing kv globals with caching funcs

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ moto = ">=4.1"
 policyuniverse = "==1.5.0.20220613"
 requests = "~=2.27"
 panther-analysis-tool = "~=0.25.0"
+panther-detection-helpers = "==0.1.1"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d973f379fc740f5156fe8307c05f577e53654dd2f0e93e82667a23bcb723ef30"
+            "sha256": "b3cd5c5b83a7074b1676de99418221dce96b0fc3c32362c016aebd91f7ea951a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -150,19 +150,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0300ca6ec8bc136eb316b32cc1e30c66b85bc497f5a5fe42e095ae4280569708",
-                "sha256:9d1b4713c888e53a218648ad71522bee9bec9d83f2999fff2494675af810b632"
+                "sha256:b927a7ed335d543c33c15fa63f1076f3fa8422959771c2187da74bc4395ab6e3",
+                "sha256:f5fcb27cdbd08ca38d699f2d2e32d96d1d9fab3368c15c6bc326256612d2cfd7"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.28.24"
+            "version": "==1.28.56"
         },
         "botocore": {
             "hashes": [
-                "sha256:2d8f412c67f9285219f52d5dbbb6ef0dfa9f606da29cbdd41b6d6474bcc4bbd4",
-                "sha256:8c7ba9b09e9104e2d473214e1ffcf84b77e04cf6f5f2344942c1eed9e299f947"
+                "sha256:66c686e4eda7051ffcc9357d9075390c8ab2f95a2977669039618ee186fb533b",
+                "sha256:70252cd8abc2fe9b791328e187620f5a3911545e2520486b01ecfad31f41b9cb"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.24"
+            "version": "==1.31.56"
         },
         "certifi": {
             "hashes": [
@@ -263,11 +263,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd",
-                "sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5"
+                "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
+                "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==8.1.6"
+            "version": "==8.1.7"
         },
         "colorama": {
             "hashes": [
@@ -285,13 +285,13 @@
             "markers": "python_version >= '3.6'",
             "version": "==21.6.0"
         },
-        "decorator": {
+        "datadog": {
             "hashes": [
-                "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330",
-                "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"
+                "sha256:47be3b2c3d709a7f5b709eb126ed4fe6cc7977d618fe5c158dd89c2a9f7d9916",
+                "sha256:a45ec997ab554208837e8c44d81d0e1456539dc14da5743687250e028bc809b7"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==5.1.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "version": "==0.47.0"
         },
         "diff-cover": {
             "hashes": [
@@ -303,19 +303,19 @@
         },
         "dynaconf": {
             "hashes": [
-                "sha256:791d8029c74548d57b0266aabd6557ebfff6540bffd7f58ba700f577c047c0f5",
-                "sha256:a28442d12860a44fad5fa1d9db918c710cbfc971e8b7694697429fb8f1c3c620"
+                "sha256:8a37ba3b16df64cb1db383eaad9c733aece218413be0fad5d785f7a907612106",
+                "sha256:df4af8d0f3b068cc6419ceceaae572070a6b8fec38fa51a1f5eb8ea4883e53de"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.2.0"
+            "version": "==3.2.3"
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5",
-                "sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f"
+                "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9",
+                "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.1.2"
+            "version": "==1.1.3"
         },
         "frozenlist": {
             "hashes": [
@@ -433,27 +433,26 @@
         },
         "jsonlines": {
             "hashes": [
-                "sha256:2579cb488d96f815b0eb81629e3e6b0332da0962a18fa3532958f7ba14a5c37f",
-                "sha256:632f5e38f93dfcb1ac8c4e09780b92af3a55f38f26e7c47ae85109d420b6ad39"
+                "sha256:0c6d2c09117550c089995247f605ae4cf77dd1533041d366351f6f298822ea74",
+                "sha256:185b334ff2ca5a91362993f42e83588a360cf95ce4b71a73548502bda52a7c55"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.1.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==4.0.0"
         },
         "jsonpath-ng": {
             "hashes": [
-                "sha256:292a93569d74029ba75ac2dc3d3630fc0e17b2df26119a165fa1d498ca47bf65",
-                "sha256:a273b182a82c1256daab86a313b937059261b5c5f8c4fa3fc38b882b344dd567",
-                "sha256:f75b95dbecb8a0f3b86fd2ead21c2b022c3f5770957492b9b6196ecccfeb10aa"
+                "sha256:5483f8e9d74c39c9abfab554c070ae783c1c8cbadf5df60d561bc705ac68a07e",
+                "sha256:6fd04833412c4b3d9299edf369542f5e67095ca84efa17cbb7f06a34958adc9f"
             ],
-            "version": "==1.5.3"
+            "version": "==1.6.0"
         },
         "jsonschema": {
             "hashes": [
-                "sha256:043dc26a3845ff09d20e4420d6012a9c91c9aa8999fa184e7efcfeccb41e32cb",
-                "sha256:6e1e7569ac13be8139b2dd2c21a55d350066ee3f80df06c608b398cdc6f30e8f"
+                "sha256:cd5f1f9ed9444e554b38ba003af06c0a8c2868131e56bfbef0550fb450c0330e",
+                "sha256:ec84cc37cfa703ef7cd4928db24f9cb31428a5d0fa77747b8b51a847458e0bbf"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.19.0"
+            "version": "==4.19.1"
         },
         "jsonschema-specifications": {
             "hashes": [
@@ -469,8 +468,11 @@
                 "sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e",
                 "sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431",
                 "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686",
+                "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c",
                 "sha256:1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559",
                 "sha256:1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc",
+                "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb",
+                "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939",
                 "sha256:282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c",
                 "sha256:2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0",
                 "sha256:2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4",
@@ -478,6 +480,7 @@
                 "sha256:3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575",
                 "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba",
                 "sha256:42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d",
+                "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd",
                 "sha256:504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3",
                 "sha256:525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00",
                 "sha256:56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155",
@@ -486,6 +489,7 @@
                 "sha256:68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f",
                 "sha256:69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8",
                 "sha256:6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b",
+                "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007",
                 "sha256:787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24",
                 "sha256:7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea",
                 "sha256:8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198",
@@ -493,9 +497,12 @@
                 "sha256:8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee",
                 "sha256:8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be",
                 "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2",
+                "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1",
                 "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707",
                 "sha256:962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6",
+                "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c",
                 "sha256:9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58",
+                "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823",
                 "sha256:aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779",
                 "sha256:ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636",
                 "sha256:ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c",
@@ -514,7 +521,9 @@
                 "sha256:df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9",
                 "sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57",
                 "sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc",
-                "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2"
+                "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc",
+                "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2",
+                "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2.1.3"
@@ -626,6 +635,13 @@
             ],
             "version": "==0.5.0"
         },
+        "panther-detection-helpers": {
+            "hashes": [
+                "sha256:8a3d48e4d5f5eae55ace51d27e75f7f0b21cf9acd88507de38d60ca2e607dd5d"
+            ],
+            "index": "pypi",
+            "version": "==0.1.1"
+        },
         "pathspec": {
             "hashes": [
                 "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20",
@@ -636,11 +652,11 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849",
-                "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"
+                "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12",
+                "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.2.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.3.0"
         },
         "ply": {
             "hashes": [
@@ -667,11 +683,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32",
-                "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"
+                "sha256:1d881c6124e08ff0a1bb75ba3ec0bfd8b5354a01c194ddd5a0a870a48d99b002",
+                "sha256:a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==7.4.0"
+            "version": "==7.4.2"
         },
         "python-dateutil": {
             "hashes": [
@@ -683,7 +699,9 @@
         },
         "pyyaml": {
             "hashes": [
+                "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5",
                 "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc",
+                "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df",
                 "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741",
                 "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206",
                 "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27",
@@ -691,7 +709,10 @@
                 "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62",
                 "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98",
                 "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696",
+                "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290",
+                "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9",
                 "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d",
+                "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6",
                 "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867",
                 "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47",
                 "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486",
@@ -699,9 +720,12 @@
                 "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3",
                 "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007",
                 "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938",
+                "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0",
                 "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c",
                 "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735",
                 "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d",
+                "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28",
+                "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4",
                 "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba",
                 "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
                 "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5",
@@ -716,7 +740,9 @@
                 "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43",
                 "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859",
                 "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673",
+                "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54",
                 "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a",
+                "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b",
                 "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab",
                 "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa",
                 "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c",
@@ -839,106 +865,106 @@
         },
         "rpds-py": {
             "hashes": [
-                "sha256:0173c0444bec0a3d7d848eaeca2d8bd32a1b43f3d3fde6617aac3731fa4be05f",
-                "sha256:01899794b654e616c8625b194ddd1e5b51ef5b60ed61baa7a2d9c2ad7b2a4238",
-                "sha256:02938432352359805b6da099c9c95c8a0547fe4b274ce8f1a91677401bb9a45f",
-                "sha256:03421628f0dc10a4119d714a17f646e2837126a25ac7a256bdf7c3943400f67f",
-                "sha256:03975db5f103997904c37e804e5f340c8fdabbb5883f26ee50a255d664eed58c",
-                "sha256:0766babfcf941db8607bdaf82569ec38107dbb03c7f0b72604a0b346b6eb3298",
-                "sha256:07e2c54bef6838fa44c48dfbc8234e8e2466d851124b551fc4e07a1cfeb37260",
-                "sha256:0836d71ca19071090d524739420a61580f3f894618d10b666cf3d9a1688355b1",
-                "sha256:095b460e117685867d45548fbd8598a8d9999227e9061ee7f012d9d264e6048d",
-                "sha256:0e7521f5af0233e89939ad626b15278c71b69dc1dfccaa7b97bd4cdf96536bb7",
-                "sha256:0f2996fbac8e0b77fd67102becb9229986396e051f33dbceada3debaacc7033f",
-                "sha256:1054a08e818f8e18910f1bee731583fe8f899b0a0a5044c6e680ceea34f93876",
-                "sha256:13b602dc3e8dff3063734f02dcf05111e887f301fdda74151a93dbbc249930fe",
-                "sha256:141acb9d4ccc04e704e5992d35472f78c35af047fa0cfae2923835d153f091be",
-                "sha256:14c408e9d1a80dcb45c05a5149e5961aadb912fff42ca1dd9b68c0044904eb32",
-                "sha256:159fba751a1e6b1c69244e23ba6c28f879a8758a3e992ed056d86d74a194a0f3",
-                "sha256:190ca6f55042ea4649ed19c9093a9be9d63cd8a97880106747d7147f88a49d18",
-                "sha256:196cb208825a8b9c8fc360dc0f87993b8b260038615230242bf18ec84447c08d",
-                "sha256:1fcdee18fea97238ed17ab6478c66b2095e4ae7177e35fb71fbe561a27adf620",
-                "sha256:207f57c402d1f8712618f737356e4b6f35253b6d20a324d9a47cb9f38ee43a6b",
-                "sha256:24a81c177379300220e907e9b864107614b144f6c2a15ed5c3450e19cf536fae",
-                "sha256:29cd8bfb2d716366a035913ced99188a79b623a3512292963d84d3e06e63b496",
-                "sha256:2d8b3b3a2ce0eaa00c5bbbb60b6713e94e7e0becab7b3db6c5c77f979e8ed1f1",
-                "sha256:35da5cc5cb37c04c4ee03128ad59b8c3941a1e5cd398d78c37f716f32a9b7f67",
-                "sha256:44659b1f326214950a8204a248ca6199535e73a694be8d3e0e869f820767f12f",
-                "sha256:47c5f58a8e0c2c920cc7783113df2fc4ff12bf3a411d985012f145e9242a2764",
-                "sha256:4bd4dc3602370679c2dfb818d9c97b1137d4dd412230cfecd3c66a1bf388a196",
-                "sha256:4ea6b73c22d8182dff91155af018b11aac9ff7eca085750455c5990cb1cfae6e",
-                "sha256:50025635ba8b629a86d9d5474e650da304cb46bbb4d18690532dd79341467846",
-                "sha256:517cbf6e67ae3623c5127206489d69eb2bdb27239a3c3cc559350ef52a3bbf0b",
-                "sha256:5855c85eb8b8a968a74dc7fb014c9166a05e7e7a8377fb91d78512900aadd13d",
-                "sha256:5a46859d7f947061b4010e554ccd1791467d1b1759f2dc2ec9055fa239f1bc26",
-                "sha256:65a0583c43d9f22cb2130c7b110e695fff834fd5e832a776a107197e59a1898e",
-                "sha256:674c704605092e3ebbbd13687b09c9f78c362a4bc710343efe37a91457123044",
-                "sha256:682726178138ea45a0766907957b60f3a1bf3acdf212436be9733f28b6c5af3c",
-                "sha256:686ba516e02db6d6f8c279d1641f7067ebb5dc58b1d0536c4aaebb7bf01cdc5d",
-                "sha256:6a5d3fbd02efd9cf6a8ffc2f17b53a33542f6b154e88dd7b42ef4a4c0700fdad",
-                "sha256:6aa8326a4a608e1c28da191edd7c924dff445251b94653988efb059b16577a4d",
-                "sha256:700375326ed641f3d9d32060a91513ad668bcb7e2cffb18415c399acb25de2ab",
-                "sha256:71f2f7715935a61fa3e4ae91d91b67e571aeb5cb5d10331ab681256bda2ad920",
-                "sha256:745f5a43fdd7d6d25a53ab1a99979e7f8ea419dfefebcab0a5a1e9095490ee5e",
-                "sha256:79f594919d2c1a0cc17d1988a6adaf9a2f000d2e1048f71f298b056b1018e872",
-                "sha256:7d68dc8acded354c972116f59b5eb2e5864432948e098c19fe6994926d8e15c3",
-                "sha256:7f67da97f5b9eac838b6980fc6da268622e91f8960e083a34533ca710bec8611",
-                "sha256:83b32f0940adec65099f3b1c215ef7f1d025d13ff947975a055989cb7fd019a4",
-                "sha256:876bf9ed62323bc7dcfc261dbc5572c996ef26fe6406b0ff985cbcf460fc8a4c",
-                "sha256:890ba852c16ace6ed9f90e8670f2c1c178d96510a21b06d2fa12d8783a905193",
-                "sha256:8b08605d248b974eb02f40bdcd1a35d3924c83a2a5e8f5d0fa5af852c4d960af",
-                "sha256:8b2eb034c94b0b96d5eddb290b7b5198460e2d5d0c421751713953a9c4e47d10",
-                "sha256:8b9ec12ad5f0a4625db34db7e0005be2632c1013b253a4a60e8302ad4d462afd",
-                "sha256:8c8d7594e38cf98d8a7df25b440f684b510cf4627fe038c297a87496d10a174f",
-                "sha256:8d3335c03100a073883857e91db9f2e0ef8a1cf42dc0369cbb9151c149dbbc1b",
-                "sha256:8d70e8f14900f2657c249ea4def963bed86a29b81f81f5b76b5a9215680de945",
-                "sha256:9039a11bca3c41be5a58282ed81ae422fa680409022b996032a43badef2a3752",
-                "sha256:91378d9f4151adc223d584489591dbb79f78814c0734a7c3bfa9c9e09978121c",
-                "sha256:9251eb8aa82e6cf88510530b29eef4fac825a2b709baf5b94a6094894f252387",
-                "sha256:933a7d5cd4b84f959aedeb84f2030f0a01d63ae6cf256629af3081cf3e3426e8",
-                "sha256:978fa96dbb005d599ec4fd9ed301b1cc45f1a8f7982d4793faf20b404b56677d",
-                "sha256:987b06d1cdb28f88a42e4fb8a87f094e43f3c435ed8e486533aea0bf2e53d931",
-                "sha256:99b1c16f732b3a9971406fbfe18468592c5a3529585a45a35adbc1389a529a03",
-                "sha256:99e7c4bb27ff1aab90dcc3e9d37ee5af0231ed98d99cb6f5250de28889a3d502",
-                "sha256:9c439fd54b2b9053717cca3de9583be6584b384d88d045f97d409f0ca867d80f",
-                "sha256:9ea4d00850ef1e917815e59b078ecb338f6a8efda23369677c54a5825dbebb55",
-                "sha256:9f30d205755566a25f2ae0382944fcae2f350500ae4df4e795efa9e850821d82",
-                "sha256:a06418fe1155e72e16dddc68bb3780ae44cebb2912fbd8bb6ff9161de56e1798",
-                "sha256:a0805911caedfe2736935250be5008b261f10a729a303f676d3d5fea6900c96a",
-                "sha256:a1f044792e1adcea82468a72310c66a7f08728d72a244730d14880cd1dabe36b",
-                "sha256:a216b26e5af0a8e265d4efd65d3bcec5fba6b26909014effe20cd302fd1138fa",
-                "sha256:a987578ac5214f18b99d1f2a3851cba5b09f4a689818a106c23dbad0dfeb760f",
-                "sha256:aad51239bee6bff6823bbbdc8ad85136c6125542bbc609e035ab98ca1e32a192",
-                "sha256:ab2299e3f92aa5417d5e16bb45bb4586171c1327568f638e8453c9f8d9e0f020",
-                "sha256:ab6919a09c055c9b092798ce18c6c4adf49d24d4d9e43a92b257e3f2548231e7",
-                "sha256:b0c43f8ae8f6be1d605b0465671124aa8d6a0e40f1fb81dcea28b7e3d87ca1e1",
-                "sha256:b1440c291db3f98a914e1afd9d6541e8fc60b4c3aab1a9008d03da4651e67386",
-                "sha256:b52e7c5ae35b00566d244ffefba0f46bb6bec749a50412acf42b1c3f402e2c90",
-                "sha256:bf4151acb541b6e895354f6ff9ac06995ad9e4175cbc6d30aaed08856558201f",
-                "sha256:c27ee01a6c3223025f4badd533bea5e87c988cb0ba2811b690395dfe16088cfe",
-                "sha256:c545d9d14d47be716495076b659db179206e3fd997769bc01e2d550eeb685596",
-                "sha256:c5934e2833afeaf36bd1eadb57256239785f5af0220ed8d21c2896ec4d3a765f",
-                "sha256:c7671d45530fcb6d5e22fd40c97e1e1e01965fc298cbda523bb640f3d923b387",
-                "sha256:c861a7e4aef15ff91233751619ce3a3d2b9e5877e0fcd76f9ea4f6847183aa16",
-                "sha256:d25b1c1096ef0447355f7293fbe9ad740f7c47ae032c2884113f8e87660d8f6e",
-                "sha256:d55777a80f78dd09410bd84ff8c95ee05519f41113b2df90a69622f5540c4f8b",
-                "sha256:d576c3ef8c7b2d560e301eb33891d1944d965a4d7a2eacb6332eee8a71827db6",
-                "sha256:dd9da77c6ec1f258387957b754f0df60766ac23ed698b61941ba9acccd3284d1",
-                "sha256:de0b6eceb46141984671802d412568d22c6bacc9b230174f9e55fc72ef4f57de",
-                "sha256:e07e5dbf8a83c66783a9fe2d4566968ea8c161199680e8ad38d53e075df5f0d0",
-                "sha256:e564d2238512c5ef5e9d79338ab77f1cbbda6c2d541ad41b2af445fb200385e3",
-                "sha256:ed89861ee8c8c47d6beb742a602f912b1bb64f598b1e2f3d758948721d44d468",
-                "sha256:ef1f08f2a924837e112cba2953e15aacfccbbfcd773b4b9b4723f8f2ddded08e",
-                "sha256:f411330a6376fb50e5b7a3e66894e4a39e60ca2e17dce258d53768fea06a37bd",
-                "sha256:f68996a3b3dc9335037f82754f9cdbe3a95db42bde571d8c3be26cc6245f2324",
-                "sha256:f7fdf55283ad38c33e35e2855565361f4bf0abd02470b8ab28d499c663bc5d7c",
-                "sha256:f963c6b1218b96db85fc37a9f0851eaf8b9040aa46dec112611697a7023da535",
-                "sha256:fa2818759aba55df50592ecbc95ebcdc99917fa7b55cc6796235b04193eb3c55",
-                "sha256:fae5cb554b604b3f9e2c608241b5d8d303e410d7dfb6d397c335f983495ce7f6",
-                "sha256:fb39aca7a64ad0c9490adfa719dbeeb87d13be137ca189d2564e596f8ba32c07"
+                "sha256:015de2ce2af1586ff5dc873e804434185199a15f7d96920ce67e50604592cae9",
+                "sha256:061c3ff1f51ecec256e916cf71cc01f9975af8fb3af9b94d3c0cc8702cfea637",
+                "sha256:08a80cf4884920863623a9ee9a285ee04cef57ebedc1cc87b3e3e0f24c8acfe5",
+                "sha256:09362f86ec201288d5687d1dc476b07bf39c08478cde837cb710b302864e7ec9",
+                "sha256:0bb4f48bd0dd18eebe826395e6a48b7331291078a879295bae4e5d053be50d4c",
+                "sha256:106af1653007cc569d5fbb5f08c6648a49fe4de74c2df814e234e282ebc06957",
+                "sha256:11fdd1192240dda8d6c5d18a06146e9045cb7e3ba7c06de6973000ff035df7c6",
+                "sha256:16a472300bc6c83fe4c2072cc22b3972f90d718d56f241adabc7ae509f53f154",
+                "sha256:176287bb998fd1e9846a9b666e240e58f8d3373e3bf87e7642f15af5405187b8",
+                "sha256:177914f81f66c86c012311f8c7f46887ec375cfcfd2a2f28233a3053ac93a569",
+                "sha256:177c9dd834cdf4dc39c27436ade6fdf9fe81484758885f2d616d5d03c0a83bd2",
+                "sha256:187700668c018a7e76e89424b7c1042f317c8df9161f00c0c903c82b0a8cac5c",
+                "sha256:1d9b5ee46dcb498fa3e46d4dfabcb531e1f2e76b477e0d99ef114f17bbd38453",
+                "sha256:22da15b902f9f8e267020d1c8bcfc4831ca646fecb60254f7bc71763569f56b1",
+                "sha256:24cd91a03543a0f8d09cb18d1cb27df80a84b5553d2bd94cba5979ef6af5c6e7",
+                "sha256:255f1a10ae39b52122cce26ce0781f7a616f502feecce9e616976f6a87992d6b",
+                "sha256:271c360fdc464fe6a75f13ea0c08ddf71a321f4c55fc20a3fe62ea3ef09df7d9",
+                "sha256:2ed83d53a8c5902ec48b90b2ac045e28e1698c0bea9441af9409fc844dc79496",
+                "sha256:2f3e1867dd574014253b4b8f01ba443b9c914e61d45f3674e452a915d6e929a3",
+                "sha256:35fbd23c1c8732cde7a94abe7fb071ec173c2f58c0bd0d7e5b669fdfc80a2c7b",
+                "sha256:37d0c59548ae56fae01c14998918d04ee0d5d3277363c10208eef8c4e2b68ed6",
+                "sha256:39d05e65f23a0fe897b6ac395f2a8d48c56ac0f583f5d663e0afec1da89b95da",
+                "sha256:3ad59efe24a4d54c2742929001f2d02803aafc15d6d781c21379e3f7f66ec842",
+                "sha256:3aed39db2f0ace76faa94f465d4234aac72e2f32b009f15da6492a561b3bbebd",
+                "sha256:3bbac1953c17252f9cc675bb19372444aadf0179b5df575ac4b56faaec9f6294",
+                "sha256:40bc802a696887b14c002edd43c18082cb7b6f9ee8b838239b03b56574d97f71",
+                "sha256:42f712b4668831c0cd85e0a5b5a308700fe068e37dcd24c0062904c4e372b093",
+                "sha256:448a66b8266de0b581246ca7cd6a73b8d98d15100fb7165974535fa3b577340e",
+                "sha256:485301ee56ce87a51ccb182a4b180d852c5cb2b3cb3a82f7d4714b4141119d8c",
+                "sha256:485747ee62da83366a44fbba963c5fe017860ad408ccd6cd99aa66ea80d32b2e",
+                "sha256:4cf0855a842c5b5c391dd32ca273b09e86abf8367572073bd1edfc52bc44446b",
+                "sha256:4eca20917a06d2fca7628ef3c8b94a8c358f6b43f1a621c9815243462dcccf97",
+                "sha256:4ed172d0c79f156c1b954e99c03bc2e3033c17efce8dd1a7c781bc4d5793dfac",
+                "sha256:5267cfda873ad62591b9332fd9472d2409f7cf02a34a9c9cb367e2c0255994bf",
+                "sha256:52b5cbc0469328e58180021138207e6ec91d7ca2e037d3549cc9e34e2187330a",
+                "sha256:53d7a3cd46cdc1689296348cb05ffd4f4280035770aee0c8ead3bbd4d6529acc",
+                "sha256:563646d74a4b4456d0cf3b714ca522e725243c603e8254ad85c3b59b7c0c4bf0",
+                "sha256:570cc326e78ff23dec7f41487aa9c3dffd02e5ee9ab43a8f6ccc3df8f9327623",
+                "sha256:5aca759ada6b1967fcfd4336dcf460d02a8a23e6abe06e90ea7881e5c22c4de6",
+                "sha256:5de11c041486681ce854c814844f4ce3282b6ea1656faae19208ebe09d31c5b8",
+                "sha256:5e271dd97c7bb8eefda5cca38cd0b0373a1fea50f71e8071376b46968582af9b",
+                "sha256:642ed0a209ced4be3a46f8cb094f2d76f1f479e2a1ceca6de6346a096cd3409d",
+                "sha256:6446002739ca29249f0beaaf067fcbc2b5aab4bc7ee8fb941bd194947ce19aff",
+                "sha256:691d50c99a937709ac4c4cd570d959a006bd6a6d970a484c84cc99543d4a5bbb",
+                "sha256:69b857a7d8bd4f5d6e0db4086da8c46309a26e8cefdfc778c0c5cc17d4b11e08",
+                "sha256:6ac3fefb0d168c7c6cab24fdfc80ec62cd2b4dfd9e65b84bdceb1cb01d385c33",
+                "sha256:6c9141af27a4e5819d74d67d227d5047a20fa3c7d4d9df43037a955b4c748ec5",
+                "sha256:7170cbde4070dc3c77dec82abf86f3b210633d4f89550fa0ad2d4b549a05572a",
+                "sha256:763ad59e105fca09705d9f9b29ecffb95ecdc3b0363be3bb56081b2c6de7977a",
+                "sha256:77076bdc8776a2b029e1e6ffbe6d7056e35f56f5e80d9dc0bad26ad4a024a762",
+                "sha256:7cd020b1fb41e3ab7716d4d2c3972d4588fdfbab9bfbbb64acc7078eccef8860",
+                "sha256:821392559d37759caa67d622d0d2994c7a3f2fb29274948ac799d496d92bca73",
+                "sha256:829e91f3a8574888b73e7a3feb3b1af698e717513597e23136ff4eba0bc8387a",
+                "sha256:850c272e0e0d1a5c5d73b1b7871b0a7c2446b304cec55ccdb3eaac0d792bb065",
+                "sha256:87d9b206b1bd7a0523375dc2020a6ce88bca5330682ae2fe25e86fd5d45cea9c",
+                "sha256:8bd01ff4032abaed03f2db702fa9a61078bee37add0bd884a6190b05e63b028c",
+                "sha256:8d54bbdf5d56e2c8cf81a1857250f3ea132de77af543d0ba5dce667183b61fec",
+                "sha256:8efaeb08ede95066da3a3e3c420fcc0a21693fcd0c4396d0585b019613d28515",
+                "sha256:8f94fdd756ba1f79f988855d948ae0bad9ddf44df296770d9a58c774cfbcca72",
+                "sha256:95cde244e7195b2c07ec9b73fa4c5026d4a27233451485caa1cd0c1b55f26dbd",
+                "sha256:975382d9aa90dc59253d6a83a5ca72e07f4ada3ae3d6c0575ced513db322b8ec",
+                "sha256:9dd9d9d9e898b9d30683bdd2b6c1849449158647d1049a125879cb397ee9cd12",
+                "sha256:a019a344312d0b1f429c00d49c3be62fa273d4a1094e1b224f403716b6d03be1",
+                "sha256:a4d9bfda3f84fc563868fe25ca160c8ff0e69bc4443c5647f960d59400ce6557",
+                "sha256:a657250807b6efd19b28f5922520ae002a54cb43c2401e6f3d0230c352564d25",
+                "sha256:a771417c9c06c56c9d53d11a5b084d1de75de82978e23c544270ab25e7c066ff",
+                "sha256:aad6ed9e70ddfb34d849b761fb243be58c735be6a9265b9060d6ddb77751e3e8",
+                "sha256:ae87137951bb3dc08c7d8bfb8988d8c119f3230731b08a71146e84aaa919a7a9",
+                "sha256:af247fd4f12cca4129c1b82090244ea5a9d5bb089e9a82feb5a2f7c6a9fe181d",
+                "sha256:b5d4bdd697195f3876d134101c40c7d06d46c6ab25159ed5cbd44105c715278a",
+                "sha256:b9255e7165083de7c1d605e818025e8860636348f34a79d84ec533546064f07e",
+                "sha256:c22211c165166de6683de8136229721f3d5c8606cc2c3d1562da9a3a5058049c",
+                "sha256:c55f9821f88e8bee4b7a72c82cfb5ecd22b6aad04033334f33c329b29bfa4da0",
+                "sha256:c7aed97f2e676561416c927b063802c8a6285e9b55e1b83213dfd99a8f4f9e48",
+                "sha256:cd2163f42868865597d89399a01aa33b7594ce8e2c4a28503127c81a2f17784e",
+                "sha256:ce5e7504db95b76fc89055c7f41e367eaadef5b1d059e27e1d6eabf2b55ca314",
+                "sha256:cff7351c251c7546407827b6a37bcef6416304fc54d12d44dbfecbb717064717",
+                "sha256:d27aa6bbc1f33be920bb7adbb95581452cdf23005d5611b29a12bb6a3468cc95",
+                "sha256:d3b52a67ac66a3a64a7e710ba629f62d1e26ca0504c29ee8cbd99b97df7079a8",
+                "sha256:de61e424062173b4f70eec07e12469edde7e17fa180019a2a0d75c13a5c5dc57",
+                "sha256:e10e6a1ed2b8661201e79dff5531f8ad4cdd83548a0f81c95cf79b3184b20c33",
+                "sha256:e1a0ffc39f51aa5f5c22114a8f1906b3c17eba68c5babb86c5f77d8b1bba14d1",
+                "sha256:e22491d25f97199fc3581ad8dd8ce198d8c8fdb8dae80dea3512e1ce6d5fa99f",
+                "sha256:e626b864725680cd3904414d72e7b0bd81c0e5b2b53a5b30b4273034253bb41f",
+                "sha256:e8c71ea77536149e36c4c784f6d420ffd20bea041e3ba21ed021cb40ce58e2c9",
+                "sha256:e8d0f0eca087630d58b8c662085529781fd5dc80f0a54eda42d5c9029f812599",
+                "sha256:ea65b59882d5fa8c74a23f8960db579e5e341534934f43f3b18ec1839b893e41",
+                "sha256:ea93163472db26ac6043e8f7f93a05d9b59e0505c760da2a3cd22c7dd7111391",
+                "sha256:eab75a8569a095f2ad470b342f2751d9902f7944704f0571c8af46bede438475",
+                "sha256:ed8313809571a5463fd7db43aaca68ecb43ca7a58f5b23b6e6c6c5d02bdc7882",
+                "sha256:ef5fddfb264e89c435be4adb3953cef5d2936fdeb4463b4161a6ba2f22e7b740",
+                "sha256:ef750a20de1b65657a1425f77c525b0183eac63fe7b8f5ac0dd16f3668d3e64f",
+                "sha256:efb9ece97e696bb56e31166a9dd7919f8f0c6b31967b454718c6509f29ef6fee",
+                "sha256:f4c179a7aeae10ddf44c6bac87938134c1379c49c884529f090f9bf05566c836",
+                "sha256:f602881d80ee4228a2355c68da6b296a296cd22bbb91e5418d54577bbf17fa7c",
+                "sha256:fc2200e79d75b5238c8d69f6a30f8284290c777039d331e7340b6c17cad24a5a",
+                "sha256:fcc1ebb7561a3e24a6588f7c6ded15d80aec22c66a070c757559b57b17ffd1cb"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.9.2"
+            "version": "==0.10.3"
         },
         "ruamel.yaml": {
             "hashes": [
@@ -993,11 +1019,11 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:3c0da2d074bf35d6870ef157158641178a4204a6e689e82546083e31e0311346",
-                "sha256:640bb492711f4c0c0905e1f62b6aaeb771881935ad27884852411f8e9cacbca9"
+                "sha256:10d6923c6359175f264811ef4bf6161a3156ce8e350e705396a7557d6293c33a",
+                "sha256:fd3889a66f5fe17299fe75b82eae6cf722554edca744ca5d5fe308b104883d2e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.6.1"
+            "version": "==0.7.0"
         },
         "schema": {
             "hashes": [
@@ -1024,11 +1050,11 @@
         },
         "sqlfluff": {
             "hashes": [
-                "sha256:86b3f85388e10c69eeea12ccaa169f66248e9240d57f22b66e84048cc7333b08",
-                "sha256:93b4c49a6640e15fa5fddbc022d0544675b9d4ac382d68da029d07c713cb6e7e"
+                "sha256:3403ce7e9133766d7336b7e26638657ec6cc9e5610e35186b7f02cc427dd49b7",
+                "sha256:85c8b683e283ff632fe28529ddb60585ea2d1d3c614fc7a1db171632b99dcce3"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.2.1"
+            "version": "==2.3.2"
         },
         "tblib": {
             "hashes": [
@@ -1064,11 +1090,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36",
-                "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"
+                "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0",
+                "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==4.7.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==4.8.0"
         },
         "urllib3": {
             "hashes": [
@@ -1196,19 +1222,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0300ca6ec8bc136eb316b32cc1e30c66b85bc497f5a5fe42e095ae4280569708",
-                "sha256:9d1b4713c888e53a218648ad71522bee9bec9d83f2999fff2494675af810b632"
+                "sha256:b927a7ed335d543c33c15fa63f1076f3fa8422959771c2187da74bc4395ab6e3",
+                "sha256:f5fcb27cdbd08ca38d699f2d2e32d96d1d9fab3368c15c6bc326256612d2cfd7"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.28.24"
+            "version": "==1.28.56"
         },
         "botocore": {
             "hashes": [
-                "sha256:2d8f412c67f9285219f52d5dbbb6ef0dfa9f606da29cbdd41b6d6474bcc4bbd4",
-                "sha256:8c7ba9b09e9104e2d473214e1ffcf84b77e04cf6f5f2344942c1eed9e299f947"
+                "sha256:66c686e4eda7051ffcc9357d9075390c8ab2f95a2977669039618ee186fb533b",
+                "sha256:70252cd8abc2fe9b791328e187620f5a3911545e2520486b01ecfad31f41b9cb"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.24"
+            "version": "==1.31.56"
         },
         "certifi": {
             "hashes": [
@@ -1370,47 +1396,47 @@
         },
         "click": {
             "hashes": [
-                "sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd",
-                "sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5"
+                "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
+                "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==8.1.6"
+            "version": "==8.1.7"
         },
         "cryptography": {
             "hashes": [
-                "sha256:0d09fb5356f975974dbcb595ad2d178305e5050656affb7890a1583f5e02a306",
-                "sha256:23c2d778cf829f7d0ae180600b17e9fceea3c2ef8b31a99e3c694cbbf3a24b84",
-                "sha256:3fb248989b6363906827284cd20cca63bb1a757e0a2864d4c1682a985e3dca47",
-                "sha256:41d7aa7cdfded09b3d73a47f429c298e80796c8e825ddfadc84c8a7f12df212d",
-                "sha256:42cb413e01a5d36da9929baa9d70ca90d90b969269e5a12d39c1e0d475010116",
-                "sha256:4c2f0d35703d61002a2bbdcf15548ebb701cfdd83cdc12471d2bae80878a4207",
-                "sha256:4fd871184321100fb400d759ad0cddddf284c4b696568204d281c902fc7b0d81",
-                "sha256:5259cb659aa43005eb55a0e4ff2c825ca111a0da1814202c64d28a985d33b087",
-                "sha256:57a51b89f954f216a81c9d057bf1a24e2f36e764a1ca9a501a6964eb4a6800dd",
-                "sha256:652627a055cb52a84f8c448185922241dd5217443ca194d5739b44612c5e6507",
-                "sha256:67e120e9a577c64fe1f611e53b30b3e69744e5910ff3b6e97e935aeb96005858",
-                "sha256:6af1c6387c531cd364b72c28daa29232162010d952ceb7e5ca8e2827526aceae",
-                "sha256:6d192741113ef5e30d89dcb5b956ef4e1578f304708701b8b73d38e3e1461f34",
-                "sha256:7efe8041897fe7a50863e51b77789b657a133c75c3b094e51b5e4b5cec7bf906",
-                "sha256:84537453d57f55a50a5b6835622ee405816999a7113267739a1b4581f83535bd",
-                "sha256:8f09daa483aedea50d249ef98ed500569841d6498aa9c9f4b0531b9964658922",
-                "sha256:95dd7f261bb76948b52a5330ba5202b91a26fbac13ad0e9fc8a3ac04752058c7",
-                "sha256:a74fbcdb2a0d46fe00504f571a2a540532f4c188e6ccf26f1f178480117b33c4",
-                "sha256:a983e441a00a9d57a4d7c91b3116a37ae602907a7618b882c8013b5762e80574",
-                "sha256:ab8de0d091acbf778f74286f4989cf3d1528336af1b59f3e5d2ebca8b5fe49e1",
-                "sha256:aeb57c421b34af8f9fe830e1955bf493a86a7996cc1338fe41b30047d16e962c",
-                "sha256:ce785cf81a7bdade534297ef9e490ddff800d956625020ab2ec2780a556c313e",
-                "sha256:d0d651aa754ef58d75cec6edfbd21259d93810b73f6ec246436a21b7841908de"
+                "sha256:004b6ccc95943f6a9ad3142cfabcc769d7ee38a3f60fb0dddbfb431f818c3a67",
+                "sha256:047c4603aeb4bbd8db2756e38f5b8bd7e94318c047cfe4efeb5d715e08b49311",
+                "sha256:0d9409894f495d465fe6fda92cb70e8323e9648af912d5b9141d616df40a87b8",
+                "sha256:23a25c09dfd0d9f28da2352503b23e086f8e78096b9fd585d1d14eca01613e13",
+                "sha256:2ed09183922d66c4ec5fdaa59b4d14e105c084dd0febd27452de8f6f74704143",
+                "sha256:35c00f637cd0b9d5b6c6bd11b6c3359194a8eba9c46d4e875a3660e3b400005f",
+                "sha256:37480760ae08065437e6573d14be973112c9e6dcaf5f11d00147ee74f37a3829",
+                "sha256:3b224890962a2d7b57cf5eeb16ccaafba6083f7b811829f00476309bce2fe0fd",
+                "sha256:5a0f09cefded00e648a127048119f77bc2b2ec61e736660b5789e638f43cc397",
+                "sha256:5b72205a360f3b6176485a333256b9bcd48700fc755fef51c8e7e67c4b63e3ac",
+                "sha256:7e53db173370dea832190870e975a1e09c86a879b613948f09eb49324218c14d",
+                "sha256:7febc3094125fc126a7f6fb1f420d0da639f3f32cb15c8ff0dc3997c4549f51a",
+                "sha256:80907d3faa55dc5434a16579952ac6da800935cd98d14dbd62f6f042c7f5e839",
+                "sha256:86defa8d248c3fa029da68ce61fe735432b047e32179883bdb1e79ed9bb8195e",
+                "sha256:8ac4f9ead4bbd0bc8ab2d318f97d85147167a488be0e08814a37eb2f439d5cf6",
+                "sha256:93530900d14c37a46ce3d6c9e6fd35dbe5f5601bf6b3a5c325c7bffc030344d9",
+                "sha256:9eeb77214afae972a00dee47382d2591abe77bdae166bda672fb1e24702a3860",
+                "sha256:b5f4dfe950ff0479f1f00eda09c18798d4f49b98f4e2006d644b3301682ebdca",
+                "sha256:c3391bd8e6de35f6f1140e50aaeb3e2b3d6a9012536ca23ab0d9c35ec18c8a91",
+                "sha256:c880eba5175f4307129784eca96f4e70b88e57aa3f680aeba3bab0e980b0f37d",
+                "sha256:cecfefa17042941f94ab54f769c8ce0fe14beff2694e9ac684176a2535bf9714",
+                "sha256:e40211b4923ba5a6dc9769eab704bdb3fbb58d56c5b336d30996c24fcf12aadb",
+                "sha256:efc8ad4e6fc4f1752ebfb58aefece8b4e3c4cae940b0994d43649bdfce8d0d4f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==41.0.3"
+            "version": "==41.0.4"
         },
         "decorator": {
             "hashes": [
                 "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330",
                 "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"
             ],
-            "markers": "python_version >= '3.5'",
+            "index": "pypi",
             "version": "==5.1.1"
         },
         "dill": {
@@ -1431,11 +1457,11 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:8d9b8cb1e80b9735e8717c9362079d3ce4c6e5ddeebedd0361b228c3a67a62f6",
-                "sha256:e3d59b1c2c6ebb9dfa7a184daf3b6dd4914237e7488a1730a6d8f6f5d0b4187f"
+                "sha256:5f4c4187de49616d710a77e98ddf17b4782060a1788df441846bddefbb89ab33",
+                "sha256:f9b9ddc0761c125d5780eab2d64be4873fc6817c2899cbcb34b02344bdc7bc54"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.32"
+            "version": "==3.1.37"
         },
         "idna": {
             "hashes": [
@@ -1525,8 +1551,11 @@
                 "sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e",
                 "sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431",
                 "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686",
+                "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c",
                 "sha256:1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559",
                 "sha256:1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc",
+                "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb",
+                "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939",
                 "sha256:282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c",
                 "sha256:2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0",
                 "sha256:2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4",
@@ -1534,6 +1563,7 @@
                 "sha256:3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575",
                 "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba",
                 "sha256:42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d",
+                "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd",
                 "sha256:504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3",
                 "sha256:525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00",
                 "sha256:56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155",
@@ -1542,6 +1572,7 @@
                 "sha256:68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f",
                 "sha256:69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8",
                 "sha256:6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b",
+                "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007",
                 "sha256:787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24",
                 "sha256:7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea",
                 "sha256:8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198",
@@ -1549,9 +1580,12 @@
                 "sha256:8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee",
                 "sha256:8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be",
                 "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2",
+                "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1",
                 "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707",
                 "sha256:962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6",
+                "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c",
                 "sha256:9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58",
+                "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823",
                 "sha256:aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779",
                 "sha256:ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636",
                 "sha256:ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c",
@@ -1570,7 +1604,9 @@
                 "sha256:df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9",
                 "sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57",
                 "sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc",
-                "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2"
+                "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc",
+                "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2",
+                "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2.1.3"
@@ -1593,11 +1629,11 @@
         },
         "moto": {
             "hashes": [
-                "sha256:545afeb4df94dfa730e2d7e87366dc26b4a33c2891f462cbb049f040c80ed1ec",
-                "sha256:7d3bd748a34641715ba469c761f72fb8ec18f349987c98f5a0f9be85a07a9911"
+                "sha256:3516f55405015e4516c549d875c7a93e7daa1622d6342af335e63cf7bfe442fd",
+                "sha256:eea3c5b29987e8b12816b355dfdcca5d7a815a9d9f17208af31fa32acbe8b389"
             ],
             "index": "pypi",
-            "version": "==4.1.14"
+            "version": "==4.2.4"
         },
         "mypy": {
             "hashes": [
@@ -1708,7 +1744,9 @@
         },
         "pyyaml": {
             "hashes": [
+                "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5",
                 "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc",
+                "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df",
                 "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741",
                 "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206",
                 "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27",
@@ -1716,7 +1754,10 @@
                 "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62",
                 "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98",
                 "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696",
+                "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290",
+                "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9",
                 "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d",
+                "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6",
                 "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867",
                 "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47",
                 "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486",
@@ -1724,9 +1765,12 @@
                 "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3",
                 "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007",
                 "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938",
+                "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0",
                 "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c",
                 "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735",
                 "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d",
+                "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28",
+                "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4",
                 "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba",
                 "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
                 "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5",
@@ -1741,7 +1785,9 @@
                 "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43",
                 "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859",
                 "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673",
+                "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54",
                 "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a",
+                "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b",
                 "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab",
                 "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa",
                 "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c",
@@ -1770,19 +1816,19 @@
         },
         "rich": {
             "hashes": [
-                "sha256:146a90b3b6b47cac4a73c12866a499e9817426423f57c5a66949c086191a8808",
-                "sha256:fb9d6c0a0f643c99eed3875b5377a184132ba9be4d61516a55273d3554d75a39"
+                "sha256:87b43e0543149efa1253f485cd845bb7ee54df16c9617b8a893650ab84b4acb6",
+                "sha256:9257b468badc3d347e146a4faa268ff229039d4c2d176ab0cffb4c4fbc73d5d9"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==13.5.2"
+            "version": "==13.5.3"
         },
         "s3transfer": {
             "hashes": [
-                "sha256:3c0da2d074bf35d6870ef157158641178a4204a6e689e82546083e31e0311346",
-                "sha256:640bb492711f4c0c0905e1f62b6aaeb771881935ad27884852411f8e9cacbca9"
+                "sha256:10d6923c6359175f264811ef4bf6161a3156ce8e350e705396a7557d6293c33a",
+                "sha256:fd3889a66f5fe17299fe75b82eae6cf722554edca744ca5d5fe308b104883d2e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.6.1"
+            "version": "==0.7.0"
         },
         "six": {
             "hashes": [
@@ -1794,11 +1840,11 @@
         },
         "smmap": {
             "hashes": [
-                "sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94",
-                "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"
+                "sha256:dceeb6c0028fdb6734471eb07c0cd2aae706ccaecab45965ee83f11c8d3b1f62",
+                "sha256:e6d8668fa5f93e706934a62d7b4db19c8d9eb8cf2adbb75ef1b675aa332b69da"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==5.0.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==5.0.1"
         },
         "stevedore": {
             "hashes": [
@@ -1826,18 +1872,18 @@
         },
         "types-pyyaml": {
             "hashes": [
-                "sha256:7d340b19ca28cddfdba438ee638cd4084bde213e501a3978738543e27094775b",
-                "sha256:a461508f3096d1d5810ec5ab95d7eeecb651f3a15b71959999988942063bf01d"
+                "sha256:334373d392fde0fdf95af5c3f1661885fa10c52167b14593eb856289e1855062",
+                "sha256:c05bc6c158facb0676674b7f11fe3960db4f389718e19e62bd2b84d6205cfd24"
             ],
-            "version": "==6.0.12.11"
+            "version": "==6.0.12.12"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36",
-                "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"
+                "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0",
+                "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==4.7.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==4.8.0"
         },
         "urllib3": {
             "hashes": [
@@ -1849,11 +1895,11 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:935539fa1413afbb9195b24880778422ed620c0fc09670945185cce4d91a8890",
-                "sha256:98c774df2f91b05550078891dee5f0eb0cb797a522c757a2452b9cee5b202330"
+                "sha256:2b8c0e447b4b9dbcc85dd97b6eeb4dcbaf6c8b6c3be0bd654e25553e0a2157d8",
+                "sha256:effc12dba7f3bd72e605ce49807bbe692bd729c3bb122a3b91747a6ae77df528"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.3.6"
+            "version": "==2.3.7"
         },
         "wrapt": {
             "hashes": [

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -10,8 +10,6 @@ import string
 import sys
 import unittest
 
-import boto3
-from moto import mock_dynamodb
 from panther_analysis_tool.immutable import ImmutableCaseInsensitiveDict, ImmutableList
 
 # pipenv run does the right thing, but IDE based debuggers may fail to import
@@ -1916,123 +1914,6 @@ class TestTailscaleHelpers(unittest.TestCase):
         self.assertEqual(returns.get("actor", ""), "<NO_ACTOR_FOUND>")
         self.assertEqual(returns.get("action", ""), "<NO_ACTION_FOUND>")
         self.assertEqual(tailscale_admin_console_event, False)
-
-
-@mock_dynamodb
-class TestOssHelpers(unittest.TestCase):
-    # pylint: disable=protected-access,assignment-from-no-return
-    def setUp(self):
-        os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
-        self._temp_dynamo = boto3.resource("dynamodb")
-        self._temp_table = self._temp_dynamo.create_table(
-            TableName="panther-kv-store",
-            KeySchema=[
-                {
-                    "AttributeName": "key",
-                    "KeyType": "HASH",
-                }
-            ],
-            AttributeDefinitions=[
-                {
-                    "AttributeName": "key",
-                    "AttributeType": "S",
-                }
-            ],
-            ProvisionedThroughput={
-                "ReadCapacityUnits": 5,
-                "WriteCapacityUnits": 5,
-            },
-        )
-        p_o_h._KV_TABLE = self._temp_table
-        self.panther_key = p_o_h.reset_counter("panther")
-        self.labs_key = p_o_h.reset_counter("labs")
-        self.string_set_key = p_o_h.put_string_set("strs", ["a", "b"])
-
-    def test_set_counter_ops(self):
-        self.assertEqual(p_o_h.get_counter("panther"), 0)
-        self.assertEqual(p_o_h.increment_counter("panther", 1), 1)
-        self.assertEqual(p_o_h.increment_counter("panther", -2), -1)
-        # something's weird when the val kwarg is zero. not sure it ever worked
-        #    global_helpers/panther_oss_helpers.py", line 227, in increment_counter
-        #    return response["Attributes"][_COUNT_COL].to_integral_value()
-        # self.assertEqual(p_o_h.increment_counter("panther", 0), -1)
-        self.assertEqual(p_o_h.increment_counter("panther", 11), 10)
-        self.assertEqual(p_o_h.get_counter("panther"), 10)
-        p_o_h.reset_counter("panther")
-        self.assertEqual(p_o_h.get_counter("panther"), 0)
-        self.assertEqual(p_o_h.get_counter("labs"), 0)
-        self.assertEqual(p_o_h.get_counter("does-not-exist"), 0)
-        # Set TTL
-        exp_time = datetime.datetime.strptime("2023-04-01T00:00 +00:00", "%Y-%m-%dT%H:%M %z")
-        p_o_h.set_key_expiration("panther", int(exp_time.timestamp()))
-        panther_item = self._temp_table.get_item(
-            Key={"key": "panther"}, ProjectionExpression=f"{p_o_h._COUNT_COL}, {p_o_h._TTL_COL}"
-        )
-        # Check TTL
-        # moto may not be timezone aware when running dynamodb mock.. we ultimately want to confirm
-        # that the expiresAt attribute is equal to exp_time.
-        self.assertEqual(panther_item["Item"]["expiresAt"], exp_time.timestamp())
-
-        ### TEST TYPE CONVERSIONS ON set_key_expiration
-        # Set TTL as a string-with-decimals, expect back an int
-        exp_time_2 = "1675238400.0000"
-        p_o_h.set_key_expiration("panther", exp_time_2)
-        panther_item = self._temp_table.get_item(
-            Key={"key": "panther"}, ProjectionExpression=f"{p_o_h._COUNT_COL}, {p_o_h._TTL_COL}"
-        )
-        self.assertEqual(panther_item["Item"]["expiresAt"], 1675238400)
-
-        # Set TTL as a string-without-decimals, expect back an int
-        exp_time_2 = "1675238800"
-        p_o_h.set_key_expiration("panther", exp_time_2)
-        panther_item = self._temp_table.get_item(
-            Key={"key": "panther"}, ProjectionExpression=f"{p_o_h._COUNT_COL}, {p_o_h._TTL_COL}"
-        )
-        self.assertEqual(panther_item["Item"]["expiresAt"], 1675238800)
-
-        # Use datetime.timestamp() with millis, which gives back a float
-        exp_time_2 = datetime.datetime.strptime(
-            "2023-02-01T00:00.123 +00:00", "%Y-%m-%dT%H:%M.%f %z"
-        )
-        p_o_h.set_key_expiration("panther", int(exp_time_2.timestamp()))
-        panther_item = self._temp_table.get_item(
-            Key={"key": "panther"}, ProjectionExpression=f"{p_o_h._COUNT_COL}, {p_o_h._TTL_COL}"
-        )
-        self.assertEqual(panther_item["Item"]["expiresAt"], int(exp_time_2.timestamp()))
-
-        # provide a timestamp that's seconds, not an actual epoch timestamp
-        now = int(datetime.datetime.now().timestamp())
-
-        # Set expiration time
-        p_o_h.set_key_expiration("panther", "86400")
-        panther_item = self._temp_table.get_item(
-            Key={"key": "panther"}, ProjectionExpression=f"{p_o_h._COUNT_COL}, {p_o_h._TTL_COL}"
-        )
-        self.assertEqual(panther_item["Item"]["expiresAt"], now + 86400)
-
-    def test_stringset_ops(self):
-        self.assertEqual(p_o_h.add_to_string_set("strs2", ["b", "a"]), {"a", "b"})
-        self.assertEqual(p_o_h.get_string_set("strs"), {"a", "b"})
-        self.assertEqual(p_o_h.add_to_string_set("strs", ["c"]), {"a", "b", "c"})
-        self.assertEqual(p_o_h.add_to_string_set("strs", set()), {"a", "b", "c"})
-        self.assertEqual(p_o_h.add_to_string_set("strs", {"b", "c", "d"}), {"a", "b", "c", "d"})
-        # tuple is allowed also
-        self.assertEqual(p_o_h.add_to_string_set("strs", ("e", "a")), {"a", "b", "c", "d", "e"})
-        # empty string is allowed
-        self.assertEqual(p_o_h.add_to_string_set("strs", ""), {"a", "b", "c", "d", "e", ""})
-        # list is allowed
-        self.assertEqual(p_o_h.add_to_string_set("strs", ["g"]), {"a", "b", "c", "d", "e", "", "g"})
-        # removal tests
-        self.assertEqual(p_o_h.remove_from_string_set("strs", ""), {"a", "b", "c", "d", "e", "g"})
-        # empty set test
-        # NOTE: this failed unit testing for me. put_string_set with the empty
-        # set as the only entry returns None
-        # old unit test -> self.assertEqual(p_o_h.put_string_set("fake2", []), set())
-        # new unit test vvv
-        self.assertEqual(p_o_h.put_string_set("fake2", []), None)
-        # Reset the stringset
-        p_o_h.reset_string_set("strs")
-        self.assertEqual(p_o_h.get_string_set("strs"), set())
 
 
 class TestKmBetweenTwoIPInfoLocs(unittest.TestCase):

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -2,8 +2,6 @@
 import json
 import os
 import re
-import time
-from collections.abc import Mapping
 from datetime import datetime
 from ipaddress import ip_address
 from math import atan2, cos, radians, sin, sqrt
@@ -165,22 +163,26 @@ def resource_lookup(resource_id: str) -> Dict[str, Any]:
 
 
 def ttl_expired(response: dict) -> bool:
-    """ Global `ttl_expired` is DEPRECATED. Instead, use `panther_detection_helpers.caching.ttl_expired`."""
+    """ Global `ttl_expired` is DEPRECATED.
+    Instead, use `panther_detection_helpers.caching.ttl_expired`."""
     return caching.ttl_expired(response)
 
 
 def get_counter(key: str, force_ttl_check: bool = False) -> int:
-    """ Global `get_counter` is DEPRECATED. Instead, use `panther_detection_helpers.caching.get_counter`."""
+    """ Global `get_counter` is DEPRECATED.
+    Instead, use `panther_detection_helpers.caching.get_counter`."""
     return caching.get_counter(key=key, force_ttl_check=force_ttl_check)
 
 
 def increment_counter(key: str, val: int = 1) -> int:
-    """ Global `increment_counter` is DEPRECATED. Instead, use `panther_detection_helpers.caching.increment_counter`."""
+    """ Global `increment_counter` is DEPRECATED.
+    Instead, use `panther_detection_helpers.caching.increment_counter`."""
     return caching.increment_counter(key=key, val=val)
 
 
 def reset_counter(key: str) -> None:
-    """ Global `reset_counter` is DEPRECATED. Instead, use `panther_detection_helpers.caching.reset_counter`."""
+    """ Global `reset_counter` is DEPRECATED.
+    Instead, use `panther_detection_helpers.caching.reset_counter`."""
     return caching.reset_counter(key=key)
 
 
@@ -191,27 +193,32 @@ def set_key_expiration(key: str, epoch_seconds: int) -> None:
 
 
 def put_dictionary(key: str, val: dict, epoch_seconds: int = None):
-    """ Global `put_dictionary` is DEPRECATED. Instead, use `panther_detection_helpers.caching.put_dictionary`."""
+    """ Global `put_dictionary` is DEPRECATED.
+    Instead, use `panther_detection_helpers.caching.put_dictionary`."""
     return caching.put_dictionary(key=key, val=val, epoch_seconds=epoch_seconds)
 
 
 def get_dictionary(key: str, force_ttl_check: bool = False) -> dict:
-    """ Global `get_dictionary` is DEPRECATED. Instead, use `panther_detection_helpers.caching.get_dictionary`."""
+    """ Global `get_dictionary` is DEPRECATED.
+    Instead, use `panther_detection_helpers.caching.get_dictionary`."""
     return caching.get_dictionary(key=key, force_ttl_check=force_ttl_check)
 
 
 def get_string_set(key: str, force_ttl_check: bool = False) -> Set[str]:
-    """ Global `get_string_set` is DEPRECATED. Instead, use `panther_detection_helpers.caching.get_string_set`."""
+    """ Global `get_string_set` is DEPRECATED.
+    Instead, use `panther_detection_helpers.caching.get_string_set`."""
     return caching.get_string_set(key=key, force_ttl_check=force_ttl_check)
 
 
 def put_string_set(key: str, val: Sequence[str], epoch_seconds: int = None) -> None:
-    """ Global `put_string_set` is DEPRECATED. Instead, use `panther_detection_helpers.caching.put_string_set`."""
+    """ Global `put_string_set` is DEPRECATED.
+    Instead, use `panther_detection_helpers.caching.put_string_set`."""
     return caching.put_string_set(key=key, val=val, epoch_seconds=epoch_seconds)
 
 
 def add_to_string_set(key: str, val: Union[str, Sequence[str]]) -> Set[str]:
-    """ Global `add_to_string_set` is DEPRECATED. Instead, use `panther_detection_helpers.caching.add_to_string_set`."""
+    """ Global `add_to_string_set` is DEPRECATED.
+    Instead, use `panther_detection_helpers.caching.add_to_string_set`."""
     return caching.add_to_string_set(key=key, val=val)
 
 
@@ -222,7 +229,8 @@ def remove_from_string_set(key: str, val: Union[str, Sequence[str]]) -> Set[str]
 
 
 def reset_string_set(key: str) -> None:
-    """ Global `reset_string_set` is DEPRECATED. Instead, use `panther_detection_helpers.caching.reset_string_set`."""
+    """ Global `reset_string_set` is DEPRECATED.
+    Instead, use `panther_detection_helpers.caching.reset_string_set`."""
     return caching.reset_string_set(key=key)
 
 
@@ -233,7 +241,8 @@ def evaluate_threshold(key: str, threshold: int = 10, expiry_seconds: int = 3600
 
 
 def check_account_age(key):
-    """ Global `check_account_age` is DEPRECATED. Instead, use `panther_detection_helpers.caching.check_account_age`."""
+    """ Global `check_account_age` is DEPRECATED.
+    Instead, use `panther_detection_helpers.caching.check_account_age`."""
     return caching.check_account_age(key=key)
 
 

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -6,11 +6,11 @@ from datetime import datetime
 from ipaddress import ip_address
 from math import atan2, cos, radians, sin, sqrt
 from typing import Any, Dict, Optional, Sequence, Set, Union
-from panther_detection_helpers import caching
 
 import boto3
 import requests
 from dateutil import parser
+from panther_detection_helpers import caching
 
 _RESOURCE_TABLE = None  # boto3.Table resource, lazily constructed
 FIPS_ENABLED = os.getenv("ENABLE_FIPS", "").lower() == "true"
@@ -163,85 +163,85 @@ def resource_lookup(resource_id: str) -> Dict[str, Any]:
 
 
 def ttl_expired(response: dict) -> bool:
-    """ Global `ttl_expired` is DEPRECATED.
+    """Global `ttl_expired` is DEPRECATED.
     Instead, use `panther_detection_helpers.caching.ttl_expired`."""
     return caching.ttl_expired(response)
 
 
 def get_counter(key: str, force_ttl_check: bool = False) -> int:
-    """ Global `get_counter` is DEPRECATED.
+    """Global `get_counter` is DEPRECATED.
     Instead, use `panther_detection_helpers.caching.get_counter`."""
     return caching.get_counter(key=key, force_ttl_check=force_ttl_check)
 
 
 def increment_counter(key: str, val: int = 1) -> int:
-    """ Global `increment_counter` is DEPRECATED.
+    """Global `increment_counter` is DEPRECATED.
     Instead, use `panther_detection_helpers.caching.increment_counter`."""
     return caching.increment_counter(key=key, val=val)
 
 
 def reset_counter(key: str) -> None:
-    """ Global `reset_counter` is DEPRECATED.
+    """Global `reset_counter` is DEPRECATED.
     Instead, use `panther_detection_helpers.caching.reset_counter`."""
     return caching.reset_counter(key=key)
 
 
 def set_key_expiration(key: str, epoch_seconds: int) -> None:
-    """ Global `set_key_expiration` is DEPRECATED.
+    """Global `set_key_expiration` is DEPRECATED.
     Instead, use `panther_detection_helpers.caching.set_key_expiration`."""
     return caching.set_key_expiration(key=key, epoch_seconds=epoch_seconds)
 
 
 def put_dictionary(key: str, val: dict, epoch_seconds: int = None):
-    """ Global `put_dictionary` is DEPRECATED.
+    """Global `put_dictionary` is DEPRECATED.
     Instead, use `panther_detection_helpers.caching.put_dictionary`."""
     return caching.put_dictionary(key=key, val=val, epoch_seconds=epoch_seconds)
 
 
 def get_dictionary(key: str, force_ttl_check: bool = False) -> dict:
-    """ Global `get_dictionary` is DEPRECATED.
+    """Global `get_dictionary` is DEPRECATED.
     Instead, use `panther_detection_helpers.caching.get_dictionary`."""
     return caching.get_dictionary(key=key, force_ttl_check=force_ttl_check)
 
 
 def get_string_set(key: str, force_ttl_check: bool = False) -> Set[str]:
-    """ Global `get_string_set` is DEPRECATED.
+    """Global `get_string_set` is DEPRECATED.
     Instead, use `panther_detection_helpers.caching.get_string_set`."""
     return caching.get_string_set(key=key, force_ttl_check=force_ttl_check)
 
 
 def put_string_set(key: str, val: Sequence[str], epoch_seconds: int = None) -> None:
-    """ Global `put_string_set` is DEPRECATED.
+    """Global `put_string_set` is DEPRECATED.
     Instead, use `panther_detection_helpers.caching.put_string_set`."""
     return caching.put_string_set(key=key, val=val, epoch_seconds=epoch_seconds)
 
 
 def add_to_string_set(key: str, val: Union[str, Sequence[str]]) -> Set[str]:
-    """ Global `add_to_string_set` is DEPRECATED.
+    """Global `add_to_string_set` is DEPRECATED.
     Instead, use `panther_detection_helpers.caching.add_to_string_set`."""
     return caching.add_to_string_set(key=key, val=val)
 
 
 def remove_from_string_set(key: str, val: Union[str, Sequence[str]]) -> Set[str]:
-    """ Global `remove_from_string_set` is DEPRECATED.
+    """Global `remove_from_string_set` is DEPRECATED.
     Instead, use `panther_detection_helpers.caching.remove_from_string_set`."""
     return caching.remove_from_string_set(key=key, val=val)
 
 
 def reset_string_set(key: str) -> None:
-    """ Global `reset_string_set` is DEPRECATED.
+    """Global `reset_string_set` is DEPRECATED.
     Instead, use `panther_detection_helpers.caching.reset_string_set`."""
     return caching.reset_string_set(key=key)
 
 
 def evaluate_threshold(key: str, threshold: int = 10, expiry_seconds: int = 3600) -> bool:
-    """ Global `evaluate_threshold` is DEPRECATED.
+    """Global `evaluate_threshold` is DEPRECATED.
     Instead, use `panther_detection_helpers.caching.evaluate_threshold`."""
     return caching.evaluate_threshold(key=key, threshold=threshold, expiry_seconds=expiry_seconds)
 
 
 def check_account_age(key):
-    """ Global `check_account_age` is DEPRECATED.
+    """Global `check_account_age` is DEPRECATED.
     Instead, use `panther_detection_helpers.caching.check_account_age`."""
     return caching.check_account_age(key=key)
 

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from ipaddress import ip_address
 from math import atan2, cos, radians, sin, sqrt
 from typing import Any, Dict, Optional, Sequence, Set, Union
+from panther_detection_helpers import caching
 
 import boto3
 import requests
@@ -163,265 +164,77 @@ def resource_lookup(resource_id: str) -> Dict[str, Any]:
     return response["Item"]["attributes"]
 
 
-# Helper functions for accessing Dynamo key-value store.
-#
-# Keys can be any string specified by rules and policies,
-# values are integer counters and/or string sets.
-#
-# Use kv_table() if you want to interact with the table directly.
-_KV_TABLE = None
-_COUNT_COL = "intCount"
-_STRING_SET_COL = "stringSet"
-_DICT_COL = "dictionary"
-_TTL_COL = "expiresAt"
-
-
-def kv_table() -> boto3.resource:
-    """Lazily build key-value table resource"""
-    # pylint: disable=global-statement
-    global _KV_TABLE
-    if not _KV_TABLE:
-        # pylint: disable=no-member
-        _KV_TABLE = boto3.resource(
-            "dynamodb",
-            endpoint_url="https://dynamodb" + FIPS_SUFFIX if FIPS_ENABLED else None,
-        ).Table("panther-kv-store")
-    return _KV_TABLE
-
-
 def ttl_expired(response: dict) -> bool:
-    """Checks whether a response from the panther-kv table has passed it's TTL date"""
-    # This can be used when the TTL timing is very exacting and DDB's cleanup is too slow
-    expiration = response.get("Item", {}).get(_TTL_COL, 0)
-    return expiration and float(expiration) <= (datetime.now()).timestamp()
+    """ Global `ttl_expired` is DEPRECATED. Instead, use `panther_detection_helpers.caching.ttl_expired`."""
+    return caching.ttl_expired(response)
 
 
 def get_counter(key: str, force_ttl_check: bool = False) -> int:
-    """Get a counter's current value (defaulting to 0 if key does not exist)."""
-    response = kv_table().get_item(
-        Key={"key": key},
-        ProjectionExpression=f"{_COUNT_COL}, {_TTL_COL}",
-    )
-    if force_ttl_check and ttl_expired(response):
-        return 0
-    return response.get("Item", {}).get(_COUNT_COL, 0)
+    """ Global `get_counter` is DEPRECATED. Instead, use `panther_detection_helpers.caching.get_counter`."""
+    return caching.get_counter(key=key, force_ttl_check=force_ttl_check)
 
 
 def increment_counter(key: str, val: int = 1) -> int:
-    """Increment a counter in the table.
-
-    Args:
-        key: The name of the counter (need not exist yet)
-        val: How much to add to the counter
-
-    Returns:
-        The new value of the count
-    """
-    response = kv_table().update_item(
-        Key={"key": key},
-        ReturnValues="UPDATED_NEW",
-        UpdateExpression="ADD #col :incr",
-        ExpressionAttributeNames={"#col": _COUNT_COL},
-        ExpressionAttributeValues={":incr": val},
-    )
-
-    # Numeric values are returned as decimal.Decimal
-    return response["Attributes"][_COUNT_COL].to_integral_value()
+    """ Global `increment_counter` is DEPRECATED. Instead, use `panther_detection_helpers.caching.increment_counter`."""
+    return caching.increment_counter(key=key, val=val)
 
 
 def reset_counter(key: str) -> None:
-    """Reset a counter to 0."""
-    kv_table().put_item(Item={"key": key, _COUNT_COL: 0})
+    """ Global `reset_counter` is DEPRECATED. Instead, use `panther_detection_helpers.caching.reset_counter`."""
+    return caching.reset_counter(key=key)
 
 
 def set_key_expiration(key: str, epoch_seconds: int) -> None:
-    """Configure the key to automatically expire at the given time.
-
-    DynamoDB typically deletes expired items within 48 hours of expiration.
-
-    Args:
-        key: The name of the counter
-        epoch_seconds: When you want the counter to expire (set to 0 to disable)
-    """
-    if isinstance(epoch_seconds, str):
-        epoch_seconds = float(epoch_seconds)
-    if isinstance(epoch_seconds, float):
-        epoch_seconds = int(epoch_seconds)
-    if not isinstance(epoch_seconds, int):
-        return
-    # if we are given an epoch seconds that is less than
-    # 604800 ( aka seven days ), then add the epoch seconds to
-    # the timestamp of now
-    if epoch_seconds < 604801:
-        epoch_seconds = int(datetime.now().timestamp()) + epoch_seconds
-    kv_table().update_item(
-        Key={"key": key},
-        UpdateExpression="SET expiresAt = :time",
-        ExpressionAttributeValues={":time": epoch_seconds},
-    )
+    """ Global `set_key_expiration` is DEPRECATED.
+    Instead, use `panther_detection_helpers.caching.set_key_expiration`."""
+    return caching.set_key_expiration(key=key, epoch_seconds=epoch_seconds)
 
 
 def put_dictionary(key: str, val: dict, epoch_seconds: int = None):
-    """Overwrite a dictionary under the given key.
-
-    The value must be JSON serializable, and therefore cannot contain:
-        - Sets
-        - Complex numbers or formulas
-        - Custom objects
-        - Keys that are not strings
-
-    Args:
-        key: The name of the dictionary
-        val: A Python dictionary
-        epoch_seconds: (Optional) Set string expiration time
-    """
-    if not isinstance(val, (dict, Mapping)):
-        raise Exception("panther_oss_helpers.put_dictionary: value is not a dictionary")
-
-    try:
-        # Serialize 'val' to a JSON string
-        data = json.dumps(val)
-    except TypeError as exc:
-        raise Exception(
-            "panther_oss_helpers.put_dictionary: "
-            "value is a dictionary, but it is not JSON serializable"
-        ) from exc
-
-    # Store the item in DynamoDB
-    kv_table().put_item(Item={"key": key, _DICT_COL: data})
-
-    if epoch_seconds:
-        set_key_expiration(key, epoch_seconds)
+    """ Global `put_dictionary` is DEPRECATED. Instead, use `panther_detection_helpers.caching.put_dictionary`."""
+    return caching.put_dictionary(key=key, val=val, epoch_seconds=epoch_seconds)
 
 
 def get_dictionary(key: str, force_ttl_check: bool = False) -> dict:
-    # Retrieve the item from DynamoDB
-    response = kv_table().get_item(Key={"key": key})
-
-    item = response.get("Item", {}).get(_DICT_COL, {})
-
-    # Check if the item was not found, if so return empty dictionary
-    if not item:
-        return {}
-
-    if force_ttl_check and ttl_expired(response):
-        return {}
-
-    try:
-        # Deserialize from JSON to a Python dictionary
-        return json.loads(item)
-    except json.decoder.JSONDecodeError as exc:
-        raise Exception(
-            "panther_oss_helpers.get_dictionary: "
-            "Data found in DynamoDB could not be decoded into JSON"
-        ) from exc
+    """ Global `get_dictionary` is DEPRECATED. Instead, use `panther_detection_helpers.caching.get_dictionary`."""
+    return caching.get_dictionary(key=key, force_ttl_check=force_ttl_check)
 
 
 def get_string_set(key: str, force_ttl_check: bool = False) -> Set[str]:
-    """Get a string set's current value (defaulting to empty set if key does not exit)."""
-    response = kv_table().get_item(
-        Key={"key": key},
-        ProjectionExpression=f"{_STRING_SET_COL}, {_TTL_COL}",
-    )
-    if force_ttl_check and ttl_expired(response):
-        return set()
-    return response.get("Item", {}).get(_STRING_SET_COL, set())
+    """ Global `get_string_set` is DEPRECATED. Instead, use `panther_detection_helpers.caching.get_string_set`."""
+    return caching.get_string_set(key=key, force_ttl_check=force_ttl_check)
 
 
 def put_string_set(key: str, val: Sequence[str], epoch_seconds: int = None) -> None:
-    """Overwrite a string set under the given key.
-
-    This is faster than (reset_string_set + add_string_set) if you know exactly what the contents
-    of the set should be.
-
-    Args:
-        key: The name of the string set
-        val: A list/set/tuple of strings to store
-        epoch_seconds: (Optional) Set string expiration time
-    """
-    if not val:
-        # Can't put an empty string set - remove it instead
-        reset_string_set(key)
-    else:
-        kv_table().put_item(Item={"key": key, _STRING_SET_COL: set(val)})
-    if epoch_seconds:
-        set_key_expiration(key, epoch_seconds)
+    """ Global `put_string_set` is DEPRECATED. Instead, use `panther_detection_helpers.caching.put_string_set`."""
+    return caching.put_string_set(key=key, val=val, epoch_seconds=epoch_seconds)
 
 
 def add_to_string_set(key: str, val: Union[str, Sequence[str]]) -> Set[str]:
-    """Add one or more strings to a set.
-
-    Args:
-        key: The name of the string set
-        val: Either a single string or a list/tuple/set of strings to add
-
-    Returns:
-        The new value of the string set
-    """
-    if isinstance(val, str):
-        item_value = {val}
-    else:
-        item_value = set(val)
-        if not item_value:
-            # We can't add empty sets, just return the existing value instead
-            return get_string_set(key)
-
-    response = kv_table().update_item(
-        Key={"key": key},
-        ReturnValues="UPDATED_NEW",
-        UpdateExpression="ADD #col :ss",
-        ExpressionAttributeNames={"#col": _STRING_SET_COL},
-        ExpressionAttributeValues={":ss": item_value},
-    )
-    return response["Attributes"][_STRING_SET_COL]
+    """ Global `add_to_string_set` is DEPRECATED. Instead, use `panther_detection_helpers.caching.add_to_string_set`."""
+    return caching.add_to_string_set(key=key, val=val)
 
 
 def remove_from_string_set(key: str, val: Union[str, Sequence[str]]) -> Set[str]:
-    """Remove one or more strings from a set.
-
-    Args:
-        key: The name of the string set
-        val: Either a single string or a list/tuple/set of strings to remove
-
-    Returns:
-        The new value of the string set
-    """
-    if isinstance(val, str):
-        item_value = {val}
-    else:
-        item_value = set(val)
-        if not item_value:
-            # We can't remove empty sets, just return the existing value instead
-            return get_string_set(key)
-
-    response = kv_table().update_item(
-        Key={"key": key},
-        ReturnValues="UPDATED_NEW",
-        UpdateExpression="DELETE #col :ss",
-        ExpressionAttributeNames={"#col": _STRING_SET_COL},
-        ExpressionAttributeValues={":ss": item_value},
-    )
-    return response["Attributes"][_STRING_SET_COL]
+    """ Global `remove_from_string_set` is DEPRECATED.
+    Instead, use `panther_detection_helpers.caching.remove_from_string_set`."""
+    return caching.remove_from_string_set(key=key, val=val)
 
 
 def reset_string_set(key: str) -> None:
-    """Reset a string set to empty."""
-    kv_table().update_item(
-        Key={"key": key},
-        UpdateExpression="REMOVE #col",
-        ExpressionAttributeNames={"#col": _STRING_SET_COL},
-    )
+    """ Global `reset_string_set` is DEPRECATED. Instead, use `panther_detection_helpers.caching.reset_string_set`."""
+    return caching.reset_string_set(key=key)
 
 
 def evaluate_threshold(key: str, threshold: int = 10, expiry_seconds: int = 3600) -> bool:
-    hourly_error_count = increment_counter(key)
-    if hourly_error_count == 1:
-        set_key_expiration(key, int(time.time()) + expiry_seconds)
-    # If it exceeds our threshold, reset and then return an alert
-    elif hourly_error_count >= threshold:
-        reset_counter(key)
-        return True
-    return False
+    """ Global `evaluate_threshold` is DEPRECATED.
+    Instead, use `panther_detection_helpers.caching.evaluate_threshold`."""
+    return caching.evaluate_threshold(key=key, threshold=threshold, expiry_seconds=expiry_seconds)
+
+
+def check_account_age(key):
+    """ Global `check_account_age` is DEPRECATED. Instead, use `panther_detection_helpers.caching.check_account_age`."""
+    return caching.check_account_age(key=key)
 
 
 def km_between_ipinfo_loc(ipinfo_loc_one: dict, ipinfo_loc_two: dict):
@@ -526,16 +339,6 @@ def add_parse_delay(event, context: dict) -> dict:
     parsing_delay = time_delta(event.get("p_event_time"), event.get("p_parse_time"))
     context["parseDelay"] = f"{parsing_delay}"
     return context
-
-
-def check_account_age(key):
-    """
-    Searches DynamoDB for stored user_id or account_id string stored by indicator creation
-    rules for new user / account creation
-    """
-    if isinstance(key, str) and key != "":
-        return bool(get_string_set(key))
-    return False
 
 
 # When a single item is loaded from json, it is loaded as a single item

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -164,85 +164,85 @@ def resource_lookup(resource_id: str) -> Dict[str, Any]:
 
 def ttl_expired(response: dict) -> bool:
     """Global `ttl_expired` is DEPRECATED.
-    Instead, use `panther_detection_helpers.caching.ttl_expired`."""
+    Instead, use `from panther_detection_helpers.caching import ttl_expired`."""
     return caching.ttl_expired(response)
 
 
 def get_counter(key: str, force_ttl_check: bool = False) -> int:
     """Global `get_counter` is DEPRECATED.
-    Instead, use `panther_detection_helpers.caching.get_counter`."""
+    Instead, use `from panther_detection_helpers.caching import get_counter`."""
     return caching.get_counter(key=key, force_ttl_check=force_ttl_check)
 
 
 def increment_counter(key: str, val: int = 1) -> int:
     """Global `increment_counter` is DEPRECATED.
-    Instead, use `panther_detection_helpers.caching.increment_counter`."""
+    Instead, use `from panther_detection_helpers.caching import increment_counter`."""
     return caching.increment_counter(key=key, val=val)
 
 
 def reset_counter(key: str) -> None:
     """Global `reset_counter` is DEPRECATED.
-    Instead, use `panther_detection_helpers.caching.reset_counter`."""
+    Instead, use `from panther_detection_helpers.caching import reset_counter`."""
     return caching.reset_counter(key=key)
 
 
 def set_key_expiration(key: str, epoch_seconds: int) -> None:
     """Global `set_key_expiration` is DEPRECATED.
-    Instead, use `panther_detection_helpers.caching.set_key_expiration`."""
+    Instead, use `from panther_detection_helpers.caching import set_key_expiration`."""
     return caching.set_key_expiration(key=key, epoch_seconds=epoch_seconds)
 
 
 def put_dictionary(key: str, val: dict, epoch_seconds: int = None):
     """Global `put_dictionary` is DEPRECATED.
-    Instead, use `panther_detection_helpers.caching.put_dictionary`."""
+    Instead, use `from panther_detection_helpers.caching import put_dictionary`."""
     return caching.put_dictionary(key=key, val=val, epoch_seconds=epoch_seconds)
 
 
 def get_dictionary(key: str, force_ttl_check: bool = False) -> dict:
     """Global `get_dictionary` is DEPRECATED.
-    Instead, use `panther_detection_helpers.caching.get_dictionary`."""
+    Instead, use `from panther_detection_helpers.caching import get_dictionary`."""
     return caching.get_dictionary(key=key, force_ttl_check=force_ttl_check)
 
 
 def get_string_set(key: str, force_ttl_check: bool = False) -> Set[str]:
     """Global `get_string_set` is DEPRECATED.
-    Instead, use `panther_detection_helpers.caching.get_string_set`."""
+    Instead, use `from panther_detection_helpers.caching import get_string_set`."""
     return caching.get_string_set(key=key, force_ttl_check=force_ttl_check)
 
 
 def put_string_set(key: str, val: Sequence[str], epoch_seconds: int = None) -> None:
     """Global `put_string_set` is DEPRECATED.
-    Instead, use `panther_detection_helpers.caching.put_string_set`."""
+    Instead, use `from panther_detection_helpers.caching import put_string_set`."""
     return caching.put_string_set(key=key, val=val, epoch_seconds=epoch_seconds)
 
 
 def add_to_string_set(key: str, val: Union[str, Sequence[str]]) -> Set[str]:
     """Global `add_to_string_set` is DEPRECATED.
-    Instead, use `panther_detection_helpers.caching.add_to_string_set`."""
+    Instead, use `from panther_detection_helpers.caching import add_to_string_set`."""
     return caching.add_to_string_set(key=key, val=val)
 
 
 def remove_from_string_set(key: str, val: Union[str, Sequence[str]]) -> Set[str]:
     """Global `remove_from_string_set` is DEPRECATED.
-    Instead, use `panther_detection_helpers.caching.remove_from_string_set`."""
+    Instead, use `from panther_detection_helpers.caching import remove_from_string_set`."""
     return caching.remove_from_string_set(key=key, val=val)
 
 
 def reset_string_set(key: str) -> None:
     """Global `reset_string_set` is DEPRECATED.
-    Instead, use `panther_detection_helpers.caching.reset_string_set`."""
+    Instead, use `from panther_detection_helpers.caching import reset_string_set`."""
     return caching.reset_string_set(key=key)
 
 
 def evaluate_threshold(key: str, threshold: int = 10, expiry_seconds: int = 3600) -> bool:
     """Global `evaluate_threshold` is DEPRECATED.
-    Instead, use `panther_detection_helpers.caching.evaluate_threshold`."""
+    Instead, use `from panther_detection_helpers.caching import evaluate_threshold`."""
     return caching.evaluate_threshold(key=key, threshold=threshold, expiry_seconds=expiry_seconds)
 
 
 def check_account_age(key):
     """Global `check_account_age` is DEPRECATED.
-    Instead, use `panther_detection_helpers.caching.check_account_age`."""
+    Instead, use `from panther_detection_helpers.caching import check_account_age`."""
     return caching.check_account_age(key=key)
 
 

--- a/rules/azure_signin_rules/azure_failed_signins.py
+++ b/rules/azure_signin_rules/azure_failed_signins.py
@@ -1,5 +1,9 @@
 from global_filter_azuresignin import filter_include_event
-from panther_azuresignin_helpers import actor_user, azure_signin_alert_context, is_sign_in_event
+from panther_azuresignin_helpers import (
+    actor_user,
+    azure_signin_alert_context,
+    is_sign_in_event,
+)
 from panther_base_helpers import deep_get
 
 

--- a/rules/azure_signin_rules/azure_legacyauth.py
+++ b/rules/azure_signin_rules/azure_legacyauth.py
@@ -2,7 +2,11 @@ import json
 from unittest.mock import MagicMock
 
 from global_filter_azuresignin import filter_include_event
-from panther_azuresignin_helpers import actor_user, azure_signin_alert_context, is_sign_in_event
+from panther_azuresignin_helpers import (
+    actor_user,
+    azure_signin_alert_context,
+    is_sign_in_event,
+)
 from panther_base_helpers import deep_get
 
 LEGACY_AUTH_USERAGENTS = ["BAV2ROPC", "CBAInPROD"]  # CBAInPROD is reported to be IMAP


### PR DESCRIPTION
### Background

`panther_detection_helpers.caching` module is replacing kv store global helpers

### Changes

* All kv store globals got their logic replace with a call to the `caching` module
* All kv store globals got a deprecation note

### Testing

* uploaded to my dev account and saw successful use of the kv store
