### PR TITLE
reverting using panther detection helpers in kv globals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint: lint-pylint lint-fmt
 lint-pylint:
 	pipenv run bandit -r $(dirs) --skip B101  # allow assert statements in tests
 	pipenv run pylint $(dirs) \
-	  --disable=missing-docstring,duplicate-code,import-error,fixme,consider-iterating-dictionary,global-variable-not-assigned \
+	  --disable=missing-docstring,duplicate-code,import-error,fixme,consider-iterating-dictionary,global-variable-not-assigned,broad-exception-raised \
 	  --load-plugins=pylint.extensions.mccabe,pylint_print \
 	  --max-line-length=100
 

--- a/global_helpers/panther_oss_helpers.py
+++ b/global_helpers/panther_oss_helpers.py
@@ -2,15 +2,15 @@
 import json
 import os
 import re
+import time
 from datetime import datetime
 from ipaddress import ip_address
 from math import atan2, cos, radians, sin, sqrt
-from typing import Any, Dict, Optional, Sequence, Set, Union
+from typing import Any, Dict, Mapping, Optional, Sequence, Set, Union
 
 import boto3
 import requests
 from dateutil import parser
-from panther_detection_helpers import caching
 
 _RESOURCE_TABLE = None  # boto3.Table resource, lazily constructed
 FIPS_ENABLED = os.getenv("ENABLE_FIPS", "").lower() == "true"
@@ -162,88 +162,263 @@ def resource_lookup(resource_id: str) -> Dict[str, Any]:
     return response["Item"]["attributes"]
 
 
+# Helper functions for accessing Dynamo key-value store.
+#
+# Keys can be any string specified by rules and policies,
+# values are integer counters and/or string sets.
+#
+# Use kv_table() if you want to interact with the table directly.
+_KV_TABLE = None
+_COUNT_COL = "intCount"
+_STRING_SET_COL = "stringSet"
+_DICT_COL = "dictionary"
+_TTL_COL = "expiresAt"
+
+
+def kv_table() -> boto3.resource:
+    """Lazily build key-value table resource"""
+    # pylint: disable=global-statement
+    global _KV_TABLE
+    if not _KV_TABLE:
+        # pylint: disable=no-member
+        _KV_TABLE = boto3.resource(
+            "dynamodb",
+            endpoint_url="https://dynamodb" + FIPS_SUFFIX if FIPS_ENABLED else None,
+        ).Table("panther-kv-store")
+    return _KV_TABLE
+
+
 def ttl_expired(response: dict) -> bool:
-    """Global `ttl_expired` is DEPRECATED.
-    Instead, use `from panther_detection_helpers.caching import ttl_expired`."""
-    return caching.ttl_expired(response)
+    """Checks whether a response from the panther-kv table has passed it's TTL date"""
+    # This can be used when the TTL timing is very exacting and DDB's cleanup is too slow
+    expiration = response.get("Item", {}).get(_TTL_COL, 0)
+    return expiration and float(expiration) <= (datetime.now()).timestamp()
 
 
 def get_counter(key: str, force_ttl_check: bool = False) -> int:
-    """Global `get_counter` is DEPRECATED.
-    Instead, use `from panther_detection_helpers.caching import get_counter`."""
-    return caching.get_counter(key=key, force_ttl_check=force_ttl_check)
+    """Get a counter's current value (defaulting to 0 if key does not exist)."""
+    response = kv_table().get_item(
+        Key={"key": key},
+        ProjectionExpression=f"{_COUNT_COL}, {_TTL_COL}",
+    )
+    if force_ttl_check and ttl_expired(response):
+        return 0
+    return response.get("Item", {}).get(_COUNT_COL, 0)
 
 
 def increment_counter(key: str, val: int = 1) -> int:
-    """Global `increment_counter` is DEPRECATED.
-    Instead, use `from panther_detection_helpers.caching import increment_counter`."""
-    return caching.increment_counter(key=key, val=val)
+    """Increment a counter in the table.
+    Args:
+        key: The name of the counter (need not exist yet)
+        val: How much to add to the counter
+    Returns:
+        The new value of the count
+    """
+    response = kv_table().update_item(
+        Key={"key": key},
+        ReturnValues="UPDATED_NEW",
+        UpdateExpression="ADD #col :incr",
+        ExpressionAttributeNames={"#col": _COUNT_COL},
+        ExpressionAttributeValues={":incr": val},
+    )
+
+    # Numeric values are returned as decimal.Decimal
+    return response["Attributes"][_COUNT_COL].to_integral_value()
 
 
 def reset_counter(key: str) -> None:
-    """Global `reset_counter` is DEPRECATED.
-    Instead, use `from panther_detection_helpers.caching import reset_counter`."""
-    return caching.reset_counter(key=key)
+    """Reset a counter to 0."""
+    kv_table().put_item(Item={"key": key, _COUNT_COL: 0})
 
 
 def set_key_expiration(key: str, epoch_seconds: int) -> None:
-    """Global `set_key_expiration` is DEPRECATED.
-    Instead, use `from panther_detection_helpers.caching import set_key_expiration`."""
-    return caching.set_key_expiration(key=key, epoch_seconds=epoch_seconds)
+    """Configure the key to automatically expire at the given time.
+    DynamoDB typically deletes expired items within 48 hours of expiration.
+    Args:
+        key: The name of the counter
+        epoch_seconds: When you want the counter to expire (set to 0 to disable)
+    """
+    if isinstance(epoch_seconds, str):
+        epoch_seconds = float(epoch_seconds)
+    if isinstance(epoch_seconds, float):
+        epoch_seconds = int(epoch_seconds)
+    if not isinstance(epoch_seconds, int):
+        return
+    # if we are given an epoch seconds that is less than
+    # 604800 ( aka seven days ), then add the epoch seconds to
+    # the timestamp of now
+    if epoch_seconds < 604801:
+        epoch_seconds = int(datetime.now().timestamp()) + epoch_seconds
+    kv_table().update_item(
+        Key={"key": key},
+        UpdateExpression="SET expiresAt = :time",
+        ExpressionAttributeValues={":time": epoch_seconds},
+    )
 
 
 def put_dictionary(key: str, val: dict, epoch_seconds: int = None):
-    """Global `put_dictionary` is DEPRECATED.
-    Instead, use `from panther_detection_helpers.caching import put_dictionary`."""
-    return caching.put_dictionary(key=key, val=val, epoch_seconds=epoch_seconds)
+    """Overwrite a dictionary under the given key.
+    The value must be JSON serializable, and therefore cannot contain:
+        - Sets
+        - Complex numbers or formulas
+        - Custom objects
+        - Keys that are not strings
+    Args:
+        key: The name of the dictionary
+        val: A Python dictionary
+        epoch_seconds: (Optional) Set string expiration time
+    """
+    if not isinstance(val, (dict, Mapping)):
+        raise Exception("panther_oss_helpers.put_dictionary: value is not a dictionary")
+
+    try:
+        # Serialize 'val' to a JSON string
+        data = json.dumps(val)
+    except TypeError as exc:
+        raise Exception(
+            "panther_oss_helpers.put_dictionary: "
+            "value is a dictionary, but it is not JSON serializable"
+        ) from exc
+
+    # Store the item in DynamoDB
+    kv_table().put_item(Item={"key": key, _DICT_COL: data})
+
+    if epoch_seconds:
+        set_key_expiration(key, epoch_seconds)
 
 
 def get_dictionary(key: str, force_ttl_check: bool = False) -> dict:
-    """Global `get_dictionary` is DEPRECATED.
-    Instead, use `from panther_detection_helpers.caching import get_dictionary`."""
-    return caching.get_dictionary(key=key, force_ttl_check=force_ttl_check)
+    # Retrieve the item from DynamoDB
+    response = kv_table().get_item(Key={"key": key})
+
+    item = response.get("Item", {}).get(_DICT_COL, {})
+
+    # Check if the item was not found, if so return empty dictionary
+    if not item:
+        return {}
+
+    if force_ttl_check and ttl_expired(response):
+        return {}
+
+    try:
+        # Deserialize from JSON to a Python dictionary
+        return json.loads(item)
+    except json.decoder.JSONDecodeError as exc:
+        raise Exception(
+            "panther_oss_helpers.get_dictionary: "
+            "Data found in DynamoDB could not be decoded into JSON"
+        ) from exc
 
 
 def get_string_set(key: str, force_ttl_check: bool = False) -> Set[str]:
-    """Global `get_string_set` is DEPRECATED.
-    Instead, use `from panther_detection_helpers.caching import get_string_set`."""
-    return caching.get_string_set(key=key, force_ttl_check=force_ttl_check)
+    """Get a string set's current value (defaulting to empty set if key does not exit)."""
+    response = kv_table().get_item(
+        Key={"key": key},
+        ProjectionExpression=f"{_STRING_SET_COL}, {_TTL_COL}",
+    )
+    if force_ttl_check and ttl_expired(response):
+        return set()
+    return response.get("Item", {}).get(_STRING_SET_COL, set())
 
 
 def put_string_set(key: str, val: Sequence[str], epoch_seconds: int = None) -> None:
-    """Global `put_string_set` is DEPRECATED.
-    Instead, use `from panther_detection_helpers.caching import put_string_set`."""
-    return caching.put_string_set(key=key, val=val, epoch_seconds=epoch_seconds)
+    """Overwrite a string set under the given key.
+    This is faster than (reset_string_set + add_string_set) if you know exactly what the contents
+    of the set should be.
+    Args:
+        key: The name of the string set
+        val: A list/set/tuple of strings to store
+        epoch_seconds: (Optional) Set string expiration time
+    """
+    if not val:
+        # Can't put an empty string set - remove it instead
+        reset_string_set(key)
+    else:
+        kv_table().put_item(Item={"key": key, _STRING_SET_COL: set(val)})
+    if epoch_seconds:
+        set_key_expiration(key, epoch_seconds)
 
 
 def add_to_string_set(key: str, val: Union[str, Sequence[str]]) -> Set[str]:
-    """Global `add_to_string_set` is DEPRECATED.
-    Instead, use `from panther_detection_helpers.caching import add_to_string_set`."""
-    return caching.add_to_string_set(key=key, val=val)
+    """Add one or more strings to a set.
+    Args:
+        key: The name of the string set
+        val: Either a single string or a list/tuple/set of strings to add
+    Returns:
+        The new value of the string set
+    """
+    if isinstance(val, str):
+        item_value = {val}
+    else:
+        item_value = set(val)
+        if not item_value:
+            # We can't add empty sets, just return the existing value instead
+            return get_string_set(key)
+
+    response = kv_table().update_item(
+        Key={"key": key},
+        ReturnValues="UPDATED_NEW",
+        UpdateExpression="ADD #col :ss",
+        ExpressionAttributeNames={"#col": _STRING_SET_COL},
+        ExpressionAttributeValues={":ss": item_value},
+    )
+    return response["Attributes"][_STRING_SET_COL]
 
 
 def remove_from_string_set(key: str, val: Union[str, Sequence[str]]) -> Set[str]:
-    """Global `remove_from_string_set` is DEPRECATED.
-    Instead, use `from panther_detection_helpers.caching import remove_from_string_set`."""
-    return caching.remove_from_string_set(key=key, val=val)
+    """Remove one or more strings from a set.
+    Args:
+        key: The name of the string set
+        val: Either a single string or a list/tuple/set of strings to remove
+    Returns:
+        The new value of the string set
+    """
+    if isinstance(val, str):
+        item_value = {val}
+    else:
+        item_value = set(val)
+        if not item_value:
+            # We can't remove empty sets, just return the existing value instead
+            return get_string_set(key)
+
+    response = kv_table().update_item(
+        Key={"key": key},
+        ReturnValues="UPDATED_NEW",
+        UpdateExpression="DELETE #col :ss",
+        ExpressionAttributeNames={"#col": _STRING_SET_COL},
+        ExpressionAttributeValues={":ss": item_value},
+    )
+    return response["Attributes"][_STRING_SET_COL]
 
 
 def reset_string_set(key: str) -> None:
-    """Global `reset_string_set` is DEPRECATED.
-    Instead, use `from panther_detection_helpers.caching import reset_string_set`."""
-    return caching.reset_string_set(key=key)
+    """Reset a string set to empty."""
+    kv_table().update_item(
+        Key={"key": key},
+        UpdateExpression="REMOVE #col",
+        ExpressionAttributeNames={"#col": _STRING_SET_COL},
+    )
 
 
 def evaluate_threshold(key: str, threshold: int = 10, expiry_seconds: int = 3600) -> bool:
-    """Global `evaluate_threshold` is DEPRECATED.
-    Instead, use `from panther_detection_helpers.caching import evaluate_threshold`."""
-    return caching.evaluate_threshold(key=key, threshold=threshold, expiry_seconds=expiry_seconds)
+    hourly_error_count = increment_counter(key)
+    if hourly_error_count == 1:
+        set_key_expiration(key, int(time.time()) + expiry_seconds)
+    # If it exceeds our threshold, reset and then return an alert
+    elif hourly_error_count >= threshold:
+        reset_counter(key)
+        return True
+    return False
 
 
 def check_account_age(key):
-    """Global `check_account_age` is DEPRECATED.
-    Instead, use `from panther_detection_helpers.caching import check_account_age`."""
-    return caching.check_account_age(key=key)
+    """
+    Searches DynamoDB for stored user_id or account_id string stored by indicator creation
+    rules for new user / account creation
+    """
+    if isinstance(key, str) and key != "":
+        return bool(get_string_set(key))
+    return False
 
 
 def km_between_ipinfo_loc(ipinfo_loc_one: dict, ipinfo_loc_two: dict):


### PR DESCRIPTION
### Background

We want to wait until PE deploys using the panther detection helpers before using them here to avoid any timing issues

### Changes

* Undo changes made here https://github.com/panther-labs/panther-analysis/pull/884
* Still moves check_account_age next to all the other kv helpers

### Testing

* CI job
