### PR TITLE
Update dependency requirement

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,7 +20,7 @@ wrapt = "~=1.15"
 policyuniverse = "==1.5.1.20230817"
 requests = "==2.31.0"
 panther-analysis-tool = "~=0.27"
-panther-detection-helpers = "==0.1.1"
+panther-detection-helpers = ">=0.1.2"
 
 [requires]
 python_version = "3.9"


### PR DESCRIPTION
This was breaking because it was too old. I would hope we can use something less strict than `==` here.