### PR TITLE
Added removed workspace.settings line back

### DIFF
--- a/rules/notion_rules/notion_workspace_settings_enforce_saml_sso_config_updated.py
+++ b/rules/notion_rules/notion_workspace_settings_enforce_saml_sso_config_updated.py
@@ -18,6 +18,7 @@ def title(event):
     state = deep_get(
         event,
         "event",
+        "workspace.settings.enforce_saml_sso_config_updated",
         "state",
         default="<NO_STATE_FOUND>",
     )


### PR DESCRIPTION
A minor bug which results in the state variable always being set to "<NO_STATE_FOUND>" so the title doesn't display correctly.

### Background

"workspace.settings.enforce_saml_sso_config_updated" line required to determine if state is enabled

### Changes

* Added the line "workspace.settings.enforce_saml_sso_config_updated", back. 

### Testing

* <Testing steps>
