### PR TITLE
Update global-helpers-unit-test call syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ deps-update:
 	pipenv update
 
 global-helpers-unit-test:
-	pipenv run python global_helpers/*_test.py
+	pipenv run python -m unittest global_helpers/*_test.py
 
 lint: lint-pylint lint-fmt
 


### PR DESCRIPTION
### Background

This patch fixes a make/unittest failure when additional files are added matching the glob `global_helpers/*_test.py`.

When globbed filenames are passed directly to `python`, and there are two or more matched files, the 2nd+ filenames are considered an argument to the first file. 

For example: `pipenv run python global_helpers/*_test.py` works when there is one file, but in the case of a second, it becomes: 

```
pipenv run python global_helpers/a_test.py global_helpers/global_helpers_test.py
```

In this invocation, `global_helpers/global_helpers_test.py` is interpreted as argv[1] to `global_helpers/a_test.py`, resulting in an error like the following:

```
======================================================================
  ERROR: global_helpers (unittest.loader._FailedTest)
  ----------------------------------------------------------------------
  AttributeError: module '__main__' has no attribute 'global_helpers'

  ----------------------------------------------------------------------
  Ran 1 test in 0.000s
```

However, if multiple filenames from a glob are passed to `python -m unittest`, then all the intended test cases are run.

This matters, because we want to add test cases for our helpers in a dedicated file.  Adding them to `global_helpers_test.py` results in unnecessary merge conflicts.

### Changes

* Update global-helpers-unit-test unittest call syntax 

### Testing

* I added `global_helpers/a_test.py` in my branch with a couple test cases and ran `make ci` before and after.  With this change in place, the tests run to completion. Without the change, I get the error mentioned above.
