### PR TITLE
Set severity to INFO if making calendar private

### DIFF
--- a/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.py
+++ b/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.py
@@ -15,3 +15,7 @@ def title(event):
         f"[{deep_get(event, 'parameters', 'calendar_id', default='<NO_CALENDAR_ID>')}] made "
         f"public by [{deep_get(event, 'actor', 'email', default='<NO_ACTOR_FOUND>')}]"
     )
+
+
+def severity(event):
+    return "INFO" if deep_get(event, "parameters", "access_level") == "none" else "MEDIUM"

--- a/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.py
+++ b/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.py
@@ -13,7 +13,8 @@ def title(event):
     return (
         f"GSuite calendar "
         f"[{deep_get(event, 'parameters', 'calendar_id', default='<NO_CALENDAR_ID>')}] made "
-        f"{public_or_private(event)} by [{deep_get(event, 'actor', 'email', default='<NO_ACTOR_FOUND>')}]"
+        f"{public_or_private(event)} by "
+        f"[{deep_get(event, 'actor', 'email', default='<NO_ACTOR_FOUND>')}]"
     )
 
 

--- a/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.py
+++ b/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.py
@@ -13,9 +13,13 @@ def title(event):
     return (
         f"GSuite calendar "
         f"[{deep_get(event, 'parameters', 'calendar_id', default='<NO_CALENDAR_ID>')}] made "
-        f"public by [{deep_get(event, 'actor', 'email', default='<NO_ACTOR_FOUND>')}]"
+        f"{public_or_private(event)} by [{deep_get(event, 'actor', 'email', default='<NO_ACTOR_FOUND>')}]"
     )
 
 
 def severity(event):
-    return "INFO" if deep_get(event, "parameters", "access_level") == "none" else "MEDIUM"
+    return "LOW" if public_or_private(event) == "private" else "MEDIUM"
+
+
+def public_or_private(event):
+    return "private" if deep_get(event, "parameters", "access_level") == "none" else "public"

--- a/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_calendar_made_public.yml
@@ -48,6 +48,34 @@ Tests:
         "type": "calendar_change"
       }
   -
+    Name: User Made Calendar Private
+    ExpectedResult: true
+    Log:
+      {
+        "actor": {
+          "email": "user@example.io",
+          "profileId": "110111111111111111111"
+        },
+        "id": {
+          "applicationName": "calendar",
+          "customerId": "D12345",
+          "time": "2022-12-10 22:33:31.852000000",
+          "uniqueQualifier": "-2888888888888888888"
+        },
+        "ipAddress": "1.2.3.4",
+        "kind": "admin#reports#activity",
+        "name": "change_calendar_acls",
+        "ownerDomain": "example.io",
+        "parameters": {
+          "access_level": "none",
+          "api_kind": "web",
+          "calendar_id": "user@example.io",
+          "grantee_email": "__public_principal__@public.calendar.google.com",
+          "user_agent": "Mozilla/5.0"
+        },
+        "type": "calendar_change"
+      }
+  -
     Name: Admin Set Default Calendar SHARING_OUTSIDE_DOMAIN Setting to READ_WRITE_ACCESS
     ExpectedResult: false
     Log:


### PR DESCRIPTION
https://developers.google.com/admin-sdk/reports/v1/appendix/activity/calendar#change_calendar_acls

None means nobody can see your calendar. This should just be info level.

### Background

When changing a calendar from freebusy to say 'none' it should only be INFO severity.

### Changes

Change severity based on access change

### Testing

Is there a way to test for severity?
