### PR TITLE
deprecating duplicate impossible travel rules

### DIFF
--- a/packs/okta.yml
+++ b/packs/okta.yml
@@ -6,7 +6,7 @@ PackDefinition:
     - Okta.AdminRoleAssigned
     - Okta.APIKeyCreated
     - Okta.APIKeyRevoked
-    - Okta.GeographicallyImprobableAccess
+    # - Okta.GeographicallyImprobableAccess DEPRECATED
     - Okta.Support.Access
     - Okta.Global.MFA.Disabled
     - Okta.ThreatInsight.Security.Threat.Detected

--- a/rules/notion_rules/notion_page_view_impossible_travel.yml
+++ b/rules/notion_rules/notion_page_view_impossible_travel.yml
@@ -1,8 +1,8 @@
 AnalysisType: rule
 Filename: notion_page_view_impossible_travel.py
 RuleID: "Notion.PageViews.ImpossibleTravel"
-DisplayName: "Notion Page View Impossible Travel"
-Enabled: true
+DisplayName: "Notion Page View Impossible Travel DEPRECATED"
+Enabled: false
 LogTypes:
     - Notion.AuditLogs
 Tags:

--- a/rules/okta_rules/okta_geo_improbable_access.yml
+++ b/rules/okta_rules/okta_geo_improbable_access.yml
@@ -1,8 +1,8 @@
 AnalysisType: rule
 Filename: okta_geo_improbable_access.py
 RuleID: "Okta.GeographicallyImprobableAccess"
-DisplayName: "Geographically Improbable Okta Login"
-Enabled: true
+DisplayName: "Geographically Improbable Okta Login - DEPRECATED"
+Enabled: false
 LogTypes:
   - Okta.SystemLog
 Tags:


### PR DESCRIPTION
### Background

Deprecating duplicate impossible travel rules which are notoriously noisy.  Global impossible travel rule will be refactored and updated in a separate PR.   https://www.notion.so/pantherlabs/Impossible-Travel-bff7c493e9314c6283be945491603c18?pvs=4

### Changes

* Deprecated impossible travel rules for Okta and Notion

### Testing

* No logic changes
