### PR TITLE
Expanded Microsoft365.Exchange.External.Forwarding to work with ForwardingAddress property

### DIFF
--- a/rules/microsoft_rules/microsoft_exchange_external_forwarding.py
+++ b/rules/microsoft_rules/microsoft_exchange_external_forwarding.py
@@ -6,7 +6,7 @@ ALLOWED_FORWARDING_DESTINATION_EMAILS = ["exception@example.com"]
 def rule(event):
     if event.get("operation", "") in ("Set-Mailbox", "New-InboxRule"):
         for param in event.get("parameters", []):
-            if param.get("Name", "") in ("ForwardingSmtpAddress", "ForwardTo"):
+            if param.get("Name", "") in ("ForwardingSmtpAddress", "ForwardTo", "ForwardingAddress"):
                 to_email = param.get("Value", "")
                 if to_email.lower().replace("smtp:", "") in ALLOWED_FORWARDING_DESTINATION_EMAILS:
                     return False

--- a/rules/microsoft_rules/microsoft_exchange_external_forwarding.yml
+++ b/rules/microsoft_rules/microsoft_exchange_external_forwarding.yml
@@ -167,6 +167,45 @@ Tests:
         usertype: 2
         workload: Exchange
       Name: Forwarding to Exception
+    - ExpectedResult: true
+      Log:
+        {
+          "AppAccessContext": {},
+          "ClientIP": "20.185.225.251:6688",
+          "CreationTime": "2023-10-24 13:06:33.000000000",
+          "ExternalAccess": false,
+          "Id": "78ab3f60-bd49-42e5-e69d-08dbd4920c3d",
+          "ObjectId": "28eb696a-03f7-47bd-a07a-b09d5f6e592e",
+          "Operation": "Set-Mailbox",
+          "OrganizationId": "18360841-3f87-44a6-8c9a-3ffc680611a0",
+          "OrganizationName": "fellowship.lotr.com",
+          "OriginatingServer": "AM6PR0402MB3448 (15.20.6933.008)",
+          "Parameters": [
+            {
+              "Name": "Identity",
+              "Value": "28eb696a-03f7-47bd-a07a-b09d5f6e592e"
+            },
+            {
+              "Name": "ForwardingAddress",
+              "Value": "sauron@mordor.dev"
+            },
+            {
+              "Name": "ForwardingSmtpAddress",
+              "Value": ""
+            },
+            {
+              "Name": "DeliverToMailboxAndForward",
+              "Value": "False"
+            }
+          ],
+          "RecordType": 1,
+          "ResultStatus": "True",
+          "UserId": "saurman@lotr.com",
+          "UserKey": "10032002CD6B7EFD",
+          "UserType": 2,
+          "Workload": "Exchange"
+        }
+      Name: Log with ForwardingAddress
 DedupPeriodMinutes: 60
 LogTypes:
     - Microsoft365.Audit.Exchange

--- a/rules/notion_rules/notion_account_changed_after_login.py
+++ b/rules/notion_rules/notion_account_changed_after_login.py
@@ -1,8 +1,8 @@
 import time
+
 from global_filter_notion import filter_include_event
 from panther_notion_helpers import notion_alert_context
 from panther_oss_helpers import get_string_set, put_string_set
-
 
 # Length of time in minutes. If a user logs in, then changes their email within this many
 # minutes, raise an alert.

--- a/rules/notion_rules/notion_login_from_new_location.py
+++ b/rules/notion_rules/notion_login_from_new_location.py
@@ -1,11 +1,11 @@
 import datetime
-import time
 import json
+import time
 
 from global_filter_notion import filter_include_event
+from panther_ipinfo_helpers import IPInfoLocation
 from panther_notion_helpers import notion_alert_context
 from panther_oss_helpers import get_dictionary, put_dictionary
-from panther_ipinfo_helpers import IPInfoLocation
 
 # How long (in seconds) to keep previous login locations in cached memory
 DEFAULT_CACHE_PERIOD = 2419200

--- a/rules/notion_rules/notion_page_accessible_to_guests.py
+++ b/rules/notion_rules/notion_page_accessible_to_guests.py
@@ -1,6 +1,6 @@
 from global_filter_notion import filter_include_event
-from panther_notion_helpers import notion_alert_context
 from panther_base_helpers import deep_get
+from panther_notion_helpers import notion_alert_context
 
 # These event types correspond to users adding or editing the default role on a public page
 event_types = ("page.permissions.guest_role_added", "page.permissions.guest_role_updated")

--- a/rules/okta_rules/okta_geo_improbable_access.py
+++ b/rules/okta_rules/okta_geo_improbable_access.py
@@ -3,10 +3,7 @@ from json import dumps, loads
 from math import asin, cos, radians, sin, sqrt
 
 from panther_base_helpers import deep_get, okta_alert_context
-from panther_detection_helpers.caching import (
-    get_string_set,
-    put_string_set,
-)
+from panther_detection_helpers.caching import get_string_set, put_string_set
 
 PANTHER_TIME_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
 EVENT_CITY_TRACKING = {}

--- a/rules/slack_rules/slack_application_dos.py
+++ b/rules/slack_rules/slack_application_dos.py
@@ -2,10 +2,7 @@ from datetime import timedelta
 from json import dumps
 
 from panther_base_helpers import deep_get, slack_alert_context
-from panther_detection_helpers.caching import (
-    get_string_set,
-    put_string_set,
-)
+from panther_detection_helpers.caching import get_string_set, put_string_set
 
 DENIAL_OF_SERVICE_ACTIONS = [
     "bulk_session_reset_by_admin",


### PR DESCRIPTION
### Background

A customer noted that the `Microsoft365.Exchange.External.Forwarding` detection doesn't alert when the property `ForwardingAddress` is used. I added this property to the detection code.

### Changes

* Added a check for `ForwardingAddress` to `Microsoft365.Exchange.External.Forwarding`.
* Added a unit test case for the above condition.

### Testing

* Ran `make test`.
