### PR TITLE
Fix Standard.ImpossibleTravel.Login

### DIFF
--- a/rules/standard_rules/impossible_travel_login.py
+++ b/rules/standard_rules/impossible_travel_login.py
@@ -106,12 +106,13 @@ def rule(event):
     last_login = get_string_set(CACHE_KEY)
     # If we haven't seen this user login in the past 1 day,
     # store this login for future use and don't alert
-    if not last_login and not IS_PRIVATE_RELAY and not IS_VPN:
-        put_string_set(
-            key=CACHE_KEY,
-            val=[dumps(new_login_stats)],
-            epoch_seconds=int((datetime.utcnow() + timedelta(days=1)).timestamp()),
-        )
+    if not last_login:
+        if not (IS_PRIVATE_RELAY or IS_VPN):
+            put_string_set(
+                key=CACHE_KEY,
+                val=[dumps(new_login_stats)],
+                epoch_seconds=int((datetime.utcnow() + timedelta(days=1)).timestamp()),
+            )
         return False
     # Load the last login from the cache into an object we can compare
     # str check is in place for unit test mocking

--- a/rules/standard_rules/impossible_travel_login.yml
+++ b/rules/standard_rules/impossible_travel_login.yml
@@ -787,4 +787,89 @@ Tests:
         "p_log_type": "Notion.AuditLogs",
         "p_source_label": "Notion-Panther-Labs"
       }
-
+  - Name: First hit from VPN should not fail
+    ExpectedResult: false
+    Mocks:
+      - objectName: put_string_set
+        returnValue: ""
+      - objectName: get_string_set
+        returnValue: ""
+    Log:
+      {
+        "actor": {
+          "alternateId": "homer.simpson@company.com",
+          "displayName": "Homer Simpson",
+          "id": "00uwuwuwuwuwuwuwuwuw",
+          "type": "User"
+        },
+        "authenticationContext": {
+          "authenticationStep": 0,
+          "externalSessionId": "idx1234"
+        },
+        "client": {
+          "device": "Computer",
+          "ipAddress": "12.12.12.12",
+          "userAgent": {
+            "browser": "CHROME",
+            "os": "Mac OS X",
+            "rawUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36"
+          },
+          "zone": "null"
+        },
+        "debugContext": {
+          "debugData": {
+          }
+        },
+        "device": {
+        },
+        "displayMessage": "User login to Okta",
+        "eventType": "user.session.start",
+        "legacyEventType": "core.user_auth.login_success",
+        "outcome": {
+          "result": "SUCCESS"
+        },
+        "p_event_time": "2023-05-26 20:18:51",
+        "p_enrichment": {
+          "ipinfo_location": {
+            "client.ipAddress": {
+              "city": "Los Angeles",
+              "country": "US",
+              "lat": "34.05223",
+              "lng": "-118.24368",
+              "p_match": "12.12.12.12",
+              "postal_code": "90009",
+              "region": "California",
+              "region_code": "CA",
+              "timezone": "America/Los_Angeles"
+            }
+          },
+          "ipinfo_privacy": {
+            "client.ipAddress": {
+              "hosting": true,
+              "p_match": "12.12.12.12",
+              "proxy": false,
+              "relay": true,
+              "service": "Apple Private Relay",
+              "tor": false,
+              "vpn": false
+            }
+          }
+        },
+        "p_log_type": "Okta.SystemLog",
+        "p_source_label": "Okta Logs",
+        "p_parse_time": "2023-05-26 20:22:51.888",
+        "published": "2023-05-26 20:18:51.888",
+        "request": {
+          "ipChain": [
+          ]
+        },
+        "securityContext": {
+        },
+        "severity": "INFO",
+        "target": [
+        ],
+        "transaction": {
+        },
+        "uuid": "79999999-ffff-eeee-bbbb-222222222222",
+        "version": "0"
+      }


### PR DESCRIPTION
Previously a login from a VPN would cause an exception, if no previous login was in the cache, as the boolean logic was far too specific.

Fix ensures that VPN logins will never enter the cache, and still exit the logic as expected.

Added test case to reveal bug.