### PR TITLE
fixed severity issue for Super admin granted

### DIFF
--- a/rules/okta_rules/okta_admin_role_assigned.py
+++ b/rules/okta_rules/okta_admin_role_assigned.py
@@ -41,6 +41,8 @@ def alert_context(event):
 
 
 def severity(event):
-    if deep_get(event, "debugContext", "debugData", "privilegeGranted") == "Super administrator":
+    if "Super administrator" in deep_get(
+        event, "debugContext", "debugData", "privilegeGranted", default=""
+    ):
         return "HIGH"
     return "INFO"

--- a/rules/okta_rules/okta_admin_role_assigned.yml
+++ b/rules/okta_rules/okta_admin_role_assigned.yml
@@ -86,3 +86,66 @@ Tests:
         "authenticationContext": {},
         "securityContext": {}
       }
+  -
+    Name: Super Admin Access Assigned (High sev)
+    ExpectedResult: true
+    Log:
+      {
+        "uuid": "2a992f80-d1ad-4f62-900e-8c68bb72a21b",
+        "published": "2020-11-25 21:27:03.496000000",
+        "eventType": "user.account.privilege.grant",
+        "version": "0",
+        "severity": "INFO",
+        "legacyEventType": "core.user.admin_privilege.granted",
+        "displayMessage": "Grant user privilege",
+        "actor": {
+          "id": "00uu1uuuuIlllaaaa356",
+          "type": "User",
+          "alternateId": "jack@acme.io",
+          "displayName": "Jack Naglieri"
+        },
+        "client": {
+          "userAgent": {
+            "browser": "CHROME",
+            "os": "Mac OS X",
+            "rawUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36"
+          },
+          "geographicalContext": {
+            "geolocation": {
+              "lat": 37.7852,
+              "lon": -122.3874
+            },
+            "city": "San Francisco",
+            "state": "California",
+            "country": "United States",
+            "postalCode": "94105"
+          },
+          "zone": "null",
+          "ipAddress": "136.24.229.58",
+          "device": "Computer"
+        },
+        "request": {},
+        "outcome": {
+          "result": "SUCCESS"
+        },
+        "target": [
+          {
+            "id": "00u6eup97mAJZWYmP357",
+            "type": "User",
+            "alternateId": "alice@acme.io",
+            "displayName": "Alice Green"
+          }
+        ],
+        "transaction": {},
+        "debugContext": {
+          "debugData": {
+            "privilegeGranted": "Super administrator, Read only admin",
+            "requestUri": "/api/internal/administrators/00u6eu8c68bb72a21b57",
+            "threatSuspected": "false",
+            "url": "/api/internal/administrators/00u6eu8c68bb72a21b57",
+            "requestId": "X777JJ9sssQQHHrrrQTyYQAABBE"
+          }
+        },
+        "authenticationContext": {},
+        "securityContext": {}
+      }


### PR DESCRIPTION
### Background

The detection will only fire as high iff that field is Super admin where it should fire as high if the field contains Super admin.

### Changes

* Update logic so severity is set to HIGH when privilegeGranted contains "Super administrator"

### Testing

* Added a unit test for high severity
