### PR TITLE
Update sync-from-upstream.yml GH action from 'master' to 'main'

### DIFF
--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -104,4 +104,3 @@ jobs:
         run: |
           echo "unhandled exception in PR create step. Check output of that step."
           exit 128
-      

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch: # or on button click  
 
 env:
-  YOUR_REPO_PRIMARY_BRANCH_NAME: "master"
+  YOUR_REPO_PRIMARY_BRANCH_NAME: "main"
 
 jobs:
   check_upstream:


### PR DESCRIPTION
### Background

Change 'master' to 'main' as default for GH action since new default branch name is 'main'

### Changes

* Changed var 

### Testing

* Tested on commercial instance
