### PR TITLE
Remove PAT clone from lint-test Workflow

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -24,12 +24,6 @@ jobs:
     steps:
       - name: Checkout panther-analysis
         uses: actions/checkout@v3
-      
-      - name: Checkout panther_analysis_tool
-        uses: actions/checkout@v3
-        with:
-          repository: panther-labs/panther_analysis_tool
-          token: ${{ secrets.PANTHER_BOT_AUTOMATION_TOKEN }}
 
       - name: Set python version  
         uses: actions/setup-python@v4


### PR DESCRIPTION
### Background

This was a temporary fix to unblock #500. Other PRs were not seeing issues when running `make test`, so this PR reverts the change to unblock forks that need to run this Check.

### Changes

* Removes the PAT clone from the `lint-test.yml` Workflow

### Testing

* The tests pass as expected without the PAT repository being cloned
