### PR TITLE
Always use the "our" CODEOWNERS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CODEOWNERS merge=ours


### PR DESCRIPTION
Each fork should have it's own CODEOWNERS. This could help with merge conflicts for that file when forked versions change their codeowners.