### PR TITLE
gcp_k8s_rules: fix logic matching irrelevant events

### DIFF
--- a/rules/gcp_k8s_rules/gcp_k8s_exec_into_pod.py
+++ b/rules/gcp_k8s_rules/gcp_k8s_exec_into_pod.py
@@ -5,7 +5,7 @@ from panther_base_helpers import deep_walk
 
 def rule(event):
     # Defaults to False (no alert) unless method is exec and principal not allowed
-    if not any(
+    if not all(
         [
             deep_walk(event, "protoPayload", "methodName") == "io.k8s.core.v1.pods.exec.create",
             deep_walk(event, "resource", "type") == "k8s_cluster",

--- a/rules/gcp_k8s_rules/gcp_k8s_exec_into_pod.yml
+++ b/rules/gcp_k8s_rules/gcp_k8s_exec_into_pod.yml
@@ -35,14 +35,14 @@ Tests:
             "callerIp": "88.88.88.88",
             "callerSuppliedUserAgent": "kubectl/v1.40.8 (darwin/amd64) kubernetes/6575935"
           },
-          "resource": {
-            "type": "k8s_cluster",
-            "labels": {
-              "project_id": "rigup-production"
-            }
-          },
           "resourceName": "core/v1/namespaces/example/pods/one-off-46666967280/exec",
           "timestamp": "2022-03-04T16:01:49.978756Z"
+        },
+        "resource": {
+          "type": "k8s_cluster",
+          "labels": {
+            "project_id": "rigup-production"
+          }
         }
       }
   -
@@ -65,14 +65,14 @@ Tests:
             "callerIp": "88.88.88.88",
             "callerSuppliedUserAgent": "kubectl/v1.40.8 (darwin/amd64) kubernetes/6575935"
           },
-          "resource": {
-            "type": "k8s_cluster",
-            "labels": {
-              "project_id": "example-production"
-            }
-          },
           "resourceName": "core/v1/namespaces/example/pods/one-off-valerii-tovstyk-1646666967280/exec",
           "timestamp": "2022-03-04T16:01:49.978756Z"
+        },
+        "resource": {
+          "type": "k8s_cluster",
+          "labels": {
+            "project_id": "rigup-production"
+          }
         }
       }
   -
@@ -95,14 +95,14 @@ Tests:
             "callerIp": "88.88.88.88",
             "callerSuppliedUserAgent": "kubectl/v1.40.8 (darwin/amd64) kubernetes/6575935"
           },
-          "resource": {
-            "type": "k8s_cluster",
-            "labels": {
-              "project_id": "example-production"
-            }
-          },
           "resourceName": "core/v1/namespaces/istio-system/pods/one-off-valerii-tovstyk-1646666967280/exec",
           "timestamp": "2022-03-04T16:01:49.978756Z"
+        },
+        "resource": {
+          "type": "k8s_cluster",
+          "labels": {
+            "project_id": "rigup-production"
+          }
         }
       }
 


### PR DESCRIPTION
### Background

The existing GCP K8S Exec into Pod rule currently matches more events than necessary, as the use of `any` means that any entry with `resource.type == "k8s_cluster"` will also result in a True rule evaluation. This also masked the issue with incorrect tests where the schema is incorrect (`resource` is a top-level field, but tests have it nested under `protoPayload`)

<details><summary>Example of a full audit log entry</summary>
<p>

```json
{
  "protoPayload": {
    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
    "authenticationInfo": {
      "principalEmail": "sanitised@example.com"
    },
    "authorizationInfo": [
      {
        "granted": true,
        "permission": "io.k8s.core.v1.pods.exec.create",
        "resource": "core/v1/namespaces/namespace_name/pods/pod_name/exec"
      }
    ],
    "methodName": "io.k8s.core.v1.pods.exec.create",
    "requestMetadata": {
      "callerIp": "100.100.100.100",
      "callerSuppliedUserAgent": "kubectl/v1.23.1 (darwin/arm64) kubernetes/86ec240"
    },
    "resourceName": "core/v1/namespaces/namespace_name/pods/pod_name/exec",
    "serviceName": "k8s.io",
    "status": {
      "code": 0
    }
  },
  "insertId": "9144c00e-479a-44eb-a756-00d43a3b8d0b",
  "resource": {
    "type": "k8s_cluster",
    "labels": {
      "cluster_name": "cluster_name",
      "project_id": "project_id",
      "location": "europe-west1"
    }
  },
  "timestamp": "2023-11-03T10:58:31.410588Z",
  "labels": {
    "apiserver.latency.k8s.io/etcd": "3.287529ms",
    "authorization.k8s.io/decision": "allow",
    "apiserver.latency.k8s.io/total": "2.941538077s",
    "authorization.k8s.io/reason": "access granted by IAM permissions."
  },
  "logName": "projects/project_id/logs/cloudaudit.googleapis.com%2Factivity",
  "operation": {
    "id": "9144c00e-479a-44eb-a756-00d43a3b8d0b",
    "producer": "k8s.io",
    "last": true
  },
  "receiveTimestamp": "2023-11-03T10:58:38.638114835Z"
}
```
</p>
</details> 

### Changes

* Change check from `any` to `all` to only evaluate events that match all conditions 
* Update test data to match real data

### Testing

* Ran `pipenv run panther_analysis_tool test --path rules/gcp_k8s_rules`
* Deployed in our own Panther instance
