### PR TITLE
Fix the Zeek selectors in luts

### DIFF
--- a/lookup_tables/greynoise/advanced/noise_advanced.yml
+++ b/lookup_tables/greynoise/advanced/noise_advanced.yml
@@ -221,44 +221,44 @@ LogTypeMap:
         - "src_ip"
     - LogType: Zeek.Conn
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DNS
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DPD
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.HTTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Notice
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.NTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssh
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssl
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Tunnel
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Weird
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zendesk.Audit
       Selectors:
         - "ip_address"

--- a/lookup_tables/greynoise/advanced/riot_advanced.yml
+++ b/lookup_tables/greynoise/advanced/riot_advanced.yml
@@ -221,44 +221,44 @@ LogTypeMap:
         - "src_ip"
     - LogType: Zeek.Conn
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DNS
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DPD
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.HTTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Notice
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.NTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssh
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssl
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Tunnel
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Weird
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zendesk.Audit
       Selectors:
         - "ip_address"

--- a/lookup_tables/greynoise/basic/noise_basic.yml
+++ b/lookup_tables/greynoise/basic/noise_basic.yml
@@ -221,44 +221,44 @@ LogTypeMap:
         - "src_ip"
     - LogType: Zeek.Conn
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DNS
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DPD
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.HTTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Notice
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.NTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssh
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssl
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Tunnel
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Weird
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zendesk.Audit
       Selectors:
         - "ip_address"

--- a/lookup_tables/ipinfo/ipinfo_asn.yml
+++ b/lookup_tables/ipinfo/ipinfo_asn.yml
@@ -287,44 +287,44 @@ LogTypeMap:
         - 'Session_IP_Address'
     - LogType: Zeek.Conn
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DNS
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DPD
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.HTTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Notice
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.NTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssh
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssl
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Tunnel
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Weird
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zendesk.Audit
       Selectors:
         - 'ip_address'

--- a/lookup_tables/ipinfo/ipinfo_asn_datalake.yml
+++ b/lookup_tables/ipinfo/ipinfo_asn_datalake.yml
@@ -287,44 +287,44 @@ LogTypeMap:
         - 'Session_IP_Address'
     - LogType: Zeek.Conn
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DNS
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DPD
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.HTTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Notice
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.NTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssh
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssl
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Tunnel
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Weird
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zendesk.Audit
       Selectors:
         - 'ip_address'

--- a/lookup_tables/ipinfo/ipinfo_location.yml
+++ b/lookup_tables/ipinfo/ipinfo_location.yml
@@ -287,44 +287,44 @@ LogTypeMap:
         - 'Session_IP_Address'
     - LogType: Zeek.Conn
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DNS
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DPD
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.HTTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Notice
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.NTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssh
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssl
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Tunnel
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Weird
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zendesk.Audit
       Selectors:
         - 'ip_address'

--- a/lookup_tables/ipinfo/ipinfo_location_datalake.yml
+++ b/lookup_tables/ipinfo/ipinfo_location_datalake.yml
@@ -287,44 +287,44 @@ LogTypeMap:
         - 'Session_IP_Address'
     - LogType: Zeek.Conn
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DNS
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DPD
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.HTTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Notice
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.NTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssh
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssl
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Tunnel
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Weird
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zendesk.Audit
       Selectors:
         - 'ip_address'

--- a/lookup_tables/ipinfo/ipinfo_privacy.yml
+++ b/lookup_tables/ipinfo/ipinfo_privacy.yml
@@ -287,44 +287,44 @@ LogTypeMap:
         - 'Session_IP_Address'
     - LogType: Zeek.Conn
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DNS
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DPD
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.HTTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Notice
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.NTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssh
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssl
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Tunnel
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Weird
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zendesk.Audit
       Selectors:
         - 'ip_address'

--- a/lookup_tables/ipinfo/ipinfo_privacy_datalake.yml
+++ b/lookup_tables/ipinfo/ipinfo_privacy_datalake.yml
@@ -287,44 +287,44 @@ LogTypeMap:
         - 'Session_IP_Address'
     - LogType: Zeek.Conn
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DNS
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DPD
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.HTTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Notice
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.NTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssh
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssl
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Tunnel
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Weird
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zendesk.Audit
       Selectors:
         - 'ip_address'

--- a/lookup_tables/tor/tor_exit_nodes.yml
+++ b/lookup_tables/tor/tor_exit_nodes.yml
@@ -290,44 +290,44 @@ LogTypeMap:
         - 'Session_IP_Address'
     - LogType: Zeek.Conn
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DNS
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.DPD
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.HTTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Notice
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.NTP
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssh
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Ssl
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Tunnel
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zeek.Weird
       Selectors:
-        - 'id.orig_h'
-        - 'id.resp_h'
+        - '$.id.orig_h'
+        - '$.id.resp_h'
     - LogType: Zendesk.Audit
       Selectors:
         - 'ip_address'


### PR DESCRIPTION
### Background

The Zeek selectors were wrong (missing `$.` which is necessary to indicate a JSON path).

This is breaking customers.

We should get this published ASAP.


