### PR TITLE
Update aws_unauthorized_api_call dedup function

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.py
+++ b/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.py
@@ -23,7 +23,7 @@ def rule(event):
 
 
 def dedup(event):
-    return deep_get(event, 'userIdentity', 'principalId', default="<UNKNOWN_PRINCIPAL>")
+    return deep_get(event, "userIdentity", "principalId", default="<UNKNOWN_PRINCIPAL>")
 
 
 def title(event):

--- a/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.py
+++ b/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.py
@@ -23,10 +23,7 @@ def rule(event):
 
 
 def dedup(event):
-    user_identity = event.get("userIdentity", {})
-    if user_identity.get("type") == "AssumedRole":
-        return aws_strip_role_session_id(user_identity.get("arn", ""))
-    return user_identity.get("arn", "")
+    return deep_get(event, 'userIdentity', 'principalId', default="<UNKNOWN_PRINCIPAL>")
 
 
 def title(event):

--- a/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.py
+++ b/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.py
@@ -1,6 +1,6 @@
 from ipaddress import ip_address
 
-from panther_base_helpers import aws_rule_context, aws_strip_role_session_id, deep_get
+from panther_base_helpers import aws_rule_context, deep_get
 
 # Do not alert on these access denied errors for these events.
 # Events could be exceptions because they are particularly noisy and provide little to no value,


### PR DESCRIPTION
### Background

Customers were running into empty `dedup` values because the `dedup` function for this rule is looking for an `arn` key in the `userIdentity` object which does not exist (based on the test logs, this used to be a valid key and was likely removed).

This PR updates the `dedup` function to use `principalId` instead.

### Changes

* Uses the `principalId` key rather than the nonexistent `arn` key

### Testing

* Tests pass as expected:
```
AWS.CloudTrail.UnauthorizedAPICall
  	[PASS] Unauthorized API Call from Within AWS (IP)
  		[PASS] [rule] true
  		[PASS] [title] Access denied to IAMUser [1111]
  		[PASS] [dedup] 1111
  		[PASS] [alertContext] {"eventName": "CreateServiceLinkedRole", "eventSource": "iam.amazonaws.com", "awsRegion": "us-east-1", "recipientAccountId": "123456789012", "sourceIPAddress": "3.10.107.144", "userAgent": "sqs.amazonaws.com", "userIdentity": {"type": "IAMUser", "principalId": "1111", "arn": "arn:aws:iam::123456789012:user/tester", "accountId": "123456789012", "accessKeyId": "1", "userName": "tester", "sessionContext": {"attributes": {"mfaAuthenticated": "true", "creationDate": "2019-01-01T00:00:00Z"}}, "invokedBy": "signin.amazonaws.com"}}
  	[PASS] Unauthorized API Call from Within AWS (FQDN)
  		[PASS] [rule] false
  	[PASS] Authorized API Call
  		[PASS] [rule] false
```
