### PR TITLE
Auto deploy on Wednesday mornings

### DIFF
--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -2,8 +2,8 @@ name: sync-panther-analysis-from-upstream
 
 on:
   schedule:
-    # 15:00Z, every Tuesday
-    - cron: "00 15 * * 2"
+    # 15:00Z, every Wednesday
+    - cron: "00 15 * * 3"
   workflow_dispatch: # or on button click  
 
 env:


### PR DESCRIPTION
We cut the release on Tuesday mornings around 10 AM Pacific, but we are upgrading customers at 7 AM on Tuesdays. This moves that to Wednesdays.