### PR TITLE
adding optional TEST_ARGS to the test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 dirs := $(shell ls | egrep 'policies|rules|helpers|models|templates|queries' | xargs)
 UNAME := $(shell uname)
+TEST_ARGS :=
 
 ifeq ($(UNAME), Darwin)
 	install_pipenv_cmd = brew install pipenv
@@ -58,13 +59,13 @@ install:
 	pipenv sync --dev
 
 test: global-helpers-unit-test
-	pipenv run panther_analysis_tool test
+	pipenv run panther_analysis_tool test $(TEST_ARGS)
 
 docker-build:
 	docker build -t panther-analysis .
 
 docker-test:
-	docker run --mount "type=bind,source=${CURDIR},target=/home/panther-analysis" panther-analysis make test
+	docker run --mount "type=bind,source=${CURDIR},target=/home/panther-analysis" panther-analysis make test TEST_ARGS="$(TEST_ARGS)"
 
 docker-lint:
 	docker run --mount "type=bind,source=${CURDIR},target=/home/panther-analysis" panther-analysis make lint


### PR DESCRIPTION
### Background

The Makefile for this repo simplifies rule testing, especially when used in combination with docker.  However, there wasn't a way to pass additional arguments to the ultimate `panther_analysis_tool test` call, such as to only [run tests for a given path](https://github.com/panther-labs/panther_analysis_tool#test).

### Changes

* Adding optional `TEST_ARGS` that can be passes to the make test targets, including passthrough to docker.

### Testing

An example of running tests only for a given path, specified with `TEST_ARGS`, e.g. `make docker-test TEST_ARGS="--path rules/aws_cloudtrail_rules/"` 

```bash
$ make docker-test TEST_ARGS="--path rules/aws_cloudtrail_rules/"
docker run --mount "type=bind,source=/home/bfeld/src/github.com/rootshellz/panther-analysis,target=/home/panther-analysis" panther-analysis make test TEST_ARGS="--path rules/aws_cloudtrail_rules/"
pipenv run python -m unittest global_helpers/*_test.py
.............................................................................................................................................
----------------------------------------------------------------------
Ran 141 tests in 12.293s

OK
pipenv run panther_analysis_tool test --path rules/aws_cloudtrail_rules/
[INFO][root]: Testing analysis items in rules/aws_cloudtrail_rules/
[...]
--------------------------
Panther CLI Test Summary
  Path: rules/aws_cloudtrail_rules/
  Passed: 63
  Failed: 0
  Invalid: 0
```

Things still work as before if no `TEST_ARGS` are passed:

```bash
$ make docker-test
docker run --mount "type=bind,source=/home/bfeld/src/github.com/rootshellz/panther-analysis,target=/home/panther-analysis" panther-analysis make test TEST_ARGS=""
pipenv run python -m unittest global_helpers/*_test.py
.............................................................................................................................................
----------------------------------------------------------------------
Ran 141 tests in 14.907s

OK
pipenv run panther_analysis_tool test
[INFO][root]: Testing analysis items in .
[...]
--------------------------
Panther CLI Test Summary
  Path: .
  Passed: 545
  Failed: 0
  Invalid: 0
```
