### PR TITLE
Set git_config_pull_rebase: true for fork sync step

### DIFF
--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -54,7 +54,8 @@ jobs:
           #  change the usptream_sync_branch to master
           upstream_sync_branch: ${{steps.set_upstream.outputs.latest-release}}
           upstream_sync_repo: panther-labs/panther-analysis
-          #test_mode: true  
+          #test_mode: true
+          git_config_pull_rebase: true
       # Create a PR from this branch back to this fork's primary branch
       - uses: actions/github-script@v6
         id: create_pr


### PR DESCRIPTION
### Background

We've had reports of merge conflicts for forks of this repo. There's a configuration option for the Fork Sync Action we use in the `sync-from-upstream` Workflow and this PR turns it on (by default it is `false`).

### Changes

* Sets `git_config_pull_rebase: true` for the `sync-from-upstream.yml` Workflow

### Testing

* N/A
