### PR TITLE
bump `shallow_since` from 1 month to 5 years to look back to the beginning of git history

### DIFF
--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -54,14 +54,10 @@ jobs:
           #  change the usptream_sync_branch to master
           upstream_sync_branch: ${{steps.set_upstream.outputs.latest-release}}
           upstream_sync_repo: panther-labs/panther-analysis
-          #test_mode: true
+          #test_mode: true 
 
-          # turning off rebase for now as it could make for more complex merges
-          #git_config_pull_rebase: true
-          
-          # we don't want shallow, we want to check all git history
+          # check all git history for a shared commit or fall back to unrelated history if necessary
           shallow_since: 5 years ago
-          # fall back to unrelated histories if necessary
           upstream_pull_args: '--allow-unrelated-histories'
       # Create a PR from this branch back to this fork's primary branch
       - uses: actions/github-script@v6

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -55,10 +55,7 @@ jobs:
           upstream_sync_branch: ${{steps.set_upstream.outputs.latest-release}}
           upstream_sync_repo: panther-labs/panther-analysis
           #test_mode: true
-          # turning off rebase for now as it could make for more complex merges
-          #git_config_pull_rebase: true 
-          # look back all the way through all git history - not just the default 1 month
-          shallow_since: 5 years ago
+          upstream_pull_args: '--allow-unrelated-histories'
       # Create a PR from this branch back to this fork's primary branch
       - uses: actions/github-script@v6
         id: create_pr

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -55,6 +55,13 @@ jobs:
           upstream_sync_branch: ${{steps.set_upstream.outputs.latest-release}}
           upstream_sync_repo: panther-labs/panther-analysis
           #test_mode: true
+
+          # turning off rebase for now as it could make for more complex merges
+          #git_config_pull_rebase: true
+          
+          # we don't want shallow, we want to check all git history
+          shallow_since: 5 years ago
+          # fall back to unrelated histories if necessary
           upstream_pull_args: '--allow-unrelated-histories'
       # Create a PR from this branch back to this fork's primary branch
       - uses: actions/github-script@v6

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -55,7 +55,10 @@ jobs:
           upstream_sync_branch: ${{steps.set_upstream.outputs.latest-release}}
           upstream_sync_repo: panther-labs/panther-analysis
           #test_mode: true
-          git_config_pull_rebase: true
+          # turning off rebase for now as it could make for more complex merges
+          #git_config_pull_rebase: true 
+          # look back all the way through all git history - not just the default 1 month
+          shallow_since: 5 years ago
       # Create a PR from this branch back to this fork's primary branch
       - uses: actions/github-script@v6
         id: create_pr


### PR DESCRIPTION
I believe that we are running into merge conflicts on every release because the forked repos that run the code are not able to find a shared commit, resulting in divergent trees.

The `shallow_since` setting default pins this to 1 month. This PR changes it to 5 years. It's not that big of a repo and this command runs in CI so I don't think it will be an issue.

I also included `--allow-unrelated-histories` in the case that we miss even a shared commit even with `shallow_since`.

I also disabled the new `git_config_pull_rebase` as I am concerned that it could result in merges that are more difficult to reconcile.

See `shallow_since` in this docs: https://github.com/aormsby/Fork-Sync-With-Upstream-action