### PR TITLE
Updating panther_user_modified to use default severity

### DIFF
--- a/rules/panther_audit_rules/panther_user_modified.py
+++ b/rules/panther_audit_rules/panther_user_modified.py
@@ -36,4 +36,4 @@ def severity(event):
     user = event.udm("actor_user")
     if user == "scim":
         return "INFO"
-    return "HIGH"
+    return "DEFAULT"


### PR DESCRIPTION
### Background

Rule was statically setting HIGH which means a UI change to override severity wouldn't stick. This change leverages the [DEFAULT](https://docs.panther.com/detections/rules/python#severity) value as the return string. This will allow overrides in the UI (or yaml file) to stick for this rule.

### Changes

* Updated return value from High > Default

### Testing

* <Testing steps>
