### PR TITLE
Add Workflow to automate panther-analysis releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Panther Analysis Release
+
+on:
+  workflow_dispatch:
+  
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-session-name: panther-analysis-release
+      - name: Install Python
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
+        with:
+          python-version: '3.11'
+      - name: Create new panther-analysis-release
+        run: |
+          export AWS_REGION=${{ secrets.AWS_REGION }}
+          export AWS_DEFAULT_REGION=${{ secrets.AWS_REGION }}
+          export OLD_VERSION=$(gh release list | grep Latest | awk '{print $1}')
+          export NEW_VERSION=$(echo $OLD_VERSION | awk -F. '{printf "%s.%d.0", $1, $2+1}')
+          pip3 install --user pipenv
+          rm -rf $(pipenv --venv)
+          make install
+          pipenv run panther_analysis_tool release --kms-key ${{ secrets.KMS_KEY_ARN }}
+          openssl dgst -binary -sha512 panther-analysis-all.zip > ${{ secrets.DIGEST_FILE }}
+          aws kms verify --key-id ${{ secrets.KMS_KEY_ARN }} --signing-algorithm ${{ secrets.SIGNING_ALGORITHM }} --message fileb://${{ secrets.DIGEST_FILE }} --message-type DIGEST --output json --signature $(cat panther-analysis-all.sig)
+          gh release create $(NEW_VERSION) panther-analysis-all.* --title $(NEW_VERSION) --latest --notes-from-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,5 +32,5 @@ jobs:
           make install
           pipenv run panther_analysis_tool release --kms-key ${{ secrets.KMS_KEY_ARN }}
           openssl dgst -binary -sha512 panther-analysis-all.zip > ${{ secrets.DIGEST_FILE }}
-          aws kms verify --key-id ${{ secrets.KMS_KEY_ARN }} --signing-algorithm ${{ secrets.SIGNING_ALGORITHM }} --message fileb://${{ secrets.DIGEST_FILE }} --message-type DIGEST --output json --signature $(cat panther-analysis-all.sig)
+          aws kms verify --key-id ${{ secrets.KMS_KEY_ARN }} --signing-algorithm ${{ secrets.SIGNING_ALGORITHM }} --message fileb://${{ secrets.DIGEST_FILE }} --message-type DIGEST --output json --signature $(cat panther-analysis-all.sig) | jq '.SignatureValid'
           gh release create $(NEW_VERSION) panther-analysis-all.* --title $(NEW_VERSION) --latest --notes-from-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PANTHER_BOT_AUTOMATION_TOKEN }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: '3.11'
+          python-version: '3.9'
       - name: Create new panther-analysis-release
         run: |
           export AWS_REGION=${{ secrets.AWS_REGION }}


### PR DESCRIPTION
### Background

We currently have a manual process for cutting `panther-analysis` releases and it is in a spot where we can automate it (at least via `workflow_dispatch`). This PR adds the initial Workflow. Once we see how this goes after a few releases, we can potentially add a cron schedule to automate the release entirely.

### Changes

* Adds `release.yml` to automate `panther-analysis` releases

### Testing

* These steps work manually so as far as that goes this has been thoroughly tested
