### PR TITLE
Add Pull config

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,5 @@
+version: "1"
+rules:
+  - base: main
+    upstream: panther-labs/panther-analysis:main
+    mergeMethod: hardreset


### PR DESCRIPTION
### Background

The current Action we rely on for syncing forks with our upstream changes is no longer maintained. This PR adds a [Pull](https://github.com/wei/pull) config so that fork owners can install the GitHub App and automatically consume the desired configuration.

### Changes

* Adds Pull configuration

### Testing

* N/A