### PR TITLE
Add EXCLUDED_BUCKET_NAMES set for aws_cloudtrail_s3_bucket_public.py policy

### DIFF
--- a/global_helpers/panther_default.py
+++ b/global_helpers/panther_default.py
@@ -10,6 +10,7 @@
 
 import base64
 import binascii
+from typing import List
 
 
 def example_helper():
@@ -84,3 +85,43 @@ def aws_key_account_id(aws_key: str):
     # (divide the 10-byte key integer by 128 and remove the fractional part(s))
     account_id = (key_id_int & mask) >> 7
     return str(account_id)
+
+
+def aws_regions() -> List[str]:
+    """return a list of AWS regions"""
+    return [
+        "ap-east-1",
+        "ap-northeast-1",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-northeast-3",
+        "ap-south-1",
+        "ap-south-2",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-southeast-3",
+        "ap-southeast-4",
+        "ca-central-1",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-central-1",
+        "eu-central-2",
+        "eu-north-1",
+        "eu-north-1",
+        "eu-south-1",
+        "eu-south-2",
+        "eu-west-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-2",
+        "eu-west-3",
+        "eu-west-3",
+        "il-central-1",
+        "me-central-1",
+        "me-south-1",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+    ]

--- a/policies/aws_cloudtrail_policies/aws_cloudtrail_s3_bucket_public.py
+++ b/policies/aws_cloudtrail_policies/aws_cloudtrail_s3_bucket_public.py
@@ -1,9 +1,14 @@
 from panther_base_helpers import deep_get
+from panther_default import aws_regions
 from panther_oss_helpers import BadLookup, resource_lookup
 
 BAD_PERMISSIONS = {
     "http://acs.amazonaws.com/groups/global/AuthenticatedUsers",
     "http://acs.amazonaws.com/groups/global/AllUsers",
+}
+
+EXCLUDED_BUCKET_NAMES = {
+    f"codepipeline-cloudtrail-placeholder-bucket-{region}" for region in aws_regions()
 }
 
 
@@ -16,7 +21,9 @@ def policy(resource):
         return True
 
     for grant in bucket["Grants"] or []:
-        if deep_get(grant, "Grantee", "URI") in BAD_PERMISSIONS:
+        if deep_get(grant, "Grantee", "URI") in BAD_PERMISSIONS and not any(
+            bucket_name in bucket_arn for bucket_name in EXCLUDED_BUCKET_NAMES
+        ):
             return False
 
     return True

--- a/policies/aws_cloudtrail_policies/aws_cloudtrail_s3_bucket_public.py
+++ b/policies/aws_cloudtrail_policies/aws_cloudtrail_s3_bucket_public.py
@@ -7,6 +7,7 @@ BAD_PERMISSIONS = {
     "http://acs.amazonaws.com/groups/global/AllUsers",
 }
 
+# docs.aws.amazon.com/codepipeline/latest/userguide/reference-ct-placeholder-buckets.html
 EXCLUDED_BUCKET_NAMES = {
     f"codepipeline-cloudtrail-placeholder-bucket-{region}" for region in aws_regions()
 }


### PR DESCRIPTION
### Background

The Events `codepipeline-cloudtrail-placeholder-bucket` Buckets are managed by AWS and are also public. This was causing the `aws_cloudtrail_s3_bucket_public` policy to alert when the buckets were inspected.

This PR adds an `EXCLUDED_BUCKET_NAMES` set for these buckets (and future buckets, if necessary) and also adds a list of AWS regions in order to build out the complete set of these bucket names.

### Changes

* Adds a function to return a list of AWS regions
* Adds an `EXCLUDED_BUCKET_NAMES` set for buckets to ignore in the policy

### Testing

* Tests still pass as expected
