### PR TITLE
Add GCP SSO persistence rules

### DIFF
--- a/packs/gcp_audit.yml
+++ b/packs/gcp_audit.yml
@@ -3,22 +3,25 @@ PackID: PantherManaged.GCP.Audit
 Description: Group of all Google Cloud Platform (GCP) Audit detections
 PackDefinition:
   IDs:
+    - GCP.Access.Attempts.Violating.IAP.Access.Controls
+    - GCP.Access.Attempts.Violating.VPC.Service.Controls
+    - GCP.BigQuery.Large.Scan
+    - GCP.Cloud.Storage.Buckets.Modified.Or.Deleted
+    - GCP.Destructive.Queries
     - GCP.GCS.IAMChanges
     - GCP.GCS.Public
     - GCP.IAM.CorporateEmail
     - GCP.IAM.CustomRoleChanges
     - GCP.IAM.OrgFolderIAMChanges
-    - GCP.SQL.ConfigChanges
-    - GCP.Access.Attempts.Violating.VPC.Service.Controls
-    - GCP.Access.Attempts.Violating.IAP.Access.Controls
-    - GCP.VPC.Flow.Logs.Disabled
-    - GCP.BigQuery.Large.Scan
-    - GCP.Destructive.Queries
+    - GCP.Inbound.SSO.Profile.Created
     - GCP.Logging.Settings.Modified
-    - GCP.Cloud.Storage.Buckets.Modified.Or.Deleted
     - GCP.Permissions.Granted.to.Create.or.Manage.Service.Account.Key
-    - GCP.User.Added.to.IAP.Protected.Service
     - GCP.Service.Account.or.Keys.Created
+    - GCP.SQL.ConfigChanges
+    - GCP.User.Added.to.IAP.Protected.Service
+    - GCP.VPC.Flow.Logs.Disabled
+    - GCP.Workforce.Pool.Created.or.Updated
+    - GCP.Workload.Identity.Pool.Created.or.Updated
     # Data model
     - Standard.GCP.AuditLog
     # Globals used in these rules/policies

--- a/rules/gcp_audit_rules/gcp_inbound_sso_profile_created_or_updated.py
+++ b/rules/gcp_audit_rules/gcp_inbound_sso_profile_created_or_updated.py
@@ -5,7 +5,7 @@ METHODS = [
 
 
 def rule(event):
-    return event.deep_walk("protoPayload", "methodName", default="") in METHODS
+    return event.deep_get("protoPayload", "methodName", default="") in METHODS
 
 
 def title(event):

--- a/rules/gcp_audit_rules/gcp_inbound_sso_profile_created_or_updated.py
+++ b/rules/gcp_audit_rules/gcp_inbound_sso_profile_created_or_updated.py
@@ -1,0 +1,34 @@
+METHODS = [
+    "google.admin.AdminService.inboundSsoProfileCreated",
+    "google.admin.AdminService.inboundSsoProfileUpdated",
+]
+
+
+def rule(event):
+    return event.deep_walk("protoPayload", "methodName", default="") in METHODS
+
+
+def title(event):
+    actor = event.deep_get(
+        "protoPayload", "authenticationInfo", "principalEmail", default="<ACTOR_NOT_FOUND>"
+    )
+    event_name = event.deep_walk(
+        "protoPayload", "metadata", "event", "eventName", default="<EVENT_NAME_NOT_FOUND>"
+    )
+
+    resource = organization_id = event.deep_walk(
+        "protoPayload", "resourceName", default="<RESOURCE_NOT_FOUND>"
+    ).split("/")
+
+    organization_id = resource[resource.index("organizations") + 1]
+
+    return f"GCP: [{actor}] performed {event_name} in organization {organization_id}"
+
+
+def alert_context(event):
+    return {
+        "resourceName": event.deep_get(
+            "protoPayload", "resourceName", default="<RESOURCE_NOT_FOUND>"
+        ),
+        "serviceName": event.deep_get("protoPayload", "serviceName", default="<SERVICE_NOT_FOUND>"),
+    }

--- a/rules/gcp_audit_rules/gcp_inbound_sso_profile_created_or_updated.yml
+++ b/rules/gcp_audit_rules/gcp_inbound_sso_profile_created_or_updated.yml
@@ -18,6 +18,7 @@ Reports:
 Severity: High
 DedupPeriodMinutes: 60
 Threshold: 1
+Reference: https://medium.com/google-cloud/detection-of-inbound-sso-persistence-techniques-in-gcp-c56f7b2a588b
 Tests:
     - Name: InboundSsoProfileDeleted-False
       ExpectedResult: false

--- a/rules/gcp_audit_rules/gcp_inbound_sso_profile_created_or_updated.yml
+++ b/rules/gcp_audit_rules/gcp_inbound_sso_profile_created_or_updated.yml
@@ -18,6 +18,8 @@ Reports:
 Severity: High
 DedupPeriodMinutes: 60
 Threshold: 1
+Runbook: >
+    Ensure that the SSO profile creation or modification was expected. Adversaries may use this to persist or allow additional access or escalate their provilege.
 Reference: https://medium.com/google-cloud/detection-of-inbound-sso-persistence-techniques-in-gcp-c56f7b2a588b
 Tests:
     - Name: InboundSsoProfileDeleted-False

--- a/rules/gcp_audit_rules/gcp_inbound_sso_profile_created_or_updated.yml
+++ b/rules/gcp_audit_rules/gcp_inbound_sso_profile_created_or_updated.yml
@@ -19,7 +19,7 @@ Severity: High
 DedupPeriodMinutes: 60
 Threshold: 1
 Runbook: >
-    Ensure that the SSO profile creation or modification was expected. Adversaries may use this to persist or allow additional access or escalate their provilege.
+    Ensure that the SSO profile creation or modification was expected. Adversaries may use this to persist or allow additional access or escalate their privilege.
 Reference: https://medium.com/google-cloud/detection-of-inbound-sso-persistence-techniques-in-gcp-c56f7b2a588b
 Tests:
     - Name: InboundSsoProfileDeleted-False

--- a/rules/gcp_audit_rules/gcp_inbound_sso_profile_created_or_updated.yml
+++ b/rules/gcp_audit_rules/gcp_inbound_sso_profile_created_or_updated.yml
@@ -1,0 +1,136 @@
+AnalysisType: rule
+Filename: gcp_inbound_sso_profile_created_or_updated.py
+RuleID: "GCP.Inbound.SSO.Profile.Created"
+DisplayName: "GCP Inbound SSO Profile Created"
+Enabled: true
+LogTypes:
+    - GCP.AuditLog
+Tags:
+  - Account Manipulation
+  - Additional Cloud Roles
+  - GCP
+  - Privilege Escalation
+Reports:
+  MITRE ATT&CK:
+    - TA0003:T1136.003
+    - TA0003:T1098.003
+    - TA0004:T1098.003
+Severity: High
+DedupPeriodMinutes: 60
+Threshold: 1
+Tests:
+    - Name: InboundSsoProfileDeleted-False
+      ExpectedResult: false
+      Log:
+        insertId: chtsf1e7iek8
+        logName: organizations/325169835352/logs/cloudaudit.googleapis.com%2Factivity
+        protoPayload:
+            '@type': type.googleapis.com/google.cloud.audit.AuditLog
+            authenticationInfo:
+                principalEmail: user@example.com
+            metadata:
+                '@type': type.googleapis.com/ccc_hosted_reporting.ActivityProto
+                activityId:
+                    timeUsec: "1700250882598435"
+                    uniqQualifier: "6879748717081533837"
+                event:
+                    - eventId: dd0c44e2
+                      eventName: INBOUND_SSO_PROFILE_DELETED
+                      eventType: INBOUND_SSO_SETTINGS
+                      parameter:
+                        - label: LABEL_OPTIONAL
+                          name: INBOUND_SSO_PROFILE_NAME
+                          type: TYPE_STRING
+                          value: inboundSamlSsoProfiles/01lmf7wd3jt9atc
+            methodName: google.admin.AdminService.inboundSsoProfileDeleted
+            requestMetadata:
+                destinationAttributes: {}
+                requestAttributes: {}
+            resourceName: organizations/123456789012/inboundSsoSettings
+            serviceName: admin.googleapis.com
+        receiveTimestamp: "2023-11-17T19:54:43.367407397Z"
+        resource:
+            labels:
+                method: google.admin.AdminService.inboundSsoProfileDeleted
+                service: admin.googleapis.com
+            type: audited_resource
+        severity: NOTICE
+        timestamp: "2023-11-17T19:54:42.598435Z"
+    - Name: InboundSsoProfileUpdated-True
+      ExpectedResult: true
+      Log:
+        insertId: crpr6bdcjfg
+        logName: organizations/123456789012/logs/cloudaudit.googleapis.com%2Factivity
+        protoPayload:
+            '@type': type.googleapis.com/google.cloud.audit.AuditLog
+            authenticationInfo:
+                principalEmail: user@@example.com
+            metadata:
+                '@type': type.googleapis.com/ccc_hosted_reporting.ActivityProto
+                activityId:
+                    timeUsec: "1700250956956215"
+                    uniqQualifier: "2009471038637356014"
+                event:
+                    - eventId: bdbc47ad
+                      eventName: INBOUND_SSO_PROFILE_UPDATED
+                      eventType: INBOUND_SSO_SETTINGS
+                      parameter:
+                        - label: LABEL_OPTIONAL
+                          name: INBOUND_SSO_PROFILE_CHANGES
+                          type: TYPE_STRING
+                          value: 'Display Name : { oldValue: Test Profile, newValue: Test Profile Update}'
+                        - label: LABEL_OPTIONAL
+                          name: INBOUND_SSO_PROFILE_NAME
+                          type: TYPE_STRING
+                          value: inboundSamlSsoProfiles/03vsz0843d02br4
+            methodName: google.admin.AdminService.inboundSsoProfileUpdated
+            requestMetadata:
+                destinationAttributes: {}
+                requestAttributes: {}
+            resourceName: organizations/123456789012/inboundSsoSettings
+            serviceName: admin.googleapis.com
+        receiveTimestamp: "2023-11-17T19:55:57.417198068Z"
+        resource:
+            labels:
+                method: google.admin.AdminService.inboundSsoProfileUpdated
+                service: admin.googleapis.com
+            type: audited_resource
+        severity: NOTICE
+        timestamp: "2023-11-17T19:55:56.956215Z"
+    - Name: InboundSsoProfileCreated-True
+      ExpectedResult: true
+      Log:
+        insertId: -rqtp5gefopij
+        logName: organizations/123456789012/logs/cloudaudit.googleapis.com%2Factivity
+        protoPayload:
+            '@type': type.googleapis.com/google.cloud.audit.AuditLog
+            authenticationInfo:
+                principalEmail: user@example.com
+            metadata:
+                '@type': type.googleapis.com/ccc_hosted_reporting.ActivityProto
+                activityId:
+                    timeUsec: "1700250924521362"
+                    uniqQualifier: "6051731645161637785"
+                event:
+                    - eventId: 637d2b33
+                      eventName: INBOUND_SSO_PROFILE_CREATED
+                      eventType: INBOUND_SSO_SETTINGS
+                      parameter:
+                        - label: LABEL_OPTIONAL
+                          name: INBOUND_SSO_PROFILE_NAME
+                          type: TYPE_STRING
+                          value: inboundSamlSsoProfiles/03vsz0843d02br4
+            methodName: google.admin.AdminService.inboundSsoProfileCreated
+            requestMetadata:
+                destinationAttributes: {}
+                requestAttributes: {}
+            resourceName: organizations/123456789012/inboundSsoSettings
+            serviceName: admin.googleapis.com
+        receiveTimestamp: "2023-11-17T19:55:25.012649522Z"
+        resource:
+            labels:
+                method: google.admin.AdminService.inboundSsoProfileCreated
+                service: admin.googleapis.com
+            type: audited_resource
+        severity: NOTICE
+        timestamp: "2023-11-17T19:55:24.521362Z"

--- a/rules/gcp_audit_rules/gcp_workforce_pool_created_or_updated.py
+++ b/rules/gcp_audit_rules/gcp_workforce_pool_created_or_updated.py
@@ -1,0 +1,32 @@
+METHODS = [
+    "google.iam.admin.v1.WorkforcePools.CreateWorkforcePool",
+    "google.iam.admin.v1.WorkforcePools.UpdateWorkforcePool",
+]
+
+
+def rule(event):
+    return event.deep_get("protoPayload", "methodName", default="") in METHODS
+
+
+def title(event):
+    actor = event.deep_get(
+        "protoPayload", "authenticationInfo", "principalEmail", default="<ACTOR_NOT_FOUND>"
+    )
+    workforce_pool = event.deep_get("protoPayload", "request", "workforcePool", "name").split("/")[
+        -1
+    ]
+
+    resource = organization_id = event.deep_get("logName", default="<LOG_NAME_NOT_FOUND>").split(
+        "/"
+    )
+
+    organization_id = resource[resource.index("organizations") + 1]
+
+    return (
+        f"GCP: [{actor}] created or updated workforce pool "
+        f"[{workforce_pool}] in organization [{organization_id}]"
+    )
+
+
+def alert_context(event):
+    return event.deep_get("protoPayload", "request", "workforcePool", default={})

--- a/rules/gcp_audit_rules/gcp_workforce_pool_created_or_updated.yml
+++ b/rules/gcp_audit_rules/gcp_workforce_pool_created_or_updated.yml
@@ -19,7 +19,7 @@ Severity: High
 DedupPeriodMinutes: 60
 Threshold: 1
 Runbook: >
-    Ensure that the Workforce Pool creation or modification was expected. Adversaries may use this to persist or allow additional access or escalate their provilege.
+    Ensure that the Workforce Pool creation or modification was expected. Adversaries may use this to persist or allow additional access or escalate their privilege.
 Reference: https://medium.com/google-cloud/detection-of-inbound-sso-persistence-techniques-in-gcp-c56f7b2a588b
 Tests:
     - Name: DeleteWorkforcePool-False

--- a/rules/gcp_audit_rules/gcp_workforce_pool_created_or_updated.yml
+++ b/rules/gcp_audit_rules/gcp_workforce_pool_created_or_updated.yml
@@ -1,0 +1,154 @@
+AnalysisType: rule
+Filename: gcp_workforce_pool_created_or_updated.py
+RuleID: "GCP.Workforce.Pool.Created.or.Updated"
+DisplayName: "GCP Workforce Pool Created or Updated"
+Enabled: true
+LogTypes:
+    - GCP.AuditLog
+Tags:
+    - Account Manipulation
+    - Additional Cloud Roles
+    - GCP
+    - Privilege Escalation
+Reports:
+  MITRE ATT&CK:
+    - TA0003:T1136.003
+    - TA0003:T1098.003
+    - TA0004:T1098.003
+Severity: High
+DedupPeriodMinutes: 60
+Threshold: 1
+Tests:
+    - Name: DeleteWorkforcePool-False
+      ExpectedResult: false
+      Log:
+        insertId: 1plwiv7e2lay7
+        logName: organizations/123456789012/logs/cloudaudit.googleapis.com%2Factivity
+        operation:
+            first: true
+            id: locations/global/workforcePools/test-pool/operations/bigar3hp32vamefaukfkaaq000000000
+            producer: iam.googleapis.com
+        protoPayload:
+            '@type': type.googleapis.com/google.cloud.audit.AuditLog
+            authenticationInfo:
+                principalEmail: user@example.com
+            authorizationInfo:
+                - granted: true
+                  permission: iam.workforcePools.delete
+                  resource: locations/global/workforcePools/test-pool
+                  resourceAttributes: {}
+            methodName: google.iam.admin.v1.WorkforcePools.DeleteWorkforcePool
+            request:
+                '@type': type.googleapis.com/google.iam.admin.v1.DeleteWorkforcePoolRequest
+                name: locations/global/workforcePools/test-pool
+            requestMetadata:
+                callerIp: 07da:0994:97fb:8db1:c68f:c109:fcdd:d594
+                callerSuppliedUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0,gzip(gfe),gzip(gfe)
+                destinationAttributes: {}
+                requestAttributes:
+                    auth: {}
+                    reason: 8uSywAYQGg5Db2xpc2V1bSBGbG93cw
+                    time: "2023-11-17T18:58:52.165673889Z"
+            resourceName: locations/global/workforcePools/test-pool
+            serviceName: iam.googleapis.com
+        receiveTimestamp: "2023-11-17T18:58:52.901258022Z"
+        resource:
+            labels:
+                method: google.iam.admin.v1.WorkforcePools.DeleteWorkforcePool
+                service: iam.googleapis.com
+            type: audited_resource
+        severity: NOTICE
+        timestamp: "2023-11-17T18:58:52.158942930Z"
+    - Name: UpdateWorkforcePool-True
+      ExpectedResult: true
+      Log:
+        insertId: 1h09dxwe33hgu
+        logName: organizations/123456789012/logs/cloudaudit.googleapis.com%2Factivity
+        operation:
+            first: true
+            id: locations/global/workforcePools/test-pool/operations/bigarg7n32vamefy6ximiaq000000000
+            producer: iam.googleapis.com
+        protoPayload:
+            '@type': type.googleapis.com/google.cloud.audit.AuditLog
+            authenticationInfo:
+                principalEmail: user@example.com
+            authorizationInfo:
+                - granted: true
+                  permission: iam.workforcePools.update
+                  resource: locations/global/workforcePools/test-pool
+                  resourceAttributes: {}
+            methodName: google.iam.admin.v1.WorkforcePools.UpdateWorkforcePool
+            request:
+                '@type': type.googleapis.com/google.iam.admin.v1.UpdateWorkforcePoolRequest
+                updateMask: description,sessionDuration,disabled,displayName
+                workforcePool:
+                    description: Test pool to facilitate detection writing
+                    displayName: Test Pool
+                    name: locations/global/workforcePools/test-pool
+                    sessionDuration: 43200s
+            requestMetadata:
+                callerIp: 07da:0994:97fb:8db1:c68f:c109:fcdd:d594
+                callerSuppliedUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0,gzip(gfe),gzip(gfe)
+                destinationAttributes: {}
+                requestAttributes:
+                    auth: {}
+                    reason: 8uSywAYQGg5Db2xpc2V1bSBGbG93cw
+                    time: "2023-11-17T18:53:15.208909504Z"
+            resourceName: locations/global/workforcePools/test-pool
+            serviceName: iam.googleapis.com
+        receiveTimestamp: "2023-11-17T18:53:16.523653141Z"
+        resource:
+            labels:
+                method: google.iam.admin.v1.WorkforcePools.UpdateWorkforcePool
+                service: iam.googleapis.com
+            type: audited_resource
+        severity: NOTICE
+        timestamp: "2023-11-17T18:53:15.200613481Z"
+    - Name: CreateWorkforcePool-True
+      ExpectedResult: true
+      Log:
+        insertId: 6432zre32u1v
+        logName: organizations/123456789012/logs/cloudaudit.googleapis.com%2Factivity
+        operation:
+            first: true
+            id: locations/global/workforcePools/test-pool/operations/bifqrwxk32vamegiyoqaoeab00000000
+            producer: iam.googleapis.com
+        protoPayload:
+            '@type': type.googleapis.com/google.cloud.audit.AuditLog
+            authenticationInfo:
+                principalEmail: user@example.com
+            authorizationInfo:
+                - granted: true
+                  permission: iam.workforcePools.create
+                  resource: organizations/123456789012
+                  resourceAttributes: {}
+            methodName: google.iam.admin.v1.WorkforcePools.CreateWorkforcePool
+            request:
+                '@type': type.googleapis.com/google.iam.admin.v1.CreateWorkforcePoolRequest
+                location: locations/global
+                workforcePool:
+                    description: Test pool
+                    displayName: Test Pool
+                    name: locations/global/workforcePools/test-pool
+                    parent: organizations/325169835352
+                    sessionDuration: 3600s
+                    state: ACTIVE
+                workforcePoolId: test-pool
+            requestMetadata:
+                callerIp: 07da:0994:97fb:8db1:c68f:c109:fcdd:d594
+                callerSuppliedUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0,gzip(gfe),gzip(gfe)
+                destinationAttributes: {}
+                requestAttributes:
+                    auth: {}
+                    reason: 8uSywAYQGg5Db2xpc2V1bSBGbG93cw
+                    time: "2023-11-17T18:47:53.284817626Z"
+            resourceName: organizations/325169835352
+            serviceName: iam.googleapis.com
+        receiveTimestamp: "2023-11-17T18:47:54.138395349Z"
+        resource:
+            labels:
+                method: google.iam.admin.v1.WorkforcePools.CreateWorkforcePool
+                service: iam.googleapis.com
+            type: audited_resource
+        severity: NOTICE
+        timestamp: "2023-11-17T18:47:53.276929945Z"

--- a/rules/gcp_audit_rules/gcp_workforce_pool_created_or_updated.yml
+++ b/rules/gcp_audit_rules/gcp_workforce_pool_created_or_updated.yml
@@ -18,6 +18,9 @@ Reports:
 Severity: High
 DedupPeriodMinutes: 60
 Threshold: 1
+Runbook: >
+    Ensure that the Workforce Pool creation or modification was expected. Adversaries may use this to persist or allow additional access or escalate their provilege.
+Reference: https://medium.com/google-cloud/detection-of-inbound-sso-persistence-techniques-in-gcp-c56f7b2a588b
 Tests:
     - Name: DeleteWorkforcePool-False
       ExpectedResult: false

--- a/rules/gcp_audit_rules/gcp_workload_identity_pool_created_or_updated.py
+++ b/rules/gcp_audit_rules/gcp_workload_identity_pool_created_or_updated.py
@@ -1,0 +1,28 @@
+METHODS = [
+    "google.iam.v1.WorkloadIdentityPools.CreateWorkloadIdentityPoolProvider",
+    "google.iam.v1.WorkloadIdentityPools.UpdateWorkloadIdentityPoolProvider",
+]
+
+
+def rule(event):
+    return event.deep_get("protoPayload", "methodName", default="") in METHODS
+
+
+def title(event):
+    actor = event.deep_get(
+        "protoPayload", "authenticationInfo", "principalEmail", default="<ACTOR_NOT_FOUND>"
+    )
+    resource = event.deep_get("protoPayload", "resourceName", default="<RESOURCE_NOT_FOUND>").split(
+        "/"
+    )
+    workload_identity_pool = resource[resource.index("workloadIdentityPools") + 1]
+    project_id = event.deep_get("resource", "labels", "project_id", default="<PROJECT_NOT_FOUND>")
+
+    return (
+        f"GCP: [{actor}] created or updated workforce pool "
+        f"[{workload_identity_pool}] in project [{project_id}]"
+    )
+
+
+def alert_context(event):
+    return event.deep_get("protoPayload", "request", "workloadIdentityPoolProvider", default={})

--- a/rules/gcp_audit_rules/gcp_workload_identity_pool_created_or_updated.yml
+++ b/rules/gcp_audit_rules/gcp_workload_identity_pool_created_or_updated.yml
@@ -19,7 +19,7 @@ Severity: High
 DedupPeriodMinutes: 60
 Threshold: 1
 Runbook: >
-    Ensure that the Workload Identity Pool creation or modification was expected. Adversaries may use this to persist or allow additional access or escalate their provilege.
+    Ensure that the Workload Identity Pool creation or modification was expected. Adversaries may use this to persist or allow additional access or escalate their privilege.
 Reference: https://medium.com/google-cloud/detection-of-inbound-sso-persistence-techniques-in-gcp-c56f7b2a588b
 Tests:
     - Name: DeleteWorkloadIdentityPoolProvider-False

--- a/rules/gcp_audit_rules/gcp_workload_identity_pool_created_or_updated.yml
+++ b/rules/gcp_audit_rules/gcp_workload_identity_pool_created_or_updated.yml
@@ -18,6 +18,9 @@ Reports:
 Severity: High
 DedupPeriodMinutes: 60
 Threshold: 1
+Runbook: >
+    Ensure that the Workload Identity Pool creation or modification was expected. Adversaries may use this to persist or allow additional access or escalate their provilege.
+Reference: https://medium.com/google-cloud/detection-of-inbound-sso-persistence-techniques-in-gcp-c56f7b2a588b
 Tests:
     - Name: DeleteWorkloadIdentityPoolProvider-False
       ExpectedResult: false

--- a/rules/gcp_audit_rules/gcp_workload_identity_pool_created_or_updated.yml
+++ b/rules/gcp_audit_rules/gcp_workload_identity_pool_created_or_updated.yml
@@ -1,0 +1,167 @@
+AnalysisType: rule
+Filename: gcp_workload_identity_pool_created_or_updated.py
+RuleID: "GCP.Workload.Identity.Pool.Created.or.Updated"
+DisplayName: "GCP Workload Identity Pool Created or Updated"
+Enabled: true
+LogTypes:
+    - GCP.AuditLog
+Tags:
+    - Account Manipulation
+    - Additional Cloud Roles
+    - GCP
+    - Privilege Escalation
+Reports:
+  MITRE ATT&CK:
+    - TA0003:T1136.003
+    - TA0003:T1098.003
+    - TA0004:T1098.003
+Severity: High
+DedupPeriodMinutes: 60
+Threshold: 1
+Tests:
+    - Name: DeleteWorkloadIdentityPoolProvider-False
+      ExpectedResult: false
+      Log:
+        insertId: 1h09dxwe33il5
+        logName: projects/test-project/logs/cloudaudit.googleapis.com%2Factivity
+        operation:
+            first: true
+            id: projects/1234567890123/locations/global/workloadIdentityPools/test-pool/operations/bigarrpp32vamefyvthk4ay000000000
+            producer: iam.googleapis.com
+        protoPayload:
+            '@type': type.googleapis.com/google.cloud.audit.AuditLog
+            authenticationInfo:
+                principalEmail: user@example.com
+                principalSubject: user:user@example.com
+            authorizationInfo:
+                - granted: true
+                  permission: iam.workloadIdentityPools.delete
+                  resource: projects/test-project/locations/global/workloadIdentityPools/test-pool
+                  resourceAttributes: {}
+            methodName: google.iam.v1.WorkloadIdentityPools.DeleteWorkloadIdentityPool
+            request:
+                '@type': type.googleapis.com/google.iam.v1.DeleteWorkloadIdentityPoolRequest
+                name: projects/test-project/locations/global/workloadIdentityPools/test-pool
+            requestMetadata:
+                callerIp: 07da:0994:97fb:8db1:c68f:c109:fcdd:d594
+                callerSuppliedUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0,gzip(gfe)
+                destinationAttributes: {}
+                requestAttributes:
+                    auth: {}
+                    time: "2023-11-17T18:58:13.519015485Z"
+            resourceName: projects/test-project/locations/global/workloadIdentityPools/test-pool
+            serviceName: iam.googleapis.com
+        receiveTimestamp: "2023-11-17T18:58:14.565078208Z"
+        resource:
+            labels:
+                method: google.iam.v1.WorkloadIdentityPools.DeleteWorkloadIdentityPool
+                project_id: test-project
+                service: iam.googleapis.com
+            type: audited_resource
+        severity: NOTICE
+        timestamp: "2023-11-17T18:58:13.511621185Z"
+    - Name: UpdateWorkloadIdentityPoolProvider-True
+      ExpectedResult: true
+      Log:
+        insertId: 1plwiv7e2lak8
+        logName: projects/test-project/logs/cloudaudit.googleapis.com%2Factivity
+        operation:
+            first: true
+            id: projects/1234567890123/locations/global/workloadIdentityPools/test-pool/providers/test-project/operations/bifqr6xo32vameeqtose200000000000
+            producer: iam.googleapis.com
+        protoPayload:
+            '@type': type.googleapis.com/google.cloud.audit.AuditLog
+            authenticationInfo:
+                principalEmail: user@example.com
+                principalSubject: user:user@example.com
+            authorizationInfo:
+                - granted: true
+                  permission: iam.workloadIdentityPoolProviders.update
+                  resource: projects/test-project/locations/global/workloadIdentityPools/test-pool/providers/test-project
+                  resourceAttributes: {}
+            methodName: google.iam.v1.WorkloadIdentityPools.UpdateWorkloadIdentityPoolProvider
+            request:
+                '@type': type.googleapis.com/google.iam.v1.UpdateWorkloadIdentityPoolProviderRequest
+                updateMask: displayName,disabled,attributeMapping,attributeCondition,aws.accountId
+                workloadIdentityPoolProvider:
+                    attributeCondition: '''admins'' in google.groups'
+                    attributeMapping:
+                        attribute.aws_role: 'assertion.arn.contains(''assumed-role'') ? assertion.arn.extract(''{account_arn}assumed-role/'') + ''assumed-role/'' + assertion.arn.extract(''assumed-role/{role_name}/'') : assertion.arn'
+                        google.subject: assertion.arn
+                    aws:
+                        accountId: "123456789012"
+                    disabled: false
+                    displayName: Test Provider
+                    name: projects/test-project/locations/global/workloadIdentityPools/test-pool/providers/test-project
+            requestMetadata:
+                callerIp: 07da:0994:97fb:8db1:c68f:c109:fcdd:d594
+                callerSuppliedUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0,gzip(gfe)
+                destinationAttributes: {}
+                requestAttributes:
+                    auth: {}
+                    time: "2023-11-17T18:56:57.745203848Z"
+            resourceName: projects/test-project/locations/global/workloadIdentityPools/test-pool/providers/test-project
+            serviceName: iam.googleapis.com
+        receiveTimestamp: "2023-11-17T18:56:58.871491875Z"
+        resource:
+            labels:
+                method: google.iam.v1.WorkloadIdentityPools.UpdateWorkloadIdentityPoolProvider
+                project_id: test-project
+                service: iam.googleapis.com
+            type: audited_resource
+        severity: NOTICE
+        timestamp: "2023-11-17T18:56:57.730630771Z"
+    - Name: CreateWorkloadIdentityPoolProvider-True
+      ExpectedResult: true
+      Log:
+        insertId: 11gmdk5e1ne4r
+        logName: projects/test-project/logs/cloudaudit.googleapis.com%2Factivity
+        operation:
+            first: true
+            id: projects/1234567890123/locations/global/workloadIdentityPools/test-pool/providers/test-project/operations/bigarpxj32vamehaqcf5oai000000000
+            producer: iam.googleapis.com
+        protoPayload:
+            '@type': type.googleapis.com/google.cloud.audit.AuditLog
+            authenticationInfo:
+                principalEmail: user@example.com
+                principalSubject: user:user@example.com
+            authorizationInfo:
+                - granted: true
+                  permission: iam.workloadIdentityPoolProviders.create
+                  resource: projects/test-project/locations/global/workloadIdentityPools/test-pool
+                  resourceAttributes: {}
+            methodName: google.iam.v1.WorkloadIdentityPools.CreateWorkloadIdentityPoolProvider
+            request:
+                '@type': type.googleapis.com/google.iam.v1.CreateWorkloadIdentityPoolProviderRequest
+                parent: projects/test-project/locations/global/workloadIdentityPools/test-pool
+                workloadIdentityPoolProvider:
+                    attributeCondition: ""
+                    attributeMapping:
+                        attribute.aws_role: 'assertion.arn.contains(''assumed-role'') ? assertion.arn.extract(''{account_arn}assumed-role/'') + ''assumed-role/'' + assertion.arn.extract(''assumed-role/{role_name}/'') : assertion.arn'
+                        google.subject: assertion.arn
+                    aws:
+                        accountId: "123456789012"
+                    disabled: false
+                    displayName: Test Provider
+                workloadIdentityPoolProviderId: test-project
+            requestMetadata:
+                callerIp: 07da:0994:97fb:8db1:c68f:c109:fcdd:d594
+                callerSuppliedUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0,gzip(gfe)
+                destinationAttributes: {}
+                requestAttributes:
+                    auth: {}
+                    time: "2023-11-17T18:45:17.961743198Z"
+            resourceLocation:
+                currentLocations:
+                    - global
+            resourceName: projects/test-project/locations/global/workloadIdentityPools/test-pool
+            serviceName: iam.googleapis.com
+        receiveTimestamp: "2023-11-17T18:45:19.404664001Z"
+        resource:
+            labels:
+                method: google.iam.v1.WorkloadIdentityPools.CreateWorkloadIdentityPoolProvider
+                project_id: test-project
+                service: iam.googleapis.com
+            type: audited_resource
+        severity: NOTICE
+        timestamp: "2023-11-17T18:45:17.952414168Z"


### PR DESCRIPTION
### Background

Adds three new GCP SSO persistence rules that cover creations and updates:
- `GCP.Inbound.SSO.Profile.Created`
- `GCP.Workforce.Pool.Created.or.Updated`
- `GCP.Workload.Identity.Pool.Created.or.Updated`

### Changes

* Adds the three aforementioned rules
* Updates the `gcp_audit` pack to include the new rules

### Testing

Tests pass as expected:
```
$ make test TEST_ARGS="--path rules/gcp_audit_rules/"
pipenv run python -m unittest global_helpers/*_test.py
.............................................................................................................................................
----------------------------------------------------------------------
Ran 141 tests in 7.125s

OK
pipenv run panther_analysis_tool test --path rules/gcp_audit_rules/
[INFO][root]: Testing analysis items in rules/gcp_audit_rules/

GCP.Access.Attempts.Violating.VPC.Service.Controls
        [PASS] Other Event
                [PASS] [rule] false
        [PASS] VPC control violation
                [PASS] [rule] true
                [PASS] [title] GCP: [user1@serviceaccount.gcp.com] performed a [google.storage.objects.get] request that violates VPC Service Controls
                [PASS] [dedup] GCP: [user1@serviceaccount.gcp.com] performed a [google.storage.objects.get] request that violates VPC Service Controls

GCP.BigQuery.Large.Scan
        [PASS] small query
                [PASS] [rule] false
        [PASS] Large Query
                [PASS] [rule] true
                [PASS] [title] GCP: [user@company.io] ran a large BigQuery query of [3097493504] bytes.
                [PASS] [dedup] GCP: [user@company.io] ran a large BigQuery query of [3097493504] bytes.
                [PASS] [alertContext] {"query": "-- This query shows a list of the daily top Google Search terms.\nSELECT\n   *\nFROM `bigquery-public-data.google_trends.top_terms`", "actor": "user@company.io", "query_size": "3097493504"}

GCP.Cloud.Storage.Buckets.Modified.Or.Deleted
        [PASS] other event
                [PASS] [rule] false
        [PASS] bucket update
                [PASS] [rule] true
                [PASS] [title] GCP: [user@company.io] performed a [storage.buckets.update] on bucket [my-bucket] in project [gcp-project1].
                [PASS] [dedup] GCP: [user@company.io] performed a [storage.buckets.update] on bucket [my-bucket] in project [gcp-project1].

GCP.Destructive.Queries
        [PASS] Drop Table Event
                [PASS] [rule] true
                [PASS] [title] GCP: [user@company.io] performed a destructive BigQuery [DROP_TABLE] query on [projects/gcp-project1/datasets/test1/tables/newtable].
                [PASS] [dedup] GCP: [user@company.io] performed a destructive BigQuery [DROP_TABLE] query on [projects/gcp-project1/datasets/test1/tables/newtable].
                [PASS] [alertContext] {"query": "DROP TABLE test1.newtable", "actor": "user@company.io", "statement": "DROP_TABLE", "table": "projects/gcp-project1/datasets/test1/tables/newtable"}
        [PASS] TableDeletion
                [PASS] [rule] true
                [PASS] [title] GCP: [user@company.io] performed a destructive BigQuery [<STATEMENT_NOT_FOUND>] query on [projects/gcp-project1/datasets/test1/tables/newtable].
                [PASS] [dedup] GCP: [user@company.io] performed a destructive BigQuery [<STATEMENT_NOT_FOUND>] query on [projects/gcp-project1/datasets/test1/tables/newtable].
                [PASS] [alertContext] {"query": "<QUERY_NOT_FOUND>", "actor": "user@company.io", "statement": "<STATEMENT_NOT_FOUND>", "table": "projects/gcp-project1/datasets/test1/tables/newtable"}

GCP.DNS.Zone.Modified.or.Deleted
        [PASS] dns.managedZones.delete-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] modified managed DNS zone [managedZones/test-zone]
                [PASS] [dedup] [GCP]: [user@domain.com] modified managed DNS zone [managedZones/test-zone]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "dns.managedZones.delete", "resourceName": "managedZones/test-zone", "serviceName": "dns.googleapis.com"}
        [PASS] dns.managedZones.patch-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] modified managed DNS zone [managedZones/test-zone]
                [PASS] [dedup] [GCP]: [user@domain.com] modified managed DNS zone [managedZones/test-zone]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "dns.managedZones.patch", "resourceName": "managedZones/test-zone", "serviceName": "dns.googleapis.com"}
        [PASS] dns.managedZones.update-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] modified managed DNS zone [managedZones/test-zone]
                [PASS] [dedup] [GCP]: [user@domain.com] modified managed DNS zone [managedZones/test-zone]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "dns.changes.create", "resourceName": "managedZones/test-zone", "serviceName": "dns.googleapis.com"}
        [PASS] dns.managedZones.get-should-not-alert
                [PASS] [rule] false

GCP.Firewall.Rule.Created
        [PASS] compute.firewalls.create-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] created firewall rule with resource ID [6563507997690081088]
                [PASS] [dedup] [GCP]: [user@domain.com] created firewall rule with resource ID [6563507997690081088]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "v1.compute.firewalls.insert", "resourceName": "projects/test-project-123456/global/firewalls/firewall-create", "serviceName": "compute.googleapis.com"}
        [PASS] appengine.firewall.create-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] created firewall rule for resource [apps/test-project-123456]
                [PASS] [dedup] [GCP]: [user@domain.com] created firewall rule for resource [apps/test-project-123456]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "google.appengine.v1.Firewall.CreateIngressRule", "resourceName": "apps/test-project-123456", "serviceName": "appengine.googleapis.com"}
        [PASS] compute.non-create.firewall.method-should-not-alert
                [PASS] [rule] false
        [PASS] appengine.compute.non-create.firewall.method-should-not-alert
                [PASS] [rule] false
        [PASS] randomservice.firewall-create.method-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] created firewall rule with resource ID [6563507997690081088]
                [PASS] [dedup] [GCP]: [user@domain.com] created firewall rule with resource ID [6563507997690081088]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "randomservice.compute.v1.Firewall.CreateIngressRule", "resourceName": "randomservice/test-project-123456/firewall/ingressRules/1000", "serviceName": ""}

GCP.Firewall.Rule.Deleted
        [PASS] compute.firewalls-delete-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] deleted firewall rule with resource ID [6563507997690081088]
                [PASS] [dedup] [GCP]: [user@domain.com] deleted firewall rule with resource ID [6563507997690081088]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "v1.compute.firewalls.delete", "resourceName": "projects/test-project-123456/global/firewalls/firewall-create", "serviceName": "compute.googleapis.com"}
        [PASS] appengine.firewall.delete-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] deleted firewall rule for resource [apps/test-project-123456/firewall/ingressRules/1000]
                [PASS] [dedup] [GCP]: [user@domain.com] deleted firewall rule for resource [apps/test-project-123456/firewall/ingressRules/1000]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "google.appengine.v1.Firewall.DeleteIngressRule", "resourceName": "apps/test-project-123456/firewall/ingressRules/1000", "serviceName": "appengine.googleapis.com"}
        [PASS] compute.non-delete.firewall.method-should-not-alert
                [PASS] [rule] false
        [PASS] appengine.non-delete.firewall.method-should-not-alert
                [PASS] [rule] false
        [PASS] randomservice.firewall-delete.method-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] deleted firewall rule with resource ID [6563507997690081088]
                [PASS] [dedup] [GCP]: [user@domain.com] deleted firewall rule with resource ID [6563507997690081088]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "randomservice.compute.v1.Firewall.DeleteIngressRule", "resourceName": "randomservice/test-project-123456/firewall/ingressRules/1000", "serviceName": ""}

GCP.Firewall.Rule.Modified
        [PASS] compute.firewalls.update-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] modified firewall rule on [projects/test-project-123456/global/firewalls/firewall-create]
                [PASS] [dedup] [GCP]: [user@domain.com] modified firewall rule on [projects/test-project-123456/global/firewalls/firewall-create]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "v1.compute.firewalls.patch", "resourceName": "projects/test-project-123456/global/firewalls/firewall-create", "serviceName": "compute.googleapis.com"}
        [PASS] appengine.firewall.update-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] modified firewall rule on [apps/test-project-123456/firewall/ingressRules/1000]
                [PASS] [dedup] [GCP]: [user@domain.com] modified firewall rule on [apps/test-project-123456/firewall/ingressRules/1000]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "google.appengine.v1.Firewall.UpdateIngressRule", "resourceName": "apps/test-project-123456/firewall/ingressRules/1000", "serviceName": "appengine.googleapis.com"}
        [PASS] compute.non-update.firewall.method-should-not-alert
                [PASS] [rule] false
        [PASS] appengine.compute.non-update.firewall.method-should-not-alert
                [PASS] [rule] false
        [PASS] randomservice.firewall-update.method-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] modified firewall rule on [randomservice/test-project-123456/firewall/ingressRules/1000]
                [PASS] [dedup] [GCP]: [user@domain.com] modified firewall rule on [randomservice/test-project-123456/firewall/ingressRules/1000]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "randomservice.compute.v1.Firewall.UpdateIngressRule", "resourceName": "randomservice/test-project-123456/firewall/ingressRules/1000", "serviceName": ""}

GCP.GCS.IAMChanges
        [PASS] GCS IAM Change
                [PASS] [rule] true
                [PASS] [dedup] western-verve-123456

GCP.GCS.Public
        [PASS] GCS AllUsers Read Permission
                [PASS] [rule] true
                [PASS] [title] GCS bucket [jacks-test-bucket] made public
                [PASS] [dedup] GCS bucket [jacks-test-bucket] made public

GCP.IAM.AdminRoleAssigned
        [PASS] Service Admin Role Assigned
                [PASS] [rule] true
                [PASS] [title] An admin role has been configured in GCP project eastern-nurve-222999
                [PASS] [dedup] An admin role has been configured in GCP project eastern-nurve-222999
        [PASS] Admin Role Assigned
                [PASS] [rule] true
                [PASS] [title] An admin role has been configured in GCP project eastern-nurve-222999
                [PASS] [dedup] An admin role has been configured in GCP project eastern-nurve-222999
        [PASS] Browser Role Assigned
                [PASS] [rule] false

GCP.IAM.CorporateEmail
        [PASS] Gmail account added
                [PASS] [rule] true
                [PASS] [title] A GCP IAM account has been created with a Gmail email in western-verve-123456
                [PASS] [dedup] A GCP IAM account has been created with a Gmail email in western-verve-123456
        [PASS] Runpanther account added
                [PASS] [rule] false

GCP.IAM.CustomRoleChanges
        [PASS] Custom Role Created
                [PASS] [rule] true
                [PASS] [dedup] western-verve-123456

GCP.IAM.OrgFolderIAMChanges
        [PASS] Terraform User Agent
                [PASS] [rule] true
                [PASS] [title] GCP.AuditLog: [terraform@platform.iam.gserviceaccount.com] made manual changes to Org policy
                [PASS] [dedup] GCP.AuditLog: [terraform@platform.iam.gserviceaccount.com] made manual changes to Org policy
                [PASS] [alertContext] {"actor": "terraform@platform.iam.gserviceaccount.com", "policy_change": {"bindingDeltas": [{"action": "ADD", "member": "user:backdoor@example.com", "role": "roles/owner"}]}, "caller_ip": "100.100.100.100", "user_agent": "Terraform/0.13.2 terraform-provider-google/3.90.1"}
                [PASS] [severity] INFO
        [PASS] Manual Change
                [PASS] [rule] true
                [PASS] [title] GCP.AuditLog: [chris@example.com] made manual changes to Org policy
                [PASS] [dedup] GCP.AuditLog: [chris@example.com] made manual changes to Org policy
                [PASS] [alertContext] {"actor": "chris@example.com", "policy_change": {"bindingDeltas": [{"action": "REMOVE", "member": "serviceAccount:diana@platform.iam.gserviceaccount.com", "role": "roles/owner"}]}, "caller_ip": "38.38.38.38", "user_agent": "Mozilla/5.0 Chrome/98.0.4758.102"}
                [PASS] [severity] HIGH

GCP.Inbound.SSO.Profile.Created
        [PASS] InboundSsoProfileDeleted-False
                [PASS] [rule] false
        [PASS] InboundSsoProfileUpdated-True
                [PASS] [rule] true
                [PASS] [title] GCP: [user@@example.com] performed INBOUND_SSO_PROFILE_UPDATED in organization 123456789012
                [PASS] [dedup] GCP: [user@@example.com] performed INBOUND_SSO_PROFILE_UPDATED in organization 123456789012
                [PASS] [alertContext] {"resourceName": "organizations/123456789012/inboundSsoSettings", "serviceName": "admin.googleapis.com"}
        [PASS] InboundSsoProfileCreated-True
                [PASS] [rule] true
                [PASS] [title] GCP: [user@example.com] performed INBOUND_SSO_PROFILE_CREATED in organization 123456789012
                [PASS] [dedup] GCP: [user@example.com] performed INBOUND_SSO_PROFILE_CREATED in organization 123456789012
                [PASS] [alertContext] {"resourceName": "organizations/123456789012/inboundSsoSettings", "serviceName": "admin.googleapis.com"}

GCP.Log.Bucket.Or.Sink.Deleted
        [PASS] logging-bucket.deleted-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] deleted logging bucket or sink [projects/test-project-123456/locations/global/buckets/testloggingbucket]
                [PASS] [dedup] [GCP]: [user@domain.com] deleted logging bucket or sink [projects/test-project-123456/locations/global/buckets/testloggingbucket]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "google.logging.v2.ConfigServiceV2.DeleteBucket", "resourceName": "projects/test-project-123456/locations/global/buckets/testloggingbucket", "serviceName": "logging.googleapis.com"}
        [PASS] logging-sink.deleted-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] deleted logging bucket or sink [projects/test-project-123456/sinks/test-1]
                [PASS] [dedup] [GCP]: [user@domain.com] deleted logging bucket or sink [projects/test-project-123456/sinks/test-1]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "google.logging.v2.ConfigServiceV2.DeleteSink", "resourceName": "projects/test-project-123456/sinks/test-1", "serviceName": "logging.googleapis.com"}
        [PASS] logging-bucket.non-deletion-should-not-alert
                [PASS] [rule] false
        [PASS] logging-sink.non-deletion-should-not-alert
                [PASS] [rule] false

GCP.Logging.Settings.Modified
        [PASS] Other Event
                [PASS] [rule] false
        [PASS] Sink Update Event
                [PASS] [rule] true
                [PASS] [title] GCP [projects/gcp-project1/sinks/log-sink] logging settings modified by [test@company.io].
                [PASS] [dedup] GCP [projects/gcp-project1/sinks/log-sink] logging settings modified by [test@company.io].
                [PASS] [alertContext] {"resource": "projects/gcp-project1/sinks/log-sink", "actor": "test@company.io", "method": "google.logging.v2.ConfigServiceV2.UpdateSink"}

GCP.Logging.Sink.Modified
        [PASS] logging-sink.modifed-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [user@domain.com] updated logging sink [projects/test-project-123456/sinks/test-1]
                [PASS] [dedup] [GCP]: [user@domain.com] updated logging sink [projects/test-project-123456/sinks/test-1]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "user@domain.com", "caller_ip": "12.12.12.12", "methodName": "google.logging.v2.ConfigServiceV2.UpdateSink", "resourceName": "projects/test-project-123456/sinks/test-1", "serviceName": "logging.googleapis.com"}
        [PASS] logging-sink.non-modified-should-not-alert
                [PASS] [rule] false

GCP.Permissions.Granted.to.Create.or.Manage.Service.Account.Key
        [PASS] other event
                [PASS] [rule] false
        [PASS] service account match
                [PASS] [rule] true
                [PASS] [title] GCP: [user@company.io] granted permissions to create or manage service account keys to [test-account3@gcp-project1.iam.gserviceaccount.com]
                [PASS] [dedup] GCP: [user@company.io] granted permissions to create or manage service account keys to [test-account3@gcp-project1.iam.gserviceaccount.com]
                [PASS] [alertContext] {"resource": {"labels": {"email_id": "test-account3@gcp-project1.iam.gserviceaccount.com", "project_id": "gcp-project1", "unique_id": "105537103139416651075"}, "type": "service_account"}, "serviceData": {"@type": "type.googleapis.com/google.iam.v1.logging.AuditData", "policyDelta": {"bindingDeltas": [{"action": "ADD", "member": "serviceAccount:test-account3@gcp-project1.iam.gserviceaccount.com", "role": "roles/iam.serviceAccountTokenCreator"}, {"action": "ADD", "member": "serviceAccount:test-account3@gcp-project1.iam.gserviceaccount.com", "role": "roles/iam.serviceAccountUser"}]}}}

GCP.Service.Account.Access.Denied
        [PASS] service-account.access-denied-should-alert
                [PASS] [rule] true
                [PASS] [title] [GCP]: [test-no-perms@test-project-123456.iam.gserviceaccount.com] performed multiple requests resulting in [IAM_PERMISSION_DENIED]
                [PASS] [dedup] [GCP]: [test-no-perms@test-project-123456.iam.gserviceaccount.com] performed multiple requests resulting in [IAM_PERMISSION_DENIED]
                [PASS] [alertContext] {"project": "test-project-123456", "principal": "test-no-perms@test-project-123456.iam.gserviceaccount.com", "caller_ip": "12.12.12.12", "methodName": "google.iam.admin.v1.CreateServiceAccount", "resourceName": "projects/test-project-123456", "serviceName": "iam.googleapis.com"}
        [PASS] service-account.access-grated-should-not-alert
                [PASS] [rule] false

GCP.Service.Account.or.Keys.Created
        [PASS] Created Service Account Key
                [PASS] [rule] true
                [PASS] [title] GCP: [staging@company.io] created Service Account Key for [created-service-account@gcp-project1.iam.gserviceaccount.com] in project [gcp-project1]
                [PASS] [dedup] GCP: [staging@company.io] created Service Account Key for [created-service-account@gcp-project1.iam.gserviceaccount.com] in project [gcp-project1]
        [PASS] Created Service Account
                [PASS] [rule] true
                [PASS] [title] GCP: [staging@company.io] created Service Account [created-service-account@gcp-project1.iam.gserviceaccount.com] in project [gcp-project1]
                [PASS] [dedup] GCP: [staging@company.io] created Service Account [created-service-account@gcp-project1.iam.gserviceaccount.com] in project [gcp-project1]
        [PASS] Other
                [PASS] [rule] false

GCP.SQL.ConfigChanges
        [PASS] Sql Instance Change
                [PASS] [rule] true
                [PASS] [dedup] western-verve-123456

GCP.UnusedRegions
        [PASS] GCE Instance Terminated
                [PASS] [rule] false
        [PASS] GCE Create Instance in SouthAmerica
                [PASS] [rule] true
                [PASS] [title] GCP resource(s) created in unused region/zone in project western-verve-123456
                [PASS] [dedup] GCP resource(s) created in unused region/zone in project western-verve-123456
        [PASS] Create GCS in Asia
                [PASS] [rule] true
                [PASS] [title] GCP resource(s) created in unused region/zone in project western-verve-123456
                [PASS] [dedup] GCP resource(s) created in unused region/zone in project western-verve-123456
        [PASS] BigQuery access log (does not have standard attribute: resource.labels.location)
                [PASS] [rule] false

GCP.User.Added.to.IAP.Protected.Service
        [PASS] other
                [PASS] [rule] false
        [PASS] Other IAP Event
                [PASS] [rule] true
                [PASS] [title] GCP: [staging@company.io] modified user access to IAP Protected Service [projects/123456789012/iap_web/compute/services/7312383563505470445]
                [PASS] [dedup] GCP: [staging@company.io] modified user access to IAP Protected Service [projects/123456789012/iap_web/compute/services/7312383563505470445]
                [PASS] [alertContext] {"bindings": [{}]}
        [PASS] Add User to IAP
                [PASS] [rule] true
                [PASS] [title] GCP: [staging@company.io] modified user access to IAP Protected Service [projects/123456789012/iap_web/compute/services/7312383563505470445]
                [PASS] [dedup] GCP: [staging@company.io] modified user access to IAP Protected Service [projects/123456789012/iap_web/compute/services/7312383563505470445]
                [PASS] [alertContext] {"bindings": [{"members": ["serviceAccount:test-account3@gcp-project1.iam.gserviceaccount.com"], "role": "roles/viewer"}]}

GCP.VPC.Flow.Logs.Disabled
        [PASS] Disable Flow Logs Event
                [PASS] [rule] true
                [PASS] [title] GCP: [user1@company.io] disabled VPC Flow Logs for [projects/gcp-project/regions/us-central1/subnetworks/default]
                [PASS] [dedup] GCP: [user1@company.io] disabled VPC Flow Logs for [projects/gcp-project/regions/us-central1/subnetworks/default]
        [PASS] Enable Flow Logs Event
                [PASS] [rule] false

GCP.Workforce.Pool.Created.or.Updated
        [PASS] DeleteWorkforcePool-False
                [PASS] [rule] false
        [PASS] UpdateWorkforcePool-True
                [PASS] [rule] true
                [PASS] [title] GCP: [user@example.com] created or updated workforce pool [test-pool] in organization [123456789012]
                [PASS] [dedup] GCP: [user@example.com] created or updated workforce pool [test-pool] in organization [123456789012]
                [PASS] [alertContext] {"description": "Test pool to facilitate detection writing", "displayName": "Test Pool", "name": "locations/global/workforcePools/test-pool", "sessionDuration": "43200s"}
        [PASS] CreateWorkforcePool-True
                [PASS] [rule] true
                [PASS] [title] GCP: [user@example.com] created or updated workforce pool [test-pool] in organization [123456789012]
                [PASS] [dedup] GCP: [user@example.com] created or updated workforce pool [test-pool] in organization [123456789012]
                [PASS] [alertContext] {"description": "Test pool", "displayName": "Test Pool", "name": "locations/global/workforcePools/test-pool", "parent": "organizations/325169835352", "sessionDuration": "3600s", "state": "ACTIVE"}

GCP.Workload.Identity.Pool.Created.or.Updated
        [PASS] DeleteWorkloadIdentityPoolProvider-False
                [PASS] [rule] false
        [PASS] UpdateWorkloadIdentityPoolProvider-True
                [PASS] [rule] true
                [PASS] [title] GCP: [user@example.com] created or updated workforce pool [test-pool] in project [test-project]
                [PASS] [dedup] GCP: [user@example.com] created or updated workforce pool [test-pool] in project [test-project]
                [PASS] [alertContext] {"attributeCondition": "'admins' in google.groups", "attributeMapping": {"attribute.aws_role": "assertion.arn.contains('assumed-role') ? assertion.arn.extract('{account_arn}assumed-role/') + 'assumed-role/' + assertion.arn.extract('assumed-role/{role_name}/') : assertion.arn", "google.subject": "assertion.arn"}, "aws": {"accountId": "123456789012"}, "disabled": false, "displayName": "Test Provider", "name": "projects/test-project/locations/global/workloadIdentityPools/test-pool/providers/test-project"}
        [PASS] CreateWorkloadIdentityPoolProvider-True
                [PASS] [rule] true
                [PASS] [title] GCP: [user@example.com] created or updated workforce pool [test-pool] in project [test-project]
                [PASS] [dedup] GCP: [user@example.com] created or updated workforce pool [test-pool] in project [test-project]
                [PASS] [alertContext] {"attributeCondition": "", "attributeMapping": {"attribute.aws_role": "assertion.arn.contains('assumed-role') ? assertion.arn.extract('{account_arn}assumed-role/') + 'assumed-role/' + assertion.arn.extract('assumed-role/{role_name}/') : assertion.arn", "google.subject": "assertion.arn"}, "aws": {"accountId": "123456789012"}, "disabled": false, "displayName": "Test Provider"}

--------------------------
Panther CLI Test Summary
        Path: rules/gcp_audit_rules/
        Passed: 27
        Failed: 0
        Invalid: 0
```