### PR TITLE
Use --generate-notes for release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,4 @@ jobs:
           pipenv run panther_analysis_tool release --kms-key ${{ secrets.KMS_KEY_ARN }}
           openssl dgst -binary -sha512 panther-analysis-all.zip > ${{ secrets.DIGEST_FILE }}
           aws kms verify --key-id ${{ secrets.KMS_KEY_ARN }} --signing-algorithm ${{ secrets.SIGNING_ALGORITHM }} --message fileb://${{ secrets.DIGEST_FILE }} --message-type DIGEST --output json --signature $(cat panther-analysis-all.sig) | jq '.SignatureValid'
-          gh release create $NEW_VERSION panther-analysis-all.* --title $NEW_VERSION --latest --notes-from-tag
+          gh release create $NEW_VERSION panther-analysis-all.* --title $NEW_VERSION --latest --generate-notes


### PR DESCRIPTION
### Background

Since we don't create a tag locally, we cannot use `--notes-from-tag`. This PR instead uses `--generate-notes` to handle all of the generation for the release.

```
--generate-notes               Automatically generate title and notes for the release
```

### Changes

* Uses `--generate-notes` rather than `--notes-from-tag` for release creation

### Testing

* I tested this locally in a separate repository and it worked as expected
