### PR TITLE
Update github_secret_scanning_alert_created rule/tests

### DIFF
--- a/rules/github_rules/github_secret_scanning_alert_created.py
+++ b/rules/github_rules/github_secret_scanning_alert_created.py
@@ -8,8 +8,10 @@ def rule(event):
 
 
 def title(event):
-    return (f"Github detected a secret in {event.get('repo', '<REPO_NOT_FOUND>')} \
-            (#{event.get('number', '<NUMBER_NOT_FOUND>')})")
+    return (
+        f"Github detected a secret in {event.get('repo', '<REPO_NOT_FOUND>')} "
+        f"(#{event.get('number', '<NUMBER_NOT_FOUND>')})"
+    )
 
 
 def alert_context(event):

--- a/rules/github_rules/github_secret_scanning_alert_created.py
+++ b/rules/github_rules/github_secret_scanning_alert_created.py
@@ -4,17 +4,21 @@ from global_filter_github import filter_include_event
 def rule(event):
     if not filter_include_event(event):
         return False
-    return event.get("action") == "secret_scanning_alert.create"
+    return event.get("action", "") == "secret_scanning_alert.create"
 
 
 def title(event):
-    return f"Github detected a secret in {event.get('repo')} (#{event.get('number')})"
+    return (f"Github detected a secret in {event.get('repo', '<REPO_NOT_FOUND>')} \
+            (#{event.get('number', '<NUMBER_NOT_FOUND>')})")
 
 
 def alert_context(event):
     return {
-        "repo": event.get("repo"),
-        "alert #": event.get("number"),
+        "github_organization": event.get("org", "<ORG_NOT_FOUND>"),
+        "github_repository": event.get("repo", "<REPO_NOT_FOUND>"),
+        "alert_number": str(event.get("number", "<NUMBER_NOT_FOUND>")),
         "url": f"https://github.com/{event.get('repo')}/security/secret-scanning/"
-        f"{event.get('number')}",
+        f"{event.get('number')}"
+        if all([event.get("repo"), event.get("number")])
+        else "<URL_NOT_FOUND>",
     }

--- a/rules/github_rules/github_secret_scanning_alert_created.yml
+++ b/rules/github_rules/github_secret_scanning_alert_created.yml
@@ -15,27 +15,51 @@ Description: GitHub detected a secret and created a secret scanning alert.
 Runbook: Review the secret to determine if it needs to be revoked or the alert suppressed. 
 Tests:
   -
-    Name: GitHub detected a secret
+    Name: secret_scanning_alert.create-true
     ExpectedResult: True
     Log:
       {
         "action": "secret_scanning_alert.create",
         "actor": "github",
-        "at_sign_timestamp": "2022-09-08 19:34:43.468",
-        "created_at": "2022-09-08 19:34:43.468",
-        "number": 1792,
-        "org": "acme-co",
-        "repo": "acme-co/website"
+        "actor_id": "1234",
+        "business": "Acme Inc.",
+        "business_id": "12345",
+        "created_at": "2023-10-18 18:20:52.209000000",
+        "number": 12,
+        "org": "acme-inc",
+        "org_id": 1234567,
+        "repo": "acme-inc/crown-jewels",
+        "repo_id": 123456789
       }
   -
-    Name: Unrelated
+    Name: git.clone-false
     ExpectedResult: False
     Log:
       {
-        "action": "unrelated.create",
-        "actor": "github",
-        "at_sign_timestamp": "2022-09-08 19:34:43.468",
-        "created_at": "2022-09-08 19:34:43.468",
-        "org": "acme-co",
-        "repo": "acme-co/website"
-      }
+      "_document_id": "KCYtigpnShPBSohA4OXbRg==",
+      "action": "git.clone",
+      "actor": "acme-inc-user",
+      "actor_id": "123456789",
+      "actor_ip": "5.6.7.8",
+      "actor_location": {
+        "country_code": "US"
+      },
+      "at_sign_timestamp": "2023-11-20 21:20:09.423",
+      "business": "acme-inc",
+      "business_id": "12345",
+      "external_identity_nameid": "",
+      "external_identity_username": "",
+      "hashed_token": "0771cae4d170dc02a6ff393d9946cd684d6145c1=",
+      "org": "acme-inc",
+      "org_id": 12345678,
+      "programmatic_access_type": "OAuth access token",
+      "repo": "acme-inc/a-repo",
+      "repository": "acme-inc/a-repo",
+      "repository_public": false,
+      "token_id": "0123456789",
+      "transport_protocol": 1,
+      "transport_protocol_name": "http",
+      "user": "",
+      "user_agent": "git/2.30.2",
+      "user_id": "0"
+    }


### PR DESCRIPTION
### Background

This PR makes minor improvements to the `GitHub.Secret.Scanning.Alert.Created` rule. The core logic was sound, but I wanted to include more accurate logs and better `.get` default values.

### Changes

* Updates `github_secret_scanning_alert_created.py`
* Updates `github_secret_scanning_alert_created.yml`

### Testing

* `make fmt; make lint; make test`
