### PR TITLE
Add threat research team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 
 # These owners will be the default owners for everything in the repo.
 
-*       @panther-labs/detections
+*       @panther-labs/detections @panther-labs/threat-research


### PR DESCRIPTION
### Background

Now that we have a separate threat research GitHub team, we can add it to `CODEOWNERS` to allow separate approvals.

### Changes

* Adds `@panther-labs/threat-research` to `CODEOWNERS`

### Testing

* N/A
