### PR TITLE
Teleport: Update Rules

### DIFF
--- a/global_helpers/panther_default.py
+++ b/global_helpers/panther_default.py
@@ -126,4 +126,3 @@ def aws_regions() -> List[str]:
         "us-west-2",
     ]
 
-

--- a/global_helpers/panther_default.py
+++ b/global_helpers/panther_default.py
@@ -125,3 +125,5 @@ def aws_regions() -> List[str]:
         "us-west-1",
         "us-west-2",
     ]
+
+

--- a/global_helpers/panther_default.py
+++ b/global_helpers/panther_default.py
@@ -125,4 +125,3 @@ def aws_regions() -> List[str]:
         "us-west-1",
         "us-west-2",
     ]
-

--- a/packs/gravitational_teleport.yml
+++ b/packs/gravitational_teleport.yml
@@ -10,5 +10,4 @@ PackDefinition:
     - Teleport.SuspiciousCommands
     # Globals used in these detections
     - panther_base_helpers
-    - panther_default
 DisplayName: "Panther Teleport Pack"

--- a/packs/gravitational_teleport.yml
+++ b/packs/gravitational_teleport.yml
@@ -10,4 +10,5 @@ PackDefinition:
     - Teleport.SuspiciousCommands
     # Globals used in these detections
     - panther_base_helpers
+    - panther_default
 DisplayName: "Panther Teleport Pack"

--- a/rules/gravitational_teleport_rules/teleport_auth_errors.py
+++ b/rules/gravitational_teleport_rules/teleport_auth_errors.py
@@ -5,5 +5,6 @@ def rule(event):
 def title(event):
     return (
         f"A high volume of SSH errors was detected from user "
-        f"[{event.get('user', '<UNKNOWN_USER>')}]"
+        f"[{event.get('user', '<UNKNOWN_USER>')}] "
+        f"on [{event.get('cluster_name', '<UNKNOWN_CLUSTER>')}]"
     )

--- a/rules/gravitational_teleport_rules/teleport_auth_errors.yml
+++ b/rules/gravitational_teleport_rules/teleport_auth_errors.yml
@@ -15,7 +15,7 @@ Reports:
 Description: A high volume of SSH errors could indicate a brute-force attack
 Threshold: 10
 DedupPeriodMinutes: 15
-Reference: https://gravitational.com/teleport/docs/admin-guide/
+Reference: https://goteleport.com/docs/management/admin/
 Runbook: >
   Check that the user making the failed requests legitimately tried logging in that many times.
 SummaryAttributes:

--- a/rules/gravitational_teleport_rules/teleport_create_user_accounts.py
+++ b/rules/gravitational_teleport_rules/teleport_create_user_accounts.py
@@ -16,4 +16,7 @@ def rule(event):
 
 
 def title(event):
-    return f"User [{event.get('user', '<UNKNOWN_USER>')}] has manually modified system users"
+    return (
+        f"User [{event.get('user', '<UNKNOWN_USER>')}] has manually modified system users "
+        f"on [{event.get('cluster_name', '<UNKNOWN_CLUSTER>')}]"
+    )

--- a/rules/gravitational_teleport_rules/teleport_create_user_accounts.yml
+++ b/rules/gravitational_teleport_rules/teleport_create_user_accounts.yml
@@ -14,7 +14,7 @@ Reports:
 Severity: High
 Description: A user has been manually created, modified, or deleted
 DedupPeriodMinutes: 15
-Reference: https://gravitational.com/teleport/docs/admin-guide/
+Reference: https://goteleport.com/docs/management/admin/
 Runbook: Analyze why it was manually created and delete it if necessary.
 SummaryAttributes:
   - event

--- a/rules/gravitational_teleport_rules/teleport_local_user_login_without_mfa.py
+++ b/rules/gravitational_teleport_rules/teleport_local_user_login_without_mfa.py
@@ -1,0 +1,24 @@
+SENSITIVE_LOCAL_USERS = ["breakglass"]
+
+
+def rule(event):
+    return (
+        event.get("event") == "user.login"
+        and event.get("success") == "true"
+        and event.get("method") == "local"
+        and not event.get("mfa_device")
+    )
+
+
+def severity(event):
+    if event.get("user") in SENSITIVE_LOCAL_USERS:
+        return "HIGH"
+    return "MEDIUM"
+
+
+def title(event):
+    return (
+        f"User [{event.get('user', '<UNKNOWN_USER>')}] logged into "
+        f"[{event.get('cluster_name', '<UNNAMED_CLUSTER>')}] locally "
+        f"without using MFA"
+    )

--- a/rules/gravitational_teleport_rules/teleport_local_user_login_without_mfa.yml
+++ b/rules/gravitational_teleport_rules/teleport_local_user_login_without_mfa.yml
@@ -1,0 +1,64 @@
+AnalysisType: rule
+Filename: teleport_local_user_login_without_mfa.py
+RuleID: Teleport.LocalUserLoginWithoutMFA
+DisplayName: User Logged in wihout MFA
+Enabled: true
+LogTypes:
+  - Gravitational.TeleportAudit
+Tags:
+  - Teleport
+Severity: High
+Description: A local User logged in without MFA
+DedupPeriodMinutes: 60
+Reports:
+  MITRE ATT&CK:
+    - TA0001:T1078
+Reference: https://goteleport.com/docs/management/admin/
+Runbook: >
+  A local user logged in without Multi-Factor Authentication
+SummaryAttributes:
+  - event
+  - code
+  - user
+  - success
+  - mfa_device
+Tests:
+  -
+    Name: User logged in with MFA
+    ExpectedResult: false
+    Log:
+      {
+        "addr.remote": "[2001:db8:feed:face:c0ff:eeb0:baf00:00d]:65123",
+        "cluster_name": "teleport.example.com",
+        "code": "T1000I",
+        "ei": 0,
+        "event": "user.login",
+        "method": "local",
+        "mfa_device": {
+          "mfa_device_name": "1Password",
+          "mfa_device_type": "WebAuthn",
+          "mfa_device_uuid": "88888888-4444-4444-4444-222222222222"
+        },
+        "success": true,
+        "time": "2023-09-20T19:00:00.123456Z",
+        "uid": "88888888-4444-4444-4444-222222222222",
+        "user": "max.mustermann",
+        "user_agent": "Examplecorp Spacedeck-web/99.9 (Hackintosh; ARM Cortex A1000)"
+      }
+  -
+    Name: User logged in without MFA
+    ExpectedResult: false
+    Log:
+      {
+        "addr.remote": "[2001:db8:face:face:face:face:face:face]:65123",
+        "cluster_name": "teleport.example.com",
+        "code": "T1000I",
+        "ei": 0,
+        "event": "user.login",
+        "method": "local",
+        "success": true,
+        "time": "2023-09-20T19:00:00.123456Z",
+        "uid": "88888888-4444-4444-4444-222222222222",
+        "user": "max.mustermann",
+        "user_agent": "Examplecorp Spacedeck-web/99.9 (Hackintosh; ARM Cortex A1000)"
+      }

--- a/rules/gravitational_teleport_rules/teleport_lock_created.py
+++ b/rules/gravitational_teleport_rules/teleport_lock_created.py
@@ -1,0 +1,10 @@
+def rule(event):
+    return event.get("event") == "lock.created"
+
+
+def title(event):
+    return (
+        f"A Teleport Lock was created by {event.get('updated_by', '<UNKNOWN_UPDATED_BY>')} "
+        f"to Lock out user {event.get('target', {}).get('user', '<UNKNOWN_USER>')} "
+        f"on [{event.get('cluster_name', '<UNKNOWN_CLUSTER>')}]"
+    )

--- a/rules/gravitational_teleport_rules/teleport_lock_created.yml
+++ b/rules/gravitational_teleport_rules/teleport_lock_created.yml
@@ -1,0 +1,40 @@
+AnalysisType: rule
+Filename: teleport_lock_created.py
+RuleID: Teleport.LockCreated
+DisplayName: A Teleport Lock was created
+Enabled: true
+LogTypes:
+  - Gravitational.TeleportAudit
+Tags:
+  - Teleport
+Severity: Info
+Description: A Teleport Lock was created
+DedupPeriodMinutes: 60
+Reference: https://goteleport.com/docs/management/admin/
+Runbook: >
+  A Teleport Lock was created; this is an unusual administrative action. Investigate to understand why a Lock was created.
+SummaryAttributes:
+  - event
+  - code
+  - time
+  - identity
+Tests:
+  -
+    Name: A Lock was created
+    ExpectedResult: true
+    Log:
+      {
+        "cluster_name": "teleport.example.com",
+        "code": "TLK00I",
+        "ei": 0,
+        "event": "lock.created",
+        "expires": "0001-01-01T00:00:00Z",
+        "name": "88888888-4444-4444-4444-222222222222",
+        "target": {
+          "user": "user-to-disable"
+        },
+        "time": "2023-09-21T00:00:00.000000Z",
+        "uid": "88888888-4444-4444-4444-222222222222",
+        "updated_by": "max.mustermann@example.com",
+        "user": "max.mustermann@example.com"
+      }

--- a/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
+++ b/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
@@ -63,7 +63,7 @@ def validity_interval(event):
     event_time = panther_nanotime_to_python_datetime(event.get("time"))
     expires = golang_nanotime_to_python_datetime(
         event.deep_get("identity", "expires", default=None)
-        )
+    )
     if not event_time and expires:
         return False
     interval = expires - event_time

--- a/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
+++ b/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
@@ -71,7 +71,7 @@ def validity_interval(event):
 
 
 def title(event):
-    identity = event.deep_get('identity', 'user', default='<Cert with no User!?>')
+    identity = event.deep_get("identity", "user", default="<Cert with no User!?>")
     return (
         f"A Certificate for [{identity}] "
         f"on [{event.get('cluster_name', '<UNKNOWN_CLUSTER>')}] "

--- a/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
+++ b/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
@@ -73,7 +73,7 @@ def validity_interval(event):
 def title(event):
     identity = event.deep_get('identity', 'user', default='<Cert with no User!?>')
     return (
-        f"A Certificate for  [{event.deep_get('identity', 'user', default='<Cert with no User!?>')}] "
+        f"A Certificate for [{identity}] "
         f"on [{event.get('cluster_name', '<UNKNOWN_CLUSTER>')}] "
         f"has been issued for an unusually long time: {validity_interval(event)!r} "
     )

--- a/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
+++ b/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
@@ -71,6 +71,7 @@ def validity_interval(event):
 
 
 def title(event):
+    identity = event.deep_get('identity', 'user', default='<Cert with no User!?>')
     return (
         f"A Certificate for  [{event.deep_get('identity', 'user', default='<Cert with no User!?>')}] "
         f"on [{event.get('cluster_name', '<UNKNOWN_CLUSTER>')}] "

--- a/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
+++ b/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
@@ -1,0 +1,76 @@
+from datetime import timedelta, datetime
+from typing import Dict, Tuple
+
+from panther_base_helpers import (
+    golang_nanotime_to_python_datetime,
+    panther_nanotime_to_python_datetime,
+)
+
+PANTHER_TIME_FORMAT = r"%Y-%m-%d %H:%M:%S.%f"
+# Tune this to be some Greatest Common Denominator of session TTLs for your
+# environment
+MAXIMUM_NORMAL_VALIDITY_INTERVAL = timedelta(hours=12)
+# To allow some time in between when a request is submitted and authorized
+# vs when the certificate actually gets generated. In practice, this is much
+# less than 5 seconds.
+ISSUANCE_GRACE_PERIOD = timedelta(seconds=5)
+
+# You can audit your logs in Panther to try and understand your role/validity
+# patterns from a known-good period of access.
+# A query example:
+# ```sql
+#  SELECT
+#     cluster_name,
+#     identity:roles,
+#     DATEDIFF('HOUR', time, identity:expires) AS validity
+#  FROM
+#     panther_logs.public.gravitational_teleportaudit
+#  WHERE
+#     p_occurs_between('2023-09-01 00:00:00','2023-10-06 21:00:00Z')
+#     AND event = 'cert.create'
+#  GROUP BY cluster_name, identity:roles, validity
+#  ORDER BY validity DESC
+# ```
+
+# A dictionary of:
+#  cluster names: to a dictionary of:
+#     role names: mapping to a tuple of:
+#        ( maximum usual validity, expiration datetime for this rule )
+CLUSTER_ROLE_MAX_VALIDITIES: Dict[str, Dict[str, Tuple[timedelta, datetime]]] = {
+    # "teleport.example.com": {
+    #     "example_role": (timedelta(hours=720), datetime(2023, 12, 01, 01, 02, 03)),
+    #     "other_example_role": (timedelta(hours=720), datetime.max),
+    # },
+}
+
+
+def rule(event):
+    if not event.get("event") == "cert.create":
+        return False
+    max_validity = MAXIMUM_NORMAL_VALIDITY_INTERVAL + ISSUANCE_GRACE_PERIOD
+    for role in event.get("identity", {}).get("roles", []):
+        validity, expiration = CLUSTER_ROLE_MAX_VALIDITIES.get(event.get("cluster_name"), {}).get(
+            role, (None, None)
+        )
+        if validity and expiration:
+            # Ignore exceptions that have passed their expiry date
+            if datetime.utcnow() < expiration:
+                max_validity = max(max_validity, validity)
+    return validity_interval(event) > max_validity
+
+
+def validity_interval(event):
+    event_time = panther_nanotime_to_python_datetime(event.get("time"))
+    expires = golang_nanotime_to_python_datetime(event.get("identity", {}).get("expires"))
+    if not event_time and expires:
+        return False
+    interval = expires - event_time
+    return interval
+
+
+def title(event):
+    return (
+        f"A Certificate for  [{event.get('identity', {}).get('user', '<Cert with no User!?>')}] "
+        f"on [{event.get('cluster_name', '<UNKNOWN_CLUSTER>')}] "
+        f"has been issued for an unusually long time: {validity_interval(event)!r} "
+    )

--- a/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
+++ b/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
@@ -48,7 +48,7 @@ def rule(event):
     if not event.get("event") == "cert.create":
         return False
     max_validity = MAXIMUM_NORMAL_VALIDITY_INTERVAL + ISSUANCE_GRACE_PERIOD
-    for role in event.get("identity", {}).get("roles", []):
+    for role in event.deep_get("identity", "roles", default=[]):
         validity, expiration = CLUSTER_ROLE_MAX_VALIDITIES.get(event.get("cluster_name"), {}).get(
             role, (None, None)
         )

--- a/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
+++ b/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
@@ -61,7 +61,9 @@ def rule(event):
 
 def validity_interval(event):
     event_time = panther_nanotime_to_python_datetime(event.get("time"))
-    expires = golang_nanotime_to_python_datetime(event.deep_get("identity", "expires", default=None))
+    expires = golang_nanotime_to_python_datetime(
+        event.deep_get("identity", "expires", default=None)
+        )
     if not event_time and expires:
         return False
     interval = expires - event_time

--- a/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
+++ b/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
@@ -61,7 +61,7 @@ def rule(event):
 
 def validity_interval(event):
     event_time = panther_nanotime_to_python_datetime(event.get("time"))
-    expires = golang_nanotime_to_python_datetime(event.get("identity", {}).get("expires"))
+    expires = golang_nanotime_to_python_datetime(event.deep_get("identity", "expires", default=None))
     if not event_time and expires:
         return False
     interval = expires - event_time

--- a/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
+++ b/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
@@ -70,7 +70,7 @@ def validity_interval(event):
 
 def title(event):
     return (
-        f"A Certificate for  [{event.get('identity', {}).get('user', '<Cert with no User!?>')}] "
+        f"A Certificate for  [{event.deep_get('identity', 'user', default='<Cert with no User!?>')}] "
         f"on [{event.get('cluster_name', '<UNKNOWN_CLUSTER>')}] "
         f"has been issued for an unusually long time: {validity_interval(event)!r} "
     )

--- a/rules/gravitational_teleport_rules/teleport_long_lived_certs.yml
+++ b/rules/gravitational_teleport_rules/teleport_long_lived_certs.yml
@@ -1,0 +1,92 @@
+AnalysisType: rule
+Filename: teleport_long_lived_certs.py
+RuleID: Teleport.LongLivedCerts
+DisplayName: A long-lived cert was created
+Enabled: true
+LogTypes:
+  - Gravitational.TeleportAudit
+Tags:
+  - Teleport
+Severity: Medium
+Description: An unusually long-lived Teleport certificate was created
+DedupPeriodMinutes: 60
+Reports:
+  MITRE ATT&CK:
+    - TA0003:T1098
+Reference: https://goteleport.com/docs/management/admin/
+Runbook: >
+  Teleport certificates are usually issued for a short period of time. Alert if long-lived certificates were created.
+SummaryAttributes:
+  - event
+  - code
+  - time
+  - identity
+Tests:
+  -
+    Name: A certificate was created for the default period of 1 hour
+    ExpectedResult: false
+    Log:
+      {
+        "cert_type": "user",
+        "cluster_name": "teleport.example.com",
+        "code": "TC000I",
+        "ei": 0,
+        "event": "cert.create",
+        "time": "2023-09-17 21:00:00.000000",
+        "identity": {
+          "disallow_reissue": true,
+          "expires": "2023-09-17T22:00:00.444444428Z",
+          "impersonator": "bot-application",
+          "kubernetes_cluster": "staging",
+          "kubernetes_groups": [
+            "application"
+          ],
+          "logins": [
+            "-teleport-nologin-88888888-4444-4444-4444-222222222222",
+            "-teleport-internal-join"
+          ],
+          "prev_identity_expires": "0001-01-01T00:00:00Z",
+          "roles": [
+            "application"
+          ],
+          "route_to_cluster": "teleport.example.com",
+          "teleport_cluster": "teleport.example.com",
+          "traits": {},
+          "user": "bot-application"
+        },
+        "uid": "88888888-4444-4444-4444-222222222222"
+      }
+  -
+    Name: A certificate was created for longer than the default period of 1 hour
+    ExpectedResult: true
+    Log:
+      {
+        "cert_type": "user",
+        "cluster_name": "teleport.example.com",
+        "code": "TC000I",
+        "ei": 0,
+        "event": "cert.create",
+        "time": "2023-09-17 21:00:00.000000",
+        "identity": {
+          "disallow_reissue": true,
+          "expires": "2043-09-17T22:00:00.444444428Z",
+          "impersonator": "bot-application",
+          "kubernetes_cluster": "staging",
+          "kubernetes_groups": [
+            "application"
+          ],
+          "logins": [
+            "-teleport-nologin-88888888-4444-4444-4444-222222222222",
+            "-teleport-internal-join"
+          ],
+          "prev_identity_expires": "0001-01-01T00:00:00Z",
+          "roles": [
+            "application"
+          ],
+          "route_to_cluster": "teleport.example.com",
+          "teleport_cluster": "teleport.example.com",
+          "traits": {},
+          "user": "bot-application"
+        },
+        "uid": "88888888-4444-4444-4444-222222222222"
+      }

--- a/rules/gravitational_teleport_rules/teleport_network_scanning.py
+++ b/rules/gravitational_teleport_rules/teleport_network_scanning.py
@@ -12,5 +12,6 @@ def rule(event):
 def title(event):
     return (
         f"User [{event.get('user', '<UNKNOWN_USER>')}] has issued a network scan with "
-        f"[{event.get('program', '<UNKNOWN_PROGRAM>')}]"
+        f"[{event.get('program', '<UNKNOWN_PROGRAM>')}] "
+        f"on [{event.get('cluster_name', '<UNKNOWN_CLUSTER>')}]"
     )

--- a/rules/gravitational_teleport_rules/teleport_network_scanning.yml
+++ b/rules/gravitational_teleport_rules/teleport_network_scanning.yml
@@ -14,7 +14,7 @@ DedupPeriodMinutes: 60
 Reports:
   MITRE ATT&CK:
     - TA0007:T1046
-Reference: https://gravitational.com/teleport/docs/admin-guide/
+Reference: https://goteleport.com/docs/management/admin/
 Runbook: >
   Find related commands within the time window and determine if the command was invoked legitimately. Examine the arguments to determine how the command was used.
 SummaryAttributes:

--- a/rules/gravitational_teleport_rules/teleport_role_created.py
+++ b/rules/gravitational_teleport_rules/teleport_role_created.py
@@ -1,0 +1,10 @@
+def rule(event):
+    return event.get("event") == "role.created"
+
+
+def title(event):
+    return (
+        f"User [{event.get('user', '<UNKNOWN_USER>')}] created Role "
+        f"[{event.get('name', '<UNKNOWN_NAME>')}] "
+        f"on [{event.get('cluster_name', '<UNKNOWN_CLUSTER>')}]"
+    )

--- a/rules/gravitational_teleport_rules/teleport_role_created.yml
+++ b/rules/gravitational_teleport_rules/teleport_role_created.yml
@@ -1,0 +1,39 @@
+AnalysisType: rule
+Filename: teleport_role_created.py
+RuleID: Teleport.RoleCreated
+DisplayName: A Teleport Role was modified or created
+Enabled: true
+LogTypes:
+  - Gravitational.TeleportAudit
+Tags:
+  - Teleport
+Severity: Medium
+Description: A Teleport Role was modified or created
+DedupPeriodMinutes: 60
+Reports:
+  MITRE ATT&CK:
+    - TA0003:T1098.001
+Reference: https://goteleport.com/docs/management/admin/
+Runbook: >
+  A Teleport Role was modified or created. Validate its legitimacy.
+SummaryAttributes:
+  - event
+  - code
+  - user
+  - name
+Tests:
+  -
+    Name: A role was created
+    ExpectedResult: true
+    Log:
+      {
+        "cluster_name": "teleport.example.com",
+        "code": "T9000I",
+        "ei": 0,
+        "event": "role.created",
+        "expires": "0001-01-01T00:00:00Z",
+        "name": "teleport-event-handler",
+        "time": "2023-09-20T23:00:000.000000Z",
+        "uid": "88888888-4444-4444-4444-222222222222",
+        "user": "max.mustermann@example.com"
+      }

--- a/rules/gravitational_teleport_rules/teleport_root_login.py
+++ b/rules/gravitational_teleport_rules/teleport_root_login.py
@@ -1,0 +1,10 @@
+def rule(event):
+    return event.get("event") == "session.start" and event.get("login") == "root"
+
+
+def title(event):
+    return (
+        f"User [{event.get('user', '<UNKNOWN_USER>')}] logged into "
+        f"[{event.get('server_hostname', '<UNKNOWN_HOSTNAME>')}] as root "
+        f"on [{event.get('cluster_name', '<UNKNOWN_CLUSTER>')}]"
+    )

--- a/rules/gravitational_teleport_rules/teleport_root_login.yml
+++ b/rules/gravitational_teleport_rules/teleport_root_login.yml
@@ -1,0 +1,57 @@
+AnalysisType: rule
+Filename: teleport_root_login.py
+RuleID: Teleport.RootLogin
+DisplayName: User Logged in as root
+Enabled: true
+LogTypes:
+  - Gravitational.TeleportAudit
+Tags:
+  - SSH
+  - Execution:Command and Scripting Interpreter
+  - Teleport
+Severity: Medium
+Description: A User logged in as root
+DedupPeriodMinutes: 60
+Reports:
+  MITRE ATT&CK:
+    - TA0002:T1059
+Reference: https://goteleport.com/docs/management/admin/
+Runbook: >
+  Use user accounts and policies, rather than root when logging in. With access to root, it is possible to evade auditing and logging.
+SummaryAttributes:
+  - event
+  - code
+  - user
+  - login
+  - server_hostname
+  - server_labels
+Tests:
+  -
+    Name: User logged in as root
+    ExpectedResult: true
+    Log:
+      {
+        "addr_remote": "192.0.2.1:35194",
+        "cluster_name": "teleport.example.com",
+        "code": "t2000i",
+        "ei": 0,
+        "event": "session.start",
+        "initial_command": [
+          ""
+        ],
+        "login": "root",
+        "namespace": "default",
+        "proto": "ssh",
+        "server_hostname": "ip-10-0-0-1.us-west-2.compute.internal",
+        "server_id": "12345678-1111-2222-3333-54e9467ff0e6",
+        "server_labels": {
+          "env": "prod",
+          "role": "project123"
+        },
+        "session_recording": "node-sync",
+        "sid": "12345678-1111-2222-3333-54e9467ff0e6",
+        "size": "80:25",
+        "time": "2023-09-18 11:22:33",
+        "uid": "12345678-1111-2222-3333-54e9467ff0e6",
+        "user": "max.mustermann@zumbeispiel.example"
+      }

--- a/rules/gravitational_teleport_rules/teleport_saml_created.py
+++ b/rules/gravitational_teleport_rules/teleport_saml_created.py
@@ -1,0 +1,9 @@
+def rule(event):
+    return event.get("event") == "saml.created"
+
+
+def title(event):
+    return (
+        f"A SAML connector was created or updated by User [{event.get('user', '<UNKNOWN_USER>')}] "
+        f"on [{event.get('cluster_name', '<UNKNOWN_CLUSTER>')}]"
+    )

--- a/rules/gravitational_teleport_rules/teleport_saml_created.yml
+++ b/rules/gravitational_teleport_rules/teleport_saml_created.yml
@@ -1,0 +1,38 @@
+AnalysisType: rule
+Filename: teleport_saml_created.py
+RuleID: Teleport.SAMLCreated
+DisplayName: A SAML Connector was created or modified
+Enabled: true
+LogTypes:
+  - Gravitational.TeleportAudit
+Tags:
+  - Teleport
+Severity: High
+Description: A SAML connector was created or modified
+DedupPeriodMinutes: 60
+Reports:
+  MITRE ATT&CK:
+    - TA0042:T1585
+Reference: https://goteleport.com/docs/management/admin/
+Runbook: >
+  When a SAML connector is modified, it can potentially change the trust model of the Teleport Cluster. Validate that these changes were expected and correct.
+SummaryAttributes:
+  - event
+  - code
+  - user
+  - name
+Tests:
+  -
+    Name: SAML Auth Connector modified
+    ExpectedResult: true
+    Log:
+      {
+        "cluster_name": "teleport.example.com",
+        "code": "T8200I",
+        "ei": 0,
+        "event": "saml.created",
+        "name": "okta",
+        "time": "2023-09-19 18:00:00",
+        "uid": "88888888-4444-4444-4444-222222222222",
+        "user": "max.mustermann@zumbeispiel.example"
+      }

--- a/rules/gravitational_teleport_rules/teleport_scheduled_jobs.py
+++ b/rules/gravitational_teleport_rules/teleport_scheduled_jobs.py
@@ -9,4 +9,7 @@ def rule(event):
 
 
 def title(event):
-    return f"User [{event.get('user', '<UNKNOWN_USER>')}] has modified scheduled jobs"
+    return (
+        f"User [{event.get('user', '<UNKNOWN_USER>')}] has modified scheduled jobs"
+        f"on [{event.get('cluster_name', '<UNKNOWN_CLUSTER>')}]"
+    )

--- a/rules/gravitational_teleport_rules/teleport_scheduled_jobs.yml
+++ b/rules/gravitational_teleport_rules/teleport_scheduled_jobs.yml
@@ -15,7 +15,7 @@ Reports:
 Description: A user has manually edited the Linux crontab
 Threshold: 10
 DedupPeriodMinutes: 15
-Reference: https://gravitational.com/teleport/docs/admin-guide/
+Reference: https://goteleport.com/docs/management/admin/
 Runbook: Validate the user behavior and rotate the host if necessary.
 SummaryAttributes:
   - event

--- a/rules/gravitational_teleport_rules/teleport_suspicious_commands.py
+++ b/rules/gravitational_teleport_rules/teleport_suspicious_commands.py
@@ -13,5 +13,6 @@ def rule(event):
 def title(event):
     return (
         f"User [{event.get('user', '<UNKNOWN_USER>')}] has executed the command "
-        f"[{event.get('program', '<UNKNOWN_PROGRAM>')}]"
+        f"[{event.get('program', '<UNKNOWN_PROGRAM>')}] "
+        f"on [{event.get('cluster_name', '<UNKNOWN_CLUSTER>')}]"
     )

--- a/rules/gravitational_teleport_rules/teleport_suspicious_commands.yml
+++ b/rules/gravitational_teleport_rules/teleport_suspicious_commands.yml
@@ -14,7 +14,7 @@ DedupPeriodMinutes: 60
 Reports:
   MITRE ATT&CK:
     - TA0002:T1059
-Reference: https://gravitational.com/teleport/docs/admin-guide/
+Reference: https://goteleport.com/docs/management/admin/
 Runbook: >
   Find related commands within the time window and determine if the command was invoked legitimately. Examine the arguments to determine how the command was used and reach out to the user to verify the intentions.
 SummaryAttributes:


### PR DESCRIPTION
This PR updates the Gravitational Teleport rule set.

- The documentation links for existing rules needed some updating to new locations
- Added the name of the Teleport cluster into some of titles (useful for multi-cluster organizations)
- Added a Rule to detect local user logins without using multi-factor auth
- Added a Rule to detect the creation of Teleport Locks (used to pre-emptively disable previously-issued certificates)
- Added a Rule to detect the creation of abnormally long-lived certificates
- Added a Rule to detect when Roles are created
- Added a Rule to detect logins as root
- Added a Rule to detect the creation of SAML connectors