### PR TITLE
Enable Dependabot for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 0
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
### Background

Recent changes such as https://github.com/panther-labs/panther-analysis/pull/939 have introduced pinned GitHub actions.  This is a great practice, but the flip side is: pinned dependencies also need to be kept up to date.  Thankfully, Dependabot can do that for us!

I'm interested in this because we want to keep actions up to date in our downstream fork, and we'll avoid merge conflicts if they're also up to date in the upstream.

### Changes

* Add a dependabot [version update](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) config for GitHub Actions

### Testing
I enabled this on my private fork of the `panther-analysis` repo and verified that I got the expected PRs.  You can check this out here:

https://github.com/wadells/panther-analysis/pulls?q=is%3Aopen+is%3Apr+author%3Aapp%2Fdependabot+label%3Agithub_actions
