### PR TITLE
k8s queries disabled by default

### DIFF
--- a/queries/kubernetes_queries/kubernetes_admission_controller_created_query.yml
+++ b/queries/kubernetes_queries/kubernetes_admission_controller_created_query.yml
@@ -1,6 +1,6 @@
 AnalysisType: scheduled_query
 QueryName: New Admission Controller Created
-Enabled: true
+Enabled: false
 Tags:
   - Optional
 Description: >

--- a/queries/kubernetes_queries/kubernetes_cron_job_created_or_modified_query.yml
+++ b/queries/kubernetes_queries/kubernetes_cron_job_created_or_modified_query.yml
@@ -1,6 +1,6 @@
 AnalysisType: scheduled_query
 QueryName: Kubernetes Cron Job Created or Modified
-Enabled: true
+Enabled: false
 Tags:
   - Optional
 Description: >

--- a/queries/kubernetes_queries/kubernetes_new_daemonset_deployed_query.yml
+++ b/queries/kubernetes_queries/kubernetes_new_daemonset_deployed_query.yml
@@ -1,6 +1,6 @@
 AnalysisType: scheduled_query
 QueryName: New DaemonSet Deployed to Kubernetes
-Enabled: true
+Enabled: false
 Tags:
   - Optional
 Description: >

--- a/queries/kubernetes_queries/kubernetes_overly_permissive_linux_capabilities_query.yml
+++ b/queries/kubernetes_queries/kubernetes_overly_permissive_linux_capabilities_query.yml
@@ -1,6 +1,6 @@
 AnalysisType: scheduled_query
 QueryName: Pod Created with Overly Permissive Linux Capabilities
-Enabled: true
+Enabled: false
 Tags:
   - Optional
 Description: >

--- a/queries/kubernetes_queries/kubernetes_pod_attached_to_node_host_network_query.yml
+++ b/queries/kubernetes_queries/kubernetes_pod_attached_to_node_host_network_query.yml
@@ -1,6 +1,6 @@
 AnalysisType: scheduled_query
 QueryName: Pod attached to the Node Host Network
-Enabled: true
+Enabled: false
 Tags:
   - Optional
 Description: >

--- a/queries/kubernetes_queries/kubernetes_pod_create_or_modify_host_path_vol_mount_query.yml
+++ b/queries/kubernetes_queries/kubernetes_pod_create_or_modify_host_path_vol_mount_query.yml
@@ -1,6 +1,6 @@
 AnalysisType: scheduled_query
 QueryName: Pod creation or modification to a Host Path Volume Mount
-Enabled: true
+Enabled: false
 Tags:
   - Optional
 Description: >

--- a/queries/kubernetes_queries/kubernetes_pod_in_default_name_space_query.yml
+++ b/queries/kubernetes_queries/kubernetes_pod_in_default_name_space_query.yml
@@ -1,6 +1,6 @@
 AnalysisType: scheduled_query
 QueryName: Kubernetes Pod Created in Pre-Configured or Default Name Spaces
-Enabled: true
+Enabled: false
 Tags:
   - Optional
 Description: >

--- a/queries/kubernetes_queries/kubernetes_pod_using_host_ipc_namespace_query.yml
+++ b/queries/kubernetes_queries/kubernetes_pod_using_host_ipc_namespace_query.yml
@@ -1,6 +1,6 @@
 AnalysisType: scheduled_query
 QueryName: Pod Created or Modified Using the Host IPC Namespace
-Enabled: true
+Enabled: false
 Tags:
   - Optional
 Description: >

--- a/queries/kubernetes_queries/kubernetes_pod_using_host_pid_namespace_query.yml
+++ b/queries/kubernetes_queries/kubernetes_pod_using_host_pid_namespace_query.yml
@@ -1,6 +1,6 @@
 AnalysisType: scheduled_query
 QueryName: Pod Created or Modified Using the Host PID Namespace
-Enabled: true
+Enabled: false
 Tags:
   - Optional
 Description: >

--- a/queries/kubernetes_queries/kubernetes_privileged_pod_created_query.yml
+++ b/queries/kubernetes_queries/kubernetes_privileged_pod_created_query.yml
@@ -1,6 +1,6 @@
 AnalysisType: scheduled_query
 QueryName: Privileged Pod Created
-Enabled: true
+Enabled: false
 Tags:
   - Optional
 Description: >

--- a/queries/kubernetes_queries/kubernetes_secret_enumeration_query.yml
+++ b/queries/kubernetes_queries/kubernetes_secret_enumeration_query.yml
@@ -1,6 +1,6 @@
 AnalysisType: scheduled_query
 QueryName: Secret Enumeration by a User
-Enabled: true
+Enabled: false
 Tags:
   - Optional
 Description: >

--- a/queries/kubernetes_queries/kubernetes_service_type_node_port_deployed_query.yml
+++ b/queries/kubernetes_queries/kubernetes_service_type_node_port_deployed_query.yml
@@ -1,6 +1,6 @@
 AnalysisType: scheduled_query
 QueryName: Kubernetes Service with Type Node Port Deployed
-Enabled: true
+Enabled: false
 Tags:
   - Optional
 Description: >

--- a/queries/kubernetes_queries/kubernetes_unauthenticated_api_request_query.yml
+++ b/queries/kubernetes_queries/kubernetes_unauthenticated_api_request_query.yml
@@ -1,6 +1,6 @@
 AnalysisType: scheduled_query
 QueryName: Unauthenticated Kubernetes API Request
-Enabled: true
+Enabled: false
 Tags:
   - Optional
 Description: >

--- a/queries/kubernetes_queries/kubernetes_unauthorized_pod_execution_query.yml
+++ b/queries/kubernetes_queries/kubernetes_unauthorized_pod_execution_query.yml
@@ -1,6 +1,6 @@
 AnalysisType: scheduled_query
 QueryName: Unauthorized Kubernetes Pod Execution
-Enabled: true
+Enabled: false
 Tags:
   - Optional
 Description: >

--- a/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
+++ b/rules/gravitational_teleport_rules/teleport_long_lived_certs.py
@@ -1,4 +1,4 @@
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from typing import Dict, Tuple
 
 from panther_base_helpers import (


### PR DESCRIPTION
### Background

scheduled queries cause errors when the referenced tables have not been created

### Changes

* set enabled: false on all k8s scheduled queries


