### PR TITLE
Update GitHub Data Model to display admin-add events instead of UNKNOWN_ROLE

### DIFF
--- a/data_models/github_data_model.py
+++ b/data_models/github_data_model.py
@@ -1,14 +1,20 @@
 import panther_event_type_helpers as event_type
 
+ADMIN_EVENTS = {
+    "business.add_admin",
+    "business.invite_admin",
+    "team.promote_maintainer",
+}
 
-def get_admin_role(_):
-    # github doesn't record the admin role in the event
-    return "<UNKNOWN_ROLE>"
+
+def get_admin_role(event):
+    action = event.get("action", "")
+    return action if action in ADMIN_EVENTS else "<UNKNOWN_ADMIN_ROLE>"
 
 
 def get_event_type(event):
-    if event.get("action") == "team.promote_maintainer":
+    if event.get("action", "") in ADMIN_EVENTS:
         return event_type.ADMIN_ROLE_ASSIGNED
-    if event.get("action") == "org.disable_two_factor_requirement":
+    if event.get("action", "") == "org.disable_two_factor_requirement":
         return event_type.MFA_DISABLED
     return None

--- a/rules/standard_rules/admin_assigned.yml
+++ b/rules/standard_rules/admin_assigned.yml
@@ -166,6 +166,33 @@ Tests:
         "p_log_type": "GitHub.Audit",
         "user": "bob"
       }
+  - Name: Github - Admin Added
+    ExpectedResult: true
+    Log:
+      {
+        "actor": "cat",
+        "action": "business.add_admin",
+        "p_log_type": "GitHub.Audit",
+        "user": "bob"
+      }
+  - Name: Github - Admin Invited
+    ExpectedResult: true
+    Log:
+      {
+        "actor": "cat",
+        "action": "business.invite_admin",
+        "p_log_type": "GitHub.Audit",
+        "user": "bob"
+      }
+  - Name: Github - Unknown Admin Role
+    ExpectedResult: false
+    Log:
+      {
+        "actor": "cat",
+        "action": "unknown.admin_role",
+        "p_log_type": "GitHub.Audit",
+        "user": "bob"
+      }
   -
     Name: Zendesk - Admin Role Downgraded
     ExpectedResult: false


### PR DESCRIPTION
### Background

GitHub's audit logs don't explicitly define an admin role and instead offers a few events that indicate admin permissions were assigned to a user (or at least when an attempt is made). 

Originally, the data model only accounted for `team.promote_maintainer`, but there are two additional events that indicate admin permissions are being assigned or attempting to be assigned (at least at an organization level).

This PR adds the additional events and returns the event name rather than `<UNKNOWN_ROLE>` when these events are encountered. Worst case, the data model falls back to `<UNKNOWN_ADMIN_ROLE>` .

### Changes

* Adds additional admin events to the GitHub Data Model
* Return the event name when possible

### Testing

* `make fmt; make lint; make test`
```
[PASS] Github - User Promoted
        [PASS] [rule] true
        [PASS] [title] GitHub.Audit: [cat] assigned admin privileges [team.promote_maintainer] to [bob]
        [PASS] [dedup] GitHub.Audit: [cat] assigned admin privileges [team.promote_maintainer] to [bob]
        [PASS] [alertContext] {"ips": [], "actor": "cat", "user": "bob"}
[PASS] Github - Admin Added
        [PASS] [rule] true
        [PASS] [title] GitHub.Audit: [cat] assigned admin privileges [business.add_admin] to [bob]
        [PASS] [dedup] GitHub.Audit: [cat] assigned admin privileges [business.add_admin] to [bob]
        [PASS] [alertContext] {"ips": [], "actor": "cat", "user": "bob"}
[PASS] Github - Admin Invited
        [PASS] [rule] true
        [PASS] [title] GitHub.Audit: [cat] assigned admin privileges [business.invite_admin] to [bob]
        [PASS] [dedup] GitHub.Audit: [cat] assigned admin privileges [business.invite_admin] to [bob]
        [PASS] [alertContext] {"ips": [], "actor": "cat", "user": "bob"}
[PASS] Github - Unknown Admin Role
        [PASS] [rule] false
```
