### PR TITLE
Allow for auto-formatting on save when using VSCode

### DIFF
--- a/.vscode/example_settings.json
+++ b/.vscode/example_settings.json
@@ -1,8 +1,18 @@
 {
     "python.defaultInterpreterPath": "XXX_pipenv_py_output_XXX",
     "yaml.schemas": {
-        "https://panther-community-us-east-1.s3.amazonaws.com/latest/logschema/schema.json": [ "schemas/*.yml", "schemas/*.yaml", "schemas/**/*yaml", "schemas/**/*.yaml"],
-        ".vscode/rule_jsonschema.json": [ "rules/*.yml", "rules/*.yaml", "rules/**/*.yaml", "rules/**/*.yml"]
+        "https://panther-community-us-east-1.s3.amazonaws.com/latest/logschema/schema.json": [
+            "schemas/*.yml",
+            "schemas/*.yaml",
+            "schemas/**/*yaml",
+            "schemas/**/*.yaml"
+        ],
+        ".vscode/rule_jsonschema.json": [
+            "rules/*.yml",
+            "rules/*.yaml",
+            "rules/**/*.yaml",
+            "rules/**/*.yml"
+        ]
     },
     "python.analysis.extraPaths": [
         "global_helpers"
@@ -16,5 +26,12 @@
     //"makefile.extensionOutputFolder": "./.vscode",
     "files.associations": {
         "panther_analysis_tool": "python"
+    },
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": true
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ If you are comfortable using the Visual Studio Code IDE, the `make vscode-config
 In addition to this command, you will need to install these vscode add-ons:
 
 1. [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
-2. [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
+2. [Black Formatter](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter)
+3. [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
 
 You will also need Visual Studio's [code](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line) configured to open Visual Studio from your CLI.
 
@@ -130,6 +131,7 @@ You will also need Visual Studio's [code](https://code.visualstudio.com/docs/set
 1. Creates two debugging targets, which will give you single-button push support for running `panther_analysis_tool test` through the debugger.
 1. Installs JSONSchema support for your custom panther-analysis schemas in the `schemas/` directory. This brings IDE hints about which fields are necessary for schemas/custom-schema.yml files.
 1. Installs JSONSchema support for panther-analysis rules in the `rules/` directory. This brings IDE hints about which fields are necessary for rules/my-rule.yml files.
+1. Configures `Black` and `isort` settings for auto-formatting on save (thus reducing the need to run `make fmt` on all files)
 
 ```shell
 user@computer:panther-analysis: make vscode-config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.black]
+line-length = 100
+target-version = ['py39']
+include = '\.pyi?$'
+
+[tool.isort]
+line_length = 100
+profile = "black"


### PR DESCRIPTION
### Background

`make fmt` runs both `isort` and `black` on all files in the repository; however, it would also be nice for individual files to be formatted automatically on save. This PR updates the configuration applied by `make vscode-config` to include settings to run the equivalent of what `make fmt` runs when saving a file.

This PR also updates the `README` file with a link to the required VSCode extension and makes a note of the added functionality for the Make target and also adds the `black` and `isort` configuration to `pyproject.toml`.

### Changes

* Adds `make fmt` equivalents to `example_settings.json`
* Updates `README.md`
* Adds `pyproject.toml`

### Testing

* The new settings work as expected -- I tested this by running `make vscode-config`, installing the formatting extension, and saving a modified file with obvious formatting issues which were then resolved on save.
