### PR TITLE
Add linting config to example_settings.json

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+skips = B101

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,15 @@
+[MAIN]
+disable=
+    missing-docstring,
+    duplicate-code,
+    import-error,
+    fixme,
+    consider-iterating-dictionary,
+    global-variable-not-assigned,
+    broad-exception-raised
+
+load-plugins=
+    pylint.extensions.mccabe,
+    pylint_print
+
+max-line-length=100

--- a/.vscode/example_settings.json
+++ b/.vscode/example_settings.json
@@ -21,9 +21,6 @@
         "**/__pycache": true,
         "**/*pyc": true
     },
-    //"python.analysis.logLevel": "Trace",
-    //"files.autoSave": "afterDelay",
-    //"makefile.extensionOutputFolder": "./.vscode",
     "files.associations": {
         "panther_analysis_tool": "python"
     },
@@ -32,6 +29,13 @@
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
             "source.organizeImports": true
-        }
-    }
+        },
+    },
+    // Add pylint.lintOnChange to your User (not Workspace) settings
+    // Cmd+Shift+P -> Preferences: Open Settings (JSON)
+    "pylint.lintOnChange": true,
+    "bandit.args": [
+        "-r",
+        "."
+    ]
 }

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,8 @@ global-helpers-unit-test:
 lint: lint-pylint lint-fmt
 
 lint-pylint:
-	pipenv run bandit -r $(dirs) --skip B101  # allow assert statements in tests
-	pipenv run pylint $(dirs) \
-	  --disable=missing-docstring,duplicate-code,import-error,fixme,consider-iterating-dictionary,global-variable-not-assigned,broad-exception-raised \
-	  --load-plugins=pylint.extensions.mccabe,pylint_print \
-	  --max-line-length=100
+	pipenv run bandit -r $(dirs)
+	pipenv run pylint $(dirs)
 
 lint-fmt:
 	@echo Checking python file formatting with the black code style checker

--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ In addition to this command, you will need to install these vscode add-ons:
 
 1. [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
 2. [Black Formatter](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter)
-3. [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
+3. [Pylint](https://marketplace.visualstudio.com/items?itemName=ms-python.pylint)
+4  [Bandit](https://marketplace.visualstudio.com/items?itemName=nwgh.bandit)
+5. [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
 
 You will also need Visual Studio's [code](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line) configured to open Visual Studio from your CLI.
 
@@ -132,6 +134,9 @@ You will also need Visual Studio's [code](https://code.visualstudio.com/docs/set
 1. Installs JSONSchema support for your custom panther-analysis schemas in the `schemas/` directory. This brings IDE hints about which fields are necessary for schemas/custom-schema.yml files.
 1. Installs JSONSchema support for panther-analysis rules in the `rules/` directory. This brings IDE hints about which fields are necessary for rules/my-rule.yml files.
 1. Configures `Black` and `isort` settings for auto-formatting on save (thus reducing the need to run `make fmt` on all files)
+1. Configures `pylint` settings for linting when changes are made
+    - Ensure that `"pylint.lintOnChange": true` is present in the User-level VSCode settings (`Cmd+Shift+P` -> `Preferences: Open Settings (JSON)`)
+2. Configures `Bandit` settings for linting when files are opened
 
 ```shell
 user@computer:panther-analysis: make vscode-config

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ You will also need Visual Studio's [code](https://code.visualstudio.com/docs/set
 1. Configures `Black` and `isort` settings for auto-formatting on save (thus reducing the need to run `make fmt` on all files)
 1. Configures `pylint` settings for linting when changes are made
     - Ensure that `"pylint.lintOnChange": true` is present in the User-level VSCode settings (`Cmd+Shift+P` -> `Preferences: Open Settings (JSON)`)
-2. Configures `Bandit` settings for linting when files are opened
+1. Configures `Bandit` settings for linting when files are opened
 
 ```shell
 user@computer:panther-analysis: make vscode-config


### PR DESCRIPTION
### Background

Similar to #981, this PR mirrors the `make lint` configuration in `example_settings.json` which are then applied to the Workspace when `make vscode-config` is run.

This PR also introduces a `.bandit` and `.pylintrc` file to make the configuration more concise.

### Changes

* Adds `make lint` configuration to `example_settings.json`
* Cleans up `make lint` using new configuration files

### Testing

* I tested this locally and the linting settings took effect after running `make vscode-config`
