### PR TITLE
Fix/ben/panther audit dynamic params

### DIFF
--- a/rules/panther_audit_rules/panther_detection_deleted.py
+++ b/rules/panther_audit_rules/panther_detection_deleted.py
@@ -22,7 +22,9 @@ def title(event):
 
 
 def alert_context(event):
-    detections_list = deep_get(event, "actionParams", "input", "detections")
+    detections_list = deep_get(event, "actionParams", "dynamic", "input", "detections")
+    if detections_list == None:
+        detections_list = deep_get(event, "actionParams", "input", "detections")
     return {
         "deleted_detections_list": [x.get("id") for x in detections_list],
         "user": event.udm("actor_user"),

--- a/rules/panther_audit_rules/panther_detection_deleted.py
+++ b/rules/panther_audit_rules/panther_detection_deleted.py
@@ -23,7 +23,7 @@ def title(event):
 
 def alert_context(event):
     detections_list = deep_get(event, "actionParams", "dynamic", "input", "detections")
-    if detections_list == None:
+    if detections_list is None:
         detections_list = deep_get(event, "actionParams", "input", "detections")
     return {
         "deleted_detections_list": [x.get("id") for x in detections_list],

--- a/rules/panther_audit_rules/panther_detection_deleted.yml
+++ b/rules/panther_audit_rules/panther_detection_deleted.yml
@@ -24,12 +24,14 @@ Tests:
       {
         "actionName": "DELETE_DETECTION",
         "actionParams": {
-          "input": {
-            "detections": [
-              {
-                "id": "GitHub.Team.Modified"
-              }
-            ]
+          "dynamic": {
+            "input": {
+              "detections": [
+                {
+                  "id": "GitHub.Team.Modified"
+                }
+              ]
+            }
           }
         },
         "actionResult": "SUCCEEDED",
@@ -55,21 +57,23 @@ Tests:
       {
       "actionName": "DELETE_DETECTION",
       "actionParams": {
-        "input": {
-          "detections": [
-            {
-              "id": "Github.Repo.Created"
-            },
-            {
-              "id": "Okta.Global.MFA.Disabled"
-            },
-            {
-              "id": "Okta.AdminRoleAssigned"
-            },
-            {
-              "id": "Okta.BruteForceLogins"
-            }
-          ]
+        "dynamic": {
+          "input": {
+            "detections": [
+              {
+                "id": "Github.Repo.Created"
+              },
+              {
+                "id": "Okta.Global.MFA.Disabled"
+              },
+              {
+                "id": "Okta.AdminRoleAssigned"
+              },
+              {
+                "id": "Okta.BruteForceLogins"
+              }
+            ]
+          }
         }
       },
       "actionResult": "SUCCEEDED",

--- a/rules/panther_audit_rules/panther_sensitive_role_created.py
+++ b/rules/panther_audit_rules/panther_sensitive_role_created.py
@@ -17,7 +17,10 @@ PANTHER_ROLE_ACTIONS = [
 def rule(event):
     if event.udm("event_type") not in PANTHER_ROLE_ACTIONS:
         return False
-    role_permissions = set(deep_get(event, "actionParams", "input", "permissions", default=""))
+    permissions = deep_get(event, "actionParams", "dynamic", "input", "permissions")
+    if permissions == None:
+        deep_get(event, "actionParams", "input", "permissions", default="")
+    role_permissions = set(permissions)
 
     return (
         len(set(PANTHER_ADMIN_PERMISSIONS).intersection(role_permissions)) > 0
@@ -26,9 +29,12 @@ def rule(event):
 
 
 def title(event):
+    role_name = deep_get(event, "actionParams", "dynamic", "input" ,"name")
+    if role_name == None:
+        role_name = deep_get(event, "actionParams", "input" ,"name", default="<UNKNWON ROLE>")
     return (
         f"Role with Admin Permissions created by {event.udm('actor_user')}"
-        f"Role Name: {deep_get(event, 'actionParams', 'input' ,'name')}"
+        f"Role Name: {role_name}"
     )
 
 

--- a/rules/panther_audit_rules/panther_sensitive_role_created.py
+++ b/rules/panther_audit_rules/panther_sensitive_role_created.py
@@ -18,7 +18,7 @@ def rule(event):
     if event.udm("event_type") not in PANTHER_ROLE_ACTIONS:
         return False
     permissions = deep_get(event, "actionParams", "dynamic", "input", "permissions")
-    if permissions == None:
+    if permissions is None:
         deep_get(event, "actionParams", "input", "permissions", default="")
     role_permissions = set(permissions)
 
@@ -29,9 +29,9 @@ def rule(event):
 
 
 def title(event):
-    role_name = deep_get(event, "actionParams", "dynamic", "input" ,"name")
-    if role_name == None:
-        role_name = deep_get(event, "actionParams", "input" ,"name", default="<UNKNWON ROLE>")
+    role_name = deep_get(event, "actionParams", "dynamic", "input", "name")
+    if role_name is None:
+        role_name = deep_get(event, "actionParams", "input", "name", default="<UNKNWON ROLE>")
     return (
         f"Role with Admin Permissions created by {event.udm('actor_user')}"
         f"Role Name: {role_name}"

--- a/rules/panther_audit_rules/panther_sensitive_role_created.yml
+++ b/rules/panther_audit_rules/panther_sensitive_role_created.yml
@@ -24,14 +24,16 @@ Tests:
       {
           "actionName": "CREATE_USER_ROLE",
           "actionParams": {
-            "input": {
-              "logTypeAccessKind": "DENY_ALL",
-              "name": "New Admins",
-              "permissions": [
-                "GeneralSettingsModify",
-                "GeneralSettingsRead",
-                "SummaryRead"
-              ]
+            "dynamic": {
+              "input": {
+                "logTypeAccessKind": "DENY_ALL",
+                "name": "New Admins",
+                "permissions": [
+                  "GeneralSettingsModify",
+                  "GeneralSettingsRead",
+                  "SummaryRead"
+                ]
+              }
             }
           },
           "actionResult": "SUCCEEDED",
@@ -58,12 +60,14 @@ Tests:
       {
           "actionName": "CREATE_USER_ROLE",
           "actionParams": {
-            "input": {
-              "logTypeAccessKind": "DENY_ALL",
-              "name": "New Admins",
-              "permissions": [
-                "SummaryRead",
-              ]
+            "dynamic": {
+              "input": {
+                "logTypeAccessKind": "DENY_ALL",
+                "name": "New Admins",
+                "permissions": [
+                  "SummaryRead",
+                ]
+              }
             }
           },
           "actionResult": "SUCCEEDED",
@@ -88,103 +92,103 @@ Tests:
       ExpectedResult: false
       Log:
         {
-  "XForwardedFor": [
-    "1.2.3.4",
-    "5.6.7.8"
-  ],
-  "actionDescription": "Adds a new User role to Panther",
-  "actionName": "CREATE_USER_ROLE",
-  "actionParams": {
-    "dynamic": {
-      "input": {
-        "logTypeAccess": [
-          "Okta.SystemLog"
+        "XForwardedFor": [
+          "1.2.3.4",
+          "5.6.7.8"
         ],
-        "logTypeAccessKind": "ALLOW",
-        "name": "ITE Role",
-        "permissions": [
-          "AlertRead",
-          "DataAnalyticsRead"
-        ]
+        "actionDescription": "Adds a new User role to Panther",
+        "actionName": "CREATE_USER_ROLE",
+        "actionParams": {
+          "dynamic": {
+            "input": {
+              "logTypeAccess": [
+                "Okta.SystemLog"
+              ],
+              "logTypeAccessKind": "ALLOW",
+              "name": "ITE Role",
+              "permissions": [
+                "AlertRead",
+                "DataAnalyticsRead"
+              ]
+            }
+          },
+          "static": {}
+        },
+        "actionResult": "FAILED",
+        "actor": {
+          "attributes": {
+            "email": "random@noreply.com",
+            "emailVerified": false,
+            "roleId": "2a7bfe22-666d-4f71-99d2-c16b8666eca1",
+            "roleName": "Admin"
+          },
+          "id": "PantherSSO_random@noreply.com",
+          "name": "random@noreply.com",
+          "type": "USER"
+        },
+        "errors": [
+          {
+            "message": "You cannot save a role that has both log type restrictions and alerts/detections permissions at this time."
+          }
+        ],
+        "p_alert_creation_time": "2023-02-09 21:47:09.745566000",
+        "p_alert_id": "7eb5ca596b2153f95885cb2440e12345",
+        "p_alert_severity": "HIGH",
+        "p_alert_update_time": "2023-02-09 21:47:09.745566000",
+        "p_any_ip_addresses": [
+          "1.2.3.4",
+          "5.6.7.8"
+        ],
+        "p_any_trace_ids": [
+          "PantherSSO_random@noreply.com"
+        ],
+        "p_any_usernames": [
+          "random@noreply.com"
+        ],
+        "p_enrichment": {
+          "ipinfo_asn": {
+            "sourceIP": {
+              "asn": "AS396982",
+              "domain": "google.com",
+              "name": "Google LLC",
+              "route": "208.127.224.0/21",
+              "type": "hosting"
+            }
+          },
+          "ipinfo_location": {
+            "sourceIP": {
+              "city": "Ashburn",
+              "country": "US",
+              "lat": "39.04372",
+              "lng": "-77.48749",
+              "postal_code": "20147",
+              "region": "Virginia",
+              "region_code": "VA",
+              "timezone": "America/New_York"
+            }
+          }
+        },
+        "p_event_time": "2023-02-09 21:45:59.352910070",
+        "p_log_type": "Panther.Audit",
+        "p_parse_time": "2023-02-09 21:46:53.858602089",
+        "p_row_id": "b29dff36ad73cb77a5d7a3a816c39c2a",
+        "p_rule_error": "'NoneType' object is not iterable: Panther.Sensitive.Role.py, line 20, in rule    role_permissions = set(deep_get(event, \"actionParams\", \"input\", \"permissions\"))",
+        "p_rule_id": "Panther.Sensitive.Role",
+        "p_rule_reports": {
+          "MITRE ATT&CK": [
+            "TA0003:T1098"
+          ]
+        },
+        "p_rule_severity": "HIGH",
+        "p_rule_tags": [
+          "DataModel",
+          "Persistence:Account Manipulation"
+        ],
+        "p_schema_version": 0,
+        "p_source_id": "9a116557-0a1c-4a21-8565-1135dfe5e82b",
+        "p_source_label": "panther-audit-logs-us-east-1",
+        "pantherVersion": "1.53.7",
+        "sourceIP": "1.2.3.4",
+        "timestamp": "2023-02-09 21:45:59.352910070",
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"
       }
-    },
-    "static": {}
-  },
-  "actionResult": "FAILED",
-  "actor": {
-    "attributes": {
-      "email": "random@noreply.com",
-      "emailVerified": false,
-      "roleId": "2a7bfe22-666d-4f71-99d2-c16b8666eca1",
-      "roleName": "Admin"
-    },
-    "id": "PantherSSO_random@noreply.com",
-    "name": "random@noreply.com",
-    "type": "USER"
-  },
-  "errors": [
-    {
-      "message": "You cannot save a role that has both log type restrictions and alerts/detections permissions at this time."
-    }
-  ],
-  "p_alert_creation_time": "2023-02-09 21:47:09.745566000",
-  "p_alert_id": "7eb5ca596b2153f95885cb2440e12345",
-  "p_alert_severity": "HIGH",
-  "p_alert_update_time": "2023-02-09 21:47:09.745566000",
-  "p_any_ip_addresses": [
-    "1.2.3.4",
-    "5.6.7.8"
-  ],
-  "p_any_trace_ids": [
-    "PantherSSO_random@noreply.com"
-  ],
-  "p_any_usernames": [
-    "random@noreply.com"
-  ],
-  "p_enrichment": {
-    "ipinfo_asn": {
-      "sourceIP": {
-        "asn": "AS396982",
-        "domain": "google.com",
-        "name": "Google LLC",
-        "route": "208.127.224.0/21",
-        "type": "hosting"
-      }
-    },
-    "ipinfo_location": {
-      "sourceIP": {
-        "city": "Ashburn",
-        "country": "US",
-        "lat": "39.04372",
-        "lng": "-77.48749",
-        "postal_code": "20147",
-        "region": "Virginia",
-        "region_code": "VA",
-        "timezone": "America/New_York"
-      }
-    }
-  },
-  "p_event_time": "2023-02-09 21:45:59.352910070",
-  "p_log_type": "Panther.Audit",
-  "p_parse_time": "2023-02-09 21:46:53.858602089",
-  "p_row_id": "b29dff36ad73cb77a5d7a3a816c39c2a",
-  "p_rule_error": "'NoneType' object is not iterable: Panther.Sensitive.Role.py, line 20, in rule    role_permissions = set(deep_get(event, \"actionParams\", \"input\", \"permissions\"))",
-  "p_rule_id": "Panther.Sensitive.Role",
-  "p_rule_reports": {
-    "MITRE ATT&CK": [
-      "TA0003:T1098"
-    ]
-  },
-  "p_rule_severity": "HIGH",
-  "p_rule_tags": [
-    "DataModel",
-    "Persistence:Account Manipulation"
-  ],
-  "p_schema_version": 0,
-  "p_source_id": "9a116557-0a1c-4a21-8565-1135dfe5e82b",
-  "p_source_label": "panther-audit-logs-us-east-1",
-  "pantherVersion": "1.53.7",
-  "sourceIP": "1.2.3.4",
-  "timestamp": "2023-02-09 21:45:59.352910070",
-  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"
-}

--- a/rules/panther_audit_rules/panther_user_modified.yml
+++ b/rules/panther_audit_rules/panther_user_modified.yml
@@ -212,10 +212,14 @@ Tests:
       "actionDescription": "User updated automatically by SAML.",
       "actionName": "UPDATE_USER",
       "actionParams": {
-          "email": "john.doe@usgs.gov",
-          "familyName": "Doe",
-          "givenName": "John",
-          "role": "AnalystReadOnly"
+        "dynamic": {
+          "input": {
+            "email": "john.doe@usgs.gov",
+            "familyName": "Doe",
+            "givenName": "John",
+            "role": "AnalystReadOnly"
+          }
+        }
       },
       "actionResult": "SUCCEEDED",
       "actor": {


### PR DESCRIPTION
### Background

In the past, Panther updated it's audit log structure to place `actionParams.input` in `actionParams.dynamic.input` instead. Apparently some of our rules didn't get updated to reflect that, and caused errors.

### Changes

* updated rule logic to handle cases where `dynamic` is used, and cases where it isn't
* updated the rule test cases to include the `dyanamic` field
* updated `Panther.Sensitive.Role - nonetype error` to have the proper indentation (for STYLE)

### Testing

* `make lint` and `make test`
