### PR TITLE
Add panther_config to packs using panther_base_helpers

### DIFF
--- a/packs/asana.yml
+++ b/packs/asana.yml
@@ -16,4 +16,5 @@ PackDefinition:
     # Globals used in these detections
     - panther_asana_helpers
     - panther_base_helpers
+    - panther_config
 DisplayName: "Panther Asana Pack"

--- a/packs/atlassian.yml
+++ b/packs/atlassian.yml
@@ -6,4 +6,5 @@ PackDefinition:
     - Atlassian.User.LoggedInAsUser
     # Globals used in these detections
     - panther_base_helpers
+    - panther_config
 DisplayName: "Panther Atlassian Pack"

--- a/packs/auth0.yml
+++ b/packs/auth0.yml
@@ -17,4 +17,5 @@ PackDefinition:
     - panther_base_helpers
     - panther_auth0_helpers
     - global_filter_auth0
+    - panther_config
 DisplayName: "Panther Auth0 Pack"

--- a/packs/aws.yml
+++ b/packs/aws.yml
@@ -145,3 +145,4 @@ PackDefinition:
     - panther_greynoise_helpers
     - panther_lookuptable_helpers
     - panther_oss_helpers
+    - panther_config

--- a/packs/aws_cis.yml
+++ b/packs/aws_cis.yml
@@ -38,4 +38,5 @@ PackDefinition:
     # Globals used in these detections
     - panther_base_helpers
     - panther_oss_helpers
+    - panther_config
 DisplayName: "Panther AWS CIS Pack"

--- a/packs/azure_signin.yml
+++ b/packs/azure_signin.yml
@@ -10,4 +10,5 @@ PackDefinition:
     - global_filter_azuresignin
     - panther_azuresignin_helpers
     - panther_base_helpers
+    - panther_config
 DisplayName: "Panther Azure.Audit SignIn Pack"

--- a/packs/cloudflare.yml
+++ b/packs/cloudflare.yml
@@ -14,3 +14,4 @@ PackDefinition:
     - panther_greynoise_helpers
     - panther_lookuptable_helpers
     - global_filter_cloudflare
+    - panther_config

--- a/packs/credential_security.yml
+++ b/packs/credential_security.yml
@@ -16,6 +16,7 @@ PackDefinition:
     - panther_base_helpers
     - panther_default
     - panther_event_type_helpers
+    - panther_config
     # Rules
     - AWS.CloudTrail.RootPasswordChanged
     - AWS.IAM.AccessKeyCompromised

--- a/packs/crowdstrike.yml
+++ b/packs/crowdstrike.yml
@@ -21,6 +21,7 @@ PackDefinition:
     - Crowdstrike.Macos.Osascript.Administrator
     # Globals used in these detections
     - panther_base_helpers
+    - panther_config
     # Data models
     - Standard.Crowdstrike.FDR
 DisplayName: "Panther Crowdstrike Pack"

--- a/packs/duo.yml
+++ b/packs/duo.yml
@@ -22,3 +22,4 @@ PackDefinition:
     # Globals used in these detections
     - panther_base_helpers
     - panther_duo_helpers
+    - panther_config

--- a/packs/gcp_audit.yml
+++ b/packs/gcp_audit.yml
@@ -39,4 +39,5 @@ PackDefinition:
     - panther_event_type_helpers
     - gcp_base_helpers
     - gcp_environment
+    - panther_config
 DisplayName: "Panther GCP Audit Pack"

--- a/packs/github.yml
+++ b/packs/github.yml
@@ -30,3 +30,4 @@ PackDefinition:
     - panther_event_type_helpers
     - panther_oss_helpers
     - global_filter_github
+    - panther_config

--- a/packs/gravitational_teleport.yml
+++ b/packs/gravitational_teleport.yml
@@ -10,4 +10,5 @@ PackDefinition:
     - Teleport.SuspiciousCommands
     # Globals used in these detections
     - panther_base_helpers
+    - panther_config
 DisplayName: "Panther Teleport Pack"

--- a/packs/greynoise_advanced.yml
+++ b/packs/greynoise_advanced.yml
@@ -8,4 +8,5 @@ PackDefinition:
     - panther_base_helpers
     - panther_greynoise_helpers
     - panther_lookuptable_helpers
+    - panther_config
 DisplayName: "GreyNoise Advanced"

--- a/packs/greynoise_basic.yml
+++ b/packs/greynoise_basic.yml
@@ -8,4 +8,5 @@ PackDefinition:
     - panther_base_helpers
     - panther_greynoise_helpers
     - panther_lookuptable_helpers
+    - panther_config
 DisplayName: "GreyNoise Basic"

--- a/packs/ipinfo.yml
+++ b/packs/ipinfo.yml
@@ -12,4 +12,5 @@ PackDefinition:
     - panther_base_helpers
     - panther_ipinfo_helpers
     - panther_lookuptable_helpers
+    - panther_config
 DisplayName: "IPInfo"

--- a/packs/mongodb.yml
+++ b/packs/mongodb.yml
@@ -8,3 +8,4 @@ PackDefinition:
     - MongoDB.External.UserInvited
     # Globals
     - panther_base_helpers
+    - panther_config

--- a/packs/notion.yml
+++ b/packs/notion.yml
@@ -20,6 +20,7 @@ PackDefinition:
     - panther_oss_helpers
     - panther_notion_helpers
     - global_filter_notion
+    - panther_config
     # Data Model
     - Standard.Notion.AuditLogs
 DisplayName: "Panther Notion Pack"

--- a/packs/okta.yml
+++ b/packs/okta.yml
@@ -29,6 +29,7 @@ PackDefinition:
     - panther_base_helpers
     - panther_oss_helpers
     - panther_event_type_helpers
+    - panther_config
     # Data Model
     - Standard.Okta.SystemLog
 DisplayName: "Panther Okta Pack"

--- a/packs/onelogin.yml
+++ b/packs/onelogin.yml
@@ -17,4 +17,5 @@ PackDefinition:
     # Globals used in these detections
     - panther_base_helpers
     - panther_oss_helpers
+    - panther_config
 DisplayName: "Panther OneLogin Pack"

--- a/packs/onepassword.yml
+++ b/packs/onepassword.yml
@@ -11,3 +11,4 @@ PackDefinition:
     # Supporting Global Helpers
     - panther_base_helpers
     - panther_event_type_helpers
+    - panther_config

--- a/packs/osquery.yml
+++ b/packs/osquery.yml
@@ -16,4 +16,5 @@ PackDefinition:
     - Osquery.SuspiciousCron
     # Globals used in these detections
     - panther_base_helpers
+    - panther_config
 DisplayName: "Panther OSQuery Pack"

--- a/packs/panther.yml
+++ b/packs/panther.yml
@@ -12,4 +12,5 @@ PackDefinition:
     # Helpers
     - panther_base_helpers
     - panther_event_type_helpers
+    - panther_config
 DisplayName: "Panther Audit Logs Pack"

--- a/packs/sentinelone.yml
+++ b/packs/sentinelone.yml
@@ -7,4 +7,5 @@ PackDefinition:
     - SentinelOne.Threats
     # Globals used in these detections
     - panther_base_helpers
+    - panther_config
 DisplayName: "Panther SentinelOne Pack"

--- a/packs/slack.yml
+++ b/packs/slack.yml
@@ -29,3 +29,4 @@ PackDefinition:
     # Globals used in these rules/policies
     - panther_base_helpers
     - panther_oss_helpers
+    - panther_config

--- a/packs/snyk.yml
+++ b/packs/snyk.yml
@@ -18,3 +18,4 @@ PackDefinition:
     - global_filter_snyk
     - panther_base_helpers
     - panther_snyk_helpers
+    - panther_config

--- a/packs/tailscale.yml
+++ b/packs/tailscale.yml
@@ -10,4 +10,5 @@ PackDefinition:
     - panther_base_helpers
     - panther_tailscale_helpers
     - global_filter_tailscale
+    - panther_config
 DisplayName: "Panther Tailscale Pack"

--- a/packs/tines.yml
+++ b/packs/tines.yml
@@ -16,3 +16,4 @@ PackDefinition:
     - global_filter_tines
     - panther_base_helpers
     - panther_tines_helpers
+    - panther_config

--- a/packs/tor.yml
+++ b/packs/tor.yml
@@ -7,4 +7,5 @@ PackDefinition:
     - panther_base_helpers
     - panther_lookuptable_helpers
     - panther_tor_helpers
+    - panther_config
 DisplayName: "Tor Lookup Tables"

--- a/packs/zendesk.yml
+++ b/packs/zendesk.yml
@@ -16,3 +16,4 @@ PackDefinition:
     # Globals
     - panther_base_helpers
     - panther_event_type_helpers
+    - panther_config

--- a/packs/zoom.yml
+++ b/packs/zoom.yml
@@ -18,3 +18,4 @@ PackDefinition:
     - panther_base_helpers
     - panther_oss_helpers
     - panther_zoom_helpers
+    - panther_config


### PR DESCRIPTION
### Background

Packs that import `panther_base_helpers` also need to import `panther_config` now that it imports `panther_config`.

### Changes

* Adds `panther_config` to all Packs that import `panther_base_helpers`

### Testing

* `make test`
