### PR TITLE
Add Azure.MonitorActivity to ip selectors for LUTs

### DIFF
--- a/lookup_tables/greynoise/advanced/noise_advanced.yml
+++ b/lookup_tables/greynoise/advanced/noise_advanced.yml
@@ -76,6 +76,9 @@ LogTypeMap:
       Selectors:
         - "callerIpAddress"
         - "$.properties.initiatedBy.user.ipAddress"
+    - LogType: Azure.MonitorActivity
+      Selectors:
+        - "callerIpAddress"
     - LogType: Bitwarden.Events
       Selectors:
         - "ipAddress"

--- a/lookup_tables/greynoise/advanced/riot_advanced.yml
+++ b/lookup_tables/greynoise/advanced/riot_advanced.yml
@@ -76,6 +76,9 @@ LogTypeMap:
       Selectors:
         - "callerIpAddress"
         - "$.properties.initiatedBy.user.ipAddress"
+    - LogType: Azure.MonitorActivity
+      Selectors:
+        - "callerIpAddress"
     - LogType: Bitwarden.Events
       Selectors:
         - "ipAddress"

--- a/lookup_tables/greynoise/basic/noise_basic.yml
+++ b/lookup_tables/greynoise/basic/noise_basic.yml
@@ -76,6 +76,9 @@ LogTypeMap:
       Selectors:
         - "callerIpAddress"
         - "$.properties.initiatedBy.user.ipAddress"
+    - LogType: Azure.MonitorActivity
+      Selectors:
+        - "callerIpAddress"
     - LogType: Bitwarden.Events
       Selectors:
         - "ipAddress"

--- a/lookup_tables/greynoise/basic/riot_basic.yml
+++ b/lookup_tables/greynoise/basic/riot_basic.yml
@@ -76,6 +76,9 @@ LogTypeMap:
       Selectors:
         - "callerIpAddress"
         - "$.properties.initiatedBy.user.ipAddress"
+    - LogType: Azure.MonitorActivity
+      Selectors:
+        - "callerIpAddress"
     - LogType: Bitwarden.Events
       Selectors:
         - "ipAddress"

--- a/lookup_tables/ipinfo/ipinfo_asn.yml
+++ b/lookup_tables/ipinfo/ipinfo_asn.yml
@@ -76,6 +76,9 @@ LogTypeMap:
       Selectors:
         - "callerIpAddress"
         - "$.properties.initiatedBy.user.ipAddress"
+    - LogType: Azure.MonitorActivity
+      Selectors:
+        - "callerIpAddress"
     - LogType: Bitwarden.Events
       Selectors:
         - "ipAddress"

--- a/lookup_tables/ipinfo/ipinfo_asn_datalake.yml
+++ b/lookup_tables/ipinfo/ipinfo_asn_datalake.yml
@@ -76,6 +76,9 @@ LogTypeMap:
       Selectors:
         - "callerIpAddress"
         - "$.properties.initiatedBy.user.ipAddress"
+    - LogType: Azure.MonitorActivity
+      Selectors:
+        - "callerIpAddress"
     - LogType: Bitwarden.Events
       Selectors:
         - "ipAddress"

--- a/lookup_tables/ipinfo/ipinfo_location.yml
+++ b/lookup_tables/ipinfo/ipinfo_location.yml
@@ -76,6 +76,9 @@ LogTypeMap:
       Selectors:
         - "callerIpAddress"
         - "$.properties.initiatedBy.user.ipAddress"
+    - LogType: Azure.MonitorActivity
+      Selectors:
+        - "callerIpAddress"
     - LogType: Bitwarden.Events
       Selectors:
         - "ipAddress"

--- a/lookup_tables/ipinfo/ipinfo_location_datalake.yml
+++ b/lookup_tables/ipinfo/ipinfo_location_datalake.yml
@@ -76,6 +76,9 @@ LogTypeMap:
       Selectors:
         - "callerIpAddress"
         - "$.properties.initiatedBy.user.ipAddress"
+    - LogType: Azure.MonitorActivity
+      Selectors:
+        - "callerIpAddress"
     - LogType: Bitwarden.Events
       Selectors:
         - "ipAddress"

--- a/lookup_tables/ipinfo/ipinfo_privacy.yml
+++ b/lookup_tables/ipinfo/ipinfo_privacy.yml
@@ -76,6 +76,9 @@ LogTypeMap:
       Selectors:
         - "callerIpAddress"
         - "$.properties.initiatedBy.user.ipAddress"
+    - LogType: Azure.MonitorActivity
+      Selectors:
+        - "callerIpAddress"
     - LogType: Bitwarden.Events
       Selectors:
         - "ipAddress"

--- a/lookup_tables/ipinfo/ipinfo_privacy_datalake.yml
+++ b/lookup_tables/ipinfo/ipinfo_privacy_datalake.yml
@@ -76,6 +76,9 @@ LogTypeMap:
       Selectors:
         - "callerIpAddress"
         - "$.properties.initiatedBy.user.ipAddress"
+    - LogType: Azure.MonitorActivity
+      Selectors:
+        - "callerIpAddress"
     - LogType: Bitwarden.Events
       Selectors:
         - "ipAddress"

--- a/lookup_tables/tor/tor_exit_nodes.yml
+++ b/lookup_tables/tor/tor_exit_nodes.yml
@@ -76,6 +76,9 @@ LogTypeMap:
       Selectors:
         - "callerIpAddress"
         - "$.properties.initiatedBy.user.ipAddress"
+    - LogType: Azure.MonitorActivity
+      Selectors:
+        - "callerIpAddress"
     - LogType: Bitwarden.Events
       Selectors:
         - "ipAddress"


### PR DESCRIPTION
### Background

LUT IP selectors should be kept up to date

### Changes

* LUT IP selectors for the new Azure.MonitorActivity schema

### Testing

* config changes
