### PR TITLE
[sync] Revert changes to aws_ami_modified_for_public_access.py/.yml (#48)

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_ami_modified_for_public_access.py
+++ b/rules/aws_cloudtrail_rules/aws_ami_modified_for_public_access.py
@@ -12,7 +12,7 @@ def rule(event):
     )
 
     for item in added_perms:
-        if item.get("userId") or item.get("group") == "all":
+        if item.get("group") == "all":
             return True
 
     return False

--- a/rules/aws_cloudtrail_rules/aws_ami_modified_for_public_access.yml
+++ b/rules/aws_cloudtrail_rules/aws_ami_modified_for_public_access.yml
@@ -190,7 +190,7 @@ Tests:
       }
   -
     Name: AMI Added to User
-    ExpectedResult: true
+    ExpectedResult: false
     Log:
       {
           "awsRegion": "us-west-2",


### PR DESCRIPTION
### Background

Customers are seeing false positives with the recently-modified `aws_ami_modified_for_public_access.py/.yml` rule. This PR reverts the change to the original behavior which was correct.

AWS docs on this: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sharingamis-intro.html

The CLI command specifies that `Group=all` is what makes an AMI public, not sharing the AMI with a user.

### Changes

* Reverts changes to `aws_ami_modified_for_public_access.py/.yml`

### Testing

* Tests pass as expected
