### PR TITLE
[sync] Reintroduce netskope_admin_user_change rule with fixed severity function

### DIFF
--- a/packs/netskope.yml
+++ b/packs/netskope.yml
@@ -4,6 +4,7 @@ Description: Group of all Netskope detections
 PackDefinition:
   IDs:
     - Netskope.AdminLoggedOutLoginFailures
+    - Netskope.AdminUserChange
     - Netskope.ManyDeletes
     - Netskope.NetskopePersonnelActivity
     - Netskope.UnauthorizedAPICalls

--- a/rules/netskope_rules/netskope_admin_user_change.yml
+++ b/rules/netskope_rules/netskope_admin_user_change.yml
@@ -1,0 +1,96 @@
+AnalysisType: rule
+RuleID: "Netskope.AdminUserChange"
+DisplayName: "An administrator account was created, deleted, or modified."
+AlertTitle: "User [{user}] performed [{audit_log_event}]"
+Detection:
+  - All:
+    - KeyPath: audit_log_event
+      Condition: IsIn
+      Values:
+        - Created new admin
+        - Added SSO Admin
+        - Edited SSO Admin Record
+        - Created new support admin
+        - Edit admin record
+        - Deleted admin
+        - Enabled admin
+        - Disabled admin
+        - Unlocked admin
+        - Updated admin settings
+        - Deleted Netskope SSO admin
+Enabled: true
+LogTypes:
+  - Netskope.Audit
+Tags:
+  - Netskope
+  - Account Manipulation
+Reports:
+  MITRE ATT&CK: 
+    - TA0004:T1098
+Reference: https://docs.netskope.com/en/netskope-help/admin-console/administration/managing-administrators/
+Severity: High
+DynamicSeverities:
+  - ChangeTo: Critical
+    Conditions:
+      - KeyPath: audit_log_event
+        Condition: IContains
+        Value: Create
+      - KeyPath: audit_log_event
+        Condition: IContains
+        Value: Add
+      - KeyPath: audit_log_event
+        Condition: IContains
+        Value: Delete
+Description: An administrator account was created, deleted, or modified.
+DedupPeriodMinutes: 60
+Threshold: 1
+Runbook: An administrator account was created, deleted, or modified.  Validate that this activity is expected and authorized.
+Tests:
+    - Name: True positive
+      ExpectedResult: true
+      Log: 
+        {
+          "_id": "e5ca619b059fccdd0cfd9398",
+          "_insertion_epoch_timestamp": 1702308331,
+          "audit_log_event": "Created new admin",
+          "count": 1,
+          "is_netskope_personnel": true,
+          "organization_unit": "",
+          "severity_level": 2,
+          "supporting_data": {
+            "data_type": "user",
+            "data_values": [
+              "11.22.33.44",
+              "adminsupport@netskope.com"
+            ]
+          },
+          "timestamp": "2023-12-11 15:25:31.000000000",
+          "type": "admin_audit_logs",
+          "ur_normalized": "adminsupport@netskope.com",
+          "user": "adminsupport@netskope.com"
+        }
+    - Name: True negative
+      ExpectedResult: false
+      Log: 
+        {
+        "_id": "1e589befa3da30132362f32a",
+        "_insertion_epoch_timestamp": 1702318213,
+        "audit_log_event": "Rest API V2 Call",
+        "count": 1,
+        "is_netskope_personnel": false,
+        "organization_unit": "",
+        "severity_level": 2,
+        "supporting_data": {
+          "data_type": "incidents",
+          "data_values": [
+            200,
+            "POST",
+            "/api/v2/incidents/uba/getuci",
+            "trid=ccb898fgrhvdd0v0lebg"
+          ]
+        },
+        "timestamp": "2023-12-11 18:10:13.000000000",
+        "type": "admin_audit_logs",
+        "ur_normalized": "service-account",
+        "user": "service-account"
+      }


### PR DESCRIPTION
### Background

This was originally part of the Netskope rule pack, but failed to upload due to bad logic in the DynamicSeverity function

### Changes

* New rule to detect when admin users are created, deleted, or updated in Netskope
* Fixed DynamicSeverity function

### Testing

* make test
