### PR TITLE
[sync] Add GCP.iam.roles.update.Privilege.Escalation rule (#49)

### DIFF
--- a/rules/gcp_audit_rules/gcp_iam_roles_update_prielege_escalation.yml
+++ b/rules/gcp_audit_rules/gcp_iam_roles_update_prielege_escalation.yml
@@ -1,0 +1,45 @@
+AnalysisType: rule
+RuleID: "GCP.iam.roles.update.Privilege.Escalation"
+DisplayName: "GCP iam.roles.update Privilege Escalation"
+Description: "If your user is assigned a custom IAM role, then iam.roles.update will allow you to update the “includedPermissons” on that role. Because it is assigned to you, you will gain the additional privileges, which could be anything you desire."
+Enabled: true
+LogTypes:
+    - GCP.AuditLog
+Tags:
+    - GCP
+Severity: High
+Reports:
+    TA0004:
+        - T1548
+DedupPeriodMinutes: 60
+Threshold: 1
+Reference: https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/
+Detection:
+    - All:
+        - KeyPath: protoPayload.authorizationInfo[*].granted
+          Condition: Contains
+          Value: true
+        - KeyPath: protoPayload.authorizationInfo[*].permission
+          Condition: Contains
+          Value: iam.roles.update
+Tests:
+    - Name: Test-876cde
+      ExpectedResult: false
+      Log:
+        p_enrichment: null
+        protoPayload:
+            authorizationInfo:
+                - granted: true
+                  permission: iam.roles.dunno
+                  resource: projects/some-research/roles/CustomRole
+                  resourceAttributes: {}
+    - Name: Test-ffdf6
+      ExpectedResult: true
+      Log:
+        p_enrichment: null
+        protoPayload:
+            authorizationInfo:
+                - granted: true
+                  permission: iam.roles.update
+                  resource: projects/some-research/roles/CustomRole
+                  resourceAttributes: {}


### PR DESCRIPTION
### Goal

Detect iam.roles.update method for privilege escalation in GCP.

## Categorization

TA0004:T1548

## Strategy Abstract

The Identity and Access Management (IAM) service manages authorization and authentication for a GCP environment. This means that there are very likely multiple privilege escalation methods that use the IAM service and/or its permissions.

## Technical Context

If your user is assigned a custom IAM role, then iam.roles.update will allow you to update the “includedPermissons” on that role. Because it is assigned to you, you will gain the additional privileges, which could be anything you desire.

## Blind Spots and Assumptions

Assumes proper GCP logging and audit policies.

## False Positives

Legitimate administrative activity that is authorized and expected.

## Validation

The exploit script for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.roles.update.py).


## Response

Again, these are not vulnerabilities in GCP, they are vulnerabilities in how you have configured your GCP environment, so it is your responsibility to be aware of these attack vectors and to defend against them. Make sure to follow the principle of least-privilege in your environments to help mitigate these security risks.

## Additional Resources

https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/