### PR TITLE
[sync] Add new GCP rules to gcp_audit.yml pack (#62)

### DIFF
--- a/packs/gcp_audit.yml
+++ b/packs/gcp_audit.yml
@@ -7,6 +7,9 @@ PackDefinition:
     - GCP.Access.Attempts.Violating.VPC.Service.Controls
     - GCP.BigQuery.Large.Scan
     - GCP.Cloud.Storage.Buckets.Modified.Or.Deleted
+    - GCP.CloudBuild.Potential.Privilege.Escalation
+    - GCP.Cloudfunctions.Functions.Create
+    - GCP.Cloudfunctions.Functions.Update
     - GCP.Destructive.Queries
     - GCP.DNS.Zone.Modified.or.Deleted
     - GCP.Firewall.Rule.Created
@@ -18,14 +21,18 @@ PackDefinition:
     - GCP.IAM.CorporateEmail
     - GCP.IAM.CustomRoleChanges
     - GCP.IAM.OrgFolderIAMChanges
+    - GCP.iam.roles.update.Privilege.Escalation
+    - GCP.iam.serviceAccountKeys.create
     - GCP.Inbound.SSO.Profile.Created
     - GCP.K8s.ExecIntoPod
     - GCP.Log.Bucket.Or.Sink.Deleted
     - GCP.Logging.Settings.Modified
     - GCP.Logging.Sink.Modified
     - GCP.Permissions.Granted.to.Create.or.Manage.Service.Account.Key
+    - GCP.Privilege.Escalation.By.Deployments.Create
     - GCP.Service.Account.Access.Denied
     - GCP.Service.Account.or.Keys.Created
+    - GCP.serviceusage.apiKeys.create.Privilege.Escalation
     - GCP.SQL.ConfigChanges
     - GCP.UnusedRegions
     - GCP.User.Added.to.IAP.Protected.Service

--- a/rules/gcp_audit_rules/gcp_iam_service_account_key_create.yml
+++ b/rules/gcp_audit_rules/gcp_iam_service_account_key_create.yml
@@ -1,0 +1,57 @@
+AnalysisType: rule
+RuleID: "GCP.iam.serviceAccountKeys.create"
+DisplayName: "GCP.Iam.ServiceAccountKeys.Create"
+Description: "If your user is assigned a custom IAM role, then iam.roles.update will allow you to update the “includedPermissons” on that role. Because it is assigned to you, you will gain the additional privileges, which could be anything you desire."
+Enabled: true
+LogTypes:
+    - GCP.AuditLog
+Severity: High
+DedupPeriodMinutes: 60
+Threshold: 1
+Reference: https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/
+Reports:
+  MITRE ATT&CK:
+    - TA0004:T1548
+Detection:
+    - All:
+        - KeyPath: protoPayload.authorizationInfo[*].granted
+          Condition: Contains
+          Value: true
+        - KeyPath: protoPayload.authorizationInfo[*].permission
+          Condition: Contains
+          Value: iam.serviceAccountKeys.create
+Tests:
+    - Name: privilege-escalation
+      ExpectedResult: true
+      Log:
+        protoPayload:
+            authorizationInfo:
+                - granted: true
+                  permission: iam.serviceAccountKeys.create
+            methodName: v2.deploymentmanager.deployments.insert
+            serviceName: deploymentmanager.googleapis.com
+        receiveTimestamp: "2024-01-19 13:47:19.465856238"
+        resource:
+            labels:
+                name: test-vm-deployment
+                project_id: panther-threat-research
+            type: deployment
+        severity: NOTICE
+        timestamp: "2024-01-19 13:47:18.279921000"
+    - Name: fail
+      ExpectedResult: false
+      Log:
+        protoPayload:
+            authorizationInfo:
+                - granted: false
+                  permission: iam.serviceAccountKeys.create
+            methodName: v2.deploymentmanager.deployments.insert
+            serviceName: deploymentmanager.googleapis.com
+        receiveTimestamp: "2024-01-19 13:47:19.465856238"
+        resource:
+            labels:
+                name: test-vm-deployment
+                project_id: panther-threat-research
+            type: deployment
+        severity: NOTICE
+        timestamp: "2024-01-19 13:47:18.279921000"

--- a/rules/gcp_audit_rules/gcp_privilege_escalation_by_deployments_create.yml
+++ b/rules/gcp_audit_rules/gcp_privilege_escalation_by_deployments_create.yml
@@ -1,0 +1,57 @@
+AnalysisType: rule
+RuleID: "GCP.Privilege.Escalation.By.Deployments.Create"
+DisplayName: "GCP.Privilege.Escalation.By.Deployments.Create"
+Description: "Detects privilege escalation in GCP by taking over the deploymentsmanager.deployments.create permission"
+Enabled: true
+LogTypes:
+    - GCP.AuditLog
+Severity: High
+DedupPeriodMinutes: 60
+Threshold: 1
+Reference: https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/
+Reports:
+  MITRE ATT&CK:
+    - TA0004:T1548
+Detection:
+    - All:
+        - KeyPath: protoPayload.authorizationInfo[*].granted
+          Condition: Contains
+          Value: true
+        - KeyPath: protoPayload.authorizationInfo[*].permission
+          Condition: Contains
+          Value: deploymentmanager.deployments.create
+Tests:
+    - Name: privilege-escalation
+      ExpectedResult: true
+      Log:
+        protoPayload:
+            authorizationInfo:
+                - granted: true
+                  permission: deploymentmanager.deployments.create
+            methodName: v2.deploymentmanager.deployments.insert
+            serviceName: deploymentmanager.googleapis.com
+        receiveTimestamp: "2024-01-19 13:47:19.465856238"
+        resource:
+            labels:
+                name: test-vm-deployment
+                project_id: panther-threat-research
+            type: deployment
+        severity: NOTICE
+        timestamp: "2024-01-19 13:47:18.279921000"
+    - Name: fail
+      ExpectedResult: false
+      Log:
+        protoPayload:
+            authorizationInfo:
+                - granted: афдиу
+                  permission: deploymentmanager.deployments.create
+            methodName: v2.deploymentmanager.deployments.insert
+            serviceName: deploymentmanager.googleapis.com
+        receiveTimestamp: "2024-01-19 13:47:19.465856238"
+        resource:
+            labels:
+                name: test-vm-deployment
+                project_id: panther-threat-research
+            type: deployment
+        severity: NOTICE
+        timestamp: "2024-01-19 13:47:18.279921000"


### PR DESCRIPTION
### Background

In order for the new GCP rules to  be usable, we need to add them to the `gcp_audit` Pack. This PR adds seven new rules to said pack.

This can merge after all of the GCP rule additions are merged.

### Changes

* Adds seven new rules to the `gcp_audit.yml` pack

### Testing

* Tests pass as expected
