### PR TITLE
[sync] improved dedup for GuardDuty passthrough alerts (#57)

### DIFF
--- a/rules/aws_guardduty_rules/aws_guardduty_high_sev_findings.py
+++ b/rules/aws_guardduty_rules/aws_guardduty_high_sev_findings.py
@@ -9,10 +9,6 @@ def rule(event):
     return 7.0 <= float(event.get("severity", 0)) <= 8.9
 
 
-def dedup(event):
-    return event.get("id")
-
-
 def title(event):
     return event.get("title")
 

--- a/rules/aws_guardduty_rules/aws_guardduty_low_sev_findings.py
+++ b/rules/aws_guardduty_rules/aws_guardduty_low_sev_findings.py
@@ -9,10 +9,6 @@ def rule(event):
     return 0.1 <= float(event.get("severity", 0)) <= 3.9
 
 
-def dedup(event):
-    return event.get("id")
-
-
 def title(event):
     return event.get("title")
 

--- a/rules/aws_guardduty_rules/aws_guardduty_low_sev_findings.yml
+++ b/rules/aws_guardduty_rules/aws_guardduty_low_sev_findings.yml
@@ -8,7 +8,7 @@ LogTypes:
 Tags:
   - AWS
 Severity: Low
-DedupPeriodMinutes: 480 # 8 hours
+DedupPeriodMinutes: 1440 # 24 hours
 Description: >
   A low-severity GuardDuty finding has been identified.
 Runbook: >

--- a/rules/aws_guardduty_rules/aws_guardduty_med_sev_findings.py
+++ b/rules/aws_guardduty_rules/aws_guardduty_med_sev_findings.py
@@ -9,10 +9,6 @@ def rule(event):
     return 4.0 <= float(event.get("severity", 0)) <= 6.9
 
 
-def dedup(event):
-    return event.get("id")
-
-
 def title(event):
     return event.get("title")
 

--- a/rules/aws_guardduty_rules/aws_guardduty_med_sev_findings.yml
+++ b/rules/aws_guardduty_rules/aws_guardduty_med_sev_findings.yml
@@ -8,7 +8,7 @@ LogTypes:
 Tags:
   - AWS
 Severity: Medium
-DedupPeriodMinutes: 60
+DedupPeriodMinutes: 480 # 8 hours
 Description: >
   A medium-severity GuardDuty finding has been identified.
 Runbook: >


### PR DESCRIPTION
### Background

Identifies duplicate GuardDuty alerts and groups them into single alerts in Panther.

### Changes

* Change dedup string from event.id to event.title, since event.id is highly unique and offers no deduplication potential
* Change dedup interval for high/med/low sev GuardDuty alerts from 1/1/8 hours to 1/8/24 hours

### Testing

* `make fmt, make lint, make test`
* Based on observations from AWS GuardDuty alert volumes in production environments
