### PR TITLE
Update PAT to 0.38.1 (#65)

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -147,19 +147,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:9e1476ce2b26437881a0381bf2daa54de619ac74ab4bd74278668acda6004a64",
-                "sha256:cd6173380768faaecf6236dbdcec15d8d032cbb162ce354fdb111056a74fc298"
+                "sha256:0d800130e43a5d4e71300cc6f91aabcef6fe6f26bc206bc61374bf695049587a",
+                "sha256:c4dec7ea9bc9210ec783d39b56d332f5a266b0d1e31a96c5092f6bd5252361ba"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.30"
+            "version": "==1.34.31"
         },
         "botocore": {
             "hashes": [
-                "sha256:caf82d91c2ff61235284a07ffdfba006873e0752e00896052f901a37720cefa4",
-                "sha256:e071a9766e7fc2221ca42ec01dfc54368a7518610787342ea622f6edc57f7891"
+                "sha256:6ee1ba451ce3d640dccd485906f68a55d9e7f3534553876e4adc75d6060a05ac",
+                "sha256:d5a2153dbe9687f510f179e03913bc9b4e266c865cabebe440c4d05ab923faa7"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.30"
+            "version": "==1.34.31"
         },
         "certifi": {
             "hashes": [
@@ -652,10 +652,10 @@
         },
         "panther-analysis-tool": {
             "hashes": [
-                "sha256:c40eda9ac7f2c84cb25ba9675562ac000c1b8149886d8382038a621291c81fdb"
+                "sha256:9386a465813b972ca9a47c2c82b395237588caa7c9cf9f7288e288c69d8590c0"
             ],
             "index": "pypi",
-            "version": "==0.38.0"
+            "version": "==0.38.1"
         },
         "panther-core": {
             "hashes": [
@@ -1295,19 +1295,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:9e1476ce2b26437881a0381bf2daa54de619ac74ab4bd74278668acda6004a64",
-                "sha256:cd6173380768faaecf6236dbdcec15d8d032cbb162ce354fdb111056a74fc298"
+                "sha256:0d800130e43a5d4e71300cc6f91aabcef6fe6f26bc206bc61374bf695049587a",
+                "sha256:c4dec7ea9bc9210ec783d39b56d332f5a266b0d1e31a96c5092f6bd5252361ba"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.30"
+            "version": "==1.34.31"
         },
         "botocore": {
             "hashes": [
-                "sha256:caf82d91c2ff61235284a07ffdfba006873e0752e00896052f901a37720cefa4",
-                "sha256:e071a9766e7fc2221ca42ec01dfc54368a7518610787342ea622f6edc57f7891"
+                "sha256:6ee1ba451ce3d640dccd485906f68a55d9e7f3534553876e4adc75d6060a05ac",
+                "sha256:d5a2153dbe9687f510f179e03913bc9b4e266c865cabebe440c4d05ab923faa7"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.30"
+            "version": "==1.34.31"
         },
         "certifi": {
             "hashes": [
@@ -1765,11 +1765,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:11c8f37bcca40db96d8144522d925583bdb7a31f7b0e37e3ed4318400a8e2380",
-                "sha256:906d548203468492d432bcb294d4bc2fff751bf84971fbb2c10918cc206ee420"
+                "sha256:0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068",
+                "sha256:ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.1.0"
+            "version": "==4.2.0"
         },
         "pycparser": {
             "hashes": [


### PR DESCRIPTION
### Background

PAT `0.38.1` was released which updates the nested PDH version from `0.1.3` to `0.2.0`. This PR updates PAT to the new version.

### Changes

* Runs `make deps-update` to update `Pipfile.lock`

### Testing

* Tests pass as expected
