### PR TITLE
Ignore Okta internal admin console accesses in stolen session rule

### DIFF
--- a/rules/okta_rules/okta_potentially_stolen_session.py
+++ b/rules/okta_rules/okta_potentially_stolen_session.py
@@ -19,6 +19,15 @@ def rule(event):
 
     session_id = deep_get(event, "authenticationContext", "externalSessionId", default="unknown")
 
+    # Some events by Okta admins may appear to have changed IPs and user agents due to internal Okta behavior:
+    # https://support.okta.com/help/s/article/okta-integrations-showing-as-rawuseragent-with-okta-ips
+    # As such, we ignore certain client ids known to originate from Okta:
+    # https://developer.okta.com/docs/api/openapi/okta-myaccount/myaccount/tag/OktaApplications/
+    if deep_get(event, "client", "id") in [
+        "okta.b58d5b75-07d4-5f25-bf59-368a1261a405"  # Admin Console
+    ]:
+        return False
+
     # Filter only on app access and session start events
     if event.get("eventType") not in EVENT_TYPES or session_id == "unknown":
         return False

--- a/rules/okta_rules/okta_potentially_stolen_session.yml
+++ b/rules/okta_rules/okta_potentially_stolen_session.yml
@@ -345,4 +345,107 @@ Tests:
           "uuid": "redacted",
           "version": "0"
       }
+  -
+    Name: Okta internal event should be ignored
+    ExpectedResult: false
+    Mocks:
+      - objectName: get_string_set
+        returnValue: >
+                        [
+                            "123456",
+                            "4.3.2.1",
+                            "user_agent:Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36",
+                            "CHROME",
+                            "MacOS"
+                        ]
+    Log:
+        {
+            "actor": {
+              "alternateId": "admin",
+              "displayName": "Bobert",
+              "id": "unknown",
+              "type": "User"
+          },
+          "authenticationContext": {
+              "authenticationStep": 0,
+              "externalSessionId": "123456789"
+          },
+          "client": {
+            "device": "Unknown",
+            "geographicalContext": {
+                "city": "Boardman",
+                "country": "United States",
+                "geolocation": {
+                    "lat": 45.8234,
+                    "lon": -119.7257
+                },
+                "postalCode": "97818",
+                "state": "Oregon"
+            },
+            "id": "okta.b58d5b75-07d4-5f25-bf59-368a1261a405",
+            "ipAddress": "44.238.82.114",
+            "userAgent": {
+                "browser": "UNKNOWN",
+                "os": "Unknown",
+                "rawUserAgent": "Okta-Integrations"
+            },
+            "zone": "null"
+        },
+          "debugContext": {
+              "debugData": {
+                  "loginResult": "VERIFICATION_ERROR",
+                  "requestId": "redacted",
+                  "requestUri": "redacted",
+                  "threatSuspected": "false",
+                  "url": "redacted"
+              }
+          },
+          "displayMessage": "User login to Okta",
+          "eventType": "user.session.start",
+          "legacyEventType": "core.user_auth.login_failed",
+          "outcome": {
+              "reason": "VERIFICATION_ERROR",
+              "result": "FAILURE"
+          },
+          "p_any_domain_names": [
+              "rnvtelecom.com.br"
+          ],
+          "p_any_ip_addresses": [
+              "redacted"
+          ],
+          "p_event_time": "redacted",
+          "p_log_type": "Okta.SystemLog",
+          "p_parse_time": "redacted",
+          "p_row_id": "redacted",
+          "p_source_id": "redacted",
+          "p_source_label": "Okta",
+          "published": "redacted",
+          "request": {
+            "ipChain": [
+                {
+                    "geographicalContext": {
+                        "city": "Boardman",
+                        "country": "United States",
+                        "geolocation": {
+                            "lat": 45.8234,
+                            "lon": -119.7257
+                        },
+                        "postalCode": "97818",
+                        "state": "Oregon"
+                    },
+                    "ip": "44.238.82.114",
+                    "version": "V4"
+                }
+            ]
+        },
+          "securityContext": {},
+          "severity": "INFO",
+          "transaction": {
+              "detail": {},
+              "id": "redacted",
+              "type": "WEB"
+          },
+          "uuid": "redacted",
+          "version": "0"
+      }
  


### PR DESCRIPTION
### Background

Okta may include events in the system log that make it look like an Okta (admin) user suddenly changed user agent and IP: https://support.okta.com/help/s/article/okta-integrations-showing-as-rawuseragent-with-okta-ips?language=en_US

Prior to February 7, the `externalSessionId` was "unknown" which meant this Panther rule ignored the problematic events. However, starting February 7th this seems to have changed and Okta has started generating session ids corresponding to these Okta-owned, internal events.

The result is that we (a customer of Panther's) started getting hit with alerts making it seem like sessions were hijacked when in fact it's just that these internal Okta user agent/ip events were causing alerts to fire.

### Changes

To fix this, note that the `client.id` field contains a unique ID associated with internal Okta applications. You can find some of these IDs documented as part of the following Okta API: https://developer.okta.com/docs/api/openapi/okta-myaccount/myaccount/tag/OktaApplications/

To mitigate the noise, I've started by checking for the "Admin Console" application and ignore events associated with that.

### Testing

* `pat test`
* We are running this variant in our company's panther instance without issue.
