### PR TITLE
Add pull_request_target to CI Checks

### DIFF
--- a/.github/workflows/check-packs.yml
+++ b/.github/workflows/check-packs.yml
@@ -14,7 +14,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-on: pull_request
+on: 
+  pull_request:
+  pull_request_target:
 
 jobs:
   check_packs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-on: pull_request
+on: 
+  pull_request:
+  pull_request_target:
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
-on: pull_request
+on: 
+  pull_request:
+  pull_request_target:
 
 jobs:
   test:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,6 @@
-on: pull_request
+on: 
+  pull_request:
+  pull_request_target:
 
 jobs:
   validate:


### PR DESCRIPTION
### Background

Fork PRs won't have access to the new secrets we're using for Workflows. This PR adds the `pull_request_target` trigger to our CI Workflows.

### Changes

* Adds `pull_request_target:` to each of the CI Workflows

### Testing

* TBD
