### PR TITLE
Remove pull request trigger

### DIFF
--- a/.github/workflows/check-packs.yml
+++ b/.github/workflows/check-packs.yml
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 on: 
-  pull_request:
   pull_request_target:
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 on: 
-  pull_request:
   pull_request_target:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,4 @@
 on: 
-  pull_request:
   pull_request_target:
 
 jobs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,4 @@
 on: 
-  pull_request:
   pull_request_target:
 
 jobs:


### PR DESCRIPTION
### Background

We can rely solely on `pull_request_target` for the CI Checks.

Otherwise, fork PRs will see failures for these Checks while the `pull_request_target` Checks will work.

### Changes

* Removes `pull_request` from CI Checks; leaves `pull_request_target`

### Testing

* N/A