### PR TITLE
[sync] Use additional event data for Okta Stolen Session Rule (#70)

### DIFF
--- a/rules/okta_rules/okta_potentially_stolen_session.yml
+++ b/rules/okta_rules/okta_potentially_stolen_session.yml
@@ -72,7 +72,8 @@ Tests:
                   "requestId": "redacted",
                   "requestUri": "redacted",
                   "threatSuspected": "false",
-                  "url": "redacted"
+                  "url": "redacted",
+                  "dtHash": "kzpx58a99d2oam082rlu588wgy1mb0zfi1e1l63f9cjx4uxc455k4t6xdiwbxian"
               }
           },
           "displayMessage": "User login to Okta",
@@ -176,6 +177,7 @@ Tests:
           },
           "debugContext": {
               "debugData": {
+                  "dtHash": "kzpx58a99d2oam082rlu588wgy1mb0zfi1e1l63f9cjx4uxc455k4t6xdiwbxian",
                   "loginResult": "VERIFICATION_ERROR",
                   "requestId": "redacted",
                   "requestUri": "redacted",
@@ -288,7 +290,8 @@ Tests:
                   "requestId": "redacted",
                   "requestUri": "redacted",
                   "threatSuspected": "false",
-                  "url": "redacted"
+                  "url": "redacted",
+                  "dtHash": "kzpx58a99d2oam082rlu588wgy1mb0zfi1e1l63f9cjx4uxc455k4t6xdiwbxian"
               }
           },
           "displayMessage": "User login to Okta",


### PR DESCRIPTION
### Background

Okta added some additional context to their event logs which was causing the `Potentially Stolen Session` Rule to fire off false positives.

This PR adds some additional checks focused on the `dtHash` field which is used for Okta threat hunting[0].

TBD if `dtHash` is included by default since it's located in the `debugContext` object. That said, we'll return `False` if `unknown` is returned like we do for `session_id`.

[0] https://www.rezonate.io/glossary/what-is-okta-dthash/

### Changes

* Adds `dtHash` checks and fuzzing to `okta_potentially_stolen_session.py`
* Adds a couple of additional fields to the String Set (`sign_on_mode` and `threat_suspected`)

### Testing

* Tests pass as expected when accounting for `dtHash`
