### PR TITLE
[sync] dedup and severity improvements for noisiest rules (#72)

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_software_discovery.py
+++ b/rules/aws_cloudtrail_rules/aws_software_discovery.py
@@ -35,5 +35,9 @@ def title(event):
     )
 
 
+def dedup(event):
+    return deep_get(event, "userIdentity", "principalId")
+
+
 def alert_context(event):
     return aws_rule_context(event)

--- a/rules/aws_cloudtrail_rules/aws_software_discovery.yml
+++ b/rules/aws_cloudtrail_rules/aws_software_discovery.yml
@@ -74,8 +74,8 @@ Tests:
         eventVersion: "1.08"
         managementEvent: false
       Name: Non Discovery Event Names
-DedupPeriodMinutes: 15
+DedupPeriodMinutes: 360 # 6 hours
 LogTypes:
     - AWS.CloudTrail
 RuleID: "AWS.Software.Discovery"
-Threshold: 5
+Threshold: 50

--- a/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.yml
+++ b/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.yml
@@ -3,7 +3,7 @@ Filename: aws_unauthorized_api_call.py
 RuleID: "AWS.CloudTrail.UnauthorizedAPICall"
 DisplayName: "Monitor Unauthorized API Calls"
 Enabled: true
-DedupPeriodMinutes: 720 # 12 hours
+DedupPeriodMinutes: 1440 # 24 hours
 LogTypes:
   - AWS.CloudTrail
 Tags:
@@ -24,7 +24,7 @@ SummaryAttributes:
   - sourceIpAddress
   - recipientAccountId
   - p_any_aws_arns
-Threshold: 10
+Threshold: 20
 Tests:
   -
     Name: Unauthorized API Call from Within AWS (IP)

--- a/rules/aws_eks_rules/system_namespace_public_ip.py
+++ b/rules/aws_eks_rules/system_namespace_public_ip.py
@@ -46,7 +46,7 @@ def title(event):
 
 def dedup(event):
     p_eks = eks_panther_obj_ref(event)
-    return f"{p_eks.get('p_source_label')}_eks_system_namespace_{p_eks.get('actor')}"
+    return f"{p_eks.get('p_source_label')}_eks_system_namespace_{p_eks.get('sourceIPs')[0]}"
 
 
 def alert_context(event):

--- a/rules/aws_eks_rules/system_namespace_public_ip.yml
+++ b/rules/aws_eks_rules/system_namespace_public_ip.yml
@@ -7,18 +7,18 @@ LogTypes:
   - Amazon.EKS.Audit
 Tags: 
   - EKS
-#Reports: # (Optional)
-#  MITRE ATT&CK:
-#    - 'TA0027:T1475' # Tactic ID:Technique ID (https://attack.mitre.org/tactics/enterprise/)
+Reports: 
+  MITRE ATT&CK:
+    - 'TA0027:T1475' # Tactic ID:Technique ID (https://attack.mitre.org/tactics/enterprise/)
 Reference: https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html
 Severity: Info
-Description: > # (Optional)
+Description: > 
   This detection identifies if an activity is recorded in the Kubernetes audit log where 
   the user:username attribute begins with "system:" or "eks:" and the requests originating 
   IP Address is a Public IP Address
-DedupPeriodMinutes: 15 # The amount of time in minutes for grouping alerts (Optional, defaults to 60)
-Threshold: 1 # The minimum number of event matches prior to an alert sending (Optional, defaults to 1)
-SummaryAttributes: # A list of fields in the event to create top 5 summaries for (Optional)
+DedupPeriodMinutes: 1440 # 24 hours
+Threshold: 1 
+SummaryAttributes: 
   - user:username
   - p_source_label
 Tests:

--- a/rules/gsuite_reports_rules/gsuite_drive_overly_visible.py
+++ b/rules/gsuite_reports_rules/gsuite_drive_overly_visible.py
@@ -27,10 +27,10 @@ def rule(event):
 
 
 def dedup(event):
-    details = details_lookup("access", RESOURCE_CHANGE_EVENTS, event)
-    if param_lookup(details.get("parameters", {}), "doc_title"):
-        return param_lookup(details.get("parameters", {}), "doc_title")
-    return "<UNKNOWN_DOC_TITLE>"
+    user = deep_get(event, "actor", "email")
+    if user is None:
+        user = deep_get(event, "actor", "profileId", default="<UNKNOWN_PROFILEID>")
+    return user
 
 
 def title(event):

--- a/rules/gsuite_reports_rules/gsuite_drive_overly_visible.yml
+++ b/rules/gsuite_reports_rules/gsuite_drive_overly_visible.yml
@@ -19,6 +19,7 @@ Runbook: >
   Investigate whether the drive document is appropriate to be this visible.
 SummaryAttributes:
   - actor:email
+DedupPeriodMinutes: 360 # 6 hours
 Tests:
   -
     Name: Access Event

--- a/rules/gsuite_reports_rules/gsuite_drive_visibility_change.py
+++ b/rules/gsuite_reports_rules/gsuite_drive_visibility_change.py
@@ -167,8 +167,7 @@ def alert_context(event):
 
 
 def dedup(event):
-    log = event.get("p_row_id")
-    return ALERT_DETAILS[log]["DOC_TITLE"]
+    return deep_get(event, "actor", "email", default="<UNKNOWN_USER>")
 
 
 def title(event):
@@ -193,12 +192,11 @@ def title(event):
         elif ALERT_DETAILS[log]["NEW_VISIBILITY"] == "public_in_the_domain":
             sharing_scope += f" (anyone in {ALERT_DETAILS[log]['TARGET_DOMAIN']})"
 
-    alert_access_scope = ALERT_DETAILS[log]["ACCESS_SCOPE"][0].replace("can_", "")
+    # alert_access_scope = ALERT_DETAILS[log]["ACCESS_SCOPE"][0].replace("can_", "")
 
     return (
-        f"User [{deep_get(event, 'actor', 'email', default='<UNKNOWN_USER>')}] made the document "
-        f"[{ALERT_DETAILS[log]['DOC_TITLE']}] externally visible to [{sharing_scope}] with "
-        f"[{alert_access_scope}] access"
+        f"User [{deep_get(event, 'actor', 'email', default='<UNKNOWN_USER>')}] made documents "
+        f"externally visible"
     )
 
 

--- a/rules/gsuite_reports_rules/gsuite_drive_visibility_change.yml
+++ b/rules/gsuite_reports_rules/gsuite_drive_visibility_change.yml
@@ -20,6 +20,7 @@ Runbook: >
   Investigate whether the drive document is appropriate to be publicly accessible.
 SummaryAttributes:
   - actor:email
+DedupPeriodMinutes: 360 # 6 hours
 Tests:
   -
     Name: Access Event

--- a/rules/okta_rules/okta_anonymizing_vpn_login.yml
+++ b/rules/okta_rules/okta_anonymizing_vpn_login.yml
@@ -8,14 +8,14 @@ LogTypes:
 Reports:
     MITRE ATT&CK:
         - TA0006:T1556 # Modify Authentication Process
-Severity: High
+Severity: Medium
 Description: >
     A user is attempting to sign-in to Okta from a known VPN anonymizer.  The threat actor would access the compromised account using anonymizing proxy services. 
 Runbook: >
     Restrict this access to trusted Network Zones and deny access from anonymizing proxies in policy using a Dynamic Network Zone.
 Reference: >
     https://sec.okta.com/articles/2023/08/cross-tenant-impersonation-prevention-and-detection
-DedupPeriodMinutes: 30
+DedupPeriodMinutes: 360 # 6 hours
 Threshold: 1
 Tests:
     - Name: Other Event


### PR DESCRIPTION
### Background

Identified top 5 noisiest Panther managed rules and improved dedup and severity functions to better match the intent of the rules

### Changes

* AWS.Software.Discovery - dedup on principalID, increase alert threshold to 50, dedup period to 6 hours
* AWS.CloudTrail.UnauthorizedAPICall - increase threshold and dedup period
* Amazon.EKS.Audit.SystemNamespaceFromPublicIP - dedup on source IP and increase dedup period
* GSuite.DriveVisibilityChanged - dedup on actor.user and increase dedup period
* Okta.Anonymizing.VPN.Login - decrease severity and increase dedup period
* Deleted duplicate deprecated GSuite.DriveVisibilityChanged rule

### Testing

* make test