### PR TITLE
standard_rules/impossible_travel_login: set IS_PRIVATE_RELAY to true only when private relay is in use

### DIFF
--- a/rules/standard_rules/impossible_travel_login.py
+++ b/rules/standard_rules/impossible_travel_login.py
@@ -72,7 +72,7 @@ def rule(event):
         IS_PRIVATE_RELAY = all(
             [
                 deep_get(ipinfo_privacy, "relay", default=False),
-                deep_get(ipinfo_privacy, "service", default="") != "",
+                deep_get(ipinfo_privacy, "service", default="") == "Apple Private Relay",
             ]
         )
         # We've found that some places, like WeWork locations,


### PR DESCRIPTION
This fixes the standard login check to properly detect the use of Apple Private Relay. The second condition in all() is overly permissive in what's considered a private relay because it looks for _any_ service.
