### PR TITLE
[sync] GCP compute.instances.create Privilege Escalation - rule (#63)

### DIFF
--- a/rules/gcp_audit_rules/gcp_computeinstances_create_privilege_escalation.py
+++ b/rules/gcp_audit_rules/gcp_computeinstances_create_privilege_escalation.py
@@ -1,0 +1,62 @@
+from gcp_base_helpers import gcp_alert_context
+from panther_base_helpers import deep_get
+
+REQUIRED_PERMISSIONS = [
+    "compute.disks.create",
+    "compute.instances.create",
+    "compute.instances.setMetadata",
+    "compute.instances.setServiceAccount",
+    "compute.subnetworks.use",
+    "compute.subnetworks.useExternalIp",
+]
+
+
+def rule(event):
+    if deep_get(event, "protoPayload", "response", "error"):
+        return False
+
+    method = deep_get(event, "protoPayload", "methodName")
+    if not method.endswith("compute.instances.insert"):
+        return False
+
+    authorization_info = deep_get(event, "protoPayload", "authorizationInfo")
+    if not authorization_info:
+        return False
+
+    granted_permissions = {}
+    for auth in authorization_info:
+        granted_permissions[auth["permission"]] = auth["granted"]
+    for permission in REQUIRED_PERMISSIONS:
+        if not granted_permissions.get(permission):
+            return False
+
+    return True
+
+
+def title(event):
+    actor = deep_get(
+        event, "protoPayload", "authenticationInfo", "principalEmail", default="<ACTOR_NOT_FOUND>"
+    )
+
+    service_accounts = deep_get(event, "protoPayload", "request", "serviceAccounts")
+    if not service_accounts:
+        service_account_emails = "<SERVICE_ACCOUNT_EMAILS_NOT_FOUND>"
+    else:
+        service_account_emails = [service_acc["email"] for service_acc in service_accounts]
+
+    project = deep_get(event, "resource", "labels", "project_id", default="<PROJECT_NOT_FOUND>")
+    return (
+        f"[GCP]: [{actor}] created a new Compute Engine instance with [{service_account_emails}] "
+        f"Service Account on project [{project}]"
+    )
+
+
+def alert_context(event):
+    context = gcp_alert_context(event)
+    service_accounts = deep_get(event, "protoPayload", "request", "serviceAccounts")
+    if not service_accounts:
+        service_account_emails = "<SERVICE_ACCOUNT_EMAILS_NOT_FOUND>"
+    else:
+        service_account_emails = [service_acc["email"] for service_acc in service_accounts]
+    context["serviceAccount"] = service_account_emails
+    return context

--- a/rules/gcp_audit_rules/gcp_computeinstances_create_privilege_escalation.yml
+++ b/rules/gcp_audit_rules/gcp_computeinstances_create_privilege_escalation.yml
@@ -1,0 +1,346 @@
+AnalysisType: rule
+LogTypes:
+    - GCP.AuditLog
+Description: Detects compute.instances.create method for privilege escalation in GCP.
+DisplayName: "GCP compute.instances.create Privilege Escalation"
+RuleID: "GCP.compute.instances.create.Privilege.Escalation"
+Enabled: true
+Reference: https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/
+Runbook: Confirm this was authorized and necessary behavior.
+Reports:
+    MITRE ATT&CK:
+        - TA0004:T1548  # Abuse Elevation Control Mechanism
+Severity: High
+Filename: gcp_computeinstances_create_privilege_escalation.py
+DedupPeriodMinutes: 60
+Threshold: 1
+Tests:
+  -
+    Name: GCP compute.instances - Potential Privilege Escalation
+    ExpectedResult: true
+    Log:
+      {
+        "protoPayload": {
+          "at_sign_type": "type.googleapis.com/google.cloud.audit.AuditLog",
+          "authenticationInfo": {
+            "principalEmail": "some.user@company.com",
+            "principalSubject": "user:some.user@company.com"
+          },
+          "authorizationInfo": [
+            {
+              "granted": true,
+              "permission": "compute.instances.create",
+              "resource": "projects/some-project/zones/us-central1-f/instances/abc",
+              "resourceAttributes": {
+                "name": "projects/some-project/zones/us-central1-f/instances/abc",
+                "service": "compute",
+                "type": "compute.instances"
+              }
+            },
+            {
+              "granted": true,
+              "permission": "compute.disks.create",
+              "resource": "projects/some-project/zones/us-central1-f/disks/abc",
+              "resourceAttributes": {
+                "name": "projects/some-project/zones/us-central1-f/disks/abc",
+                "service": "compute",
+                "type": "compute.disks"
+              }
+            },
+            {
+              "granted": true,
+              "permission": "compute.subnetworks.use",
+              "resource": "projects/some-project/regions/us-central1/subnetworks/default",
+              "resourceAttributes": {
+                "name": "projects/some-project/regions/us-central1/subnetworks/default",
+                "service": "compute",
+                "type": "compute.subnetworks"
+              }
+            },
+            {
+              "granted": true,
+              "permission": "compute.subnetworks.useExternalIp",
+              "resource": "projects/some-project/regions/us-central1/subnetworks/default",
+              "resourceAttributes": {
+                "name": "projects/some-project/regions/us-central1/subnetworks/default",
+                "service": "compute",
+                "type": "compute.subnetworks"
+              }
+            },
+            {
+              "granted": true,
+              "permission": "compute.instances.setMetadata",
+              "resource": "projects/some-project/zones/us-central1-f/instances/abc",
+              "resourceAttributes": {
+                "name": "projects/some-project/zones/us-central1-f/instances/abc",
+                "service": "compute",
+                "type": "compute.instances"
+              }
+            },
+            {
+              "granted": true,
+              "permission": "compute.instances.setServiceAccount",
+              "resource": "projects/some-project/zones/us-central1-f/instances/abc",
+              "resourceAttributes": {
+                "name": "projects/some-project/zones/us-central1-f/instances/abc",
+                "service": "compute",
+                "type": "compute.instances"
+              }
+            }
+          ],
+          "methodName": "v1.compute.instances.insert",
+          "request": {
+            "@type": "type.googleapis.com/compute.instances.insert",
+            "disks": ...,
+            "machineType": ...,
+            "name": ...,
+            "networkInterfaces": ...,
+            "serviceAccounts": [
+              {
+                "email": "abcmail@some-project.iam.gserviceaccount.com",
+                "scopes": [
+                  "https://www.googleapis.com/auth/cloud-platform",
+                  "https://www.googleapis.com/auth/iam"
+                ]
+              }
+            ]
+          },
+          "requestMetadata": {
+            "callerIP": "1.2.3.4",
+            "callerSuppliedUserAgent": "(gzip),gzip(gfe)",
+            "destinationAttributes": { },
+            "requestAttributes": {
+              "auth": { },
+              "time": "2024-01-30T12:52:36.003867Z"
+            }
+          },
+          "resourceLocation": ...,
+          "resourceName": "projects/some-project/zones/us-central1-f/instances/abc",
+          "response": {
+            "@type": "type.googleapis.com/operation",
+            "id": "8758546889396539388",
+            "insertTime": "2024-01-30T04:52:35.886-08:00",
+            "name": "operation-1706619154623-610293c7a6a25-934f1c35-1efebb12",
+            "operationType": "insert",
+            "progress": "0",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/some-project/zones/us-central1-f/operations/operation-1706619154623-610293c7a6a25-934f1c35-1efebb12",
+            "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/some-project/zones/us-central1-f/operations/8758546889396539388",
+            "startTime": "2024-01-30T04:52:35.887-08:00",
+            "status": "RUNNING",
+            "targetId": "1454427709413609468",
+            "targetLink": "https://www.googleapis.com/compute/v1/projects/some-project/zones/us-central1-f/instances/abc",
+            "user": "some.user@company.com",
+            "zone": "https://www.googleapis.com/compute/v1/projects/some-project/zones/us-central1-f"
+          },
+          "serviceName": "compute.googleapis.com"
+        },
+        "receiveTimestamp": "2024-01-30 12:52:36.642422049",
+        "resource": {
+          "labels": {
+            "instance_id": "1454427709413609468",
+            "project_id": "some-project",
+            "zone": "us-central1-f"
+          },
+          "type": "gce_instance"
+        },
+        "severity": "NOTICE",
+        "timestamp": "2024-01-30 12:52:34.676384000"
+      }
+  -
+    Name: GCP compute.instances - Error
+    ExpectedResult: false
+    Log:
+      {
+        "protoPayload": {
+          "at_sign_type": "type.googleapis.com/google.cloud.audit.AuditLog",
+          "authenticationInfo": {
+            "principalEmail": "some.user@company.com",
+            "principalSubject": "user:some.user@company.com"
+          },
+          "authorizationInfo": [
+            {
+              "granted": true,
+              "permission": "compute.instances.create",
+              "resource": "projects/some-project/zones/us-central1-f/instances/abc",
+              "resourceAttributes": {
+                "name": "projects/some-project/zones/us-central1-f/instances/abc",
+                "service": "compute",
+                "type": "compute.instances"
+              }
+            },
+            {
+              "granted": true,
+              "permission": "compute.disks.create",
+              "resource": "projects/some-project/zones/us-central1-f/disks/abc",
+              "resourceAttributes": {
+                "name": "projects/some-project/zones/us-central1-f/disks/abc",
+                "service": "compute",
+                "type": "compute.disks"
+              }
+            },
+            {
+              "granted": true,
+              "permission": "compute.subnetworks.use",
+              "resource": "projects/some-project/regions/us-central1/subnetworks/default",
+              "resourceAttributes": {
+                "name": "projects/some-project/regions/us-central1/subnetworks/default",
+                "service": "compute",
+                "type": "compute.subnetworks"
+              }
+            },
+            {
+              "granted": true,
+              "permission": "compute.subnetworks.useExternalIp",
+              "resource": "projects/some-project/regions/us-central1/subnetworks/default",
+              "resourceAttributes": {
+                "name": "projects/some-project/regions/us-central1/subnetworks/default",
+                "service": "compute",
+                "type": "compute.subnetworks"
+              }
+            },
+            {
+              "granted": true,
+              "permission": "compute.instances.setMetadata",
+              "resource": "projects/some-project/zones/us-central1-f/instances/abc",
+              "resourceAttributes": {
+                "name": "projects/some-project/zones/us-central1-f/instances/abc",
+                "service": "compute",
+                "type": "compute.instances"
+              }
+            },
+            {
+              "granted": true,
+              "permission": "compute.instances.setServiceAccount",
+              "resource": "projects/some-project/zones/us-central1-f/instances/abc",
+              "resourceAttributes": {
+                "name": "projects/some-project/zones/us-central1-f/instances/abc",
+                "service": "compute",
+                "type": "compute.instances"
+              }
+            }
+          ],
+          "methodName": "v1.compute.instances.insert",
+          "request": {
+            "@type": ...,
+            "disks": ...,
+            "machineType": ...,
+            "name": ...,
+            "networkInterfaces": ...,
+            "serviceAccounts": [
+              {
+                "email": "abcmail@some-project.iam.gserviceaccount.com",
+                "scopes": [
+                  "https://www.googleapis.com/auth/cloud-platform",
+                  "https://www.googleapis.com/auth/iam"
+                ]
+              }
+            ]
+          },
+          "requestMetadata": ...,
+          "resourceLocation": ...,
+          "resourceName": "projects/some-project/zones/us-central1-f/instances/abc",
+          "response": {
+            "@type": "type.googleapis.com/error",
+            "error": {
+              "code": 404,
+              "errors": [
+                {
+                  "domain": "global",
+                  "message": "The resource 'abc' was not found",
+                  "reason": "notFound"
+                }
+              ],
+              "message": "The resource 'abc' was not found"
+            }
+          },
+          "serviceName": "compute.googleapis.com",
+          "status": {
+            "code": 5,
+            "message": "The resource 'abc' was not found"
+          }
+        },
+        "receiveTimestamp": "2024-01-30 11:03:56.719662927",
+        "resource": {
+          "labels": {
+            "instance_id": "",
+            "project_id": "some-project",
+            "zone": "us-central1-f"
+          },
+          "type": "gce_instance"
+        },
+        "severity": "ERROR",
+        "timestamp": "2024-01-30 11:03:55.700872000"
+      }
+  - Name: GCP compute.instances - Not All Permissions
+    ExpectedResult: false
+    Log:
+      {
+        "protoPayload": {
+          "at_sign_type": "type.googleapis.com/google.cloud.audit.AuditLog",
+          "authenticationInfo": {
+            "principalEmail": "some.user@company.com",
+            "principalSubject": "user:some.user@company.com"
+          },
+          "authorizationInfo": [
+            {
+              "granted": true,
+              "permission": "compute.instances.create",
+              "resource": "projects/some-project/zones/us-central1-f/instances/abc",
+              "resourceAttributes": {
+                "name": "projects/some-project/zones/us-central1-f/instances/abc",
+                "service": "compute",
+                "type": "compute.instances"
+              }
+            },
+            {
+              "granted": true,
+              "permission": "compute.disks.create",
+              "resource": "projects/some-project/zones/us-central1-f/disks/abc",
+              "resourceAttributes": {
+                "name": "projects/some-project/zones/us-central1-f/disks/abc",
+                "service": "compute",
+                "type": "compute.disks"
+              }
+            },
+            {
+              "granted": true,
+              "permission": "compute.subnetworks.use",
+              "resource": "projects/some-project/regions/us-central1/subnetworks/default",
+              "resourceAttributes": {
+                "name": "projects/some-project/regions/us-central1/subnetworks/default",
+                "service": "compute",
+                "type": "compute.subnetworks"
+              }
+            },
+            {
+              "granted": true,
+              "permission": "compute.subnetworks.useExternalIp",
+              "resource": "projects/some-project/regions/us-central1/subnetworks/default",
+              "resourceAttributes": {
+                "name": "projects/some-project/regions/us-central1/subnetworks/default",
+                "service": "compute",
+                "type": "compute.subnetworks"
+              }
+            },
+            {
+              "granted": true,
+              "permission": "compute.instances.setMetadata",
+              "resource": "projects/some-project/zones/us-central1-f/instances/abc",
+              "resourceAttributes": {
+                "name": "projects/some-project/zones/us-central1-f/instances/abc",
+                "service": "compute",
+                "type": "compute.instances"
+              }
+            },
+          ],
+          "methodName": "v1.compute.instances.insert",
+          "request": ...,
+          "requestMetadata": ...,
+          "resourceLocation": ...,
+          "resourceName": ...,
+          "response": ...,
+          "serviceName": ...
+        },
+        "receiveTimestamp": ...,
+        "resource": ...
+      }


### PR DESCRIPTION
### Goal
Detect compute.instances.create method for privilege escalation in GCP.

### Categorization
TA0004:T1548

### Strategy Abstract
The Identity and Access Management (IAM) service manages authorization and authentication for a GCP environment. This means that there are very likely multiple privilege escalation methods that use the IAM service and/or its permissions.

### Technical Context
This method creates a new Compute Engine instance with a specified Service Account, then sends the token belonging to that Service Account to an external server. This means you don’t need to access the instance at all.

The following permissions are required for this method:
- compute.disks.create
- compute.instances.create
- compute.instances.setMetadata
- compute.instances.setServiceAccount
- compute.subnetworks.use
- compute.subnetworks.useExternalIp
- iam.serviceAccounts.actAs

### Blind Spots and Assumptions
Assumes proper GCP logging and audit policies.

### False Positives
Legitimate administrative activity that is authorized and expected.

### Validation
The exploit script for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/compute.instances.create.py).

### Priority
High or Critical

### Response
Again, these are not vulnerabilities in GCP, they are vulnerabilities in how you have configured your GCP environment, so it is your responsibility to be aware of these attack vectors and to defend against them. Make sure to follow the principle of least-privilege in your environments to help mitigate these security risks.

### Additional Resources
[Privilege Escalation in Google Cloud Platform - Part 1 (IAM) - Rhino Security Labs](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/)
****