### PR TITLE
[sync] GitHub Data Model Admin Actions update (#79)

### DIFF
--- a/data_models/github_data_model.py
+++ b/data_models/github_data_model.py
@@ -6,14 +6,25 @@ ADMIN_EVENTS = {
     "team.promote_maintainer",
 }
 
+CONDITIONAL_ADMIN_EVENTS = {
+    "team.add_repository",
+}
+
 
 def get_admin_role(event):
     action = event.get("action", "")
+    permission = event.get("permission", "")
+    if action in CONDITIONAL_ADMIN_EVENTS and permission == "admin":
+        return action
     return action if action in ADMIN_EVENTS else "<UNKNOWN_ADMIN_ROLE>"
 
 
 def get_event_type(event):
-    if event.get("action", "") in ADMIN_EVENTS:
+    action = event.get("action", "")
+    permission = event.get("permission", "")
+    if action in ADMIN_EVENTS:
+        return event_type.ADMIN_ROLE_ASSIGNED
+    if action in CONDITIONAL_ADMIN_EVENTS and permission == "admin":
         return event_type.ADMIN_ROLE_ASSIGNED
     if event.get("action", "") == "org.disable_two_factor_requirement":
         return event_type.MFA_DISABLED


### PR DESCRIPTION
### Background

Updates GitHub data model to consider `action = 'team.add_repository' and permission = 'admin'` as an admin event for udm.assigned_admin_role and udm.get_event_type methods

### Changes

* Adds a CONDITIONAL_ADMIN_EVENTS variable that considers events as admin related when permission also equals "admin"

### Testing

* make test
