### PR TITLE
[sync] Add GCP.K8s.IOC.Activity rule (#80)

### DIFF
--- a/lookup_tables/tor/tor_exit_nodes.yml
+++ b/lookup_tables/tor/tor_exit_nodes.yml
@@ -211,6 +211,7 @@ LogTypeMap:
         - "$.protoPayload.requestMetadata.callerIP"
         - "$.httpRequest.remoteIP"
         - "$.httpRequest.serverIP"
+        - "$.requestMetadata.callerIP"
     - LogType: GCP.HTTPLoadBalancer
       Selectors:
         - "$.jsonPayload.removeIp"

--- a/rules/gcp_k8s_rules/gcp_k8s_ioc_activity.yml
+++ b/rules/gcp_k8s_rules/gcp_k8s_ioc_activity.yml
@@ -1,0 +1,44 @@
+AnalysisType: rule
+RuleID: "GCP.K8s.IOC.Activity"
+DisplayName: "GCP K8s IOCActivity"
+Enabled: true
+LogTypes:
+  - GCP.AuditLog
+Tags:
+  - GCP
+  - Optional
+Severity: Medium
+Description: This detection monitors for any kuberentes API Request originating from an Indicator of Compromise.
+Detection:
+    - All:
+      - KeyPath: operation.producer
+        Condition: Equals
+        Value: k8s.io
+      - KeyPath: p_enrichment.tor_exit_nodes
+        Condition: IsNotNullOrEmpty
+Reference: https://medium.com/snowflake/from-logs-to-detection-using-snowflake-and-panther-to-detect-k8s-threats-d72f70a504d7
+Tests:
+  -
+    Name: triggers
+    ExpectedResult: true
+    Log:
+      {
+        "operation": {"producer":"k8s.io"},
+        "p_enrichment": {
+          "tor_exit_nodes": [
+            "1.1.1.1"
+          ]
+        }
+      }
+  -
+    Name: ignore
+    ExpectedResult: false
+    Log:
+      {
+        "operation": {"producer":"chrome"},
+        "p_enrichment": {
+          "tor_exit_nodes": [
+            "1.1.1.1"
+          ]
+        }
+      }


### PR DESCRIPTION
### Background

Adds a new `GCP.K8s.IOC.Activity` rule to mirror https://github.com/panther-labs/panther-analysis-internal/blob/main/queries/kubernetes_queries/kubernetes_ioc_activity.yml in GCP

### Changes

* <Describe changes here>

### Testing

* <Testing steps>
