### PR TITLE
Add .Simple suffix to Simple Rule IDs

### DIFF
--- a/packs/gcp_audit.yml
+++ b/packs/gcp_audit.yml
@@ -7,9 +7,9 @@ PackDefinition:
     - GCP.Access.Attempts.Violating.VPC.Service.Controls
     - GCP.BigQuery.Large.Scan
     - GCP.Cloud.Storage.Buckets.Modified.Or.Deleted
-    - GCP.CloudBuild.Potential.Privilege.Escalation
-    - GCP.Cloudfunctions.Functions.Create
-    - GCP.Cloudfunctions.Functions.Update
+    - GCP.CloudBuild.Potential.Privilege.Escalation.Simple
+    - GCP.Cloudfunctions.Functions.Create.Simple
+    - GCP.Cloudfunctions.Functions.Update.Simple
     - GCP.Destructive.Queries
     - GCP.DNS.Zone.Modified.or.Deleted
     - GCP.Firewall.Rule.Created
@@ -20,32 +20,32 @@ PackDefinition:
     - GCP.IAM.CorporateEmail
     - GCP.IAM.CustomRoleChanges
     - GCP.IAM.OrgFolderIAMChanges
-    - GCP.iam.roles.update.Privilege.Escalation
-    - GCP.iam.serviceAccountKeys.create
+    - GCP.iam.roles.update.Privilege.Escalation.Simple
+    - GCP.iam.serviceAccountKeys.create.Simple
     - GCP.Inbound.SSO.Profile.Created
+    - GCP.K8s.New.Daemonset.Deployed.Simple
     - GCP.Log.Bucket.Or.Sink.Deleted
     - GCP.Logging.Settings.Modified
     - GCP.Logging.Sink.Modified
     - GCP.Permissions.Granted.to.Create.or.Manage.Service.Account.Key
-    - GCP.Privilege.Escalation.By.Deployments.Create
+    - GCP.Privilege.Escalation.By.Deployments.Create.Simple
     - GCP.Service.Account.Access.Denied
     - GCP.Service.Account.or.Keys.Created
-    - GCP.serviceusage.apiKeys.create.Privilege.Escalation
+    - GCP.serviceusage.apiKeys.create.Privilege.Escalation.Simple
     - GCP.SQL.ConfigChanges
+    - GCP.Storage.Hmac.Keys.Create
     - GCP.User.Added.to.IAP.Protected.Service
     - GCP.VPC.Flow.Logs.Disabled
     - GCP.Workforce.Pool.Created.or.Updated
     - GCP.Workload.Identity.Pool.Created.or.Updated
-    - GCP.Storage.Hmac.Keys.Create
-    - GCP.K8s.New.Daemonset.Deployed
     # Data model
     - Standard.GCP.AuditLog
     # Globals used in these rules/policies
-    - panther_base_helpers
-    - panther_event_type_helpers
     - gcp_base_helpers
     - gcp_environment
+    - panther_base_helpers
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
+    - panther_event_type_helpers
 DisplayName: "Panther GCP Audit Pack"

--- a/packs/netskope.yml
+++ b/packs/netskope.yml
@@ -3,7 +3,7 @@ PackID: PantherManaged.Netskope
 Description: Group of all Netskope detections
 PackDefinition:
   IDs:
-    - Netskope.AdminLoggedOutLoginFailures
-    - Netskope.AdminUserChange
-    - Netskope.NetskopePersonnelActivity
+    - Netskope.AdminLoggedOutLoginFailures.Simple
+    - Netskope.AdminUserChange.Simple
+    - Netskope.NetskopePersonnelActivity.Simple
 DisplayName: "Panther Netskope Pack"

--- a/simple_rules/gcp_audit_rules/gcp_cloudbuild_potential_privilege_escalation_simple.yml
+++ b/simple_rules/gcp_audit_rules/gcp_cloudbuild_potential_privilege_escalation_simple.yml
@@ -5,7 +5,7 @@ Description: Detects privilege escalation attacks designed to gain access to the
   A user with permissions to start a new build with Cloud Build can gain access to the Cloud Build Service Account 
   and abuse it for more access to the environment.
 DisplayName: "GCP CloudBuild Potential Privilege Escalation"
-RuleID: "GCP.CloudBuild.Potential.Privilege.Escalation"
+RuleID: "GCP.CloudBuild.Potential.Privilege.Escalation.Simple"
 Enabled: true
 Reference: https://rhinosecuritylabs.com/gcp/iam-privilege-escalation-gcp-cloudbuild/
 Runbook: Confirm this was authorized and necessary behavior. To defend against this privilege escalation attack, 

--- a/simple_rules/gcp_audit_rules/gcp_cloudfunctions_functions_create_simple.yml
+++ b/simple_rules/gcp_audit_rules/gcp_cloudfunctions_functions_create_simple.yml
@@ -1,5 +1,5 @@
 AnalysisType: rule
-RuleID: "GCP.Cloudfunctions.Functions.Create"
+RuleID: "GCP.Cloudfunctions.Functions.Create.Simple"
 DisplayName: "GCP cloudfunctions functions create"
 Description: "The Identity and Access Management (IAM) service manages authorization and authentication for a GCP environment. This means that there are very likely multiple privilege escalation methods that use the IAM service and/or its permissions."
 Enabled: true

--- a/simple_rules/gcp_audit_rules/gcp_cloudfunctions_functions_update_simple.yml
+++ b/simple_rules/gcp_audit_rules/gcp_cloudfunctions_functions_update_simple.yml
@@ -1,5 +1,5 @@
 AnalysisType: rule
-RuleID: "GCP.Cloudfunctions.Functions.Update"
+RuleID: "GCP.Cloudfunctions.Functions.Update.Simple"
 DisplayName: "GCP cloudfunctions functions update"
 Description: "The Identity and Access Management (IAM) service manages authorization and authentication for a GCP environment. This means that there are very likely multiple privilege escalation methods that use the IAM service and/or its permissions."
 Enabled: true

--- a/simple_rules/gcp_audit_rules/gcp_iam_roles_update_privilege_escalation_simple.yml
+++ b/simple_rules/gcp_audit_rules/gcp_iam_roles_update_privilege_escalation_simple.yml
@@ -1,5 +1,5 @@
 AnalysisType: rule
-RuleID: "GCP.iam.roles.update.Privilege.Escalation"
+RuleID: "GCP.iam.roles.update.Privilege.Escalation.Simple"
 DisplayName: "GCP iam.roles.update Privilege Escalation"
 Description: "If your user is assigned a custom IAM role, then iam.roles.update will allow you to update the “includedPermissons” on that role. Because it is assigned to you, you will gain the additional privileges, which could be anything you desire."
 Enabled: true

--- a/simple_rules/gcp_audit_rules/gcp_iam_service_account_key_create_simple.yml
+++ b/simple_rules/gcp_audit_rules/gcp_iam_service_account_key_create_simple.yml
@@ -1,5 +1,5 @@
 AnalysisType: rule
-RuleID: "GCP.iam.serviceAccountKeys.create"
+RuleID: "GCP.iam.serviceAccountKeys.create.Simple"
 DisplayName: "GCP.Iam.ServiceAccountKeys.Create"
 Description: "If your user is assigned a custom IAM role, then iam.roles.update will allow you to update the “includedPermissons” on that role. Because it is assigned to you, you will gain the additional privileges, which could be anything you desire."
 Enabled: true

--- a/simple_rules/gcp_audit_rules/gcp_privilege_escalation_by_deployments_create_simple.yml
+++ b/simple_rules/gcp_audit_rules/gcp_privilege_escalation_by_deployments_create_simple.yml
@@ -1,5 +1,5 @@
 AnalysisType: rule
-RuleID: "GCP.Privilege.Escalation.By.Deployments.Create"
+RuleID: "GCP.Privilege.Escalation.By.Deployments.Create.Simple"
 DisplayName: "GCP.Privilege.Escalation.By.Deployments.Create"
 Description: "Detects privilege escalation in GCP by taking over the deploymentsmanager.deployments.create permission"
 Enabled: true

--- a/simple_rules/gcp_audit_rules/gcp_serviceusage_apikeys_create_privilege_escalation_simple.yml
+++ b/simple_rules/gcp_audit_rules/gcp_serviceusage_apikeys_create_privilege_escalation_simple.yml
@@ -5,7 +5,7 @@ Description: Detects serviceusage.apiKeys.create method for privilege escalation
   created with no restrictions, which means they have access to the entire GCP project they were created in. We can 
   capitalize on that fact by creating a new API key that may have more privileges than our own user.
 DisplayName: "GCP serviceusage.apiKeys.create Privilege Escalation"
-RuleID: "GCP.serviceusage.apiKeys.create.Privilege.Escalation"
+RuleID: "GCP.serviceusage.apiKeys.create.Privilege.Escalation.Simple"
 Enabled: true
 Reference: https://rhinosecuritylabs.com/cloud-security/privilege-escalation-google-cloud-platform-part-2/
 Runbook: Confirm this was authorized and necessary behavior. This is not a vulnerability in GCP, it is a vulnerability 

--- a/simple_rules/gcp_k8s_rules/gcp_k8s_ioc_activity_simple.yml
+++ b/simple_rules/gcp_k8s_rules/gcp_k8s_ioc_activity_simple.yml
@@ -1,5 +1,5 @@
 AnalysisType: rule
-RuleID: "GCP.K8s.IOC.Activity"
+RuleID: "GCP.K8s.IOC.Activity.Simple"
 DisplayName: "GCP K8s IOCActivity"
 Enabled: true
 LogTypes:

--- a/simple_rules/gcp_k8s_rules/gcp_kubernetes_new_daemonset_deployed_simple.yml
+++ b/simple_rules/gcp_k8s_rules/gcp_kubernetes_new_daemonset_deployed_simple.yml
@@ -1,5 +1,5 @@
 AnalysisType: rule
-RuleID: "GCP.K8s.New.Daemonset.Deployed"
+RuleID: "GCP.K8s.New.Daemonset.Deployed.Simple"
 DisplayName: "GCP K8s New Daemonset Deployed"
 Description: "Detects Daemonset creation in GCP Kubernetes clusters."
 Enabled: true

--- a/simple_rules/netskope_rules/netskope_admin_logged_out_simple.yml
+++ b/simple_rules/netskope_rules/netskope_admin_logged_out_simple.yml
@@ -1,5 +1,5 @@
 AnalysisType: rule
-RuleID: "Netskope.AdminLoggedOutLoginFailures"
+RuleID: "Netskope.AdminLoggedOutLoginFailures.Simple"
 DisplayName: "Admin logged out because of successive login failures"
 AlertTitle: "Admin [{user}] was logged out because of successive login failures"
 Detection:

--- a/simple_rules/netskope_rules/netskope_admin_user_change_simple.yml
+++ b/simple_rules/netskope_rules/netskope_admin_user_change_simple.yml
@@ -1,5 +1,5 @@
 AnalysisType: rule
-RuleID: "Netskope.AdminUserChange"
+RuleID: "Netskope.AdminUserChange.Simple"
 DisplayName: "An administrator account was created, deleted, or modified."
 AlertTitle: "User [{user}] performed [{audit_log_event}]"
 Detection:

--- a/simple_rules/netskope_rules/netskope_many_deletes_simple.yml
+++ b/simple_rules/netskope_rules/netskope_many_deletes_simple.yml
@@ -1,5 +1,5 @@
 AnalysisType: rule
-RuleID: "Netskope.ManyDeletes"
+RuleID: "Netskope.ManyDeletes.Simple"
 DisplayName: "Netskope Many Objects Deleted"
 AlertTitle: "[{user}] deleted many objects in a short time"
 Detection:

--- a/simple_rules/netskope_rules/netskope_personnel_action_simple.yml
+++ b/simple_rules/netskope_rules/netskope_personnel_action_simple.yml
@@ -1,5 +1,5 @@
 AnalysisType: rule
-RuleID: "Netskope.NetskopePersonnelActivity"
+RuleID: "Netskope.NetskopePersonnelActivity.Simple"
 DisplayName: "Action Performed by Netskope Personnel"
 AlertTitle: "Action [{audit_log_event}] performed by Netskope personnel [{user}]"
 Detection:

--- a/simple_rules/netskope_rules/netskope_unauthorized_api_calls_simple.yml
+++ b/simple_rules/netskope_rules/netskope_unauthorized_api_calls_simple.yml
@@ -1,5 +1,5 @@
 AnalysisType: rule
-RuleID: "Netskope.UnauthorizedAPICalls"
+RuleID: "Netskope.UnauthorizedAPICalls.Simple"
 DisplayName: "Netskope Many Unauthorized API Calls"
 AlertTitle: "Many unauthorized API calls from user [{user}]"
 Detection:


### PR DESCRIPTION
### Background

This PR adds a `.Simple` suffix to Simple Detection Rules in order to differentiate them from Python Rules.

### Changes

* Adds a `.Simple` suffix to Simple Detection Rules

### Testing

* Test pass as expected
