### PR TITLE
[sync] Add GCP.K8s.Pod.Using.Host.PID.Namespace rule (#84)

### DIFF
--- a/simple_rules/gcp_k8s_rules/gcp_k8s_pod_using_host_pid_namespace_simple.yml
+++ b/simple_rules/gcp_k8s_rules/gcp_k8s_pod_using_host_pid_namespace_simple.yml
@@ -1,0 +1,70 @@
+AnalysisType: rule
+RuleID: "GCP.K8s.Pod.Using.Host.PID.Namespace.Simple"
+DisplayName: "GCP K8s Pod Using Host PID Namespace"
+Enabled: true
+LogTypes:
+  - GCP.AuditLog
+Tags:
+  - GCP
+  - Optional
+Severity: Medium
+Description: This detection monitors for any pod creation or modification using the host PID namespace. The Host PID namespace enables a pod and its containers to have direct access and share the same view as of the host’s processes. This can offer a powerful escape hatch to the underlying host.
+Detection:
+  - All:
+    - KeyPath: protoPayload.methodName
+      Condition: IsIn
+      Values:
+        - io.k8s.core.v1.pods.create
+        - io.k8s.core.v1.pods.update
+        - io.k8s.core.v1.pods.patch
+    - Any:
+      - KeyPath: protoPayload.request.spec.hostPID
+        Condition: Equals
+        Value: true
+      - KeyPath: protoPayload.response.spec.hostPID
+        Condition: Equals
+        Value: true
+Reference: https://medium.com/snowflake/from-logs-to-detection-using-snowflake-and-panther-to-detect-k8s-threats-d72f70a504d7
+Tests:
+  -
+    Name: triggers
+    ExpectedResult: true
+    Log:
+      {
+        "authorizationInfo": [
+          {
+            "granted": true,
+            "permission": "io.k8s.core.v1.pods.create",
+            "resource": "core/v1/namespaces/default/pods/nginx-test"
+          }
+        ],
+        "protoPayload": {
+          "methodName": "io.k8s.core.v1.pods.create",
+          "request": {
+            "spec": {
+              "hostPID": true,
+            }
+          }
+        }
+      }
+  -
+    Name: ignore
+    ExpectedResult: false
+    Log:
+      {
+        "authorizationInfo": [
+          {
+            "granted": true,
+            "permission": "io.k8s.core.v1.pods.create",
+            "resource": "core/v1/namespaces/default/pods/nginx-test"
+          }
+        ],
+        "protoPayload": {
+          "methodName": "io.k8s.core.v1.pods.create",
+          "request": {
+            "spec": {
+              "hostPID": false,
+            }
+          }
+        }
+      }


### PR DESCRIPTION
Add GCP.K8s.Pod.Using.Host.PID.Namespace rule to mirror https://github.com/panther-labs/panther-analysis-internal/blob/main/queries/kubernetes_queries/kubernetes_pod_using_host_pid_namespace.yml in GCP