### PR TITLE
updates source_ip in crowdstrike datamodel to aip

### DIFF
--- a/data_models/crowdstrike_fdr_data_model.yml
+++ b/data_models/crowdstrike_fdr_data_model.yml
@@ -19,6 +19,6 @@ Mappings:
     - Name: process_name
       Method: get_process_name
     - Name: source_ip
-      Path: $.event.LocalAddressIP4
+      Path: $.aip
     - Name: source_port
       Path: $.event.LocalPort


### PR DESCRIPTION
### Background
Rules that reference CrowdStrike source_ip datamodel field were returning None

### Changes

* Updates CrowdStrike datamodel source_ip to $.aip

### Testing

* make test returns expected IP instead of None
