### PR TITLE
Fix GCP.K8S.Pot.Create.Or.Modify.Host.Path.Volume.Mount detection

### DIFF
--- a/rules/gcp_k8s_rules/gcp_k8s_pod_create_or_modify_host_path_vol_mount.py
+++ b/rules/gcp_k8s_rules/gcp_k8s_pod_create_or_modify_host_path_vol_mount.py
@@ -28,8 +28,11 @@ def rule(event):
     volume_mount_path = deep_walk(
         event, "protoPayload", "request", "spec", "volumes", "hostPath", "path"
     )
-    if volume_mount_path not in SUSPICIOUS_PATHS and not any(
-        path in SUSPICIOUS_PATHS for path in volume_mount_path
+
+    if (
+        not volume_mount_path
+        or volume_mount_path not in SUSPICIOUS_PATHS
+        and not any(path in SUSPICIOUS_PATHS for path in volume_mount_path)
     ):
         return False
 


### PR DESCRIPTION
### Background
Detection fails if volume  mount path is not present in log.

