### PR TITLE
Fixed IndexOutOfRange error in get_zoom_usergroup_context

### DIFF
--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -30,6 +30,7 @@ import panther_snyk_helpers as p_snyk_h  # pylint: disable=C0413
 import panther_tailscale_helpers as p_tscale_h  # pylint: disable=C0413
 import panther_tines_helpers as p_tines_h  # pylint: disable=C0413
 import panther_tor_helpers as p_tor_h  # pylint: disable=C0413
+import panther_zoom_helpers as p_zoom_h  # pylint: disable=C0413
 
 # pylint: disable=too-many-lines
 
@@ -2359,6 +2360,26 @@ class TestAzureSigninHelpers(unittest.TestCase):
                 "source_ip": "<NO_SOURCEIP>",
                 "resourceDisplayName": "<NO_RESOURCEDISPLAYNAME>",
                 "resourceId": "<NO_RESOURCEID>",
+            },
+        )
+
+
+class TestZoomHelpers(unittest.TestCase):
+    def test_change_filed_is_empty_on_update_context(self):
+        event = {
+            "action": "Update",
+            "category_type": "User Group",
+            "operation_detail": "Edit Group Recruiting ",
+            "time": "2024-02-20 17:23:30",
+        }
+        returns = p_zoom_h.get_zoom_usergroup_context(event)
+        self.assertEqual(
+            returns,
+            {
+                "GroupName": "Recruiting",
+                "Change": "",
+                "DisabledSetting": False,
+                "EnabledSetting": False,
             },
         )
 

--- a/global_helpers/panther_zoom_helpers.py
+++ b/global_helpers/panther_zoom_helpers.py
@@ -41,8 +41,10 @@ def get_zoom_usergroup_context(event):
             operation_context["GroupName"] = " ".join(raw_string.split()[1:])
 
         if action == "Update":
-            operation_context["GroupName"] = " ".join(raw_string.split("-")[0].split()[2:])
-            operation_context["Change"] = raw_string.split("-")[1].strip()
+            columns = raw_string.split("-")
+            operation_context["GroupName"] = " ".join(columns[0].split()[2:])
+            operation_context["Change"] = columns[1].strip() if len(columns) > 1 else ""
+
             operation_context["DisabledSetting"] = "On to Off" in operation_context["Change"]
             operation_context["EnabledSetting"] = "Off to On" in operation_context["Change"]
 


### PR DESCRIPTION
### Background

The [get_zoom_usergroup_context](https://github.com/panther-labs/panther-analysis/blob/release/global_helpers/panther_zoom_helpers.py#L26) function is returning IndexOutOfRange errors if there is no `-` in event's `operation_detail`  field 
