### PR TITLE
Fix key when retrieving string_set in Okta Stolen Session Rule

### DIFF
--- a/rules/gcp_audit_rules/gcp_cloudfunctions_functions_create.py
+++ b/rules/gcp_audit_rules/gcp_cloudfunctions_functions_create.py
@@ -1,5 +1,5 @@
 from gcp_base_helpers import gcp_alert_context
-from panther_base_helpers import deep_walk, deep_get
+from panther_base_helpers import deep_get, deep_walk
 
 
 def rule(event):

--- a/rules/gcp_audit_rules/gcp_cloudfunctions_functions_update.py
+++ b/rules/gcp_audit_rules/gcp_cloudfunctions_functions_update.py
@@ -1,5 +1,5 @@
 from gcp_base_helpers import gcp_alert_context
-from panther_base_helpers import deep_walk, deep_get
+from panther_base_helpers import deep_get, deep_walk
 
 
 def rule(event):

--- a/rules/gcp_audit_rules/gcp_iam_roles_update_privilege_escalation.py
+++ b/rules/gcp_audit_rules/gcp_iam_roles_update_privilege_escalation.py
@@ -1,5 +1,5 @@
 from gcp_base_helpers import gcp_alert_context
-from panther_base_helpers import deep_walk, deep_get
+from panther_base_helpers import deep_get, deep_walk
 
 
 def rule(event):

--- a/rules/gcp_audit_rules/gcp_iam_service_account_key_create.py
+++ b/rules/gcp_audit_rules/gcp_iam_service_account_key_create.py
@@ -1,5 +1,5 @@
 from gcp_base_helpers import gcp_alert_context
-from panther_base_helpers import deep_walk, deep_get
+from panther_base_helpers import deep_get, deep_walk
 
 
 def rule(event):

--- a/rules/gcp_audit_rules/gcp_privilege_escalation_by_deploymants_create.py
+++ b/rules/gcp_audit_rules/gcp_privilege_escalation_by_deploymants_create.py
@@ -1,5 +1,5 @@
 from gcp_base_helpers import gcp_alert_context
-from panther_base_helpers import deep_walk, deep_get
+from panther_base_helpers import deep_get, deep_walk
 
 
 def rule(event):

--- a/rules/gcp_k8s_rules/gcp_k8s_cron_job_created_or_modified.py
+++ b/rules/gcp_k8s_rules/gcp_k8s_cron_job_created_or_modified.py
@@ -1,5 +1,5 @@
 from gcp_base_helpers import gcp_alert_context
-from panther_base_helpers import deep_walk, deep_get
+from panther_base_helpers import deep_get, deep_walk
 
 
 def rule(event):

--- a/rules/gcp_k8s_rules/gcp_k8s_new_daemonset_deployed.py
+++ b/rules/gcp_k8s_rules/gcp_k8s_new_daemonset_deployed.py
@@ -1,5 +1,5 @@
 from gcp_base_helpers import gcp_alert_context
-from panther_base_helpers import deep_walk, deep_get
+from panther_base_helpers import deep_get, deep_walk
 
 
 def rule(event):

--- a/rules/okta_rules/okta_potentially_stolen_session.py
+++ b/rules/okta_rules/okta_potentially_stolen_session.py
@@ -36,8 +36,10 @@ def rule(event):
     ):
         return False
 
+    key = session_id + "-" + dt_hash
+
     # lookup if we've previously stored the session cookie
-    PREVIOUS_SESSION = get_string_set(session_id)
+    PREVIOUS_SESSION = get_string_set(key)
 
     # For unit test mocks we need to eval the string to a set
     if isinstance(PREVIOUS_SESSION, str):
@@ -45,7 +47,6 @@ def rule(event):
 
     # If the sessionID has not been seen before, store information about it
     if not PREVIOUS_SESSION:
-        key = session_id + "-" + dt_hash
         put_string_set(
             key,
             [


### PR DESCRIPTION
### Background

We store a concatenation of the Session ID, a hyphen, and the DT Hash in `okta_potentially_stolen_session.py` but only try to retrieve the `session_id` to see if a previous session exists. 

This will never find anything given we updated how sessions are stored.

### Changes

* Looks for the correct key in `get_string_set`

### Testing

* `make fmt; make lint; make test`
