### PR TITLE
Add GCP.IAM.serviceAccounts.getAccessToken.Privilege.Escalation  rule

### DIFF
--- a/packs/gcp_audit.yml
+++ b/packs/gcp_audit.yml
@@ -39,6 +39,9 @@ PackDefinition:
     - GCP.VPC.Flow.Logs.Disabled
     - GCP.Workforce.Pool.Created.or.Updated
     - GCP.Workload.Identity.Pool.Created.or.Updated
+    - GCP.IAM.serviceAccounts.getAccessToken.Privilege.Escalation
+    - GCP.IAM.serviceAccounts.signJwt.Privilege.Escalation
+    - GCP.compute.instances.create.Privilege.Escalation
     # Data model
     - Standard.GCP.AuditLog
     # Globals used in these rules/policies

--- a/rules/gcp_audit_rules/gcp_iam_service_accounts_get_access_token_privilege_escalation.py
+++ b/rules/gcp_audit_rules/gcp_iam_service_accounts_get_access_token_privilege_escalation.py
@@ -1,0 +1,20 @@
+from gcp_base_helpers import gcp_alert_context
+from panther_base_helpers import deep_walk
+
+
+def rule(event):
+    authorization_info = deep_walk(event, "protoPayload", "authorizationInfo")
+    if not authorization_info:
+        return False
+
+    for auth in authorization_info:
+        if (
+            auth.get("permission") == "iam.serviceAccounts.getAccessToken"
+            and auth.get("granted") is True
+        ):
+            return True
+    return False
+
+
+def alert_context(event):
+    return gcp_alert_context(event)

--- a/rules/gcp_audit_rules/gcp_iam_service_accounts_get_access_token_privilege_escalation.yml
+++ b/rules/gcp_audit_rules/gcp_iam_service_accounts_get_access_token_privilege_escalation.yml
@@ -1,0 +1,115 @@
+AnalysisType: rule
+Filename: gcp_iam_service_accounts_get_access_token_privilege_escalation.py
+RuleID: "GCP.IAM.serviceAccounts.getAccessToken.Privilege.Escalation"
+DisplayName: "GCP IAM serviceAccounts getAccessToken Privilege Escalation"
+Enabled: true
+LogTypes:
+  - GCP.AuditLog
+Reports:
+  MITRE ATT&CK:
+    - TA0004:T1548
+Severity: High
+Description: The Identity and Access Management (IAM) service manages authorization and authentication for a GCP environment. 
+  This means that there are very likely multiple privilege escalation methods that use the IAM service and/or its permissions.
+Reference: https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/
+Tests:
+  -
+    Name: iam.serviceAccounts.getAccessToken granted
+    ExpectedResult: true
+    Log:
+      {
+        "protoPayload": {
+          "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+          "status": { },
+          "authenticationInfo": {
+            "principalEmail": "some-project@company.iam.gserviceaccount.com",
+            "serviceAccountKeyName": "//iam.googleapis.com/projects/some-project/serviceAccounts/some-project@company.iam.gserviceaccount.com/keys/a378358365ff3d22e9c1a72fecf4605ddff76b47",
+            "principalSubject": "serviceAccount:some-project@company.iam.gserviceaccount.com"
+          },
+          "requestMetadata": {
+            "callerIp": "1.2.3.4",
+            "requestAttributes": {
+              "time": "2024-02-26T17:15:16.327542536Z",
+              "auth": { }
+            },
+            "destinationAttributes": { }
+          },
+          "serviceName": "iamcredentials.googleapis.com",
+          "methodName": "SignJwt",
+          "authorizationInfo": [
+            {
+              "permission": "iam.serviceAccounts.getAccessToken",
+              "granted": true,
+              "resourceAttributes": { }
+            }
+          ],
+          "resourceName": "projects/-/serviceAccounts/114885146936855121342",
+          "request": {
+            "name": "projects/-/serviceAccounts/some-project@company.iam.gserviceaccount.com",
+            "@type": "type.googleapis.com/google.iam.credentials.v1.SignJwtRequest"
+          },
+        },
+        "insertId": "1hu88qbef4d2o",
+        "resource": {
+          "type": "service_account",
+          "labels": {
+            "project_id": "some-project",
+            "unique_id": "114885146936855121342",
+            "email_id": "some-project@company.iam.gserviceaccount.com"
+          }
+        },
+        "timestamp": "2024-02-26T17:15:16.314854637Z",
+        "severity": "INFO",
+        "logName": "projects/some-project/logs/cloudaudit.googleapis.com%2Fdata_access",
+        "receiveTimestamp": "2024-02-26T17:15:17.100020459Z"
+      }
+  -
+    Name: iam.serviceAccounts.getAccessToken not granted
+    ExpectedResult: false
+    Log:
+      {
+        "protoPayload": {
+          "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+          "status": { },
+          "authenticationInfo": {
+            "principalEmail": "some-project@company.iam.gserviceaccount.com",
+            "serviceAccountKeyName": "//iam.googleapis.com/projects/some-project/serviceAccounts/some-project@company.iam.gserviceaccount.com/keys/a378358365ff3d22e9c1a72fecf4605ddff76b47",
+            "principalSubject": "serviceAccount:some-project@company.iam.gserviceaccount.com"
+          },
+          "requestMetadata": {
+            "callerIp": "1.2.3.4",
+            "requestAttributes": {
+              "time": "2024-02-26T17:15:16.327542536Z",
+              "auth": { }
+            },
+            "destinationAttributes": { }
+          },
+          "serviceName": "iamcredentials.googleapis.com",
+          "methodName": "SignJwt",
+          "authorizationInfo": [
+            {
+              "permission": "iam.serviceAccounts.getAccessToken",
+              "granted": false,
+              "resourceAttributes": { }
+            }
+          ],
+          "resourceName": "projects/-/serviceAccounts/114885146936855121342",
+          "request": {
+            "name": "projects/-/serviceAccounts/some-project@company.iam.gserviceaccount.com",
+            "@type": "type.googleapis.com/google.iam.credentials.v1.SignJwtRequest"
+          },
+        },
+        "insertId": "1hu88qbef4d2o",
+        "resource": {
+          "type": "service_account",
+          "labels": {
+            "project_id": "some-project",
+            "unique_id": "114885146936855121342",
+            "email_id": "some-project@company.iam.gserviceaccount.com"
+          }
+        },
+        "timestamp": "2024-02-26T17:15:16.314854637Z",
+        "severity": "INFO",
+        "logName": "projects/some-project/logs/cloudaudit.googleapis.com%2Fdata_access",
+        "receiveTimestamp": "2024-02-26T17:15:17.100020459Z"
+      }


### PR DESCRIPTION
### Background
The Identity and Access Management (IAM) service manages authorization and authentication for a GCP environment. This means that there are very likely multiple privilege escalation methods that use the IAM service and/or its permissions.

### Changes
Add GCP.IAM.serviceAccounts.getAccessToken.Privilege.Escalation rule and add missing rules to gcp_audit pack 

