### PR TITLE
Update PAT to 0.44.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,7 +19,7 @@ wrapt = "~=1.15"
 [packages]
 policyuniverse = "==1.5.1.20230817"
 requests = "==2.31.0"
-panther-analysis-tool = "~=0.43"
+panther-analysis-tool = "~=0.44"
 panther-detection-helpers = "==0.3.0"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "aca502d0fd97988594799a78728af30425dc2e73fc220187dad728f85e5bd493"
+            "sha256": "0d3b5f20e2eeccda6d06f157bdf4dd6deddb6a523d3a8e1da45997a2fd969ccc"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -147,19 +147,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:00a7cff4887e8a46c8b2ce438f33d5f87cf7812f303227adc0266f28338af6d5",
-                "sha256:14f1e23b3f83ec365628a6ef849f1038b4c7338c4fabff159007c711b8147efc"
+                "sha256:54150a52eb93028b8e09df00319e8dcb68be7459333d5da00d706d75ba5130d6",
+                "sha256:8d7902e2c0c62837457ba18146e3feaf1dec62018617edc5c0336b65b305b682"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.68"
+            "version": "==1.34.70"
         },
         "botocore": {
             "hashes": [
-                "sha256:3ad0ec67f78beecc039c3c31c93a83181e30b6f789261bdbb9f5c8e8dc551812",
-                "sha256:e7ae9d69cc3e7b31d926e6a1a9ae673ba02da263e35cf12ff2bae35a21755cc6"
+                "sha256:c86944114e85c8a8d5da06fb84f2609ed3bd23cd2fc06b30250bef7e37e8c589",
+                "sha256:fa03d4972cd57d505e6c0eb5d7c7a1caeb7dd49e84f963f7ebeca41fe8ab736e"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.68"
+            "version": "==1.34.70"
         },
         "certifi": {
             "hashes": [
@@ -668,10 +668,10 @@
         },
         "panther-analysis-tool": {
             "hashes": [
-                "sha256:c64e4c92bfd0017d6b9345094c3377c4ee91b5f6df3a85e6b5e7f5cb8d171762"
+                "sha256:4dedb3b70acb80af0870183f0fe0588952409ee3ae4ad43e720550b75f9f58e9"
             ],
             "index": "pypi",
-            "version": "==0.43.0"
+            "version": "==0.44.0"
         },
         "panther-core": {
             "hashes": [
@@ -715,7 +715,6 @@
                 "sha256:7920896195af163230635f1a5cee0958f56003ef8c421f805ec81f134f80a57c"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==1.5.1.20230817"
         },
         "pygments": {
@@ -912,7 +911,6 @@
                 "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==2.31.0"
         },
         "rpds-py": {
@@ -1125,11 +1123,11 @@
         },
         "sqlfluff": {
             "hashes": [
-                "sha256:5ee18a5f897efc4d8656b83bac9b8e07093195d22d10b05a3ecd27c8d35dfcde",
-                "sha256:b781de6a3302e40029b243480b5d839e0faca89a638fdc3d1ba1766343d2b127"
+                "sha256:46b5aa5326560eba078ae39b232bb19b8e5abdabeaa18ed8556f18b558330d71",
+                "sha256:cca1f62f38e31c60461f6e6f3b233552d4625b60395d78eadb74c6695fb2370d"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.0.2"
+            "version": "==3.0.3"
         },
         "tblib": {
             "hashes": [
@@ -1291,7 +1289,6 @@
                 "sha256:509f7af645bc0cd8fd4587abc1a038fc795636671ee8204d502b933aee44f381"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==1.7.8"
         },
         "black": {
@@ -1310,24 +1307,23 @@
                 "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==22.12.0"
         },
         "boto3": {
             "hashes": [
-                "sha256:00a7cff4887e8a46c8b2ce438f33d5f87cf7812f303227adc0266f28338af6d5",
-                "sha256:14f1e23b3f83ec365628a6ef849f1038b4c7338c4fabff159007c711b8147efc"
+                "sha256:54150a52eb93028b8e09df00319e8dcb68be7459333d5da00d706d75ba5130d6",
+                "sha256:8d7902e2c0c62837457ba18146e3feaf1dec62018617edc5c0336b65b305b682"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.68"
+            "version": "==1.34.70"
         },
         "botocore": {
             "hashes": [
-                "sha256:3ad0ec67f78beecc039c3c31c93a83181e30b6f789261bdbb9f5c8e8dc551812",
-                "sha256:e7ae9d69cc3e7b31d926e6a1a9ae673ba02da263e35cf12ff2bae35a21755cc6"
+                "sha256:c86944114e85c8a8d5da06fb84f2609ed3bd23cd2fc06b30250bef7e37e8c589",
+                "sha256:fa03d4972cd57d505e6c0eb5d7c7a1caeb7dd49e84f963f7ebeca41fe8ab736e"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.68"
+            "version": "==1.34.70"
         },
         "certifi": {
             "hashes": [
@@ -1543,7 +1539,6 @@
                 "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.5'",
             "version": "==5.1.1"
         },
         "dill": {
@@ -1552,7 +1547,6 @@
                 "sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==0.3.8"
         },
         "idna": {
@@ -1569,7 +1563,6 @@
                 "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.8.0'",
             "version": "==5.13.2"
         },
         "jinja2": {
@@ -1727,7 +1720,6 @@
                 "sha256:261d312d1d69c2afccb450a0566666d7b75d76ed6a7d00aac278a9633b073ff0"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==5.0.3"
         },
         "mypy": {
@@ -1761,7 +1753,6 @@
                 "sha256:fe28657de3bfec596bbeef01cb219833ad9d38dd5393fc649f4b366840baefe6"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==1.9.0"
         },
         "mypy-extensions": {
@@ -1817,7 +1808,6 @@
                 "sha256:f4fcac7ae74cfe36bc8451e931d8438e4a476c20314b1101c458ad0f05191fad"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.7.2'",
             "version": "==2.17.7"
         },
         "pylint-print": {
@@ -1826,7 +1816,6 @@
                 "sha256:a2b2599e7887b93e551db2624c523c1e6e9e58c3be8416cd98d41e4427e2669b"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==1.0.1"
         },
         "python-dateutil": {
@@ -1900,7 +1889,6 @@
                 "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==2.31.0"
         },
         "responses": {
@@ -2057,7 +2045,6 @@
                 "sha256:ffa565331890b90056c01db69c0fe634a776f8019c143a5ae265f9c6bc4bd6d4"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==1.16.0"
         },
         "xmltodict": {


### PR DESCRIPTION
### Background

This PR updates PAT to `0.44.0` which should help with #1153 

### Changes

* Updates PAT to `0.44.0`

### Testing

* `make fmt; make lint; make test`
