### PR TITLE
Use make venv rather than make install

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,9 +18,6 @@ jobs:
       - name: Install pipenv
         run: pip install pipenv
 
-      - name: Install
-        run: make install
-
       - name: Setup venv
         run: make venv
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,6 @@ jobs:
       - name: Install pipenv
         run: pip install pipenv
 
-      - name: Install
-        run: make install
-
       - name: Setup venv
         run: make venv
 

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Install pipenv
         run: pip install pipenv
 
-      - name: Install
-        run: make install
-
       - name: Setup venv
         run: make venv
 


### PR DESCRIPTION
### Background

All of our Workflows were doing `make install` and then `make venv`. These duplicate the `pipenv --sync-dev` calls so they were redundant. 

We also don't need the `npm install` step for PRs, so this PR just uses `make venv` for all Workflows.

### Changes

- Removes `make install` calls from all Workflows

### Testing

Checks pass as expected.
