### PR TITLE
Add MongoDB.2FA.Disabled rule

### DIFF
--- a/packs/mongodb.yml
+++ b/packs/mongodb.yml
@@ -5,6 +5,7 @@ DisplayName: "Panther MongoDB Atlas Pack"
 PackDefinition:
   IDs:
     - MongoDB.Atlas.ApiKeyCreated
+    - MongoDB.2FA.Disabled
     # Globals
     - panther_base_helpers
     - panther_mongodb_helpers

--- a/rules/mongodb_rules/mongodb_2fa_disabled.py
+++ b/rules/mongodb_rules/mongodb_2fa_disabled.py
@@ -1,0 +1,14 @@
+from panther_mongodb_helpers import mongodb_alert_context
+
+
+def rule(event):
+    return event.deep_get("eventTypeName", default="") == "ORG_TWO_FACTOR_AUTH_OPTIONAL"
+
+
+def title(event):
+    user = event.deep_get("username", default="<USER_NOT_FOUND>")
+    return f"MongoDB Atlas: [{user}] has disabled 2FA"
+
+
+def alert_context(event):
+    return mongodb_alert_context(event)

--- a/rules/mongodb_rules/mongodb_2fa_disabled.yml
+++ b/rules/mongodb_rules/mongodb_2fa_disabled.yml
@@ -1,0 +1,59 @@
+AnalysisType: rule
+Description: "2FA was disabled."
+DisplayName: "MongoDB 2FA Disabled"
+Enabled: true
+Filename: mongodb_2fa_disabled.py
+Severity: Medium
+Reference: https://www.mongodb.com/docs/atlas/security-multi-factor-authentication/
+Tests:
+  - ExpectedResult: false
+    Log:
+      created: "2023-06-07 16:57:55"
+      currentValue: {}
+      eventTypeName: ORG_TWO_FACTOR_AUTH_REQUIRED
+      id: 6480b7139bd8a012345ABCDE
+      isGlobalAdmin: false
+      links:
+        - href: https://cloud.mongodb.com/api/atlas/v1.0/orgs/12345xyzlmnce4f17d6e8e130/events/6480b7139bd8a012345ABCDE
+          rel: self
+      orgId: 12345xyzlmnce4f17d6e8e130
+      p_event_time: "2023-06-07 16:57:55"
+      p_log_type: MongoDB.OrganizationEvent
+      p_parse_time: "2023-06-07 17:04:42.59"
+      p_row_id: ea276b16216684d9e198c0d0188a3d
+      p_schema_version: 0
+      p_source_id: 7c3cb124-9c30-492c-99e6-46518c232d73
+      p_source_label: MongoDB
+      remoteAddress: 1.2.3.4
+      targetUsername: insider@company.com
+      userId: 647f654f93bebc69123abc1
+      username: user@company.com
+    Name: 2FA ebabled
+  - ExpectedResult: true
+    Log:
+      created: "2023-06-07 16:57:55"
+      currentValue: {}
+      eventTypeName: ORG_TWO_FACTOR_AUTH_OPTIONAL
+      id: 6480b7139bd8a012345ABCDE
+      isGlobalAdmin: false
+      links:
+        - href: https://cloud.mongodb.com/api/atlas/v1.0/orgs/12345xyzlmnce4f17d6e8e130/events/6480b7139bd8a012345ABCDE
+          rel: self
+      orgId: 12345xyzlmnce4f17d6e8e130
+      p_event_time: "2023-06-07 16:57:55"
+      p_log_type: MongoDB.OrganizationEvent
+      p_parse_time: "2023-06-07 17:04:42.59"
+      p_row_id: ea276b16216684d9e198c0d0188a3d
+      p_schema_version: 0
+      p_source_id: 7c3cb124-9c30-492c-99e6-46518c232d73
+      p_source_label: MongoDB
+      remoteAddress: 1.2.3.4
+      targetUsername: outsider@other.com
+      userId: 647f654f93bebc69123abc1
+      username: user@company.com
+    Name: 2FA disabled
+DedupPeriodMinutes: 60
+LogTypes:
+  - MongoDB.OrganizationEvent
+RuleID: "MongoDB.2FA.Disabled"
+Threshold: 1


### PR DESCRIPTION
### Goal

Detect when 2FA settings are disabled.

### Categorization

https://attack.mitre.org/techniques/T1556/006/ 

### Strategy Abstract

Check MongoDB Atlas logs for indicators of 2FA being disabled.

### Technical Context

Disable 2FA settings in MongoDB Atlas to generate relevant events.

### Blind Spots and Assumptions

Assumes proper MongoDB logging.

### False Positives

Could be valid administrator activity.

#### Validation

Disable 2FA settings to trigger alerts. 

### Priority

Medium

### Response

Re-enable 2FA settings and reset user credentials.

### Additional Resources

https://www.mongodb.com/docs/atlas/security-multi-factor-authentication/