### PR TITLE
 Add MongoDB.User.Created.Or.Deleted and Add MongoDB.User.Roles.Changed rules

### DIFF
--- a/packs/mongodb.yml
+++ b/packs/mongodb.yml
@@ -5,6 +5,7 @@ DisplayName: "Panther MongoDB Atlas Pack"
 PackDefinition:
   IDs:
     - MongoDB.Atlas.ApiKeyCreated
+    - MongoDB.User.Created.Or.Deleted
     # Globals
     - panther_base_helpers
     - panther_mongodb_helpers

--- a/packs/mongodb.yml
+++ b/packs/mongodb.yml
@@ -6,6 +6,7 @@ PackDefinition:
   IDs:
     - MongoDB.Atlas.ApiKeyCreated
     - MongoDB.User.Created.Or.Deleted
+    - MongoDB.User.Roles.Changed
     # Globals
     - panther_base_helpers
     - panther_mongodb_helpers

--- a/rules/mongodb_rules/mongodb_user_created_or_deleted.py
+++ b/rules/mongodb_rules/mongodb_user_created_or_deleted.py
@@ -1,0 +1,18 @@
+from panther_mongodb_helpers import mongodb_alert_context
+
+
+def rule(event):
+    return event.deep_get("eventTypeName", default="") in ("JOINED_ORG", "REMOVED_FROM_ORG")
+
+
+def title(event):
+    event_name = event.get("eventTypeName")
+    target_username = event.get("targetUsername", "<USER_NOT_FOUND>")
+    org_id = event.get("orgId", "<ORG_NOT_FOUND>")
+    action = "has joined org" if event_name == "JOINED_ORG" else "was removed from org"
+
+    return f"MongoDB Atlas: [{target_username}] {action} [{org_id}]"
+
+
+def alert_context(event):
+    return mongodb_alert_context(event)

--- a/rules/mongodb_rules/mongodb_user_created_or_deleted.yml
+++ b/rules/mongodb_rules/mongodb_user_created_or_deleted.yml
@@ -1,0 +1,82 @@
+AnalysisType: rule
+Description: "User was created or deleted."
+DisplayName: "MongoDB user was created or deleted"
+Enabled: true
+Filename: mongodb_user_created_or_deleted.py
+Severity: Low
+Reference: https://www.mongodb.com/docs/v4.2/tutorial/create-users/
+Tests:
+  - ExpectedResult: false
+    Log:
+      created: "2023-06-07 16:57:55"
+      currentValue: {}
+      eventTypeName: CAT_JUMPED
+      id: 6480b7139bd8a012345ABCDE
+      isGlobalAdmin: false
+      links:
+        - href: https://cloud.mongodb.com/api/atlas/v1.0/orgs/12345xyzlmnce4f17d6e8e130/events/6480b7139bd8a012345ABCDE
+          rel: self
+      orgId: 12345xyzlmnce4f17d6e8e130
+      p_event_time: "2023-06-07 16:57:55"
+      p_log_type: MongoDB.OrganizationEvent
+      p_parse_time: "2023-06-07 17:04:42.59"
+      p_row_id: ea276b16216684d9e198c0d0188a3d
+      p_schema_version: 0
+      p_source_id: 7c3cb124-9c30-492c-99e6-46518c232d73
+      p_source_label: MongoDB
+      remoteAddress: 1.2.3.4
+      targetUsername: insider@company.com
+      userId: 647f654f93bebc69123abc1
+      username: user@company.com
+    Name: Random event
+  - ExpectedResult: true
+    Log:
+      created: "2023-06-07 16:57:55"
+      currentValue: {}
+      eventTypeName: JOINED_ORG
+      id: 6480b7139bd8a012345ABCDE
+      isGlobalAdmin: false
+      links:
+        - href: https://cloud.mongodb.com/api/atlas/v1.0/orgs/12345xyzlmnce4f17d6e8e130/events/6480b7139bd8a012345ABCDE
+          rel: self
+      orgId: 12345xyzlmnce4f17d6e8e130
+      p_event_time: "2023-06-07 16:57:55"
+      p_log_type: MongoDB.OrganizationEvent
+      p_parse_time: "2023-06-07 17:04:42.59"
+      p_row_id: ea276b16216684d9e198c0d0188a3d
+      p_schema_version: 0
+      p_source_id: 7c3cb124-9c30-492c-99e6-46518c232d73
+      p_source_label: MongoDB
+      remoteAddress: 1.2.3.4
+      targetUsername: insider@company.com
+      userId: 647f654f93bebc69123abc1
+      username: user@company.com
+    Name: User joined Org
+  - ExpectedResult: true
+    Log:
+      created: "2023-06-07 16:57:55"
+      currentValue: {}
+      eventTypeName: REMOVED_FROM_ORG
+      id: 6480b7139bd8a012345ABCDE
+      isGlobalAdmin: false
+      links:
+        - href: https://cloud.mongodb.com/api/atlas/v1.0/orgs/12345xyzlmnce4f17d6e8e130/events/6480b7139bd8a012345ABCDE
+          rel: self
+      orgId: 12345xyzlmnce4f17d6e8e130
+      p_event_time: "2023-06-07 16:57:55"
+      p_log_type: MongoDB.OrganizationEvent
+      p_parse_time: "2023-06-07 17:04:42.59"
+      p_row_id: ea276b16216684d9e198c0d0188a3d
+      p_schema_version: 0
+      p_source_id: 7c3cb124-9c30-492c-99e6-46518c232d73
+      p_source_label: MongoDB
+      remoteAddress: 1.2.3.4
+      targetUsername: outsider@other.com
+      userId: 647f654f93bebc69123abc1
+      username: user@company.com
+    Name: User removed from Org
+DedupPeriodMinutes: 60
+LogTypes:
+  - MongoDB.OrganizationEvent
+RuleID: "MongoDB.User.Created.Or.Deleted"
+Threshold: 1

--- a/rules/mongodb_rules/mongodb_user_created_or_deleted.yml
+++ b/rules/mongodb_rules/mongodb_user_created_or_deleted.yml
@@ -3,7 +3,7 @@ Description: "User was created or deleted."
 DisplayName: "MongoDB user was created or deleted"
 Enabled: true
 Filename: mongodb_user_created_or_deleted.py
-Severity: High
+Severity: Medium
 Reference: https://www.mongodb.com/docs/v4.2/tutorial/create-users/
 Tests:
   - ExpectedResult: false

--- a/rules/mongodb_rules/mongodb_user_roles_changed.py
+++ b/rules/mongodb_rules/mongodb_user_roles_changed.py
@@ -1,0 +1,16 @@
+from panther_mongodb_helpers import mongodb_alert_context
+
+
+def rule(event):
+    return event.deep_get("eventTypeName") == "USER_ROLES_CHANGED_AUDIT"
+
+
+def title(event):
+    target_username = event.get("targetUsername", "<USER_NOT_FOUND>")
+    org_id = event.get("orgId", "<ORG_NOT_FOUND>")
+
+    return f"MongoDB Atlas: User [{target_username}] roles changed in org [{org_id}]"
+
+
+def alert_context(event):
+    return mongodb_alert_context(event)

--- a/rules/mongodb_rules/mongodb_user_roles_changed.yml
+++ b/rules/mongodb_rules/mongodb_user_roles_changed.yml
@@ -1,9 +1,9 @@
 AnalysisType: rule
-Description: "User was created or deleted."
-DisplayName: "MongoDB user was created or deleted"
+Description: "User roles changed."
+DisplayName: "MongoDB user roles changed"
 Enabled: true
-Filename: mongodb_user_created_or_deleted.py
-Severity: High
+Filename: mongodb_user_roles_changed.py
+Severity: Low
 Reference: https://www.mongodb.com/docs/v4.2/tutorial/create-users/
 Tests:
   - ExpectedResult: false
@@ -33,7 +33,7 @@ Tests:
     Log:
       created: "2023-06-07 16:57:55"
       currentValue: {}
-      eventTypeName: JOINED_ORG
+      eventTypeName: USER_ROLES_CHANGED_AUDIT
       id: 6480b7139bd8a012345ABCDE
       isGlobalAdmin: false
       links:
@@ -51,32 +51,9 @@ Tests:
       targetUsername: insider@company.com
       userId: 647f654f93bebc69123abc1
       username: user@company.com
-    Name: User joined Org
-  - ExpectedResult: true
-    Log:
-      created: "2023-06-07 16:57:55"
-      currentValue: {}
-      eventTypeName: REMOVED_FROM_ORG
-      id: 6480b7139bd8a012345ABCDE
-      isGlobalAdmin: false
-      links:
-        - href: https://cloud.mongodb.com/api/atlas/v1.0/orgs/12345xyzlmnce4f17d6e8e130/events/6480b7139bd8a012345ABCDE
-          rel: self
-      orgId: 12345xyzlmnce4f17d6e8e130
-      p_event_time: "2023-06-07 16:57:55"
-      p_log_type: MongoDB.OrganizationEvent
-      p_parse_time: "2023-06-07 17:04:42.59"
-      p_row_id: ea276b16216684d9e198c0d0188a3d
-      p_schema_version: 0
-      p_source_id: 7c3cb124-9c30-492c-99e6-46518c232d73
-      p_source_label: MongoDB
-      remoteAddress: 1.2.3.4
-      targetUsername: outsider@other.com
-      userId: 647f654f93bebc69123abc1
-      username: user@company.com
-    Name: User removed from Org
+    Name: User roles changed
 DedupPeriodMinutes: 60
 LogTypes:
   - MongoDB.OrganizationEvent
-RuleID: "MongoDB.User.Created.Or.Deleted"
+RuleID: "MongoDB.User.Roles.Changed"
 Threshold: 1


### PR DESCRIPTION
## Goal

Detect when new users are added and deleted.  The severity of the alerts should be higher if the users have administrative privileges.

## Categorization

https://attack.mitre.org/techniques/T1136/003/ 

https://attack.mitre.org/techniques/T1531/ 

## Strategy Abstract

Looks for events in the MongoDB Atlas logs related to user creation and deletion.

## Technical Context

Use the test MongoDB Atlas system to create/delete users to generate relevant events.

## Blind Spots and Assumptions

Assumes proper MongoDB Atlas logging.

## False Positives

Could be valid administrator activity

## Validation

Create/delete users and admins to trigger alerts.  

## Priority

Low if user, High if admin

## Response

Validate that the action was authorized and expected.

## Additional Resources

https://www.mongodb.com/docs/v4.2/tutorial/create-users/ 

https://www.mongodb.com/docs/atlas/reference/user-roles/