### PR TITLE
Format code before committing it

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+make fmt

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ pat-update:
 fmt:
 	pipenv run isort --profile=black $(dirs)
 	pipenv run black --line-length=100 $(dirs)
-	npx prettier . --write
+	npx prettier . --write --list-different
 
 install:
 	pipenv sync --dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,14 +4,31 @@
   "requires": true,
   "packages": {
     "": {
-      "dependencies": {
+      "devDependencies": {
+        "husky": "^9.0.11",
         "prettier": "^3.2.5"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/prettier": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
       "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
-  "dependencies": {
+  "devDependencies": {
+    "husky": "^9.0.11",
     "prettier": "^3.2.5"
+  },
+  "scripts": {
+    "prepare": "husky"
   }
 }


### PR DESCRIPTION
### Background

Adds git pre-commit hook to format the source code.

### Changes

- Moves `prettier` to a dev dependency
- Adds a `make fmt` pre-commit hook using [husky](https://typicode.github.io/husky/)
- Makes `prettier` print only the changed files

### Testing

- Runs successfully before a git commit
