### PR TITLE
MongoDB - alerting disabled (rule)

### DIFF
--- a/packs/mongodb.yml
+++ b/packs/mongodb.yml
@@ -5,6 +5,7 @@ DisplayName: "Panther MongoDB Atlas Pack"
 PackDefinition:
   IDs:
     - MongoDB.Atlas.ApiKeyCreated
+    - MongoDB.Alerting.Disabled.Or.Deleted
     # Globals
     - panther_base_helpers
     - panther_mongodb_helpers

--- a/rules/mongodb_rules/mongodb_alerting_disabled.py
+++ b/rules/mongodb_rules/mongodb_alerting_disabled.py
@@ -1,0 +1,20 @@
+from panther_mongodb_helpers import mongodb_alert_context
+
+
+def rule(event):
+    return event.deep_get("eventTypeName", default="") in [
+        "ALERT_CONFIG_DISABLED_AUDIT",
+        "ALERT_CONFIG_DELETED_AUDIT",
+    ]
+
+
+def title(event):
+    user = event.deep_get("username", default="<USER_NOT_FOUND>")
+    alert_id = event.deep_get("alertConfigId", default="<ALERT_NOT_FOUND>")
+    return f"MongoDB: [{user}] has disabled or deleted security alert [{alert_id}]"
+
+
+def alert_context(event):
+    context = mongodb_alert_context(event)
+    context["alertConfigId"] = event.deep_get("alertConfigId", default="<ALERT_NOT_FOUND>")
+    return context

--- a/rules/mongodb_rules/mongodb_alerting_disabled.yml
+++ b/rules/mongodb_rules/mongodb_alerting_disabled.yml
@@ -1,0 +1,50 @@
+AnalysisType: rule
+Description: MongoDB provides security alerting policies for notifying admins when certain conditions are met. 
+  This rule detects when these policies are disabled or deleted.
+DisplayName: "MongoDB security alerts disabled or deleted"
+Enabled: true
+LogTypes:
+    - MongoDB.OrganizationEvent
+RuleID: "MongoDB.Alerting.Disabled.Or.Deleted"
+Filename: mongodb_alerting_disabled.py
+Severity: High
+Reports:
+  MITRE ATT&CK:
+    - TA0005:T1562.001  # Impair Defenses: Disable or Modify Tools
+Reference: https://www.mongodb.com/docs/atlas/configure-alerts/
+Runbook: Re-enable security alerts
+Tests:
+    - Name: Alert added
+      ExpectedResult: false
+      Log:
+        {
+          "alertConfigId": "alert_id",
+          "created": "2024-04-01 11:57:54.000000000",
+          "currentValue": { },
+          "eventTypeName": "ALERT_CONFIG_ADDED_AUDIT",
+          "id": "alert_id",
+          "isGlobalAdmin": false,
+          "links": [ ],
+          "orgId": "some_org_id",
+          "remoteAddress": "1.2.3.4",
+          "userId": "user_id",
+          "username": "some_user@company.com"
+        }
+    - Name: Alert deleted
+      ExpectedResult: true
+      Log:
+        {
+          "alertConfigId": "alert_id",
+          "created": "2024-04-01 11:58:52.000000000",
+          "currentValue": { },
+          "eventTypeName": "ALERT_CONFIG_DELETED_AUDIT",
+          "id": "alert_id",
+          "isGlobalAdmin": false,
+          "links": [ ],
+          "orgId": "some_org_id",
+          "remoteAddress": "1.2.3.4",
+          "userId": "user_id",
+          "username": "some_user@company.com"
+        }
+DedupPeriodMinutes: 60
+Threshold: 1

--- a/rules/mongodb_rules/mongodb_alerting_disabled.yml
+++ b/rules/mongodb_rules/mongodb_alerting_disabled.yml
@@ -1,50 +1,51 @@
 AnalysisType: rule
-Description: MongoDB provides security alerting policies for notifying admins when certain conditions are met. 
+Description:
+  MongoDB provides security alerting policies for notifying admins when certain conditions are met.
   This rule detects when these policies are disabled or deleted.
 DisplayName: "MongoDB security alerts disabled or deleted"
 Enabled: true
 LogTypes:
-    - MongoDB.OrganizationEvent
+  - MongoDB.OrganizationEvent
 RuleID: "MongoDB.Alerting.Disabled.Or.Deleted"
 Filename: mongodb_alerting_disabled.py
 Severity: High
 Reports:
   MITRE ATT&CK:
-    - TA0005:T1562.001  # Impair Defenses: Disable or Modify Tools
+    - TA0005:T1562.001 # Impair Defenses: Disable or Modify Tools
 Reference: https://www.mongodb.com/docs/atlas/configure-alerts/
 Runbook: Re-enable security alerts
 Tests:
-    - Name: Alert added
-      ExpectedResult: false
-      Log:
-        {
-          "alertConfigId": "alert_id",
-          "created": "2024-04-01 11:57:54.000000000",
-          "currentValue": { },
-          "eventTypeName": "ALERT_CONFIG_ADDED_AUDIT",
-          "id": "alert_id",
-          "isGlobalAdmin": false,
-          "links": [ ],
-          "orgId": "some_org_id",
-          "remoteAddress": "1.2.3.4",
-          "userId": "user_id",
-          "username": "some_user@company.com"
-        }
-    - Name: Alert deleted
-      ExpectedResult: true
-      Log:
-        {
-          "alertConfigId": "alert_id",
-          "created": "2024-04-01 11:58:52.000000000",
-          "currentValue": { },
-          "eventTypeName": "ALERT_CONFIG_DELETED_AUDIT",
-          "id": "alert_id",
-          "isGlobalAdmin": false,
-          "links": [ ],
-          "orgId": "some_org_id",
-          "remoteAddress": "1.2.3.4",
-          "userId": "user_id",
-          "username": "some_user@company.com"
-        }
+  - Name: Alert added
+    ExpectedResult: false
+    Log:
+      {
+        "alertConfigId": "alert_id",
+        "created": "2024-04-01 11:57:54.000000000",
+        "currentValue": {},
+        "eventTypeName": "ALERT_CONFIG_ADDED_AUDIT",
+        "id": "alert_id",
+        "isGlobalAdmin": false,
+        "links": [],
+        "orgId": "some_org_id",
+        "remoteAddress": "1.2.3.4",
+        "userId": "user_id",
+        "username": "some_user@company.com",
+      }
+  - Name: Alert deleted
+    ExpectedResult: true
+    Log:
+      {
+        "alertConfigId": "alert_id",
+        "created": "2024-04-01 11:58:52.000000000",
+        "currentValue": {},
+        "eventTypeName": "ALERT_CONFIG_DELETED_AUDIT",
+        "id": "alert_id",
+        "isGlobalAdmin": false,
+        "links": [],
+        "orgId": "some_org_id",
+        "remoteAddress": "1.2.3.4",
+        "userId": "user_id",
+        "username": "some_user@company.com",
+      }
 DedupPeriodMinutes: 60
 Threshold: 1


### PR DESCRIPTION
## Goal

Detect when security alerts are disabled or deleted.

## Categorization

https://attack.mitre.org/techniques/T1562/001/ 

## Strategy Abstract

MongoDB provides security alerting policies for notifying admins when certain conditions are met.  Detect when these policies are disabled or deleted.

## Technical Context

Disable/delete security alerts in MongoDB Atlas to generate relevant logs.

## Blind Spots and Assumptions

Assumes proper MongoDB Atlas logging.

## False Positives

N/A

## Validation

Disable/delete security alert settings to generate alerts in Panther instance.

## Priority

High

## Response

Re-enable security alerts