### PR TITLE
fix - Okta Password Accessed False positive

### DIFF
--- a/rules/okta_rules/okta_password_accessed.py
+++ b/rules/okta_rules/okta_password_accessed.py
@@ -11,7 +11,7 @@ def rule(event):
         return False
 
     # event['target'] = [{...}, {...}, {...}]
-    TARGET_USERS = get_val_from_list(event.get("target", [{}]), "alternateId", "type", "AppUser")
+    TARGET_USERS = get_val_from_list(event.get("target", [{}]), "alternateId", "type", "User")
     TARGET_APP_NAMES = get_val_from_list(
         event.get("target", [{}]), "alternateId", "type", "AppInstance"
     )

--- a/rules/okta_rules/okta_password_accessed.yml
+++ b/rules/okta_rules/okta_password_accessed.yml
@@ -198,3 +198,74 @@ Tests:
         "uuid": "XXXXXXXXXXXXXXXX",
         "version": "0",
       }
+  - Name: User accessed their own password - 2
+    ExpectedResult: false
+    Log:
+      {
+        "actor":
+          {
+            "alternateId": "john.doe@emaildomain.com",
+            "displayName": "John Doe",
+            "id": "00u3nwfjxxxxxxxxxxxx",
+            "type": "User",
+          },
+        "authenticationContext":
+          { "authenticationStep": 0, "externalSessionId": "XXXXXXXXXXXXXXXXX" },
+        "client":
+          {
+            "device": "Mobile",
+            "geographicalContext":
+              {
+                "country": "Iceland",
+                "geolocation": { "lat": 81.09596, "lon": -10.30578 },
+                "state": "Colorado",
+              },
+            "ipAddress": "218.56.201.220",
+            "userAgent":
+              {
+                "browser": "CHROME",
+                "os": "Android 1.x",
+                "rawUserAgent": "Mozilla/5.0 (Linux; Android 11; ONEPLUS A6013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Mobile Safari/537.36",
+              },
+            "zone": "null",
+          },
+        "debugContext": { "debugData": "" },
+        "eventType": "application.user_membership.show_password",
+        "legacyEventType": "app.generic.show.password",
+        "outcome": { "result": "SUCCESS" },
+        "published": "2024-03-27 13:17:41.835000000",
+        "severity": "INFO",
+        "securityContext":
+          {
+            "asNumber": 940252,
+            "asOrg": "t-mobile",
+            "domain": ".",
+            "isProxy": false,
+            "isp": "t-mobile usa  inc.",
+          },
+        "target":
+          [
+            {
+              "alternateId": "John Doe",
+              "displayName": "John Doe",
+              "id": "00u3nwfjxxxxxxxxxxxx",
+              "type": "AppUser",
+            },
+            {
+              "alternateId": "Software",
+              "displayName": "On The Fly App",
+              "id": "11u3nwfjxxxxxxxxxxxx",
+              "type": "AppInstance",
+            },
+            {
+              "alternateId": "john.doe@emaildomain.com",
+              "displayName": "John Doe",
+              "id": "00u3nwfjxxxxxxxxxxxx",
+              "type": "User",
+            },
+          ],
+        "transaction":
+          { "detail": {}, "id": "XXXXXXXXXXXXXXXX", "type": "WEB" },
+        "uuid": "XXXXXXXXXXXXXXXX",
+        "version": "0",
+      }


### PR DESCRIPTION
### Background

Problem is in the confusion between User and AppUser fields in logs. AppUser alternatId is only their name, User is their email for alternatId.
So the actor.alternateId is email and taken from User.
target.alternateId is name and taken from AppUser.

### Changes

- fixed false positives for `Okta Password Accessed` rule ([Jira](https://panther-labs.atlassian.net/browse/THREAT-267))
