### PR TITLE
MongoDB - Allow access from anywhere (rule)

### DIFF
--- a/packs/mongodb.yml
+++ b/packs/mongodb.yml
@@ -5,6 +5,7 @@ DisplayName: "Panther MongoDB Atlas Pack"
 PackDefinition:
   IDs:
     - MongoDB.Atlas.ApiKeyCreated
+    - MongoDB.Access.Allowed.From.Anywhere
     # Globals
     - panther_base_helpers
     - panther_mongodb_helpers

--- a/rules/mongodb_rules/mongodb_access_allowed_from_anywhere.py
+++ b/rules/mongodb_rules/mongodb_access_allowed_from_anywhere.py
@@ -1,0 +1,22 @@
+from panther_mongodb_helpers import mongodb_alert_context
+
+
+def rule(event):
+    if (
+        event.deep_get("eventTypeName", default="") == "NETWORK_PERMISSION_ENTRY_ADDED"
+        and event.deep_get("whitelistEntry", default="") == "0.0.0.0/0"
+    ):
+        return True
+    return False
+
+
+def title(event):
+    user = event.deep_get("username", default="<USER_NOT_FOUND>")
+    group_id = event.deep_get("groupId", default="<GROUP_NOT_FOUND>")
+    return f"MongoDB: [{user}] has allowed access to group [{group_id}] from anywhere"
+
+
+def alert_context(event):
+    context = mongodb_alert_context(event)
+    context["groupId"] = event.deep_get("groupId", default="<GROUP_NOT_FOUND>")
+    return context

--- a/rules/mongodb_rules/mongodb_access_allowed_from_anywhere.yml
+++ b/rules/mongodb_rules/mongodb_access_allowed_from_anywhere.yml
@@ -1,0 +1,47 @@
+AnalysisType: rule
+Description: Atlas only allows client connections to the database deployment from entries in the project's IP access list. This rule detects when 0.0.0.0/0 is added to that list, which allows access from anywhere.
+DisplayName: "MongoDB access allowed from anywhere"
+Enabled: true
+LogTypes:
+  - MongoDB.ProjectEvent
+RuleID: "MongoDB.Access.Allowed.From.Anywhere"
+Filename: mongodb_access_allowed_from_anywhere.py
+Severity: High
+Reports:
+  MITRE ATT&CK:
+    - T1021 # Remote Services
+Reference: https://www.mongodb.com/docs/atlas/security/ip-access-list/
+Runbook: Check if this activity was legitimate. If not, delete 0.0.0.0/0 from the list of allowed ips.
+Tests:
+  - Name: Allowed access from anywhere
+    ExpectedResult: true
+    Log:
+      {
+        "created": "2024-04-03 11:13:04.000000000",
+        "currentValue": {},
+        "eventTypeName": "NETWORK_PERMISSION_ENTRY_ADDED",
+        "groupId": "some_group_id",
+        "id": "123abc",
+        "isGlobalAdmin": false,
+        "remoteAddress": "1.2.3.4",
+        "userId": "123abc",
+        "username": "some_user@company.com",
+        "whitelistEntry": "0.0.0.0/0",
+      }
+  - Name: Allowed access from specific ip
+    ExpectedResult: false
+    Log:
+      {
+        "created": "2024-04-03 11:13:04.000000000",
+        "currentValue": {},
+        "eventTypeName": "NETWORK_PERMISSION_ENTRY_ADDED",
+        "groupId": "some_group_id",
+        "id": "123abc",
+        "isGlobalAdmin": false,
+        "remoteAddress": "1.2.3.4",
+        "userId": "123abc",
+        "username": "some_user@company.com",
+        "whitelistEntry": "1.2.3.4/32",
+      }
+DedupPeriodMinutes: 60
+Threshold: 1


### PR DESCRIPTION
## Goal

Detect when 0.0.0.0 is added to the project's IP access list, which allows access from anywhere.

## Categorization

https://attack.mitre.org/techniques/T1021/ 

## Strategy Abstract

Atlas only allows client connections to the database deployment from entries in the project's IP access list. Detect when 0.0.0.0 is added to that list, which allows access from anywhere.

## Technical Context

Allow access to project from anywhere to generate relevant logs.

## Blind Spots and Assumptions

Assumes proper MongoDB Atlas logging.

## False Positives

Could be legitimate administrator activity for specific project.

## Validation

Allow access to project from anywhere to trigger alerts. 

## Priority

Medium

## Response

Check if this activity was legitimate. If not, delete 0.0.0.0 from the list of allowed ips.

## Additional Resources

https://www.mongodb.com/docs/atlas/security/ip-access-list/