### PR TITLE
Add MongoDB.Identity.Provider.Activity rule

### DIFF
--- a/packs/mongodb.yml
+++ b/packs/mongodb.yml
@@ -11,6 +11,7 @@ PackDefinition:
     - MongoDB.User.Created.Or.Deleted
     - MongoDB.User.Roles.Changed
     - MongoDB.2FA.Disabled
+    - MongoDB.Identity.Provider.Activity
     # Globals
     - panther_base_helpers
     - panther_mongodb_helpers

--- a/rules/mongodb_rules/mongodb_identity_provider_activity.py
+++ b/rules/mongodb_rules/mongodb_identity_provider_activity.py
@@ -1,0 +1,30 @@
+from panther_mongodb_helpers import mongodb_alert_context
+
+
+def rule(event):
+    important_event_types = {
+        "FEDERATION_SETTINGS_CREATED",
+        "FEDERATION_SETTINGS_DELETED",
+        "FEDERATION_SETTINGS_UPDATED",
+        "IDENTITY_PROVIDER_CREATED",
+        "IDENTITY_PROVIDER_UPDATED",
+        "IDENTITY_PROVIDER_DELETED",
+        "IDENTITY_PROVIDER_ACTIVATED",
+        "IDENTITY_PROVIDER_DEACTIVATED",
+        "IDENTITY_PROVIDER_JWKS_REVOKED",
+        "OIDC_IDENTITY_PROVIDER_UPDATED",
+        "OIDC_IDENTITY_PROVIDER_ENABLED",
+        "OIDC_IDENTITY_PROVIDER_DISABLED",
+    }
+    return event.deep_get("eventTypeName") in important_event_types
+
+
+def title(event):
+    target_username = event.get("targetUsername", "<USER_NOT_FOUND>")
+    org_id = event.get("orgId", "<ORG_NOT_FOUND>")
+
+    return f"MongoDB Atlas: User [{target_username}] roles changed in org [{org_id}]"
+
+
+def alert_context(event):
+    return mongodb_alert_context(event)

--- a/rules/mongodb_rules/mongodb_identity_provider_activity.yml
+++ b/rules/mongodb_rules/mongodb_identity_provider_activity.yml
@@ -1,0 +1,25 @@
+AnalysisType: rule
+Description: "Changes to identity provider settings are privileged activities that should be carefully audited.  Attackers may add or change IDP integrations to gain persistence to environments"
+DisplayName: "MongoDB Identity Provider Activity"
+Enabled: true
+Filename: mongodb_identity_provider_activity.py
+Severity: Medium
+Reference: https://attack.mitre.org/techniques/T1556/007/
+Tests:
+  - ExpectedResult: false
+    Log:
+      eventTypeName: cat_jumped
+    Name: Random event
+  - ExpectedResult: true
+    Log:
+      eventTypeName: FEDERATION_SETTINGS_CREATED
+    Name: FEDERATION_SETTINGS_CREATED
+  - ExpectedResult: true
+    Log:
+      eventTypeName: IDENTITY_PROVIDER_CREATED
+    Name: IDENTITY_PROVIDER_CREATED
+DedupPeriodMinutes: 60
+LogTypes:
+  - MongoDB.OrganizationEvent
+RuleID: "MongoDB.Identity.Provider.Activity"
+Threshold: 1


### PR DESCRIPTION
### Goal

Detect when changes are made to IDP settings

### Categorization

https://attack.mitre.org/techniques/T1556/007/ 

### Strategy Abstract

Changes to identity provider settings are privileged activities that should be carefully audited.  Attackers may add or change IDP integrations to gain persistence to environments

### Technical Context

"FEDERATION_SETTINGS_CREATED" "FEDERATION_SETTINGS_DELETED" "FEDERATION_SETTINGS_UPDATED" "IDENTITY_PROVIDER_CREATED" "IDENTITY_PROVIDER_UPDATED" "IDENTITY_PROVIDER_DELETED" "IDENTITY_PROVIDER_ACTIVATED" "OIDC_IDENTITY_PROVIDER_UPDATED" "IDENTITY_PROVIDER_DEACTIVATED" "IDENTITY_PROVIDER_JWKS_REVOKED" "OIDC_IDENTITY_PROVIDER_ENABLED" "OIDC_IDENTITY_PROVIDER_DISABLED"

### Blind Spots and Assumptions

Assumes proper MongoDB Atlas logging

### False Positives

IDP related events could be legitimate administrative activity, but should be carefully reviewed to ensure the activity was authorized and expected

### Priority

Medium

### Response

Carefully review the activity to ensure it is authorized and expected