### PR TITLE
MITRE ATT&CK Mappings for MS Rules

### DIFF
--- a/global_helpers/panther_ipinfo_helpers.py
+++ b/global_helpers/panther_ipinfo_helpers.py
@@ -9,7 +9,8 @@ IPINFO_PRIVACY_LUT_NAME = "ipinfo_privacy"
 
 
 # pylint: disable=multiple-statements
-class PantherIPInfoException(Exception): ...
+class PantherIPInfoException(Exception):
+    ...
 
 
 class IPInfoLocation(LookupTableMatches):

--- a/global_helpers/panther_snyk_helpers.py
+++ b/global_helpers/panther_snyk_helpers.py
@@ -8,7 +8,7 @@ def snyk_alert_context(event) -> dict:
         a_c.get("actor", "<NO_USERID>") != "<NO_USERID>"
         and a_c.get("groupId", "<NO_GROUPID>") != "<NO_GROUPID>"
     ):
-        a_c["actor_link"] = (
-            f"https://app.snyk.io/group/{a_c.get('groupId')}/manage/member/{a_c.get('actor')}"
-        )
+        a_c[
+            "actor_link"
+        ] = f"https://app.snyk.io/group/{a_c.get('groupId')}/manage/member/{a_c.get('actor')}"
     return a_c

--- a/rules/microsoft_rules/microsoft365_brute_force_login_by_user.yml
+++ b/rules/microsoft_rules/microsoft365_brute_force_login_by_user.yml
@@ -3,6 +3,9 @@ Description: A Microsoft365 user was denied login access several times
 DisplayName: "Microsoft365 Brute Force Login by User"
 Enabled: true
 Filename: microsoft365_brute_force_login_by_user.py
+Reports:
+  MITRE ATT&CK:
+    - TA0006:T1110 # Credential Access - Brute Force
 Runbook: Analyze the IP they came from and actions taken before/after.
 Reference: https://learn.microsoft.com/en-us/microsoft-365/troubleshoot/authentication/access-denied-when-connect-to-office-365
 Severity: Medium

--- a/rules/microsoft_rules/microsoft365_external_sharing.yml
+++ b/rules/microsoft_rules/microsoft365_external_sharing.yml
@@ -3,6 +3,9 @@ Description: Document shared externally
 DisplayName: "Microsoft365 External Document Sharing"
 Enabled: true
 Filename: microsoft365_external_sharing.py
+Reports:
+  MITRE ATT&CK:
+    - TA0009:T1039 # Collection - Data from Network Shared Drive
 Runbook: Check the document metadata to ensure it is not a sensitive document.
 Reference: https://support.microsoft.com/en-us/topic/manage-sharing-with-external-users-in-microsoft-365-small-business-2951a85f-c970-4375-aa4f-6b0d7035fe35#:~:text=Top%20of%20Page-,Turn%20external%20sharing%20on%20or%20off,-The%20ability%20to
 Severity: Low

--- a/rules/microsoft_rules/microsoft365_mfa_disabled.yml
+++ b/rules/microsoft_rules/microsoft365_mfa_disabled.yml
@@ -3,6 +3,11 @@ Description: A user's MFA has been removed
 DisplayName: "Microsoft365 MFA Disabled"
 Enabled: true
 Filename: microsoft365_mfa_disabled.py
+Reports:
+  MITRE ATT&CK:
+    - TA003:T1556 # Persistence - Modify Authentication Process
+    - TA005:T1556 # Defense Evansion - Modify Authentication Process
+    - TA006:T1556 # Credential Access - Modify Authentication Process
 Runbook: Depending on company policy, either suggest or require the user re-enable two step verification.
 Reference: https://learn.microsoft.com/en-us/microsoft-365/admin/security-and-compliance/set-up-multi-factor-authentication?view=o365-worldwide
 Severity: Low

--- a/rules/microsoft_rules/microsoft_exchange_external_forwarding.yml
+++ b/rules/microsoft_rules/microsoft_exchange_external_forwarding.yml
@@ -3,6 +3,9 @@ Description: Detects creation of forwarding rule to external domains
 DisplayName: "Microsoft Exchange External Forwarding"
 Enabled: true
 Filename: microsoft_exchange_external_forwarding.py
+Reports:
+  MITRE ATT&CK:
+    - TA0009:T1114 # Collection - Email Collection
 Reference: https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/outbound-spam-policies-external-email-forwarding?view=o365-worldwide
 Severity: High
 Tests:


### PR DESCRIPTION
### Background

It became apparent that some rules don't have MITRE mappings associated with them. This PR addresses the issue for Microsoft rules.

### Changes

-  Added MITRE report mappings for all 4 Microsoft rules
- Ran the auto formatter for 2 helper modules

### Testing

- Good 'ol `make test` - nothing beats that
