### PR TITLE
Introduce mypy, ruff, and pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,16 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,8 +9,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.9'
-    - uses: pre-commit/action@v3.0.1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+      - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,11 @@ repos:
           (?x)^(
               global_helpers/panther_base_helpers.*
           )$
+      - id: ruff-format
+        files: |
+          (?x)^(
+              global_helpers/panther_base_helpers.*
+          )$
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.9.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,11 @@ repos:
     rev: v0.4.1
     hooks:
       - id: ruff
-        args: [ --fix, --exit-non-zero-on-fix ]
+        args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.9.0
     hooks:
       - id: mypy
-        args: [ --strict, --ignore-missing-imports ]
-        additional_dependencies:
-          [ panther-detection-helpers, panther-core ]
+        args: [--strict, --ignore-missing-imports]
+        additional_dependencies: [panther-detection-helpers, panther-core]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,5 +18,12 @@ repos:
     rev: v1.9.0
     hooks:
       - id: mypy
-        args: [--strict, --warn-return-any, --warn-unused-configs, --ignore-missing-imports ]
-        additional_dependencies: [ panther-detection-helpers, panther-core, types-python-dateutil ]
+        args:
+          [
+            --strict,
+            --warn-return-any,
+            --warn-unused-configs,
+            --ignore-missing-imports,
+          ]
+        additional_dependencies:
+          [panther-detection-helpers, panther-core, types-python-dateutil]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
+# Enable ruff and mypy for code paths that have been updated for full mypy compliance (opt-in)
 files: |
   (?x)^(
       global_helpers/panther_base_helpers.*
   )$
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.7
+    rev: v0.4.1
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
-
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.9.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,9 @@
 # Enable ruff and mypy for code paths that have been updated for full mypy compliance (opt-in)
 files: |
   (?x)^(
-      global_helpers/panther_base_helpers.*
+      global_helpers/panther_base_helpers\.py|
+      global_helpers/panther_greynoise_helpers\.py|
+      global_helpers/panther_lookuptable_helpers\.py
   )$
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -15,4 +17,4 @@ repos:
     hooks:
       - id: mypy
         args: [--strict, --ignore-missing-imports]
-        additional_dependencies: [panther-detection-helpers, panther-core]
+        additional_dependencies: [ panther-detection-helpers, panther-core, types-python-dateutil ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,9 @@ files: |
   (?x)^(
       global_helpers/panther_base_helpers\.py|
       global_helpers/panther_greynoise_helpers\.py|
-      global_helpers/panther_lookuptable_helpers\.py
+      global_helpers/panther_lookuptable_helpers\.py|
+      global_helpers/panther_config(_.*)?\.py|
+      global_helpers/panther_event_type_helpers\.py
   )$
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -16,5 +18,5 @@ repos:
     rev: v1.9.0
     hooks:
       - id: mypy
-        args: [--strict, --ignore-missing-imports]
+        args: [--strict, --warn-return-any, --warn-unused-configs, --ignore-missing-imports ]
         additional_dependencies: [ panther-detection-helpers, panther-core, types-python-dateutil ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.7
+    hooks:
+      - id: ruff
+        args: [ --fix, --exit-non-zero-on-fix ]
+        files: |
+          (?x)^(
+              global_helpers/panther_base_helpers.*
+          )$
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.9.0
+    hooks:
+      - id: mypy
+        args: [ --strict, --ignore-missing-imports ]
+        files: |
+          (?x)^(
+              global_helpers/panther_base_helpers.*
+          )$
+        additional_dependencies:
+          [ panther-detection-helpers ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,19 @@
+files: |
+  (?x)^(
+      global_helpers/panther_base_helpers.*
+  )$
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.3.7
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
-        files: |
-          (?x)^(
-              global_helpers/panther_base_helpers.*
-          )$
+
       - id: ruff-format
-        files: |
-          (?x)^(
-              global_helpers/panther_base_helpers.*
-          )$
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.9.0
     hooks:
       - id: mypy
         args: [ --strict, --ignore-missing-imports ]
-        files: |
-          (?x)^(
-              global_helpers/panther_base_helpers.*
-          )$
         additional_dependencies:
-          [ panther-detection-helpers ]
+          [ panther-detection-helpers, panther-core ]

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -378,10 +378,11 @@ def deep_walk(
 
 
 def get_val_from_list(
-        list_of_dicts: Sequence[Mapping[_K, _V]],
-        return_field_key: _K,
-        field_cmp_key: _K,
-        field_cmp_val: _V) -> set[Optional[_V]]:
+    list_of_dicts: Sequence[Mapping[_K, _V]],
+    return_field_key: _K,
+    field_cmp_key: _K,
+    field_cmp_val: _V,
+) -> set[Optional[_V]]:
     """Return a specific field in a list of Python dictionaries.
     We return the empty set if the comparison key is not found"""
     values_of_return_field = set()
@@ -537,7 +538,7 @@ def is_base64(b64: str) -> str:
     # if the string is base64 encoded, return the decoded ASCII string
     # otherwise return an empty string
     # handle false positives for very short strings
-    if len(b64) < 12: # noqa: PLR2004
+    if len(b64) < 12:  # noqa: PLR2004
         return ""
     # Check if the matched string can be decoded back into ASCII
     try:

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -1,18 +1,19 @@
+from __future__ import annotations
+
 import json
 import re
 from base64 import b64decode
 from binascii import Error as AsciiError
 from collections import OrderedDict
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from fnmatch import fnmatch
 from functools import reduce
 from ipaddress import ip_address, ip_network
-from typing import Any, List, Optional, Sequence, Union, TypeVar, cast
-
-from panther_core import PantherEvent
+from typing import Any, Optional, TypeVar, Union, cast
 
 from panther_config import config
+from panther_core import PantherEvent
 
 # # # # # # # # # # # # # #
 #       Exceptions        #
@@ -317,7 +318,7 @@ def deep_get(dictionary: Mapping[str, Any], *keys: str, default: Any = None) -> 
 # pylint: disable=too-complex,too-many-return-statements
 def deep_walk(
     obj: Optional[Any], *keys: str, default: Optional[str] = None, return_val: str = "all"
-) -> Union[Optional[Any], Optional[List[Any]]]:
+) -> Union[Optional[Any], Optional[list[Any]]]:
     """Safely retrieve a value stored in complex dictionary structure
 
     Similar to deep_get but supports accessing dictionary keys within nested lists as well
@@ -376,7 +377,11 @@ def deep_walk(
     }.get(return_val, "all")
 
 
-def get_val_from_list(list_of_dicts: Sequence[Mapping[_K, _V]], return_field_key: _K, field_cmp_key: _K, field_cmp_val: _V) -> set[Optional[_V]]:
+def get_val_from_list(
+        list_of_dicts: Sequence[Mapping[_K, _V]],
+        return_field_key: _K,
+        field_cmp_key: _K,
+        field_cmp_val: _V) -> set[Optional[_V]]:
     """Return a specific field in a list of Python dictionaries.
     We return the empty set if the comparison key is not found"""
     values_of_return_field = set()
@@ -427,7 +432,7 @@ def eks_panther_obj_ref(event: PantherEvent) -> dict[str, Any]:
     obj_subres = deep_get(event, "objectRef", "subresource", default="")
     p_source_label = event.get("p_source_label", "<NO_P_SOURCE_LABEL>")
     if obj_subres:
-        obj_res = "/".join([obj_res, obj_subres])
+        obj_res = f"{obj_res}/{obj_subres}"
     return {
         "actor": user,
         "ns": obj_ns,
@@ -532,7 +537,7 @@ def is_base64(b64: str) -> str:
     # if the string is base64 encoded, return the decoded ASCII string
     # otherwise return an empty string
     # handle false positives for very short strings
-    if len(b64) < 12:
+    if len(b64) < 12: # noqa: PLR2004
         return ""
     # Check if the matched string can be decoded back into ASCII
     try:

--- a/global_helpers/panther_config.py
+++ b/global_helpers/panther_config.py
@@ -5,7 +5,7 @@ import panther_config_overrides
 
 
 class Config:  # pylint: disable=too-few-public-methods
-    def __getattr__(self, name) -> Any:
+    def __getattr__(self, name: str) -> Any:
         if hasattr(panther_config_overrides, name):
             return getattr(panther_config_overrides, name)
         return getattr(panther_config_defaults, name, None)

--- a/global_helpers/panther_config_defaults.py
+++ b/global_helpers/panther_config_defaults.py
@@ -1,6 +1,8 @@
 """
 Here, default values for `panther_config.config` are defined
 """
+from ipaddress import IPv4Network, IPv6Network
+from typing import Union
 
 # A list of public DNS domain names that fall under the administrative domain of
 # the Panther installation
@@ -14,7 +16,7 @@ MS_EXCHANGE_ALLOWED_FORWARDING_DESTINATION_DOMAINS = ORGANIZATION_DOMAINS
 MS_EXCHANGE_ALLOWED_FORWARDING_DESTINATION_EMAILS = ["postmaster@" + ORGANIZATION_DOMAINS[0]]
 TELEPORT_ORGANIZATION_DOMAINS = ORGANIZATION_DOMAINS
 
-DMZ_NETWORKS = [
+DMZ_NETWORKS: list[Union[IPv4Network, IPv6Network]] = [
     # ip_network("10.1.0.0/24"),
 ]
 
@@ -24,6 +26,6 @@ DMZ_TAGS = set(
     ]
 )
 
-PCI_NETWORKS = [
+PCI_NETWORKS: list[Union[IPv6Network, IPv6Network]] = [
     # ip_network("10.0.0.0/24"),
 ]

--- a/global_helpers/panther_config_defaults.py
+++ b/global_helpers/panther_config_defaults.py
@@ -1,6 +1,7 @@
 """
 Here, default values for `panther_config.config` are defined
 """
+
 from ipaddress import IPv4Network, IPv6Network
 from typing import Union
 

--- a/global_helpers/panther_config_defaults.py
+++ b/global_helpers/panther_config_defaults.py
@@ -2,8 +2,12 @@
 Here, default values for `panther_config.config` are defined
 """
 
-from ipaddress import IPv4Network, IPv6Network
-from typing import Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from ipaddress import IPv4Network, IPv6Network
 
 # A list of public DNS domain names that fall under the administrative domain of
 # the Panther installation
@@ -21,12 +25,10 @@ DMZ_NETWORKS: list[Union[IPv4Network, IPv6Network]] = [
     # ip_network("10.1.0.0/24"),
 ]
 
-DMZ_TAGS = set(
-    [
-        ("environment", "dmz"),
-    ]
-)
+DMZ_TAGS = {
+    ("environment", "dmz"),
+}
 
-PCI_NETWORKS: list[Union[IPv6Network, IPv6Network]] = [
+PCI_NETWORKS: list[Union[IPv4Network, IPv6Network]] = [
     # ip_network("10.0.0.0/24"),
 ]

--- a/global_helpers/panther_greynoise_helpers.py
+++ b/global_helpers/panther_greynoise_helpers.py
@@ -4,6 +4,8 @@ from collections.abc import Sequence
 from typing import Union
 
 from dateutil import parser
+from panther_core import PantherEvent
+
 from panther_base_helpers import deep_get
 from panther_lookuptable_helpers import LookupTableMatches
 
@@ -26,12 +28,12 @@ class PantherGreyNoiseException(Exception):
 
 
 class GreyNoiseBasic(LookupTableMatches):
-    def __init__(self, event):
+    def __init__(self, event: PantherEvent):
         super().__init__()
         super()._register(event, "greynoise_noise_basic")
         self.sublevel = "basic"
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str):
         def advanced_only():
             advanced_methods = [
                 method
@@ -77,7 +79,7 @@ class GreyNoiseBasic(LookupTableMatches):
 
 class GreyNoiseAdvanced(GreyNoiseBasic):
     # pylint: disable=W0231
-    def __init__(self, event):
+    def __init__(self, event: PantherEvent):
         super().__init__(event)
         super()._register(event, "greynoise_noise_advanced")
         self.sublevel = "advanced"

--- a/global_helpers/panther_greynoise_helpers.py
+++ b/global_helpers/panther_greynoise_helpers.py
@@ -4,9 +4,8 @@ from collections.abc import Sequence
 from typing import Union
 
 from dateutil import parser
-from panther_core import PantherEvent
-
 from panther_base_helpers import deep_get
+from panther_core import PantherEvent
 from panther_lookuptable_helpers import LookupTableMatches
 
 

--- a/global_helpers/panther_lookuptable_helpers.py
+++ b/global_helpers/panther_lookuptable_helpers.py
@@ -1,9 +1,8 @@
 from collections.abc import Mapping, Sequence
 from typing import Optional, Union
 
-from panther_core import PantherEvent
-
 from panther_base_helpers import deep_get
+from panther_core import PantherEvent
 
 ENRICHMENT_KEY = "p_enrichment"
 IGNORE_ENRICHMENTS = "p_any_"

--- a/global_helpers/panther_lookuptable_helpers.py
+++ b/global_helpers/panther_lookuptable_helpers.py
@@ -24,7 +24,7 @@ class LookupTableMatches:
 
     def _lookup(self, match_field: str, *keys: str) -> Union[list[Any], Any]:
         if self.lut_matches is None:
-            raise ValueError("Must call _register before _lookup")
+            return None
 
         match = deep_get(self.lut_matches, match_field)
         if not match:

--- a/global_helpers/panther_lookuptable_helpers.py
+++ b/global_helpers/panther_lookuptable_helpers.py
@@ -11,6 +11,7 @@ IGNORE_ENRICHMENTS = "p_any_"
 # pylint: disable=too-few-public-methods
 class LookupTableMatches:
     lut_matches: Optional[PantherEvent]
+
     def __init__(self):
         self.lut_matches = None
         self._p_matched = {}

--- a/global_helpers/panther_lookuptable_helpers.py
+++ b/global_helpers/panther_lookuptable_helpers.py
@@ -1,4 +1,7 @@
 from collections.abc import Mapping, Sequence
+from typing import Optional, Union
+
+from panther_core import PantherEvent
 
 from panther_base_helpers import deep_get
 
@@ -8,14 +11,15 @@ IGNORE_ENRICHMENTS = "p_any_"
 
 # pylint: disable=too-few-public-methods
 class LookupTableMatches:
+    lut_matches: Optional[PantherEvent]
     def __init__(self):
         self.lut_matches = None
         self._p_matched = {}
 
-    def _register(self, event, lookuptable_name: str):
+    def _register(self, event: PantherEvent, lookuptable_name: str):
         self.lut_matches = deep_get(event, ENRICHMENT_KEY, lookuptable_name)
 
-    def _lookup(self, match_field: str, *keys) -> list or str:
+    def _lookup(self, match_field: str, *keys) -> Union[list, str, None]:
         match = deep_get(self.lut_matches, match_field)
         if not match:
             return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,14 @@ lint.ignore = [
     "S104", # Not worried about network binding
     "TCH002", # Not worried about importing panther_core
     "SIM110", # Overkill simplification
+    "ANN101", # Deprecated and overkill typing of Self
 
     "DTZ007", # Naive timezone datetimes. May want to re-enable this?
+    "N802", # function naming: Should probably be enabled
 ]
 line-length = 100
 
 target-version = "py39"
+
+[tool.ruff.lint.flake8-annotations]
+mypy-init-return = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ lint.select = ["ALL"]
 lint.ignore = [
     "D", # No docstrings required
     "INP001", # Implicit package is fine in panther-analysis
-    #"E501", # Don't enforce line length
+    "ISC001", # Incompatible with ruff-format
     "ERA001", # Commented out code is common :(
     "ANN401", # Using typing.Any is going to be common for a while
     "COM812", # Trailing commas are a taste thing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,24 @@ include = '\.pyi?$'
 [tool.isort]
 line_length = 100
 profile = "black"
+
+[tool.ruff]
+lint.select = ["ALL"]
+lint.ignore = [
+    "D", # No docstrings required
+    "INP001", # Implicit package is fine in panther-analysis
+    #"E501", # Don't enforce line length
+    "ERA001", # Commented out code is common :(
+    "ANN401", # Using typing.Any is going to be common for a while
+    "COM812", # Trailing commas are a taste thing
+    "UP007", # Pipes for or'ing types aren't available in 3.9
+    "TRY003", "EM101", "N818", # Weird opinions about exceptions
+    "S104", # Not worried about network binding
+    "TCH002", # Not worried about importing panther_core
+    "SIM110", # Overkill simplification
+
+    "DTZ007", # Naive timezone datetimes. May want to re-enable this?
+]
+line-length = 100
+
+target-version = "py39"


### PR DESCRIPTION
### Background

When writing detections for Panther, I would like to use as much python type hinting as possible, while also reducing the bugs that I run into. To enable this, `mypy` and `ruff` allow for extensive code quality and type hinting checks.

I am open to breaking this PR up if the ruff/pre-commit portions are not acceptable upstream. While I think they would help with panther-analysis code quality, I don't want them to cause the type hinting improvements to be rejected.

In my experience `ruff` has totally supplanted pylint/flake8 as the best linting tool for Python as it is a superset of nearly all other tools, and is also radically faster.

### Changes

- Applied mypy to `panther_base_helpers.py` and directly adjacent code until mypy was error free
- Applied ruff to `panther_base_helpers.py` and directly adjacent code, then modified ruleset to align to Panther code patterns
- Applied ruff-format to `panther_base_helpers.py` and directly adjacent code
- Introduced pre-commit to run the above tools on the specific files that have been improved
- Added pre-commit to GitHub Actions to enforce the improvements

### Questions

- Panther has used inconsistent type hints in many locations, using `dict`, `Mapping`, and `PantherEvent` (rarely) as hints for the `event` object that gets passed around. While `dict` is not really appropriate in many cases, it isn't always clear whether `Mapping` or `PantherEvent` is the best choice. Open to thoughts here.
- `ruff-format` is meant to be equivalent to `black` which is already in use in this codebase. Y'all may want to switch to it in time, since it is much faster, or remove it from this commit if you prefer using `black` everywhere.
- mypy is not happy that `python-core` (and to a lesser degree `panther_detection_helpers`) is not marked as having types. I would be happy to address that, but the repos are not public. Typing those libraries are the best next step.
