### PR TITLE
Update invalid timestamps

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_iam_assume_role_blocklist_ignored.yml
+++ b/rules/aws_cloudtrail_rules/aws_iam_assume_role_blocklist_ignored.yml
@@ -80,7 +80,7 @@ Tests:
               {
                 "attributes":
                   {
-                    "creationDate": "2019-01-00T00:00:00Z",
+                    "creationDate": "2019-01-01T00:00:00Z",
                     "mfaAuthenticated": "true",
                   },
               },
@@ -143,7 +143,7 @@ Tests:
               {
                 "attributes":
                   {
-                    "creationDate": "2019-01-00T00:00:00Z",
+                    "creationDate": "2019-01-01T00:00:00Z",
                     "mfaAuthenticated": "true",
                   },
               },
@@ -207,7 +207,7 @@ Tests:
               {
                 "attributes":
                   {
-                    "creationDate": "2019-01-00T00:00:00Z",
+                    "creationDate": "2019-01-01T00:00:00Z",
                     "mfaAuthenticated": "true",
                   },
               },

--- a/rules/aws_cloudtrail_rules/aws_root_access_key_created.yml
+++ b/rules/aws_cloudtrail_rules/aws_root_access_key_created.yml
@@ -76,7 +76,7 @@ Tests:
         "eventID": "1111",
         "eventName": "CreateAccessKey",
         "eventSource": "iam.amazonaws.com",
-        "eventTime": "2019-01-00T00:00:00Z",
+        "eventTime": "2019-01-01T00:00:00Z",
         "eventType": "AwsApiCall",
         "eventVersion": "1.05",
         "recipientAccountId": "123456789012",
@@ -105,7 +105,7 @@ Tests:
               {
                 "attributes":
                   {
-                    "creationDate": "2019-01-00T00:00:00Z",
+                    "creationDate": "2019-01-01T00:00:00Z",
                     "mfaAuthenticated": "true",
                   },
               },


### PR DESCRIPTION
### Background

Some of our test data timestamps was for the 0th day of the month, which doesn't exist. This would cause some YAML parsers to have the big sad when they tried to parse our rules, unless you took special care to configure them to ignore those invalid timestamps. This makes those timestamps valid..

### Changes

- Make timestamps valid

### Testing

- `pat test`
