### PR TITLE
add file/host state to msft graph alert context

### DIFF
--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -473,7 +473,9 @@ def msft_graph_alert_context(event):
     return {
         "category": event.get("category", ""),
         "description": event.get("description", ""),
-        "userstates": event.get("userstates", []),
+        "userStates": event.get("userStates", []),
+        "fileStates": event.get("fileStates", []),
+        "hostStates": event.get("hostStates", []),
     }
 
 


### PR DESCRIPTION
### Background

MSFT Graph alert context included userStates, but not fileStates or hostStates.

### Changes

- Add fileStates and hostStates to MSFT Graph alert context, if present

### Testing

- make test
