### PR TITLE
Update PAT to 0.48.0; PDH to 0.4.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,8 +19,8 @@ wrapt = "~=1.15"
 [packages]
 policyuniverse = "==1.5.1.20230817"
 requests = "==2.31.0"
-panther-analysis-tool = "~=0.46"
-panther-detection-helpers = "==0.3.0"
+panther-analysis-tool = "~=0.48"
+panther-detection-helpers = "==0.4.0"
 
 [requires]
 python_version = "3.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "hash": {
-      "sha256": "d907e739836caea4ac6bc211838f30fcd992a6b1554822499e6afae2e011d550"
+      "sha256": "0d2bae7d56a67c3955954c5c15351a876208d46d458051d6a1789b5241c541e4"
     },
     "pipfile-spec": 6,
     "requires": {
@@ -139,19 +139,19 @@
     },
     "boto3": {
       "hashes": [
-        "sha256:22f65b3c9b7a419f8f39c2dddc421e14fab8cbb3bd8a9d467e874237d39f59b1",
-        "sha256:bbb87d641c73462e53b1777083b55c8f13921618ad08757478a8122985c56c13"
+        "sha256:decf52f8d5d8a1b10c9ff2a0e96ee207ed79e33d2e53fdf0880a5cbef70785e0",
+        "sha256:e836b71d79671270fccac0a4d4c8ec239a6b82ea47c399b64675aa597d0ee63b"
       ],
       "markers": "python_version >= '3.8'",
-      "version": "==1.34.94"
+      "version": "==1.34.95"
     },
     "botocore": {
       "hashes": [
-        "sha256:99b11be9a28f9051af4c96fa121e9c3f22a86d499abd773c9e868b2a38961bae",
-        "sha256:f00a79002e0cb9d6895ecd0919c506402850177d7b6c4d2634fa2da362d95bcb"
+        "sha256:6bd76a2eadb42b91fa3528392e981ad5b4dfdee3968fa5b904278acf6cbf15ff",
+        "sha256:ead5823e0dd6751ece5498cb979fd9abf190e691c8833bcac6876fd6ca261fa7"
       ],
       "markers": "python_version >= '3.8'",
-      "version": "==1.34.94"
+      "version": "==1.34.95"
     },
     "certifi": {
       "hashes": [
@@ -460,11 +460,11 @@
     },
     "jsonschema": {
       "hashes": [
-        "sha256:7996507afae316306f9e2290407761157c6f78002dcf7419acb99822143d1c6f",
-        "sha256:85727c00279f5fa6bedbe6238d2aa6403bedd8b4864ab11207d07df3cc1b2ee5"
+        "sha256:5b22d434a45935119af990552c862e5d6d564e8f6601206b305a61fdf661a2b7",
+        "sha256:ff4cfd6b1367a40e7bc6411caec72effadd3db0bbe5017de188f2d6108335802"
       ],
       "markers": "python_version >= '3.8'",
-      "version": "==4.21.1"
+      "version": "==4.22.0"
     },
     "jsonschema-specifications": {
       "hashes": [
@@ -652,10 +652,10 @@
     },
     "panther-analysis-tool": {
       "hashes": [
-        "sha256:bf3839acb3ee81589d033ae923260c0371b7b990ce86a074a2496dce0b94247a"
+        "sha256:220b9f8dfb7780854f756b4886e62d26ac28f7afb21e745786bdedef7cf6cd2b"
       ],
       "index": "pypi",
-      "version": "==0.46.1"
+      "version": "==0.48.0"
     },
     "panther-core": {
       "hashes": [
@@ -665,10 +665,10 @@
     },
     "panther-detection-helpers": {
       "hashes": [
-        "sha256:7ec0e4f18b41432cd2a0508170e1f783c89f25c555c70a8d7c0fd0a663b972b7"
+        "sha256:151d35778cb2cb1901a35b91326b5b22cca3d7593f31059dc19d13fc5598987a"
       ],
       "index": "pypi",
-      "version": "==0.3.0"
+      "version": "==0.4.0"
     },
     "pathspec": {
       "hashes": [
@@ -1279,19 +1279,19 @@
     },
     "boto3": {
       "hashes": [
-        "sha256:22f65b3c9b7a419f8f39c2dddc421e14fab8cbb3bd8a9d467e874237d39f59b1",
-        "sha256:bbb87d641c73462e53b1777083b55c8f13921618ad08757478a8122985c56c13"
+        "sha256:decf52f8d5d8a1b10c9ff2a0e96ee207ed79e33d2e53fdf0880a5cbef70785e0",
+        "sha256:e836b71d79671270fccac0a4d4c8ec239a6b82ea47c399b64675aa597d0ee63b"
       ],
       "markers": "python_version >= '3.8'",
-      "version": "==1.34.94"
+      "version": "==1.34.95"
     },
     "botocore": {
       "hashes": [
-        "sha256:99b11be9a28f9051af4c96fa121e9c3f22a86d499abd773c9e868b2a38961bae",
-        "sha256:f00a79002e0cb9d6895ecd0919c506402850177d7b6c4d2634fa2da362d95bcb"
+        "sha256:6bd76a2eadb42b91fa3528392e981ad5b4dfdee3968fa5b904278acf6cbf15ff",
+        "sha256:ead5823e0dd6751ece5498cb979fd9abf190e691c8833bcac6876fd6ca261fa7"
       ],
       "markers": "python_version >= '3.8'",
-      "version": "==1.34.94"
+      "version": "==1.34.95"
     },
     "certifi": {
       "hashes": [


### PR DESCRIPTION
### Background

This PR updates PAT to 0.48.0 and `panther_detection_helpers` to `0.4.0`. Both of these releases add Python 3.11 support.

### Changes

- Updates PAT to `0.48.0`
- Updates PDH to `0.4.0`

### Testing

- `make fmt; make lint; make test`
