### PR TITLE
Replace panther_analysis_tool import with updated import

### DIFF
--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -10,7 +10,7 @@ import string
 import sys
 import unittest
 
-from panther_analysis_tool.immutable import ImmutableCaseInsensitiveDict, ImmutableList
+from panther_core.immutable import ImmutableCaseInsensitiveDict, ImmutableList
 
 # pipenv run does the right thing, but IDE based debuggers may fail to import
 #   so noting, we append this directory to sys.path


### PR DESCRIPTION
### Background

We no longer ship PAT as an included library since its core functionality has been moved to other included libraries. This PR updates the last remaining reference to a PAT import.

### Changes

- Updates `from panther_analysis_tool.immutable` to `from panther_core.immutable`

### Testing

- `make test`
