### PR TITLE
migrates the gcp_storage_hmac_keys_create rule to

### DIFF
--- a/rules/gcp_audit_rules/gcp_storage_hmac_keys_create.py
+++ b/rules/gcp_audit_rules/gcp_storage_hmac_keys_create.py
@@ -1,0 +1,8 @@
+def rule(event):
+    auth_info = event.deep_walk("protoPayload", "authorizationInfo", default=[])
+    auth_info = auth_info if isinstance(auth_info, list) else [auth_info]
+
+    for auth in auth_info:
+        if auth.get("granted", False) and auth.get("permission", "") == "storage.hmacKeys.create":
+            return True
+    return False

--- a/rules/gcp_audit_rules/gcp_storage_hmac_keys_create.yml
+++ b/rules/gcp_audit_rules/gcp_storage_hmac_keys_create.yml
@@ -12,14 +12,7 @@ Reference: https://rhinosecuritylabs.com/cloud-security/privilege-escalation-goo
 Reports:
   MITRE ATT&CK:
     - TA0004:T1548
-Detection:
-  - All:
-      - KeyPath: protoPayload.authorizationInfo[*].granted
-        Condition: Contains
-        Value: true
-      - KeyPath: protoPayload.authorizationInfo[*].permission
-        Condition: Contains
-        Value: storage.hmacKeys.create
+Filename: gcp_storage_hmac_keys_create.py
 Tests:
   - Name: privilege-escalation
     ExpectedResult: true


### PR DESCRIPTION
python from sdyaml

### Background

One rule was still in sdyaml format

### Changes

- replaces Detection yaml logic with python rule function

### Testing

- make test
