### PR TITLE
AWS Honeypot Detections threat-306

### DIFF
--- a/packs/aws_decoy.yml
+++ b/packs/aws_decoy.yml
@@ -1,0 +1,11 @@
+AnalysisType: pack
+PackID: PantherManaged.AWSDecoy
+Description: Group of all AWS Decoy resources detections
+PackDefinition:
+  IDs:
+    - Decoy.S3.Accessed
+    - Decoy.Systems.Manager.Parameter.Accessed
+    - Decoy.DynamoDB.Accessed
+    - Decoy.IAM.Assumed
+    - Decoy.Secret.Accessed
+DisplayName: "Panther AWS Decoy Detections"

--- a/rules/aws_securityfinding_rules/decoy_dynamodb_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_dynamodb_accessed.py
@@ -34,4 +34,3 @@ def title(event):
     # It's possible to just return the Title as a whole string
     secret = event["Resources"][0]["Id"]
     return f"Suspicious activity detected accessing private decoy DynamoDB table {secret}"
-

--- a/rules/aws_securityfinding_rules/decoy_dynamodb_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_dynamodb_accessed.py
@@ -42,4 +42,3 @@ def title(event):
 # def alert_context(event):
     # (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
     # return {'key':'value'}
-    

--- a/rules/aws_securityfinding_rules/decoy_dynamodb_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_dynamodb_accessed.py
@@ -1,6 +1,6 @@
 def rule(event):
     # List of suspicious API events
-    #NOTE: There may be more API events that's not listed
+    # NOTE: There may be more API events that's not listed
     suspicious_api_events = [
         "BatchExecuteStatement",
         "BatchGetItem",
@@ -14,9 +14,8 @@ def rule(event):
         "Scan",
         "TransactGetItems",
         "TransactWriteItems",
-        "UpdateItem"
+        "UpdateItem",
     ]
-
 
     # Return True if the API value is in the list of suspicious API events
     if event["GeneratorId"] == "dynamodb.amazonaws.com":
@@ -26,19 +25,21 @@ def rule(event):
         return api_value in suspicious_api_events
     return False
 
+
 def title(event):
     # (Optional) Return a string which will be shown as the alert title.
     # If no 'dedup' function is defined, the return value of this method will act as dedup string.
 
     # NOTE: Not sure if the offending actor Id will always be in the 0th index of Resources
     # It's possible to just return the Title as a whole string
-    secret = event['Resources'][0]['Id']
+    secret = event["Resources"][0]["Id"]
     return f"Suspicious activity detected accessing private decoy DynamoDB table {secret}"
 
+
 # def dedup(event):
-    #  (Optional) Return a string which will be used to deduplicate similar alerts.
-    # return ''
+#  (Optional) Return a string which will be used to deduplicate similar alerts.
+# return ''
 
 # def alert_context(event):
-    # (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
-    # return {'key':'value'}
+# (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
+# return {'key':'value'}

--- a/rules/aws_securityfinding_rules/decoy_dynamodb_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_dynamodb_accessed.py
@@ -28,7 +28,7 @@ def rule(event):
 
 def title(event):
     # (Optional) Return a string which will be shown as the alert title.
-    # If no 'dedup' function is defined, the return value of this method will act as deduplication string.
+    # If no 'dedup' function is defined, the return value of this method will act as dedup string.
 
     # NOTE: Not sure if the offending actor Id will always be in the 0th index of Resources
     # It's possible to just return the Title as a whole string
@@ -40,5 +40,6 @@ def title(event):
     # return ''
 
 # def alert_context(event):
-    #  (Optional) Return a dictionary with additional data to be included in the alert sent to the SNS/SQS/Webhook destination
+    #  (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook destination
     # return {'key':'value'}
+    

--- a/rules/aws_securityfinding_rules/decoy_dynamodb_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_dynamodb_accessed.py
@@ -40,6 +40,6 @@ def title(event):
     # return ''
 
 # def alert_context(event):
-    #  (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook destination
+    # (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
     # return {'key':'value'}
     

--- a/rules/aws_securityfinding_rules/decoy_dynamodb_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_dynamodb_accessed.py
@@ -35,11 +35,3 @@ def title(event):
     secret = event["Resources"][0]["Id"]
     return f"Suspicious activity detected accessing private decoy DynamoDB table {secret}"
 
-
-# def dedup(event):
-#  (Optional) Return a string which will be used to deduplicate similar alerts.
-# return ''
-
-# def alert_context(event):
-# (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
-# return {'key':'value'}

--- a/rules/aws_securityfinding_rules/decoy_dynamodb_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_dynamodb_accessed.py
@@ -1,0 +1,44 @@
+def rule(event):
+    # List of suspicious API events
+    #NOTE: There may be more API events that's not listed
+    suspicious_api_events = [
+        "BatchExecuteStatement",
+        "BatchGetItem",
+        "BatchWriteItem",
+        "DeleteItem",
+        "ExecuteStatement",
+        "ExecuteTransaction",
+        "GetItem",
+        "PutItem",
+        "Query",
+        "Scan",
+        "TransactGetItems",
+        "TransactWriteItems",
+        "UpdateItem"
+    ]
+
+
+    # Return True if the API value is in the list of suspicious API events
+    if event["GeneratorId"] == "dynamodb.amazonaws.com":
+        # Extract the API value from the event
+        api_value = event["Action"]["AwsApiCallAction"]["Api"]
+
+        return api_value in suspicious_api_events
+    return False
+
+def title(event):
+    # (Optional) Return a string which will be shown as the alert title.
+    # If no 'dedup' function is defined, the return value of this method will act as deduplication string.
+
+    # NOTE: Not sure if the offending actor Id will always be in the 0th index of Resources
+    # It's possible to just return the Title as a whole string
+    secret = event['Resources'][0]['Id']
+    return f"Suspicious activity detected accessing private decoy DynamoDB table {secret}"
+
+# def dedup(event):
+    #  (Optional) Return a string which will be used to deduplicate similar alerts.
+    # return ''
+
+# def alert_context(event):
+    #  (Optional) Return a dictionary with additional data to be included in the alert sent to the SNS/SQS/Webhook destination
+    # return {'key':'value'}

--- a/rules/aws_securityfinding_rules/decoy_dynamodb_accessed.yml
+++ b/rules/aws_securityfinding_rules/decoy_dynamodb_accessed.yml
@@ -1,0 +1,219 @@
+AnalysisType: rule
+Filename: decoy_dynamodb_accessed.py
+RuleID: "Decoy.DynamoDB.Accessed"
+DisplayName: "Decoy DynamoDB Accessed"
+Enabled: false
+LogTypes:
+    - AWS.SecurityFindingFormat
+Severity: High
+Description: Actor accessed Decoy DynamoDB
+DedupPeriodMinutes: 60
+Threshold: 1
+Reference: https://aws.amazon.com/blogs/security/how-to-detect-suspicious-activity-in-your-aws-account-by-using-private-decoy-resources/
+InlineFilters:
+    - All: []
+Tests:
+    - Name: DynamoDB-Decoy-Accessed
+      ExpectedResult: true
+      Log:
+        Action:
+            ActionType: AWS_API_CALL
+            AwsApiCallAction:
+                Api: Scan
+                CallerType: remoteIp
+                DomainDetails: {}
+                RemoteIpDetails:
+                    City: {}
+                    Country: {}
+                    GeoLocation: {}
+                    IpAddressV4: 11.111.11.111
+                    Organization: {}
+                ServiceName: dynamodb.amazonaws.com
+            DnsRequestAction: {}
+            NetworkConnectionAction:
+                LocalPortDetails: {}
+                RemotePortDetails: {}
+            PortProbeAction: {}
+        AwsAccountId: "123456789012"
+        CompanyName: Custom
+        CreatedAt: "2024-05-24 22:53:24.000000000"
+        Description: Private decoy DynamoDB table arn:aws:dynamodb:us-east-1:123456789012:table/Panther-DataTable was accessed by arn:aws:iam::123456789012:user/tester. This DynamoDB table has been provisioned to monitor and generate security events when accessed and can be an indicator of unintended or unauthorized access to your AWS Account.
+        FindingProviderFields:
+            Severity:
+                Label: HIGH
+                Normalized: 70
+            Types:
+                - Unusual Behaviors
+        GeneratorId: dynamodb.amazonaws.com
+        Id: 1abc2de3-69ea-4e15-91c6-27eb4a07bd21
+        ProcessedAt: "2024-05-24T22:53:41.884Z"
+        ProductArn: arn:aws:securityhub:us-east-1:123456789012:product/123456789012/default
+        ProductFields:
+            Custom/DecoyDetector/apiResult: SUCCESS
+            Custom/DecoyDetector/requestID: ab1cd234-1986-4c45-8546-fdb1776e23b0
+            Custom/DecoyDetector/userAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
+            aws/securityhub/CompanyName: Personal
+            aws/securityhub/FindingId: arn:aws:securityhub:us-east-1:123456789012:product/123456789012/default/1abc2de3-69ea-4e15-91c6-27eb4a07bd21
+            aws/securityhub/ProductName: Default
+        ProductName: DecoyDetector
+        RecordState: ACTIVE
+        Region: us-east-1
+        Resources:
+            - Id: <id>
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Target
+              Type: AwsDynamoDbTable
+            - Details:
+                AwsIamAccessKey:
+                    AccessKeyId: ABC9ONWNS3155VIEJC8U
+                    AccountId: "123456789012"
+                    PrincipalId: ABC9ONWNS3155VIEJC8U:john.doe
+                    PrincipalType: AssumedRole
+                    SessionContext:
+                        Attributes:
+                            CreationDate: "2024-05-24T22:32:38Z"
+                            MfaAuthenticated: false
+                        SessionIssuer:
+                            AccountId: "123456789012"
+                            Arn: arn:aws:iam::123456789012:user/tester
+                            PrincipalId: tester
+                            Type: Role
+                            UserName: user/tester
+              Id: ABC9ONWNS3155VIEJC8U
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamAccessKey
+            - Id: arn:aws:iam::123456789012:user/tester
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamRole
+        SchemaVersion: "2018-10-08"
+        Severity:
+            Label: HIGH
+            Normalized: 70
+        Title: Suspicious activity detected accessing private decoy DynamoDB table arn:aws:dynamodb:us-east-1:123456789012:table/Panther-DataTable
+        Types:
+            - Unusual Behaviors
+        UpdatedAt: "2024-05-24 22:53:24.000000000"
+        Workflow:
+            Status: NEW
+        WorkflowState: NEW
+        p_any_actor_ids: []
+        p_any_aws_account_ids: []
+        p_any_aws_arns: []
+        p_any_ip_addresses: []
+        p_any_trace_ids: []
+        p_any_usernames: []
+        p_event_time: "2024-05-24 22:53:24.000000000"
+        p_log_type: AWS.SecurityFindingFormat
+        p_parse_time: "2024-05-24 22:55:04.312964001"
+        p_row_id: 8e1c8ebd709fb49e9eb5a1c61ff1a303
+        p_schema_version: 0
+        p_source_id: e29fd64f-53d9-43ab-92ca-575a8af289e6
+        p_source_label: AWS Security Hub
+        p_udm: {}
+    - Name: DynamoDB-Decoy-Not-Accessed
+      ExpectedResult: false
+      Log:
+        Action:
+            ActionType: AWS_API_CALL
+            AwsApiCallAction:
+                Api: DescribeEndpoints
+                CallerType: remoteIp
+                DomainDetails: {}
+                RemoteIpDetails:
+                    City: {}
+                    Country: {}
+                    GeoLocation: {}
+                    IpAddressV4: 11.111.11.111
+                    Organization: {}
+                ServiceName: dynamodb.amazonaws.com
+            DnsRequestAction: {}
+            NetworkConnectionAction:
+                LocalPortDetails: {}
+                RemotePortDetails: {}
+            PortProbeAction: {}
+        AwsAccountId: "123456789012"
+        CompanyName: Custom
+        CreatedAt: "2024-05-24 22:53:24.000000000"
+        Description: Private decoy DynamoDB table arn:aws:dynamodb:us-east-1:123456789012:table/Panther-DataTable was not accessed by arn:aws:iam::123456789012:user/tester. This DynamoDB table has been provisioned to monitor and generate security events when accessed and can be an indicator of unintended or unauthorized access to your AWS Account.
+        FindingProviderFields:
+            Severity:
+                Label: HIGH
+                Normalized: 70
+            Types:
+                - Unusual Behaviors
+        GeneratorId: dynamodb.amazonaws.com
+        Id: 1abc2de3-69ea-4e15-91c6-27eb4a07bd21
+        ProcessedAt: "2024-05-24T22:53:41.884Z"
+        ProductArn: arn:aws:securityhub:us-east-1:123456789012:product/123456789012/default
+        ProductFields:
+            Custom/DecoyDetector/apiResult: SUCCESS
+            Custom/DecoyDetector/requestID: ab1cd234-1986-4c45-8546-fdb1776e23b0
+            Custom/DecoyDetector/userAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
+            aws/securityhub/CompanyName: Personal
+            aws/securityhub/FindingId: arn:aws:securityhub:us-east-1:123456789012:product/123456789012/default/1abc2de3-69ea-4e15-91c6-27eb4a07bd21
+            aws/securityhub/ProductName: Default
+        ProductName: DecoyDetector
+        RecordState: ACTIVE
+        Region: us-east-1
+        Resources:
+            - Id: <id>
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Target
+              Type: AwsDynamoDbTable
+            - Details:
+                AwsIamAccessKey:
+                    AccessKeyId: ABC9ONWNS3155VIEJC8U
+                    AccountId: "123456789012"
+                    PrincipalId: ABC9ONWNS3155VIEJC8U:john.doe
+                    PrincipalType: AssumedRole
+                    SessionContext:
+                        Attributes:
+                            CreationDate: "2024-05-24T22:32:38Z"
+                            MfaAuthenticated: false
+                        SessionIssuer:
+                            AccountId: "123456789012"
+                            Arn: arn:aws:iam::123456789012:user/tester
+                            PrincipalId: tester
+                            Type: Role
+                            UserName: user/tester
+              Id: ABC9ONWNS3155VIEJC8U
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamAccessKey
+            - Id: arn:aws:iam::123456789012:user/tester
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamRole
+        SchemaVersion: "2018-10-08"
+        Severity:
+            Label: HIGH
+            Normalized: 70
+        Title: Non-Suspicious activity detected accessing private decoy DynamoDB table arn:aws:dynamodb:us-east-1:123456789012:table/Panther-DataTable
+        Types:
+            - Unusual Behaviors
+        UpdatedAt: "2024-05-24 22:53:24.000000000"
+        Workflow:
+            Status: NEW
+        WorkflowState: NEW
+        p_any_actor_ids: []
+        p_any_aws_account_ids: []
+        p_any_aws_arns: []
+        p_any_ip_addresses: []
+        p_any_trace_ids: []
+        p_any_usernames: []
+        p_event_time: "2024-05-24 22:53:24.000000000"
+        p_log_type: AWS.SecurityFindingFormat
+        p_parse_time: "2024-05-24 22:55:04.312964001"
+        p_row_id: 8e1c8ebd709fb49e9eb5a1c61ff1a303
+        p_schema_version: 0
+        p_source_id: e29fd64f-53d9-43ab-92ca-575a8af289e6
+        p_source_label: AWS Security Hub
+        p_udm: {}

--- a/rules/aws_securityfinding_rules/decoy_iam_assumed.py
+++ b/rules/aws_securityfinding_rules/decoy_iam_assumed.py
@@ -1,0 +1,29 @@
+def rule(event):
+    # List of suspicious API events
+    #NOTE: There may be more API events that's not listed
+    suspicious_api_events = ["AssumeRole"]
+
+    # Return True if the API value is in the list of suspicious API events
+    if event["GeneratorId"] == "sts.amazonaws.com":
+        # Extract the API value from the event
+        api_value = event["Action"]["AwsApiCallAction"]["Api"]
+
+        return api_value in suspicious_api_events
+    return False
+
+def title(event):
+    # (Optional) Return a string which will be shown as the alert title.
+    # If no 'dedup' function is defined, the return value of this method will act as deduplication string.
+
+    # NOTE: Not sure if the offending actor Id will always be in the 0th index of Resources
+    # It's possible to just return the Title as a whole string
+    secret = event['Resources'][0]['Id']
+    return f"Suspicious activity detected accessing private decoy IAM role {secret}"
+
+# def dedup(event):
+    #  (Optional) Return a string which will be used to deduplicate similar alerts.
+    # return ''
+
+# def alert_context(event):
+    #  (Optional) Return a dictionary with additional data to be included in the alert sent to the SNS/SQS/Webhook destination
+    # return {'key':'value'}

--- a/rules/aws_securityfinding_rules/decoy_iam_assumed.py
+++ b/rules/aws_securityfinding_rules/decoy_iam_assumed.py
@@ -27,4 +27,3 @@ def title(event):
 # def alert_context(event):
     # (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
     # return {'key':'value'}
-    

--- a/rules/aws_securityfinding_rules/decoy_iam_assumed.py
+++ b/rules/aws_securityfinding_rules/decoy_iam_assumed.py
@@ -1,6 +1,6 @@
 def rule(event):
     # List of suspicious API events
-    #NOTE: There may be more API events that's not listed
+    # NOTE: There may be more API events that's not listed
     suspicious_api_events = ["AssumeRole"]
 
     # Return True if the API value is in the list of suspicious API events
@@ -11,19 +11,21 @@ def rule(event):
         return api_value in suspicious_api_events
     return False
 
+
 def title(event):
     # (Optional) Return a string which will be shown as the alert title.
     # If no 'dedup' function is defined, the return value of this method will act as dedup string.
 
     # NOTE: Not sure if the offending actor Id will always be in the 0th index of Resources
     # It's possible to just return the Title as a whole string
-    secret = event['Resources'][0]['Id']
+    secret = event["Resources"][0]["Id"]
     return f"Suspicious activity detected accessing private decoy IAM role {secret}"
 
+
 # def dedup(event):
-    #  (Optional) Return a string which will be used to deduplicate similar alerts.
-    # return ''
+#  (Optional) Return a string which will be used to deduplicate similar alerts.
+# return ''
 
 # def alert_context(event):
-    # (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
-    # return {'key':'value'}
+# (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
+# return {'key':'value'}

--- a/rules/aws_securityfinding_rules/decoy_iam_assumed.py
+++ b/rules/aws_securityfinding_rules/decoy_iam_assumed.py
@@ -20,4 +20,3 @@ def title(event):
     # It's possible to just return the Title as a whole string
     secret = event["Resources"][0]["Id"]
     return f"Suspicious activity detected accessing private decoy IAM role {secret}"
-

--- a/rules/aws_securityfinding_rules/decoy_iam_assumed.py
+++ b/rules/aws_securityfinding_rules/decoy_iam_assumed.py
@@ -21,11 +21,3 @@ def title(event):
     secret = event["Resources"][0]["Id"]
     return f"Suspicious activity detected accessing private decoy IAM role {secret}"
 
-
-# def dedup(event):
-#  (Optional) Return a string which will be used to deduplicate similar alerts.
-# return ''
-
-# def alert_context(event):
-# (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
-# return {'key':'value'}

--- a/rules/aws_securityfinding_rules/decoy_iam_assumed.py
+++ b/rules/aws_securityfinding_rules/decoy_iam_assumed.py
@@ -13,7 +13,7 @@ def rule(event):
 
 def title(event):
     # (Optional) Return a string which will be shown as the alert title.
-    # If no 'dedup' function is defined, the return value of this method will act as deduplication string.
+    # If no 'dedup' function is defined, the return value of this method will act as dedup string.
 
     # NOTE: Not sure if the offending actor Id will always be in the 0th index of Resources
     # It's possible to just return the Title as a whole string
@@ -25,5 +25,6 @@ def title(event):
     # return ''
 
 # def alert_context(event):
-    #  (Optional) Return a dictionary with additional data to be included in the alert sent to the SNS/SQS/Webhook destination
+    #  (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook destination
     # return {'key':'value'}
+    

--- a/rules/aws_securityfinding_rules/decoy_iam_assumed.py
+++ b/rules/aws_securityfinding_rules/decoy_iam_assumed.py
@@ -25,6 +25,6 @@ def title(event):
     # return ''
 
 # def alert_context(event):
-    #  (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook destination
+    # (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
     # return {'key':'value'}
     

--- a/rules/aws_securityfinding_rules/decoy_iam_assumed.yml
+++ b/rules/aws_securityfinding_rules/decoy_iam_assumed.yml
@@ -1,0 +1,217 @@
+AnalysisType: rule
+Filename: decoy_iam_assumed.py
+RuleID: "Decoy.IAM.Assumed"
+DisplayName: "Decoy IAM Assumed"
+Enabled: false
+LogTypes:
+    - AWS.SecurityFindingFormat
+Severity: High
+Description: Actor assumed decoy IAM role
+DedupPeriodMinutes: 60
+Threshold: 1
+Reference: https://aws.amazon.com/blogs/security/how-to-detect-suspicious-activity-in-your-aws-account-by-using-private-decoy-resources/
+InlineFilters:
+    - All: []
+Tests:
+    - Name: IAM-Decoy-Assumed
+      ExpectedResult: true
+      Log:
+        Action:
+            ActionType: AWS_API_CALL
+            AwsApiCallAction:
+                Api: AssumeRole
+                CallerType: remoteIp
+                DomainDetails: {}
+                RemoteIpDetails:
+                    City: {}
+                    Country: {}
+                    GeoLocation: {}
+                    IpAddressV4: 11.1.111.11
+                    Organization: {}
+                ServiceName: sts.amazonaws.com
+            DnsRequestAction: {}
+            NetworkConnectionAction:
+                LocalPortDetails: {}
+                RemotePortDetails: {}
+            PortProbeAction: {}
+        AwsAccountId: "123456789012"
+        CompanyName: Custom
+        CreatedAt: "2024-05-24 13:17:15.000000000"
+        Description: Private decoy IAM role arn:aws:iam::123456789012:role/Dummy-Test-InfoRole-ab21cde50f was accessed by arn:aws:iam::123456789012:user/tester. This IAM role has been provisioned to monitor and generate security events when accessed and can be an indicator of unintended or unauthorized access to your AWS Account.
+        FindingProviderFields:
+            Severity:
+                Label: HIGH
+                Normalized: 70
+            Types:
+                - Unusual Behaviors
+        GeneratorId: sts.amazonaws.com
+        Id: 1abc2de3-69ea-4e15-91c6-27eb4a07bd21
+        ProcessedAt: "2024-05-24T13:17:21.469Z"
+        ProductArn: arn:aws:securityhub:us-east-1:123456789012:product/123456789012/default
+        ProductFields:
+            Custom/DecoyDetector/apiResult: SUCCESS
+            Custom/DecoyDetector/requestID: ab1cd123-1986-4c45-8546-fdb1776e23b0
+            Custom/DecoyDetector/userAgent: AWS Signin, aws-internal/3 aws-sdk-java/1.12.720 Linux/5.10.215-181.850.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/17.0.11+10-LTS java/17.0.11 kotlin/1.3.72 vendor/Amazon.com_Inc. cfg/retry-mode/standard cfg/auth-source#unknown
+            aws/securityhub/CompanyName: Personal
+            aws/securityhub/FindingId: arn:aws:service:region:123456789012:resource/12345ab9-436d-4d59-ac58-ed6b3127e440
+            aws/securityhub/ProductName: Default
+        ProductName: DecoyDetector
+        RecordState: ACTIVE
+        Region: us-east-1
+        Resources:
+            - Id: arn:aws:iam::123456789012:role/Dummy-Test-InfoRole-ab21cde50f
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Target
+              Type: AwsIamRole
+            - Details:
+                AwsIamAccessKey:
+                    AccessKeyId: ABC9ONWNS3155VIEJC8U
+                    AccountId: "123456789012"
+                    PrincipalId: ABCDEFGH0TOGJSGNQKI0:john.doe
+                    PrincipalType: AssumedRole
+                    SessionContext:
+                        Attributes:
+                            CreationDate: "2024-05-24T22:32:38Z"
+                            MfaAuthenticated: false
+                        SessionIssuer:
+                            AccountId: "123456789012"
+                            Arn: arn:aws:iam::123456789012:user/tester
+                            PrincipalId: ABCDEFGH0TOGJSGNQKI0
+                            Type: Role
+                            UserName: user_ab21cde50f
+              Id: ABC9ONWNS3155VIEJC8U
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamAccessKey
+            - Id: arn:aws:iam::123456789012:user/tester
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamRole
+        SchemaVersion: "2018-10-08"
+        Severity:
+            Label: HIGH
+            Normalized: 70
+        Title: Suspicious activity detected accessing private decoy IAM role arn:aws:iam::123456789012:role/Dummy-Test-InfoRole-ab21cde50f
+        Types:
+            - Unusual Behaviors
+        UpdatedAt: "2024-05-24 13:17:15.000000000"
+        Workflow:
+            Status: NEW
+        WorkflowState: NEW
+        p_any_actor_ids: []
+        p_any_aws_account_ids: []
+        p_any_aws_arns: []
+        p_any_trace_ids: []
+        p_any_usernames: []
+        p_event_time: "2024-05-24 22:34:07.000000000"
+        p_log_type: AWS.SecurityFindingFormat
+        p_parse_time: "2024-05-24 22:35:04.272574202"
+        p_row_id: zjj8nmnw9f90uulxfa3bmen8rv5stlcx
+        p_schema_version: 0
+        p_source_id: bb4e16c5-43dd-450c-9227-39f0d152659c
+        p_source_label: AWS Security Hub
+        p_udm: {}
+    - Name: IAM-Decoy-Not-Assumed
+      ExpectedResult: false
+      Log:
+        Action:
+            ActionType: AWS_API_CALL
+            AwsApiCallAction:
+                Api: ListRoles
+                CallerType: remoteIp
+                DomainDetails: {}
+                RemoteIpDetails:
+                    City: {}
+                    Country: {}
+                    GeoLocation: {}
+                    IpAddressV4: 99.6.134.57
+                    Organization: {}
+                ServiceName: sts.amazonaws.com
+            DnsRequestAction: {}
+            NetworkConnectionAction:
+                LocalPortDetails: {}
+                RemotePortDetails: {}
+            PortProbeAction: {}
+        AwsAccountId: "123456789012"
+        CompanyName: Custom
+        CreatedAt: "2024-05-24 13:17:15.000000000"
+        Description: Private decoy IAM role arn:aws:iam::123456789012:role/Dummy-Test-InfoRole-ab21cde50f was not accessed by arn:aws:iam::123456789012:user/tester. This IAM role has been provisioned to monitor and generate security events when accessed and can be an indicator of unintended or unauthorized access to your AWS Account.
+        FindingProviderFields:
+            Severity:
+                Label: HIGH
+                Normalized: 70
+            Types:
+                - Unusual Behaviors
+        GeneratorId: sts.amazonaws.com
+        Id: 1abc2de3-69ea-4e15-91c6-27eb4a07bd21
+        ProcessedAt: "2024-05-24T13:17:21.469Z"
+        ProductArn: arn:aws:securityhub:us-east-1:123456789012:product/123456789012/default
+        ProductFields:
+            Custom/DecoyDetector/apiResult: SUCCESS
+            Custom/DecoyDetector/requestID: ab1cd123-1986-4c45-8546-fdb1776e23b0
+            Custom/DecoyDetector/userAgent: AWS Signin, aws-internal/3 aws-sdk-java/1.12.720 Linux/5.10.215-181.850.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/17.0.11+10-LTS java/17.0.11 kotlin/1.3.72 vendor/Amazon.com_Inc. cfg/retry-mode/standard cfg/auth-source#unknown
+            aws/securityhub/CompanyName: Personal
+            aws/securityhub/FindingId: arn:aws:service:region:123456789012:resource/12345ab9-436d-4d59-ac58-ed6b3127e440
+            aws/securityhub/ProductName: Default
+        ProductName: DecoyDetector
+        RecordState: ACTIVE
+        Region: us-east-1
+        Resources:
+            - Id: arn:aws:iam::123456789012:role/Dummy-Test-InfoRole-ab21cde50f
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Target
+              Type: AwsIamRole
+            - Details:
+                AwsIamAccessKey:
+                    AccessKeyId: ABC9ONWNS3155VIEJC8U
+                    AccountId: "123456789012"
+                    PrincipalId: ABCDEFGH0TOGJSGNQKI0:john.doe
+                    PrincipalType: AssumedRole
+                    SessionContext:
+                        Attributes:
+                            CreationDate: "2024-05-24T22:32:38Z"
+                            MfaAuthenticated: false
+                        SessionIssuer:
+                            AccountId: "123456789012"
+                            Arn: arn:aws:iam::123456789012:user/tester
+                            PrincipalId: ABCDEFGH0TOGJSGNQKI0
+                            Type: Role
+                            UserName: user_ab21cde50f
+              Id: ABC9ONWNS3155VIEJC8U
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamAccessKey
+            - Id: arn:aws:iam::123456789012:user/tester
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamRole
+        SchemaVersion: "2018-10-08"
+        Severity:
+            Label: HIGH
+            Normalized: 70
+        Title: Non-Suspicious activity detected accessing private decoy IAM role arn:aws:iam::123456789012:role/Dummy-Test-InfoRole-ab21cde50f
+        Types:
+            - Unusual Behaviors
+        UpdatedAt: "2024-05-24 13:17:15.000000000"
+        Workflow:
+            Status: NEW
+        WorkflowState: NEW
+        p_any_actor_ids: []
+        p_any_aws_account_ids: []
+        p_any_aws_arns: []
+        p_any_trace_ids: []
+        p_any_usernames: []
+        p_event_time: "2024-05-24 22:34:07.000000000"
+        p_log_type: AWS.SecurityFindingFormat
+        p_parse_time: "2024-05-24 22:35:04.272574202"
+        p_row_id: zjj8nmnw9f90uulxfa3bmen8rv5stlcx
+        p_schema_version: 0
+        p_source_id: bb4e16c5-43dd-450c-9227-39f0d152659c
+        p_source_label: AWS Security Hub
+        p_udm: {}

--- a/rules/aws_securityfinding_rules/decoy_s3_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_s3_accessed.py
@@ -1,0 +1,49 @@
+def rule(event):
+    # List of suspicious API events
+    #NOTE: There may be more API events that's not listed
+    suspicious_api_events = [
+        "HeadObject",
+        "GetObject",
+        "GetObjectAcl",
+        "GetObjectAttributes",
+        "GetObjectLegalHold",
+        "GetObjectLockConfiguration",
+        "GetObjectRetention",
+        "GetObjectTagging",
+        "GetObjectTorrent",
+        "PutObject",
+        "PutObjectAcl",
+        "PutObjectLegalHold",
+        "PutObjectLockConfiguration",
+        "PutObjectRetention",
+        "PutObjectTagging",
+        "SelectObjectContent",
+        "DeleteObject",
+        "DeleteObjects",
+        "DeleteObjectTagging"
+    ]
+
+    # Return True if the API value is in the list of suspicious API events
+    if event["GeneratorId"] == "s3.amazonaws.com":
+        # Extract the API value from the event
+        api_value = event["Action"]["AwsApiCallAction"]["Api"]
+
+        return api_value in suspicious_api_events
+    return False
+
+def title(event):
+    # (Optional) Return a string which will be shown as the alert title.
+    # If no 'dedup' function is defined, the return value of this method will act as deduplication string.
+
+    # NOTE: Not sure if the offending actor Id will always be in the 0th index of Resources
+    # It's possible to just return the Title as a whole string
+    secret = event['Resources'][0]['Id']
+    return f"Suspicious activity detected accessing private decoy S3 bucket {secret}"
+
+# def dedup(event):
+    #  (Optional) Return a string which will be used to deduplicate similar alerts.
+    # return ''
+
+# def alert_context(event):
+    #  (Optional) Return a dictionary with additional data to be included in the alert sent to the SNS/SQS/Webhook destination
+    # return {'key':'value'}

--- a/rules/aws_securityfinding_rules/decoy_s3_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_s3_accessed.py
@@ -41,11 +41,3 @@ def title(event):
     secret = event["Resources"][0]["Id"]
     return f"Suspicious activity detected accessing private decoy S3 bucket {secret}"
 
-
-# def dedup(event):
-#  (Optional) Return a string which will be used to deduplicate similar alerts.
-# return ''
-
-# def alert_context(event):
-# (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
-# return {'key':'value'}

--- a/rules/aws_securityfinding_rules/decoy_s3_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_s3_accessed.py
@@ -33,7 +33,7 @@ def rule(event):
 
 def title(event):
     # (Optional) Return a string which will be shown as the alert title.
-    # If no 'dedup' function is defined, the return value of this method will act as deduplication string.
+    # If no 'dedup' function is defined, the return value of this method will act as dedup string.
 
     # NOTE: Not sure if the offending actor Id will always be in the 0th index of Resources
     # It's possible to just return the Title as a whole string
@@ -45,5 +45,6 @@ def title(event):
     # return ''
 
 # def alert_context(event):
-    #  (Optional) Return a dictionary with additional data to be included in the alert sent to the SNS/SQS/Webhook destination
+    #  (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook destination
     # return {'key':'value'}
+    

--- a/rules/aws_securityfinding_rules/decoy_s3_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_s3_accessed.py
@@ -45,6 +45,6 @@ def title(event):
     # return ''
 
 # def alert_context(event):
-    #  (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook destination
+    # (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
     # return {'key':'value'}
     

--- a/rules/aws_securityfinding_rules/decoy_s3_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_s3_accessed.py
@@ -40,4 +40,3 @@ def title(event):
     # It's possible to just return the Title as a whole string
     secret = event["Resources"][0]["Id"]
     return f"Suspicious activity detected accessing private decoy S3 bucket {secret}"
-

--- a/rules/aws_securityfinding_rules/decoy_s3_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_s3_accessed.py
@@ -47,4 +47,3 @@ def title(event):
 # def alert_context(event):
     # (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
     # return {'key':'value'}
-    

--- a/rules/aws_securityfinding_rules/decoy_s3_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_s3_accessed.py
@@ -1,6 +1,6 @@
 def rule(event):
     # List of suspicious API events
-    #NOTE: There may be more API events that's not listed
+    # NOTE: There may be more API events that's not listed
     suspicious_api_events = [
         "HeadObject",
         "GetObject",
@@ -20,7 +20,7 @@ def rule(event):
         "SelectObjectContent",
         "DeleteObject",
         "DeleteObjects",
-        "DeleteObjectTagging"
+        "DeleteObjectTagging",
     ]
 
     # Return True if the API value is in the list of suspicious API events
@@ -31,19 +31,21 @@ def rule(event):
         return api_value in suspicious_api_events
     return False
 
+
 def title(event):
     # (Optional) Return a string which will be shown as the alert title.
     # If no 'dedup' function is defined, the return value of this method will act as dedup string.
 
     # NOTE: Not sure if the offending actor Id will always be in the 0th index of Resources
     # It's possible to just return the Title as a whole string
-    secret = event['Resources'][0]['Id']
+    secret = event["Resources"][0]["Id"]
     return f"Suspicious activity detected accessing private decoy S3 bucket {secret}"
 
+
 # def dedup(event):
-    #  (Optional) Return a string which will be used to deduplicate similar alerts.
-    # return ''
+#  (Optional) Return a string which will be used to deduplicate similar alerts.
+# return ''
 
 # def alert_context(event):
-    # (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
-    # return {'key':'value'}
+# (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
+# return {'key':'value'}

--- a/rules/aws_securityfinding_rules/decoy_s3_accessed.yml
+++ b/rules/aws_securityfinding_rules/decoy_s3_accessed.yml
@@ -1,0 +1,237 @@
+AnalysisType: rule
+Filename: decoy_s3_accessed.py
+RuleID: "Decoy.S3.Accessed"
+DisplayName: "Decoy S3 Accessed"
+Enabled: false
+LogTypes:
+    - AWS.SecurityFindingFormat
+Severity: High
+Description: Actor accessed S3 Manager decoy secret
+DedupPeriodMinutes: 60
+Threshold: 1
+Reference: https://aws.amazon.com/blogs/security/how-to-detect-suspicious-activity-in-your-aws-account-by-using-private-decoy-resources/
+InlineFilters:
+    - All: []
+Tests:
+    - Name: S3-Decoy-Accessed
+      ExpectedResult: true
+      Log:
+        Action:
+            ActionType: AWS_API_CALL
+            AwsApiCallAction:
+                Api: GetObject
+                CallerType: remoteIp
+                DomainDetails: {}
+                RemoteIpDetails:
+                    City: {}
+                    Country: {}
+                    GeoLocation: {}
+                    IpAddressV4: 111.111.111.111
+                    Organization: {}
+                ServiceName: s3.amazonaws.com
+            DnsRequestAction: {}
+            NetworkConnectionAction:
+                LocalPortDetails: {}
+                RemotePortDetails: {}
+            PortProbeAction: {}
+        AwsAccountId: "123456789012"
+        CompanyName: Custom
+        CreatedAt: "2024-05-24 00:26:57.000000000"
+        Description: Private decoy S3 bucket panther-databucket was accessed by arn:aws:iam::123456789012:user/tester. This S3 bucket has been provisioned to monitor and generate security events when accessed and can be an indicator of unintended or unauthorized access to your AWS Account.
+        FindingProviderFields:
+            Severity:
+                Label: HIGH
+                Normalized: 70
+            Types:
+                - Unusual Behaviors
+        GeneratorId: s3.amazonaws.com
+        Id: ABC9ONWNS3155VIEJC8U
+        ProcessedAt: "2024-05-24T00:27:12.237Z"
+        ProductArn: arn:aws:securityhub:us-east-1:123456789012:product/123456789012/default
+        ProductFields:
+            Custom/DecoyDetector/apiResult: SUCCESS
+            Custom/DecoyDetector/requestID: ab1cd234-1986-4c45-8546-fdb1776e23b0
+            Custom/DecoyDetector/userAgent: '[Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36]'
+            aws/securityhub/CompanyName: Personal
+            aws/securityhub/FindingId: arn:aws:service:region:123456789012:resource/12345ab6-436d-4d59-ac58-ed6b3127e440
+            aws/securityhub/ProductName: Default
+        ProductName: DecoyDetector
+        RecordState: ACTIVE
+        Region: us-east-1
+        Resources:
+            - Id: arn:aws:s3:::panther-databucket
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Target
+              Tags:
+                aws:cloudformation:logical-id: DataBucket
+                aws:cloudformation:stack-id: arn:aws:cloudformation:us-east-1:123456789012:stack/Panther/a1b2c345-12f6-11ef-8c74-12deb08d9ef1
+                aws:cloudformation:stack-name: Panther
+              Type: AwsS3Bucket
+            - Id: arn:aws:s3:::panther-databucket/object
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Target
+              Type: AwsS3Object
+            - Details:
+                AwsIamAccessKey:
+                    AccessKeyId: ABCDEFG1HIJ2KLMNOPQR
+                    AccountId: "123456789012"
+                    PrincipalId: ABCDEFG1HIJ2KLMNOPQR:john.doe
+                    PrincipalType: AssumedRole
+                    SessionContext:
+                        Attributes:
+                            CreationDate: "2024-05-23T20:20:57Z"
+                            MfaAuthenticated: false
+                        SessionIssuer:
+                            AccountId: "123456789012"
+                            Arn: arn:aws:iam::123456789012:role/tester
+                            PrincipalId: ABCDEFG1HIJ2KLMNOPQR
+                            Type: Role
+                            UserName: tester
+              Id: ABCDEFG1HIJ2KLMNOPQR
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamAccessKey
+            - Id: ABCDEFG1HIJ2KLMNOPQR
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamRole
+        SchemaVersion: "2018-10-08"
+        Severity:
+            Label: HIGH
+            Normalized: 70
+        Title: Suspicious activity detected accessing private decoy S3 bucket panther-databucket
+        Types:
+            - Unusual Behaviors
+        UpdatedAt: "2024-05-24 00:26:57.000000000"
+        Workflow:
+            Status: NEW
+        WorkflowState: NEW
+        p_any_actor_ids: []
+        p_any_aws_account_ids: []
+        p_any_aws_arns: []
+        p_any_ip_addresses: []
+        p_any_trace_ids: []
+        p_any_usernames: []
+        p_event_time: "2024-05-24 00:26:57.000000000"
+        p_log_type: AWS.SecurityFindingFormat
+        p_parse_time: "2024-05-24 00:30:04.569556803"
+        p_row_id: 624c79c882affe88a1dce9c31fb68f0e
+        p_schema_version: 0
+        p_source_id: e29fd64f-53d9-43ab-92ca-575a8af289e6
+        p_source_label: AWS Security Hub
+        p_udm: {}
+    - Name: S3-Decoy-Not-Accessed
+      ExpectedResult: false
+      Log:
+        Action:
+            ActionType: AWS_API_CALL
+            AwsApiCallAction:
+                Api: ListBuckets
+                CallerType: remoteIp
+                DomainDetails: {}
+                RemoteIpDetails:
+                    City: {}
+                    Country: {}
+                    GeoLocation: {}
+                    IpAddressV4: 111.111.111.111
+                    Organization: {}
+                ServiceName: s3.amazonaws.com
+            DnsRequestAction: {}
+            NetworkConnectionAction:
+                LocalPortDetails: {}
+                RemotePortDetails: {}
+            PortProbeAction: {}
+        AwsAccountId: "123456789012"
+        CompanyName: Custom
+        CreatedAt: "2024-05-24 00:26:57.000000000"
+        Description: Private decoy S3 bucket panther-databucket was not accessed by arn:aws:iam::123456789012:user/tester. This S3 bucket has been provisioned to monitor and generate security events when accessed and can be an indicator of unintended or unauthorized access to your AWS Account.
+        FindingProviderFields:
+            Severity:
+                Label: HIGH
+                Normalized: 70
+            Types:
+                - Unusual Behaviors
+        GeneratorId: s3.amazonaws.com
+        Id: ABC9ONWNS3155VIEJC8U
+        ProcessedAt: "2024-05-24T00:27:12.237Z"
+        ProductArn: arn:aws:securityhub:us-east-1:123456789012:product/123456789012/default
+        ProductFields:
+            Custom/DecoyDetector/apiResult: SUCCESS
+            Custom/DecoyDetector/requestID: ab1cd234-1986-4c45-8546-fdb1776e23b0
+            Custom/DecoyDetector/userAgent: '[Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36]'
+            aws/securityhub/CompanyName: Personal
+            aws/securityhub/FindingId: arn:aws:service:region:123456789012:resource/12345ab6-436d-4d59-ac58-ed6b3127e440
+            aws/securityhub/ProductName: Default
+        ProductName: DecoyDetector
+        RecordState: ACTIVE
+        Region: us-east-1
+        Resources:
+            - Id: arn:aws:s3:::panther-databucket
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Target
+              Tags:
+                aws:cloudformation:logical-id: DataBucket
+                aws:cloudformation:stack-id: arn:aws:cloudformation:us-east-1:123456789012:stack/Panther/a1b2c345-12f6-11ef-8c74-12deb08d9ef1
+                aws:cloudformation:stack-name: Panther
+              Type: AwsS3Bucket
+            - Id: arn:aws:s3:::panther-databucket/object
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Target
+              Type: AwsS3Object
+            - Details:
+                AwsIamAccessKey:
+                    AccessKeyId: ABCDEFG1HIJ2KLMNOPQR
+                    AccountId: "123456789012"
+                    PrincipalId: ABCDEFG1HIJ2KLMNOPQR:john.doe
+                    PrincipalType: AssumedRole
+                    SessionContext:
+                        Attributes:
+                            CreationDate: "2024-05-23T20:20:57Z"
+                            MfaAuthenticated: false
+                        SessionIssuer:
+                            AccountId: "123456789012"
+                            Arn: arn:aws:iam::123456789012:role/tester
+                            PrincipalId: ABCDEFG1HIJ2KLMNOPQR
+                            Type: Role
+                            UserName: tester
+              Id: ABCDEFG1HIJ2KLMNOPQR
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamAccessKey
+            - Id: ABCDEFG1HIJ2KLMNOPQR
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamRole
+        SchemaVersion: "2018-10-08"
+        Severity:
+            Label: HIGH
+            Normalized: 70
+        Title: Non-Suspicious activity detected accessing private decoy S3 bucket panther-databucket
+        Types:
+            - Unusual Behaviors
+        UpdatedAt: "2024-05-24 00:26:57.000000000"
+        Workflow:
+            Status: NEW
+        WorkflowState: NEW
+        p_any_actor_ids: []
+        p_any_aws_account_ids: []
+        p_any_aws_arns: []
+        p_any_ip_addresses: []
+        p_any_trace_ids: []
+        p_any_usernames: []
+        p_event_time: "2024-05-24 00:26:57.000000000"
+        p_log_type: AWS.SecurityFindingFormat
+        p_parse_time: "2024-05-24 00:30:04.569556803"
+        p_row_id: 624c79c882affe88a1dce9c31fb68f0e
+        p_schema_version: 0
+        p_source_id: e29fd64f-53d9-43ab-92ca-575a8af289e6
+        p_source_label: AWS Security Hub
+        p_udm: {}

--- a/rules/aws_securityfinding_rules/decoy_secret_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_secret_accessed.py
@@ -1,6 +1,6 @@
 def rule(event):
     # List of suspicious API events
-    #NOTE: There may be more API events that's not listed
+    # NOTE: There may be more API events that's not listed
     suspicious_api_events = ["Decrypt", "Encrypt", "GenerateDataKey"]
 
     # Return True if the API value is in the list of suspicious API events
@@ -11,19 +11,21 @@ def rule(event):
         return api_value in suspicious_api_events
     return False
 
+
 def title(event):
     # (Optional) Return a string which will be shown as the alert title.
     # If no 'dedup' function is defined, the return value of this method will act as dedup string.
 
     # NOTE: Not sure if the offending actor Id will always be in the 0th index of Resources
     # It's possible to just return the Title as a whole string
-    secret = event['Resources'][0]['Id']
+    secret = event["Resources"][0]["Id"]
     return f"Suspicious activity detected accessing private decoy secret {secret}"
 
+
 # def dedup(event):
-    #  (Optional) Return a string which will be used to deduplicate similar alerts.
-    # return ''
+#  (Optional) Return a string which will be used to deduplicate similar alerts.
+# return ''
 
 # def alert_context(event):
-    # (Optional) Return a dict with  data to be included in the alert sent to the SNS/SQS/Webhook
-    # return {'key':'value'}
+# (Optional) Return a dict with  data to be included in the alert sent to the SNS/SQS/Webhook
+# return {'key':'value'}

--- a/rules/aws_securityfinding_rules/decoy_secret_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_secret_accessed.py
@@ -25,6 +25,6 @@ def title(event):
     # return ''
 
 # def alert_context(event):
-    #  (Optional) Return a dict with  data to be included in the alert sent to the SNS/SQS/Webhook destination
+    # (Optional) Return a dict with  data to be included in the alert sent to the SNS/SQS/Webhook
     # return {'key':'value'}
     

--- a/rules/aws_securityfinding_rules/decoy_secret_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_secret_accessed.py
@@ -21,11 +21,3 @@ def title(event):
     secret = event["Resources"][0]["Id"]
     return f"Suspicious activity detected accessing private decoy secret {secret}"
 
-
-# def dedup(event):
-#  (Optional) Return a string which will be used to deduplicate similar alerts.
-# return ''
-
-# def alert_context(event):
-# (Optional) Return a dict with  data to be included in the alert sent to the SNS/SQS/Webhook
-# return {'key':'value'}

--- a/rules/aws_securityfinding_rules/decoy_secret_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_secret_accessed.py
@@ -20,4 +20,3 @@ def title(event):
     # It's possible to just return the Title as a whole string
     secret = event["Resources"][0]["Id"]
     return f"Suspicious activity detected accessing private decoy secret {secret}"
-

--- a/rules/aws_securityfinding_rules/decoy_secret_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_secret_accessed.py
@@ -13,7 +13,7 @@ def rule(event):
 
 def title(event):
     # (Optional) Return a string which will be shown as the alert title.
-    # If no 'dedup' function is defined, the return value of this method will act as deduplication string.
+    # If no 'dedup' function is defined, the return value of this method will act as dedup string.
 
     # NOTE: Not sure if the offending actor Id will always be in the 0th index of Resources
     # It's possible to just return the Title as a whole string
@@ -25,5 +25,6 @@ def title(event):
     # return ''
 
 # def alert_context(event):
-    #  (Optional) Return a dictionary with additional data to be included in the alert sent to the SNS/SQS/Webhook destination
+    #  (Optional) Return a dict with  data to be included in the alert sent to the SNS/SQS/Webhook destination
     # return {'key':'value'}
+    

--- a/rules/aws_securityfinding_rules/decoy_secret_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_secret_accessed.py
@@ -1,0 +1,29 @@
+def rule(event):
+    # List of suspicious API events
+    #NOTE: There may be more API events that's not listed
+    suspicious_api_events = ["Decrypt", "Encrypt", "GenerateDataKey"]
+
+    # Return True if the API value is in the list of suspicious API events
+    if event["GeneratorId"] == "secretsmanager.amazonaws.com":
+        # Extract the API value from the event
+        api_value = event["Action"]["AwsApiCallAction"]["Api"]
+
+        return api_value in suspicious_api_events
+    return False
+
+def title(event):
+    # (Optional) Return a string which will be shown as the alert title.
+    # If no 'dedup' function is defined, the return value of this method will act as deduplication string.
+
+    # NOTE: Not sure if the offending actor Id will always be in the 0th index of Resources
+    # It's possible to just return the Title as a whole string
+    secret = event['Resources'][0]['Id']
+    return f"Suspicious activity detected accessing private decoy secret {secret}"
+
+# def dedup(event):
+    #  (Optional) Return a string which will be used to deduplicate similar alerts.
+    # return ''
+
+# def alert_context(event):
+    #  (Optional) Return a dictionary with additional data to be included in the alert sent to the SNS/SQS/Webhook destination
+    # return {'key':'value'}

--- a/rules/aws_securityfinding_rules/decoy_secret_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_secret_accessed.py
@@ -27,4 +27,3 @@ def title(event):
 # def alert_context(event):
     # (Optional) Return a dict with  data to be included in the alert sent to the SNS/SQS/Webhook
     # return {'key':'value'}
-    

--- a/rules/aws_securityfinding_rules/decoy_secret_accessed.yml
+++ b/rules/aws_securityfinding_rules/decoy_secret_accessed.yml
@@ -1,0 +1,223 @@
+AnalysisType: rule
+Filename: decoy_secret_accessed.py
+RuleID: "Decoy.Secret.Accessed"
+DisplayName: "Decoy Secret Accessed"
+Enabled: false
+LogTypes:
+    - AWS.SecurityFindingFormat
+Severity: High
+Description: Actor accessed Secrets Manager decoy secret
+DedupPeriodMinutes: 60
+Threshold: 1
+Reference: https://aws.amazon.com/blogs/security/how-to-detect-suspicious-activity-in-your-aws-account-by-using-private-decoy-resources/
+InlineFilters:
+    - All: []
+Tests:
+    - Name: Secret-Decoy-Accessed
+      ExpectedResult: true
+      Log:
+        Action:
+            ActionType: AWS_API_CALL
+            AwsApiCallAction:
+                Api: Decrypt
+                CallerType: remoteIp
+                DomainDetails: {}
+                ServiceName: kms.amazonaws.com
+            DnsRequestAction: {}
+            NetworkConnectionAction:
+                LocalPortDetails: {}
+                RemotePortDetails: {}
+            PortProbeAction: {}
+        AwsAccountId: "123456789012"
+        CompanyName: Custom
+        CreatedAt: "2024-05-23 20:49:02.000000000"
+        Description: Private decoy secret arn:aws:secretsmanager:us-east-1:123456789012:secret:Dummy-Secret-ab12cde34f was accessed by arn:aws:iam::123456789012:user/tester. This secret has been provisioned to monitor and generate security events when accessed and can be an indicator of unintended or unauthorized access to your AWS Account.
+        FindingProviderFields:
+            Severity:
+                Label: HIGH
+                Normalized: 70
+            Types:
+                - Unusual Behaviors
+        GeneratorId: secretsmanager.amazonaws.com
+        Id: 1abc2de3-69ea-4e15-91c6-27eb4a07bd21
+        ProcessedAt: "2024-05-23T20:49:08.396Z"
+        ProductArn: arn:aws:securityhub:us-east-1:123456789012:product/123456789012/default
+        ProductFields:
+            Custom/DecoyDetector/apiResult: SUCCESS
+            Custom/DecoyDetector/requestID: ab1cd234-1986-4c45-8546-fdb1776e23b0
+            Custom/DecoyDetector/userAgent: secretsmanager.amazonaws.com
+            aws/securityhub/CompanyName: Personal
+            aws/securityhub/FindingId: arn:aws:securityhub:us-east-1:123456789012:product/123456789012/default/1abc2de3-69ea-4e15-91c6-27eb4a07bd21
+            aws/securityhub/ProductName: Default
+        ProductName: DecoyDetector
+        RecordState: ACTIVE
+        Region: us-east-1
+        Resources:
+            - Id: arn:aws:secretsmanager:us-east-1:123456789012:secret:Dummy-Secret-ab12cde34f
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Target
+              Tags:
+                aws:cloudformation:logical-id: DummySecret
+                aws:cloudformation:stack-id: arn:aws:cloudformation:us-east-1:123456789012:stack/Panther/ab1cd123-1986-4c45-8546-fdb1776e23b0
+                aws:cloudformation:stack-name: Panther
+              Type: AwsSecretsManagerSecret
+            - Id: arn:aws:kms:us-east-1:123456789012:key/1abc2de3-69ea-4e15-91c6-27eb4a07bd21
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Target
+              Type: AwsKmsKey
+            - Details:
+                AwsIamAccessKey:
+                    AccessKeyId: ABC12DEFSG3455VIEJC8U
+                    AccountId: "123456789012"
+                    PrincipalId: ABC12DEFSG3455VIEJC8U:john.doe
+                    PrincipalType: AssumedRole
+                    SessionContext:
+                        Attributes:
+                            CreationDate: "2024-05-23T20:20:57Z"
+                            MfaAuthenticated: false
+                        SessionIssuer:
+                            AccountId: "123456789012"
+                            Arn: arn:aws:iam::123456789012:user/tester
+                            PrincipalId: ABC12DEFSG3455VIEJC8U
+                            Type: Role
+                            UserName: tester
+              Id: ABC12DEFSG3455VIEJC8U
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamAccessKey
+            - Id: arn:aws:iam::123456789012:user/tester
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamRole
+        SchemaVersion: "2018-10-08"
+        Severity:
+            Label: HIGH
+            Normalized: 70
+        Title: Suspicious activity detected accessing private decoy secret arn:aws:secretsmanager:us-east-1:123456789012:secret:Dummy-Secret-ab12cde34f
+        Types:
+            - Unusual Behaviors
+        UpdatedAt: "2024-05-23 20:49:02.000000000"
+        Workflow:
+            Status: NEW
+        WorkflowState: NEW
+        p_any_actor_ids: []
+        p_any_aws_account_ids: []
+        p_any_aws_arns: []
+        p_any_trace_ids: []
+        p_any_usernames: []
+        p_event_time: "2024-05-23 20:49:02.000000000"
+        p_log_type: AWS.SecurityFindingFormat
+        p_parse_time: "2024-05-23 20:55:04.316376687"
+        p_row_id: d2b6e541507bace8c6c2b6c31fcedc10
+        p_schema_version: 0
+        p_source_id: e29fd64f-53d9-43ab-92ca-575a8af289e6
+        p_source_label: AWS Security Hub test events
+        p_udm: {}
+    - Name: Secret-Decoy-Listed-Not-Accessed
+      ExpectedResult: false
+      Log:
+        Action:
+            ActionType: AWS_API_CALL
+            AwsApiCallAction:
+                Api: ListKeys
+                CallerType: remoteIp
+                DomainDetails: {}
+                ServiceName: kms.amazonaws.com
+            DnsRequestAction: {}
+            NetworkConnectionAction:
+                LocalPortDetails: {}
+                RemotePortDetails: {}
+            PortProbeAction: {}
+        AwsAccountId: "123456789012"
+        CompanyName: Custom
+        CreatedAt: "2024-05-23 20:49:02.000000000"
+        Description: Private decoy secret arn:aws:secretsmanager:us-east-1:123456789012:secret:Dummy-Secret-ab12cde34f was not accessed by arn:aws:iam::123456789012:user/tester. This secret has been provisioned to monitor and generate security events when accessed and can be an indicator of unintended or unauthorized access to your AWS Account.
+        FindingProviderFields:
+            Severity:
+                Label: HIGH
+                Normalized: 70
+            Types:
+                - Unusual Behaviors
+        GeneratorId: secretsmanager.amazonaws.com
+        Id: 1abc2de3-69ea-4e15-91c6-27eb4a07bd21
+        ProcessedAt: "2024-05-23T20:49:08.396Z"
+        ProductArn: arn:aws:securityhub:us-east-1:123456789012:product/123456789012/default
+        ProductFields:
+            Custom/DecoyDetector/apiResult: SUCCESS
+            Custom/DecoyDetector/requestID: ab1cd234-1986-4c45-8546-fdb1776e23b0
+            Custom/DecoyDetector/userAgent: secretsmanager.amazonaws.com
+            aws/securityhub/CompanyName: Personal
+            aws/securityhub/FindingId: arn:aws:securityhub:us-east-1:123456789012:product/123456789012/default/1abc2de3-69ea-4e15-91c6-27eb4a07bd21
+            aws/securityhub/ProductName: Default
+        ProductName: DecoyDetector
+        RecordState: ACTIVE
+        Region: us-east-1
+        Resources:
+            - Id: arn:aws:secretsmanager:us-east-1:123456789012:secret:Dummy-Secret-ab12cde34f
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Target
+              Tags:
+                aws:cloudformation:logical-id: DummySecret
+                aws:cloudformation:stack-id: arn:aws:cloudformation:us-east-1:123456789012:stack/Panther/ab1cd123-1986-4c45-8546-fdb1776e23b0
+                aws:cloudformation:stack-name: Panther
+              Type: AwsSecretsManagerSecret
+            - Id: arn:aws:kms:us-east-1:123456789012:key/1abc2de3-69ea-4e15-91c6-27eb4a07bd21
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Target
+              Type: AwsKmsKey
+            - Details:
+                AwsIamAccessKey:
+                    AccessKeyId: ABC12DEFSG3455VIEJC8U
+                    AccountId: "123456789012"
+                    PrincipalId: ABC12DEFSG3455VIEJC8U:john.doe
+                    PrincipalType: AssumedRole
+                    SessionContext:
+                        Attributes:
+                            CreationDate: "2024-05-23T20:20:57Z"
+                            MfaAuthenticated: false
+                        SessionIssuer:
+                            AccountId: "123456789012"
+                            Arn: arn:aws:iam::123456789012:user/tester
+                            PrincipalId: ABC12DEFSG3455VIEJC8U
+                            Type: Role
+                            UserName: tester
+              Id: ABC12DEFSG3455VIEJC8U
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamAccessKey
+            - Id: arn:aws:iam::123456789012:user/tester
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamRole
+        SchemaVersion: "2018-10-08"
+        Severity:
+            Label: HIGH
+            Normalized: 70
+        Title: Non-Suspicious activity detected accessing private decoy secret arn:aws:secretsmanager:us-east-1:123456789012:secret:Dummy-Secret-ab12cde34f
+        Types:
+            - Unusual Behaviors
+        UpdatedAt: "2024-05-23 20:49:02.000000000"
+        Workflow:
+            Status: NEW
+        WorkflowState: NEW
+        p_any_actor_ids: []
+        p_any_aws_account_ids: []
+        p_any_aws_arns: []
+        p_any_trace_ids: []
+        p_any_usernames: []
+        p_event_time: "2024-05-23 20:49:02.000000000"
+        p_log_type: AWS.SecurityFindingFormat
+        p_parse_time: "2024-05-23 20:55:04.316376687"
+        p_row_id: d2b6e541507bace8c6c2b6c31fcedc10
+        p_schema_version: 0
+        p_source_id: e29fd64f-53d9-43ab-92ca-575a8af289e6
+        p_source_label: AWS Security Hub test events
+        p_udm: {}

--- a/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
@@ -1,0 +1,29 @@
+def rule(event):
+    # List of suspicious API events
+    #NOTE: There may be more API events that's not listed
+    suspicious_api_events = ["Decrypt"]
+
+    # Return True if the API value is in the list of suspicious API events
+    if event["GeneratorId"] == "ssm.amazonaws.com":
+        # Extract the API value from the event
+        api_value = event["Action"]["AwsApiCallAction"]["Api"]
+
+        return api_value in suspicious_api_events
+    return False
+
+def title(event):
+    # (Optional) Return a string which will be shown as the alert title.
+    # If no 'dedup' function is defined, the return value of this method will act as deduplication string.
+
+    # NOTE: Not sure if the offending actor Id will always be in the 0th index of Resources
+    # It's possible to just return the Title as a whole string
+    secret = event['Resources'][0]['Id']
+    return f"Suspicious activity detected accessing private decoy Systems Manager parameter {secret}"
+
+# def dedup(event):
+    #  (Optional) Return a string which will be used to deduplicate similar alerts.
+    # return ''
+
+# def alert_context(event):
+    #  (Optional) Return a dictionary with additional data to be included in the alert sent to the SNS/SQS/Webhook destination
+    # return {'key':'value'}

--- a/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
@@ -21,4 +21,3 @@ def title(event):
     secret = event["Resources"][0]["Id"]
     return f"Suspicious activity detected accessing \
     private decoy Systems Manager parameter {secret}"
-

--- a/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
@@ -22,11 +22,3 @@ def title(event):
     return f"Suspicious activity detected accessing \
     private decoy Systems Manager parameter {secret}"
 
-
-# def dedup(event):
-#  (Optional) Return a string which will be used to deduplicate similar alerts.
-# return ''
-
-# def alert_context(event):
-# (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
-# return {'key':'value'}

--- a/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
@@ -28,4 +28,3 @@ def title(event):
 # def alert_context(event):
     # (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
     # return {'key':'value'}
-    

--- a/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
@@ -18,8 +18,8 @@ def title(event):
     # NOTE: Not sure if the offending actor Id will always be in the 0th index of Resources
     # It's possible to just return the Title as a whole string
     secret = event['Resources'][0]['Id']
-    return f"Suspicious activity detected accessing private decoy Systems Manager parameter "
-    f"{secret}"
+    return f"Suspicious activity detected accessing \
+    private decoy Systems Manager parameter {secret}"
 
 # def dedup(event):
     #  (Optional) Return a string which will be used to deduplicate similar alerts.

--- a/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
@@ -13,7 +13,7 @@ def rule(event):
 
 def title(event):
     # (Optional) Return a string which will be shown as the alert title.
-    # If no 'dedup' function is defined, the return value of this method will act as deduplication string.
+    # If no 'dedup' function is defined, the return value of this method will act as dedup string.
 
     # NOTE: Not sure if the offending actor Id will always be in the 0th index of Resources
     # It's possible to just return the Title as a whole string
@@ -25,5 +25,6 @@ def title(event):
     # return ''
 
 # def alert_context(event):
-    #  (Optional) Return a dictionary with additional data to be included in the alert sent to the SNS/SQS/Webhook destination
+    #  (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook destination
     # return {'key':'value'}
+    

--- a/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
@@ -25,6 +25,6 @@ def title(event):
     # return ''
 
 # def alert_context(event):
-    #  (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook destination
+    # (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
     # return {'key':'value'}
     

--- a/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
@@ -18,7 +18,8 @@ def title(event):
     # NOTE: Not sure if the offending actor Id will always be in the 0th index of Resources
     # It's possible to just return the Title as a whole string
     secret = event['Resources'][0]['Id']
-    return f"Suspicious activity detected accessing private decoy Systems Manager parameter {secret}"
+    return f"Suspicious activity detected accessing private decoy Systems Manager parameter "
+    f"{secret}"
 
 # def dedup(event):
     #  (Optional) Return a string which will be used to deduplicate similar alerts.

--- a/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
+++ b/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.py
@@ -1,6 +1,6 @@
 def rule(event):
     # List of suspicious API events
-    #NOTE: There may be more API events that's not listed
+    # NOTE: There may be more API events that's not listed
     suspicious_api_events = ["Decrypt"]
 
     # Return True if the API value is in the list of suspicious API events
@@ -11,20 +11,22 @@ def rule(event):
         return api_value in suspicious_api_events
     return False
 
+
 def title(event):
     # (Optional) Return a string which will be shown as the alert title.
     # If no 'dedup' function is defined, the return value of this method will act as dedup string.
 
     # NOTE: Not sure if the offending actor Id will always be in the 0th index of Resources
     # It's possible to just return the Title as a whole string
-    secret = event['Resources'][0]['Id']
+    secret = event["Resources"][0]["Id"]
     return f"Suspicious activity detected accessing \
     private decoy Systems Manager parameter {secret}"
 
+
 # def dedup(event):
-    #  (Optional) Return a string which will be used to deduplicate similar alerts.
-    # return ''
+#  (Optional) Return a string which will be used to deduplicate similar alerts.
+# return ''
 
 # def alert_context(event):
-    # (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
-    # return {'key':'value'}
+# (Optional) Return a dict with data to be included in the alert sent to the SNS/SQS/Webhook
+# return {'key':'value'}

--- a/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.yml
+++ b/rules/aws_securityfinding_rules/decoy_systems_manager_parameter_accessed.yml
@@ -1,0 +1,215 @@
+AnalysisType: rule
+Filename: decoy_systems_manager_parameter_accessed.py
+RuleID: "Decoy.Systems.Manager.Parameter.Accessed"
+DisplayName: "Decoy Systems Manager Parameter Accessed"
+Enabled: false
+LogTypes:
+    - AWS.SecurityFindingFormat
+Severity: High
+Description: Actor accessed Decoy Systems Manager parameter
+DedupPeriodMinutes: 60
+Threshold: 1
+Reference: https://aws.amazon.com/blogs/security/how-to-detect-suspicious-activity-in-your-aws-account-by-using-private-decoy-resources/
+InlineFilters:
+    - All: []
+Tests:
+    - Name: Systems-Manager-Parameter-Decoy-Accessed
+      ExpectedResult: true
+      Log:
+        Action:
+            ActionType: AWS_API_CALL
+            AwsApiCallAction:
+                Api: Decrypt
+                CallerType: remoteIp
+                DomainDetails: {}
+                ServiceName: kms.amazonaws.com
+            DnsRequestAction: {}
+            NetworkConnectionAction:
+                LocalPortDetails: {}
+                RemotePortDetails: {}
+            PortProbeAction: {}
+        AwsAccountId: "123456789012"
+        CompanyName: Custom
+        CreatedAt: "2024-05-24 22:34:07.000000000"
+        Description: Private decoy Systems Manager parameter arn:aws:ssm:us-east-1:123456789012:parameter/info-parameter was accessed by arn:aws:iam::123456789012:user/tester. This Systems Manager parameter has been provisioned to monitor and generate security events when accessed and can be an indicator of unintended or unauthorized access to your AWS Account.
+        FindingProviderFields:
+            Severity:
+                Label: HIGH
+                Normalized: 70
+            Types:
+                - Unusual Behaviors
+        GeneratorId: ssm.amazonaws.com
+        Id: 6abc0de0-69ea-4e15-91c6-27eb4a07bd21
+        ProcessedAt: "2024-05-24T22:34:15.644Z"
+        ProductArn: arn:aws:securityhub:us-east-1:123456789012:product/123456789012/default
+        ProductFields:
+            Custom/DecoyDetector/apiResult: SUCCESS
+            Custom/DecoyDetector/requestID: ab8cd646-1986-4c45-8546-fdb1776e23b0
+            Custom/DecoyDetector/userAgent: AWS Internal
+            aws/securityhub/CompanyName: Personal
+            aws/securityhub/FindingId: arn:aws:service:region:123456789012:resource/12345ab6-436d-4d59-ac58-ed6b3127e440
+            aws/securityhub/ProductName: Default
+        ProductName: DecoyDetector
+        RecordState: ACTIVE
+        Region: us-east-1
+        Resources:
+            - Id: arn:aws:ssm:us-east-1:123456789012:parameter/info-parameter
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Target
+              Type: Other
+            - Id: arn:aws:kms:us-east-1:123456789012:key/007ab31c-bf66-2264-a916-49f6d2ebd1db
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Target
+              Type: AwsKmsKey
+            - Details:
+                AwsIamAccessKey:
+                    AccessKeyId: ABC9ONWNS3155VIEJC8U
+                    AccountId: "123456789012"
+                    PrincipalId: ABCDEFG0TOGJSGNQKI0:john.doe
+                    PrincipalType: AssumedRole
+                    SessionContext:
+                        Attributes:
+                            CreationDate: "2024-05-24T22:32:38Z"
+                            MfaAuthenticated: false
+                        SessionIssuer:
+                            AccountId: "123456789012"
+                            Arn: arn:aws:iam::123456789012:user/tester
+                            PrincipalId: ABCDEFG0TOGJSGNQKI0
+                            Type: Role
+                            UserName: user_ab21cde50f
+              Id: ABC9ONWNS3155VIEJC8U
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamAccessKey
+            - Id: arn:aws:iam::123456789012:user/tester
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamRole
+        SchemaVersion: "2018-10-08"
+        Severity:
+            Label: HIGH
+            Normalized: 70
+        Title: Suspicious activity detected accessing private decoy Systems Manager parameter arn:aws:ssm:us-east-1:123456789012:parameter/info-parameter
+        Types:
+            - Unusual Behaviors
+        UpdatedAt: "2024-05-24 22:34:07.000000000"
+        Workflow:
+            Status: NEW
+        WorkflowState: NEW
+        p_any_actor_ids: []
+        p_any_aws_account_ids: []
+        p_any_aws_arns: []
+        p_any_trace_ids: []
+        p_any_usernames: []
+        p_event_time: "2024-05-24 22:34:07.000000000"
+        p_log_type: AWS.SecurityFindingFormat
+        p_parse_time: "2024-05-24 22:35:04.272574202"
+        p_row_id: zjj8nmnw9f90uulxfa3bmen8rv5stlcx
+        p_schema_version: 0
+        p_source_id: bb4e16c5-43dd-450c-9227-39f0d152659c
+        p_source_label: AWS Security Hub
+        p_udm: {}
+    - Name: Systems-Manager-Parameter-Decoy-Not-Accessed
+      ExpectedResult: false
+      Log:
+        Action:
+            ActionType: AWS_API_CALL
+            AwsApiCallAction:
+                Api: DescribeParameters
+                CallerType: remoteIp
+                DomainDetails: {}
+                ServiceName: kms.amazonaws.com
+            DnsRequestAction: {}
+            NetworkConnectionAction:
+                LocalPortDetails: {}
+                RemotePortDetails: {}
+            PortProbeAction: {}
+        AwsAccountId: "123456789012"
+        CompanyName: Custom
+        CreatedAt: "2024-05-24 22:34:07.000000000"
+        Description: Private decoy Systems Manager parameter arn:aws:ssm:us-east-1:123456789012:parameter/info-parameter was not accessed by arn:aws:iam::123456789012:user/tester. This Systems Manager parameter has been provisioned to monitor and generate security events when accessed and can be an indicator of unintended or unauthorized access to your AWS Account.
+        FindingProviderFields:
+            Severity:
+                Label: HIGH
+                Normalized: 70
+            Types:
+                - Unusual Behaviors
+        GeneratorId: ssm.amazonaws.com
+        Id: 6abc0de0-69ea-4e15-91c6-27eb4a07bd21
+        ProcessedAt: "2024-05-24T22:34:15.644Z"
+        ProductArn: arn:aws:securityhub:us-east-1:123456789012:product/123456789012/default
+        ProductFields:
+            Custom/DecoyDetector/apiResult: SUCCESS
+            Custom/DecoyDetector/requestID: ab1cd234-1986-4c45-8546-fdb1776e23b0
+            Custom/DecoyDetector/userAgent: AWS Internal
+            aws/securityhub/CompanyName: Personal
+            aws/securityhub/FindingId: arn:aws:service:region:123456789012:resource/12345ab6-436d-4d59-ac58-ed6b3127e440
+            aws/securityhub/ProductName: Default
+        ProductName: DecoyDetector
+        RecordState: ACTIVE
+        Region: us-east-1
+        Resources:
+            - Id: arn:aws:ssm:us-east-1:123456789012:parameter/info-parameter
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Target
+              Type: Other
+            - Id: arn:aws:kms:us-east-1:123456789012:key/007ab31c-bf66-2264-a916-49f6d2ebd1db
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Target
+              Type: AwsKmsKey
+            - Details:
+                AwsIamAccessKey:
+                    AccessKeyId: ABC9ONWNS3155VIEJC8U
+                    AccountId: "123456789012"
+                    PrincipalId: ABCDEFG0TOGJSGNQKI0:john.doe
+                    PrincipalType: AssumedRole
+                    SessionContext:
+                        Attributes:
+                            CreationDate: "2024-05-24T22:32:38Z"
+                            MfaAuthenticated: false
+                        SessionIssuer:
+                            AccountId: "123456789012"
+                            Arn: arn:aws:iam::123456789012:user/tester
+                            PrincipalId: ABCDEFG0TOGJSGNQKI0
+                            Type: Role
+                            UserName: user_ab21cde50f
+              Id: ABC9ONWNS3155VIEJC8U
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamAccessKey
+            - Id: arn:aws:iam::123456789012:user/tester
+              Partition: aws
+              Region: us-east-1
+              ResourceRole: Actor
+              Type: AwsIamRole
+        SchemaVersion: "2018-10-08"
+        Severity:
+            Label: HIGH
+            Normalized: 70
+        Title: Non-Suspicious activity detected accessing private decoy Systems Manager parameter arn:aws:ssm:us-east-1:123456789012:parameter/info-parameter
+        Types:
+            - Unusual Behaviors
+        UpdatedAt: "2024-05-24 22:34:07.000000000"
+        Workflow:
+            Status: NEW
+        WorkflowState: NEW
+        p_any_actor_ids: []
+        p_any_aws_account_ids: []
+        p_any_aws_arns: []
+        p_any_trace_ids: []
+        p_any_usernames: []
+        p_event_time: "2024-05-24 22:34:07.000000000"
+        p_log_type: AWS.SecurityFindingFormat
+        p_parse_time: "2024-05-24 22:35:04.272574202"
+        p_row_id: zjj8nmnw9f90uulxfa3bmen8rv5stlcx
+        p_schema_version: 0
+        p_source_id: bb4e16c5-43dd-450c-9227-39f0d152659c
+        p_source_label: AWS Security Hub
+        p_udm: {}


### PR DESCRIPTION
## Goal

Detect access to AWS honeypot resources

## Categorization

Honeypots, Deception

## Strategy Abstract

This post focuses on another approach of creating private decoy resources in your account that are intended to look legitimate, but don’t have any useful or sensitive data and are not exposed publicly. These decoys are designed to alert you about suspicious activities that could indicate AWS credentials exposure or account compromise. You can use the decoys in conjunction with other techniques, such as creating deception environments and public and private honeypots to better detect suspicious activity in your accounts and applications.

## Technical Context

Technical Context provides detailed information and background needed for a responder to understand all components of the alert. This should appropriately link to any platform or tooling knowledge and should include information about the direct aspects of the alert. The goal of the Technical Context section is to provide a self-contained reference for a responder to make a judgement call on any potential alert, even if they do not have direct subject matter expertise on the ADS itself.

## Blind Spots and Assumptions

You must have created a CloudTrail trail to log [management events](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-management-events-with-cloudtrail.html) for the AWS account in the Region where you deploy the private decoys. This trail can be created locally in the account or can be an [organization trail](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-trail-organization.html). Ensure that you have enabled both [read and write events](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-management-events-with-cloudtrail.html#read-write-events-mgmt), and enabled all AWS KMS events in the trail (this is the default configuration).

## False Positives

You should ensure that your monitoring services and tools are configured to query the configuration of resources and not the data stored in resources. Otherwise, you might get a large volume of false positives because every time a resource is accessed, a custom finding is created in Security Hub. For example, consider a service like Security Hub Security Standards checks, or a cloud security posture management (CSPM) tool that monitors your S3 buckets by describing the properties of all buckets in your account. Such tools will find the decoy S3 bucket and will interrogate its configuration by making calls such as GetBucketPolicy and GetBucketLogging. However, as long as these tools don’t try to read data in the bucket through calls such as GetObject, the EventBridge rules that are configured as described in this post won’t generate a finding.

## Validation

S3 object access

aws s3 cp s3://<bucket_name/object_name> /tmp

aws s3 cp s3://<bucket_name/object_name> s3://<any_existing_bucket>

IAM role assumption

aws sts assume-role –role-arn <role_name> –role-session-name BlogTestRole

Secrets Manager access

aws secretsmanager get-secret-value –secret-id <secret_name>

Parameter Store access

aws ssm get-parameters –names <ssm_parameter> –with-decryption

DynamoDB table scan

aws dynamodb scan –table-name <table_name>

## Priority

High

## Response

Imagine that an unauthorized user has obtained credentials for your account. This could also be an insider, malicious or careless, using their valid credentials inappropriately. The unauthorized user might use these credentials to invoke AWS API calls to list resources in your account. As the next step, they might try to access resources that are commonly used to store sensitive data—such as objects in [Amazon Simple Storage Service (Amazon S3)](http://aws.amazon.com/s3) buckets, secrets in [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/), or items in [Amazon DynamoDB](http://aws.amazon.com/dynamodb). They might also try to elevate their privileges by assuming other [Identity and Access Management (IAM)](http://aws.amazon.com/iam) roles in your account. In your role as a security professional, your task is to detect this suspicious behaviour and take actions in response.

## Additional Resources

https://aws.amazon.com/blogs/security/how-to-detect-suspicious-activity-in-your-aws-account-by-using-private-decoy-resources/ 

https://github.com/aws-samples/aws-private-decoy-resources