### PR TITLE
Update PAT to 0.50.1

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -644,10 +644,10 @@
         },
         "panther-analysis-tool": {
             "hashes": [
-                "sha256:0b32db433df8ae2f05e476f83981263e2e7718b24b2241c8a42316d5b3c15afb"
+                "sha256:d85f5e26703b2b485125e49a323ca82c125767f9deabdb6eda6e92974b320356"
             ],
             "index": "pypi",
-            "version": "==0.50.0"
+            "version": "==0.50.1"
         },
         "panther-core": {
             "hashes": [


### PR DESCRIPTION
### Background

PAT `0.50.1` contains a small Regex fix.

### Changes

- Updates PAT to `0.50.1` via `make deps-update`

### Testing

- Tests pass as expected
