### PR TITLE
Edit: Downgrade Okta.Anonymizing.VPN.Login to INFO severity if Apple Relay used

### DIFF
--- a/rules/okta_rules/okta_anonymizing_vpn_login.py
+++ b/rules/okta_rules/okta_anonymizing_vpn_login.py
@@ -18,3 +18,14 @@ def title(event):
 
 def alert_context(event):
     return okta_alert_context(event)
+
+
+def severity(event):
+    # If the user is using Apple Private Relay, demote the severity to INFO
+    if (
+        event.deep_get("p_enrichment", "ipinfo_privacy", "client.ipAddress", "service")
+        == "Apple Private Relay"
+    ):
+        return "INFO"
+    # Return Medium by default
+    return "MEDIUM"

--- a/rules/okta_rules/okta_anonymizing_vpn_login.yml
+++ b/rules/okta_rules/okta_anonymizing_vpn_login.yml
@@ -156,3 +156,82 @@ Tests:
         type: WEB
       uuid: AbC-123-XyZ
       version: "0"
+  - Name: Apple Private Relay Used
+    ExpectedResult: true
+    Log:
+      actor:
+        alternateId: homer.simpson@duff.com
+        displayName: Homer Simpson
+        id: 00abc123
+        type: User
+      authenticationcontext:
+        authenticationStep: 0
+        externalSessionId: 100-abc-9999
+      client:
+        device: Computer
+        geographicalContext:
+          city: Springfield
+          country: United States
+          geolocation:
+            lat: 20
+            lon: -25
+          postalCode: "12345"
+          state: Ohio
+        ipAddress: 1.3.2.4
+        userAgent:
+          browser: CHROME
+          os: Mac OS X
+          rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36
+        zone: "null"
+      debugcontext:
+        debugData:
+          requestId: AbCdEf12G
+          requestUri: /api/v1/users/AbCdEfG/lifecycle/reset_factors
+          url: /api/v1/users/AbCdEfG/lifecycle/reset_factors?
+      displaymessage: Authentication of user via MFA
+      eventtype: user.session.start
+      legacyeventtype: core.user.factor.attempt_fail
+      outcome:
+        reason: FastPass declined phishing attempt
+        result: FAILURE
+      p_enrichment:
+        ipinfo_privacy:
+          client.ipAddress:
+            hosting: true
+            p_match: 1.2.3.4
+            proxy: false
+            relay: true
+            service: Apple Private Relay
+            tor: false
+            vpn: false
+      published: "2022-06-22 18:18:29.015"
+      request:
+        ipChain:
+          - geographicalContext:
+              city: Springfield
+              country: United States
+              geolocation:
+                lat: 20
+                lon: -25
+              postalCode: "12345"
+              state: Ohio
+            ip: 1.3.2.4
+            version: V4
+      securitycontext:
+        asNumber: 701
+        asOrg: verizon
+        domain: anonymous.org
+        isProxy: true
+        isp: verizon
+      severity: INFO
+      target:
+        - alternateId: peter.griffin@company.com
+          displayName: Peter Griffin
+          id: 0002222AAAA
+          type: User
+      transaction:
+        detail: {}
+        id: ABcDeFgG
+        type: WEB
+      uuid: AbC-123-XyZ
+      version: "0"


### PR DESCRIPTION
### Background

Some customers have reported a high false-positive rate for this rule from employees signing in from apple devices using Apple Private Relay. While it's true that Apple Relay is an annonymizing service, the majority of logins from the Relay will be genuine. This PR will cause any alerts generated by Apple Relay logins to be INFO severity, allowing them to be recorded and referencable, but not forwarded to analysts for investigation.

### Changes

- Added a `severity` function to change the alert severity to INFO if `ipinfo_privacy` determines the source IP belongs to Apple Relay
- Added a unit test for a mocked Apple Relay login

### Testing

- Ran all test cases, confirmed they passed with the expected severities (where applicable)
