### PR TITLE
Remove unnecessary pipenv step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ WORKDIR /home/panther-analysis
 # Install requirements
 COPY Pipfile .
 COPY Pipfile.lock .
-RUN pipenv uninstall --all
 RUN pipenv sync --dev
 
 # Remove pipfile so it doesn't interfere with local files after install


### PR DESCRIPTION
### Background

There's no reason to run `pipenv uninstall --all` in a hermetic environment (hence the failure).

### Changes

- Removes `pipenv uninstall --all` `RUN` directive.

### Testing

- Image builds successfully