### PR TITLE
Remove explorer/powershell relationship

### DIFF
--- a/rules/crowdstrike_rules/crowdstrike_unusual_parent_child_processes.py
+++ b/rules/crowdstrike_rules/crowdstrike_unusual_parent_child_processes.py
@@ -2,7 +2,6 @@ from panther_base_helpers import crowdstrike_detection_alert_context, deep_get
 
 SUSPICIOUS_PARENT_CHILD_COMBINATIONS_WINDOWS = {
     ("svchost.exe", "cmd.exe"),
-    ("explorer.exe", "powershell.exe"),
     ("winword.exe", "cmd.exe"),
     ("winword.exe", "powershell.exe"),
     ("excel.exe", "cmd.exe"),


### PR DESCRIPTION
Explorer launching powershell isn't a critical alert. Explorer and CMD launching powershell are the two most common ways to execute the application. Any regular powershell user is likely to trigger this daily. 

The relationships present is the rule are not a strong match for the underlying "T1036.005 Masquerading: Match Legitimate Name or Location" used in the rule reference https://medium.com/falconforce/falconfriday-e4554e9e6665. That technique is meant to be tagged to approximate names or locations of legitimate system files and this rule has no logic to account for that, the rule is no more than `if match(parent and child): alert critical`. Today this rule is largely for unusual executions of powershell or cmd from office or svchost binaries.

Either remove this relationship entirely, or drop the severity of explorer/powershell to INFO. I would also recommend this rule be reviewed in full as there's much to be desired for its quality. 
