### PR TITLE
Correct the target and actor in Slack Audit log UserPrivilegeEscalation plus clean up

### DIFF
--- a/rules/slack_rules/slack_user_privilege_escalation.py
+++ b/rules/slack_rules/slack_user_privilege_escalation.py
@@ -13,22 +13,26 @@ def rule(event):
 
 
 def title(event):
-    username = deep_get(event, "actor", "user", "name", default="<unknown-actor>")
-    email = deep_get(event, "actor", "user", "email", default="<unknown-email>")
+    # This is the user taking the action.
+    actor_username = deep_get(event, "actor", "user", "name", default="<unknown-actor>")
+    actor_email = deep_get(event, "actor", "user", "email", default="<unknown-email>")
+    # This is the user the action is taken on.
+    entity_username = deep_get(event, "entity", "user", "name", default="<unknown-actor>")
+    entity_email = deep_get(event, "entity", "user", "email", default="<unknown-email>")
+    action = event.get("action")
+    if action == "owner_transferred":
+        return f"{USER_PRIV_ESC_ACTIONS[action]} from {actor_username} ({actor_email})"
 
-    if event.get("action") == "owner_transferred":
-        return f"Slack Owner Transferred from {username} ({email})"
+    if action == "permissions_assigned":
+        return f"{USER_PRIV_ESC_ACTIONS[action]} {entity_username} ({entity_email})"
 
-    if event.get("action") == "permissions_assigned":
-        return f"Slack User, {username} ({email}), assigned permissions"
+    if action == "role_change_to_admin":
+        return f"{USER_PRIV_ESC_ACTIONS[action]} {entity_username} ({entity_email})"
 
-    if event.get("action") == "role_change_to_admin":
-        return f"Slack User, {username} ({email}), promoted to admin"
+    if action == "role_change_to_owner":
+        return f"{USER_PRIV_ESC_ACTIONS[action]} {entity_username} ({entity_email})"
 
-    if event.get("action") == "role_change_to_owner":
-        return f"Slack User, {username} ({email}), promoted to Owner"
-
-    return f"Slack User Privilege Escalation event {event.get('action')} on {username} ({email})"
+    return f"Slack User Privilege Escalation event {action} on {entity_username} ({entity_email})"
 
 
 def severity(event):

--- a/rules/slack_rules/slack_user_privilege_escalation.yml
+++ b/rules/slack_rules/slack_user_privilege_escalation.yml
@@ -6,153 +6,177 @@ Enabled: true
 LogTypes:
   - Slack.AuditLogs
 Tags:
+  - Slack
+  - Privilege Escalation
   - Account Manipulation
   - Additional Cloud Roles
-  - Privilege Escalation
-  - Slack
-Severity: High
 Reports:
   MITRE ATT&CK:
     - TA0004:T1098.003
+Severity: High
 Description: Detects when a Slack user gains escalated privileges
+Reference: https://slack.com/intl/en-gb/help/articles/201314026-Permissions-by-role-in-Slack
 DedupPeriodMinutes: 60
 Threshold: 1
-Reference: https://slack.com/intl/en-gb/help/articles/201314026-Permissions-by-role-in-Slack
-InlineFilters:
-  - All: []
 SummaryAttributes:
-  - p_any_emails
   - p_any_ip_addresses
+  - p_any_emails
 Tests:
   - Name: Owner Transferred
     ExpectedResult: true
     Log:
-      action: owner_transferred
-      actor:
-        type: user
-        user:
-          email: actor@example.com
-          id: A012B3CDEFG
-          name: username
-          team: T01234N56GB
-      context:
-        ip_address: 1.2.3.4
-        location:
-          domain: test-workspace
-          id: T01234N56GB
-          name: test-workspace
-          type: workspace
-        ua: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36
-      entity:
-        type: user
-        user:
-          email: entity@example.com
-          id: A012B3CDEFG
-          name: username
-          team: T01234N56GB
+      {
+        "action": "owner_transferred",
+        "actor":
+          {
+            "type": "user",
+            "user":
+              {
+                "email": "user@example.com",
+                "id": "A012B3CDEFG",
+                "name": "username",
+                "team": "T01234N56GB",
+              },
+          },
+        "context":
+          {
+            "ip_address": "1.2.3.4",
+            "location":
+              {
+                "domain": "test-workspace",
+                "id": "T01234N56GB",
+                "name": "test-workspace",
+                "type": "workspace",
+              },
+            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
+          },
+      }
   - Name: Permissions Assigned
     ExpectedResult: true
     Log:
-      action: permissions_assigned
-      actor:
-        type: user
-        user:
-          email: actor@example.com
-          id: A012B3CDEFG
-          name: username
-          team: T01234N56GB
-      context:
-        ip_address: 1.2.3.4
-        location:
-          domain: test-workspace
-          id: T01234N56GB
-          name: test-workspace
-          type: workspace
-        ua: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36
-      entity:
-        type: user
-        user:
-          email: entity@example.com
-          id: A012B3CDEFG
-          name: username
-          team: T01234N56GB
+      {
+        "action": "permissions_assigned",
+        "actor":
+          {
+            "type": "user",
+            "user":
+              {
+                "email": "user@example.com",
+                "id": "A012B3CDEFG",
+                "name": "username",
+                "team": "T01234N56GB",
+              },
+          },
+        "context":
+          {
+            "ip_address": "1.2.3.4",
+            "location":
+              {
+                "domain": "test-workspace",
+                "id": "T01234N56GB",
+                "name": "test-workspace",
+                "type": "workspace",
+              },
+            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
+          },
+      }
   - Name: Role Changed to Admin
     ExpectedResult: true
     Log:
-      action: role_change_to_admin
-      actor:
-        type: user
-        user:
-          email: actor@example.com
-          id: A012B3CDEFG
-          name: username
-          team: T01234N56GB
-      context:
-        ip_address: 1.2.3.4
-        location:
-          domain: test-workspace
-          id: T01234N56GB
-          name: test-workspace
-          type: workspace
-        ua: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36
-      entity:
-        type: user
-        user:
-          email: entity@example.com
-          id: A012B3CDEFG
-          name: username
-          team: T01234N56GB
+      {
+        "action": "role_change_to_admin",
+        "actor":
+          {
+            "type": "user",
+            "user":
+              {
+                "email": "user@example.com",
+                "id": "A012B3CDEFG",
+                "name": "username",
+                "team": "T01234N56GB",
+              },
+          },
+        "context":
+          {
+            "ip_address": "1.2.3.4",
+            "location":
+              {
+                "domain": "test-workspace",
+                "id": "T01234N56GB",
+                "name": "test-workspace",
+                "type": "workspace",
+              },
+            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
+          },
+      }
   - Name: Role Changed to Owner
     ExpectedResult: true
     Log:
-      action: role_change_to_owner
-      actor:
-        type: user
-        user:
-          email: actor@example.com
-          id: A012B3CDEFG
-          name: username
-          team: T01234N56GB
-      context:
-        ip_address: 1.2.3.4
-        location:
-          domain: test-workspace
-          id: T01234N56GB
-          name: test-workspace
-          type: workspace
-        ua: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36
-      entity:
-        type: user
-        user:
-          email: entity@example.com
-          id: A012B3CDEFG
-          name: username
-          team: T01234N56GB
+      {
+        "action": "role_change_to_owner",
+        "actor":
+          {
+            "type": "user",
+            "user":
+              {
+                "email": "user@example.com",
+                "id": "A012B3CDEFG",
+                "name": "username",
+                "team": "T01234N56GB",
+              },
+          },
+        "context":
+          {
+            "ip_address": "1.2.3.4",
+            "location":
+              {
+                "domain": "test-workspace",
+                "id": "T01234N56GB",
+                "name": "test-workspace",
+                "type": "workspace",
+              },
+            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
+          },
+      }
   - Name: User Logout
     ExpectedResult: false
     Log:
-      action: user_logout
-      actor:
-        type: user
-        user:
-          email: user@example.com
-          id: W012J3FEWAU
-          name: primary-owner
-          team: T01234N56GB
-      context:
-        ip_address: 1.2.3.4
-        location:
-          domain: test-workspace-1
-          id: T01234N56GB
-          name: test-workspace-1
-          type: workspace
-        ua: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36
-      date_create: "2022-07-28 15:22:32"
-      entity:
-        type: user
-        user:
-          email: user@example.com
-          id: W012J3FEWAU
-          name: primary-owner
-          team: T01234N56GB
-      id: 72cac009-9eb3-4dde-bac6-ee49a32a1789
+      {
+        "action": "user_logout",
+        "actor":
+          {
+            "type": "user",
+            "user":
+              {
+                "email": "user@example.com",
+                "id": "W012J3FEWAU",
+                "name": "primary-owner",
+                "team": "T01234N56GB",
+              },
+          },
+        "context":
+          {
+            "ip_address": "1.2.3.4",
+            "location":
+              {
+                "domain": "test-workspace-1",
+                "id": "T01234N56GB",
+                "name": "test-workspace-1",
+                "type": "workspace",
+              },
+            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
+          },
+        "date_create": "2022-07-28 15:22:32",
+        "entity":
+          {
+            "type": "user",
+            "user":
+              {
+                "email": "user@example.com",
+                "id": "W012J3FEWAU",
+                "name": "primary-owner",
+                "team": "T01234N56GB",
+              },
+          },
+        "id": "72cac009-9eb3-4dde-bac6-ee49a32a1789",
+      }

--- a/rules/slack_rules/slack_user_privilege_escalation.yml
+++ b/rules/slack_rules/slack_user_privilege_escalation.yml
@@ -6,177 +6,153 @@ Enabled: true
 LogTypes:
   - Slack.AuditLogs
 Tags:
-  - Slack
-  - Privilege Escalation
   - Account Manipulation
   - Additional Cloud Roles
+  - Privilege Escalation
+  - Slack
+Severity: High
 Reports:
   MITRE ATT&CK:
     - TA0004:T1098.003
-Severity: High
 Description: Detects when a Slack user gains escalated privileges
-Reference: https://slack.com/intl/en-gb/help/articles/201314026-Permissions-by-role-in-Slack
 DedupPeriodMinutes: 60
 Threshold: 1
+Reference: https://slack.com/intl/en-gb/help/articles/201314026-Permissions-by-role-in-Slack
+InlineFilters:
+  - All: []
 SummaryAttributes:
-  - p_any_ip_addresses
   - p_any_emails
+  - p_any_ip_addresses
 Tests:
   - Name: Owner Transferred
     ExpectedResult: true
     Log:
-      {
-        "action": "owner_transferred",
-        "actor":
-          {
-            "type": "user",
-            "user":
-              {
-                "email": "user@example.com",
-                "id": "A012B3CDEFG",
-                "name": "username",
-                "team": "T01234N56GB",
-              },
-          },
-        "context":
-          {
-            "ip_address": "1.2.3.4",
-            "location":
-              {
-                "domain": "test-workspace",
-                "id": "T01234N56GB",
-                "name": "test-workspace",
-                "type": "workspace",
-              },
-            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
-          },
-      }
+      action: owner_transferred
+      actor:
+        type: user
+        user:
+          email: actor@example.com
+          id: A012B3CDEFG
+          name: username
+          team: T01234N56GB
+      context:
+        ip_address: 1.2.3.4
+        location:
+          domain: test-workspace
+          id: T01234N56GB
+          name: test-workspace
+          type: workspace
+        ua: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36
+      entity:
+        type: user
+        user:
+          email: entity@example.com
+          id: A012B3CDEFG
+          name: username
+          team: T01234N56GB
   - Name: Permissions Assigned
     ExpectedResult: true
     Log:
-      {
-        "action": "permissions_assigned",
-        "actor":
-          {
-            "type": "user",
-            "user":
-              {
-                "email": "user@example.com",
-                "id": "A012B3CDEFG",
-                "name": "username",
-                "team": "T01234N56GB",
-              },
-          },
-        "context":
-          {
-            "ip_address": "1.2.3.4",
-            "location":
-              {
-                "domain": "test-workspace",
-                "id": "T01234N56GB",
-                "name": "test-workspace",
-                "type": "workspace",
-              },
-            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
-          },
-      }
+      action: permissions_assigned
+      actor:
+        type: user
+        user:
+          email: actor@example.com
+          id: A012B3CDEFG
+          name: username
+          team: T01234N56GB
+      context:
+        ip_address: 1.2.3.4
+        location:
+          domain: test-workspace
+          id: T01234N56GB
+          name: test-workspace
+          type: workspace
+        ua: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36
+      entity:
+        type: user
+        user:
+          email: entity@example.com
+          id: A012B3CDEFG
+          name: username
+          team: T01234N56GB
   - Name: Role Changed to Admin
     ExpectedResult: true
     Log:
-      {
-        "action": "role_change_to_admin",
-        "actor":
-          {
-            "type": "user",
-            "user":
-              {
-                "email": "user@example.com",
-                "id": "A012B3CDEFG",
-                "name": "username",
-                "team": "T01234N56GB",
-              },
-          },
-        "context":
-          {
-            "ip_address": "1.2.3.4",
-            "location":
-              {
-                "domain": "test-workspace",
-                "id": "T01234N56GB",
-                "name": "test-workspace",
-                "type": "workspace",
-              },
-            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
-          },
-      }
+      action: role_change_to_admin
+      actor:
+        type: user
+        user:
+          email: actor@example.com
+          id: A012B3CDEFG
+          name: username
+          team: T01234N56GB
+      context:
+        ip_address: 1.2.3.4
+        location:
+          domain: test-workspace
+          id: T01234N56GB
+          name: test-workspace
+          type: workspace
+        ua: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36
+      entity:
+        type: user
+        user:
+          email: entity@example.com
+          id: A012B3CDEFG
+          name: username
+          team: T01234N56GB
   - Name: Role Changed to Owner
     ExpectedResult: true
     Log:
-      {
-        "action": "role_change_to_owner",
-        "actor":
-          {
-            "type": "user",
-            "user":
-              {
-                "email": "user@example.com",
-                "id": "A012B3CDEFG",
-                "name": "username",
-                "team": "T01234N56GB",
-              },
-          },
-        "context":
-          {
-            "ip_address": "1.2.3.4",
-            "location":
-              {
-                "domain": "test-workspace",
-                "id": "T01234N56GB",
-                "name": "test-workspace",
-                "type": "workspace",
-              },
-            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
-          },
-      }
+      action: role_change_to_owner
+      actor:
+        type: user
+        user:
+          email: actor@example.com
+          id: A012B3CDEFG
+          name: username
+          team: T01234N56GB
+      context:
+        ip_address: 1.2.3.4
+        location:
+          domain: test-workspace
+          id: T01234N56GB
+          name: test-workspace
+          type: workspace
+        ua: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36
+      entity:
+        type: user
+        user:
+          email: entity@example.com
+          id: A012B3CDEFG
+          name: username
+          team: T01234N56GB
   - Name: User Logout
     ExpectedResult: false
     Log:
-      {
-        "action": "user_logout",
-        "actor":
-          {
-            "type": "user",
-            "user":
-              {
-                "email": "user@example.com",
-                "id": "W012J3FEWAU",
-                "name": "primary-owner",
-                "team": "T01234N56GB",
-              },
-          },
-        "context":
-          {
-            "ip_address": "1.2.3.4",
-            "location":
-              {
-                "domain": "test-workspace-1",
-                "id": "T01234N56GB",
-                "name": "test-workspace-1",
-                "type": "workspace",
-              },
-            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
-          },
-        "date_create": "2022-07-28 15:22:32",
-        "entity":
-          {
-            "type": "user",
-            "user":
-              {
-                "email": "user@example.com",
-                "id": "W012J3FEWAU",
-                "name": "primary-owner",
-                "team": "T01234N56GB",
-              },
-          },
-        "id": "72cac009-9eb3-4dde-bac6-ee49a32a1789",
-      }
+      action: user_logout
+      actor:
+        type: user
+        user:
+          email: user@example.com
+          id: W012J3FEWAU
+          name: primary-owner
+          team: T01234N56GB
+      context:
+        ip_address: 1.2.3.4
+        location:
+          domain: test-workspace-1
+          id: T01234N56GB
+          name: test-workspace-1
+          type: workspace
+        ua: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36
+      date_create: "2022-07-28 15:22:32"
+      entity:
+        type: user
+        user:
+          email: user@example.com
+          id: W012J3FEWAU
+          name: primary-owner
+          team: T01234N56GB
+      id: 72cac009-9eb3-4dde-bac6-ee49a32a1789


### PR DESCRIPTION
### Background

Updating the Slack Audit log UserPrivilegeEscalation to correctly user target instead of actor. We got alerts for our IT team promoted to Admin or Owner. Realized it was an error in the alert and corrected it. 

### Changes

- Updated the Slack UserPrivilegeEscalation alert to correctly differentiate between the actor and target. Actor being the user making the change and target being the user, the chances are occurring on.
- Used the already definded dict `USER_PRIV_ESC_ACTIONS` for alert Titles
- Updated alert Titles to correctly reference the target instead of the actor. 
- Add local variable `action` to improve readability.
- Updated tests to test the new behavior
- Updated tests to be YAML
- Formatted YAML file with Prettier

### Testing

- `pipenv run panther_analysis_tool test --skip-disabled-tests --sort-test-results`
