### PR TITLE
Formatting: Converting Tabs to Spaces in YAML Files

### DIFF
--- a/queries/aws_queries/cloudtrail_2_minute_count_query.yml
+++ b/queries/aws_queries/cloudtrail_2_minute_count_query.yml
@@ -2,11 +2,11 @@ AnalysisType: scheduled_query
 Enabled: false
 Query: |-
   SELECT
-  	count(*) as num_logs, p_log_type
+    count(*) as num_logs, p_log_type
   FROM
-  	panther_logs.public.aws_cloudtrail
+    panther_logs.public.aws_cloudtrail
   WHERE
-  	p_occurs_since('5m')
+    p_occurs_since('5m')
   GROUP BY p_log_type
 QueryName: "AWS CloudTrail 2-minute count"
 Schedule:

--- a/rules/carbonblack_rules/cb_audit_flagged.yml
+++ b/rules/carbonblack_rules/cb_audit_flagged.yml
@@ -48,7 +48,7 @@ Tests:
     ExpectedResult: true
     Log:
       {
-      	"description": "Requested sensor update to version: 2.16.0.2566828 for the following device: ABCDEFG012 (ID: 21360056)",
+        "description": "Requested sensor update to version: 2.16.0.2566828 for the following device: ABCDEFG012 (ID: 21360056)",
         "eventId": "ac5f46923e9c11efaadd07ba65d6cd7b",
         "eventTime": "2024-07-10 09:13:29.952000000",
         "flagged": true,


### PR DESCRIPTION
### Background

Some of our YAML files use tabs instead of spaces, which is discouraged by YAML spec. [See this conversation in Slack](https://panther-labs.slack.com/archives/C0719AH18SV/p1721055874307739) for additional context.

### Changes

- This PR replaces all tabs with spaces in our YAML files.

### Testing

- `pat validate` succeeded
