### PR TITLE
Update safe lookup

### DIFF
--- a/rules/gcp_audit_rules/gcp_cloud_run_set_iam_policy.py
+++ b/rules/gcp_audit_rules/gcp_cloud_run_set_iam_policy.py
@@ -6,7 +6,8 @@ def rule(event):
     if deep_get(event, "severity") == "ERROR":
         return False
 
-    if not deep_get(event, "protoPayload", "methodName", default="").endswith("Services.SetIamPolicy"):
+    method_name = deep_get(event, "protoPayload", "methodName", default="")
+    if not method_name.endswith("Services.SetIamPolicy"):
         return False
 
     authorization_info = deep_walk(event, "protoPayload", "authorizationInfo")

--- a/rules/gcp_audit_rules/gcp_cloud_run_set_iam_policy.py
+++ b/rules/gcp_audit_rules/gcp_cloud_run_set_iam_policy.py
@@ -6,7 +6,7 @@ def rule(event):
     if deep_get(event, "severity") == "ERROR":
         return False
 
-    if not deep_get(event, "protoPayload", "methodName").endswith("Services.SetIamPolicy"):
+    if not deep_get(event, "protoPayload", "methodName", default="").endswith("Services.SetIamPolicy"):
         return False
 
     authorization_info = deep_walk(event, "protoPayload", "authorizationInfo")

--- a/rules/gcp_audit_rules/gcp_cloud_run_set_iam_policy.yml
+++ b/rules/gcp_audit_rules/gcp_cloud_run_set_iam_policy.yml
@@ -152,3 +152,56 @@ Tests:
         "severity": "NOTICE",
         "timestamp": "2024-02-02 09:44:26.029835000",
       }
+  - Name: No method provided
+    ExpectedResult: false
+    Log:
+      {
+        "insertId": "l3jvzyd2s2s",
+        "logName": "projects/some-project/logs/cloudaudit.googleapis.com%2Factivity",
+        "protoPayload":
+          {
+            "at_sign_type": "type.googleapis.com/google.cloud.audit.AuditLog",
+            "authenticationInfo":
+              {
+                "principalEmail": "some.user@company.com",
+                "principalSubject": "user:some.user@company.com",
+              },
+            "authorizationInfo":
+              [
+                {
+                  "granted": false,
+                  "permission": "run.services.setIamPolicy",
+                  "resource": "projects/some-project/locations/us-west1/services/cloudrun-exfil",
+                  "resourceAttributes": {},
+                },
+                {
+                  "granted": false,
+                  "permission": "run.services.setIamPolicy",
+                  "resourceAttributes": {},
+                },
+              ],
+            "request":
+              {
+                "@type": "type.googleapis.com/google.iam.v1.SetIamPolicyRequest",
+                "policy":
+                  {
+                    "bindings":
+                      [
+                        {
+                          "members": ["user:some.user@company.com"],
+                          "role": "roles/run.invoker",
+                        },
+                      ],
+                  },
+                "resource": "projects/some-project/locations/us-west1/services/cloudrun-exfil",
+              },
+            "requestMetadata": ...,
+            "resourceLocation": ...,
+            "resourceName": "projects/some-project/locations/us-west1/services/cloudrun-exfil",
+            "serviceName": "run.googleapis.com",
+          },
+        "receiveTimestamp": "2024-02-02 09:44:26.653891982",
+        "resource": ...,
+        "severity": "NOTICE",
+        "timestamp": "2024-02-02 09:44:26.029835000",
+      }


### PR DESCRIPTION
### Background

This unsafe lookup is triggering `AttributeError("'NoneType' object has no attribute 'endswith'")` for some customers.

### Changes

- Ensure a safe default is set for this case

### Testing

- Added a new unit test that covers this code path
