### PR TITLE
Update default timeouts

### DIFF
--- a/correlation_rules/aws_cloudtrail_stopinstance_followed_by_modifyinstanceattributes.yml
+++ b/correlation_rules/aws_cloudtrail_stopinstance_followed_by_modifyinstanceattributes.yml
@@ -23,7 +23,7 @@ Detection:
       LookbackWindowMinutes: 90
       Schedule:
         RateMinutes: 60
-        TimeoutMinutes: 1
+        TimeoutMinutes: 5
 Tests:
     - Name: Instance Stopped, Followed By Script Change
       ExpectedResult: true

--- a/correlation_rules/aws_potentially_compromised_service_role.yml
+++ b/correlation_rules/aws_potentially_compromised_service_role.yml
@@ -23,7 +23,7 @@ Detection:
           - On: requestParameters.roleArn
     Schedule:
       RateMinutes: 60
-      TimeoutMinutes: 5
+      TimeoutMinutes: 15
     LookbackWindowMinutes: 1440
 Tests:
     - Name: Role Assumed By Service, Followed By Role Assumed By User

--- a/correlation_rules/aws_potentially_compromised_service_role.yml
+++ b/correlation_rules/aws_potentially_compromised_service_role.yml
@@ -23,7 +23,7 @@ Detection:
           - On: requestParameters.roleArn
     Schedule:
       RateMinutes: 60
-      TimeoutMinutes: 2
+      TimeoutMinutes: 5
     LookbackWindowMinutes: 1440
 Tests:
     - Name: Role Assumed By Service, Followed By Role Assumed By User

--- a/correlation_rules/aws_privilege_escalation_via_user_compromise.yml
+++ b/correlation_rules/aws_privilege_escalation_via_user_compromise.yml
@@ -20,7 +20,7 @@ Detection:
             - On: p_alert_context.ip_accessKeyId
       Schedule:
         RateMinutes: 15
-        TimeoutMinutes: 2
+        TimeoutMinutes: 5
       LookbackWindowMinutes: 60
 Tests:
     - Name: Access Key Created and Used from Same IP

--- a/correlation_rules/aws_user_takeover_via_password_reset.yml
+++ b/correlation_rules/aws_user_takeover_via_password_reset.yml
@@ -20,7 +20,7 @@ Detection:
             - On: sourceIPAddress
       Schedule:
         RateMinutes: 15
-        TimeoutMinutes: 2
+        TimeoutMinutes: 5
       LookbackWindowMinutes: 60
 Tests:
     - Name: Password Reset, Then Login From Same IP

--- a/correlation_rules/gcp_cloud_run_service_create_followed_by_set_iam_policy.yml
+++ b/correlation_rules/gcp_cloud_run_service_create_followed_by_set_iam_policy.yml
@@ -26,7 +26,7 @@ Detection:
       LookbackWindowMinutes: 90
       Schedule:
         RateMinutes: 60 
-        TimeoutMinutes: 1
+        TimeoutMinutes: 5
 Tests:
     - Name: GCP Service Run, Followed By IAM Policy Change From Same IP
       ExpectedResult: true

--- a/correlation_rules/github_advanced_security_change_not_followed_by_repo_archived.yml
+++ b/correlation_rules/github_advanced_security_change_not_followed_by_repo_archived.yml
@@ -21,7 +21,7 @@ Detection:
     LookbackWindowMinutes: 15
     Schedule:
       RateMinutes: 10
-      TimeoutMinutes: 1
+      TimeoutMinutes: 5
 Tests:
     - Name: Security Change on Repo, Followed By Same Repo Archived
       ExpectedResult: false

--- a/correlation_rules/okta_login_without_push.yml
+++ b/correlation_rules/okta_login_without_push.yml
@@ -26,7 +26,7 @@ Detection:
             To: new.email
     Schedule:
       RateMinutes: 5
-      TimeoutMinutes: 2
+      TimeoutMinutes: 3
     LookbackWindowMinutes: 30
 Tests:
   - Name: Okta Login, Followed By Push Authorized Login

--- a/correlation_rules/potential_compromised_okta_credentials.yml
+++ b/correlation_rules/potential_compromised_okta_credentials.yml
@@ -25,7 +25,7 @@ Detection:
             To: new.employee.email
     Schedule:
       RateMinutes: 5
-      TimeoutMinutes: 1
+      TimeoutMinutes: 2
     LookbackWindowMinutes: 30
 Tests:
   - Name: Login Without Marker, Followed By Phishing Detection

--- a/correlation_rules/potential_compromised_okta_credentials.yml
+++ b/correlation_rules/potential_compromised_okta_credentials.yml
@@ -25,7 +25,7 @@ Detection:
             To: new.employee.email
     Schedule:
       RateMinutes: 5
-      TimeoutMinutes: 2
+      TimeoutMinutes: 3
     LookbackWindowMinutes: 30
 Tests:
   - Name: Login Without Marker, Followed By Phishing Detection

--- a/correlation_rules/secret_exposed_and_not_quarantined.yml
+++ b/correlation_rules/secret_exposed_and_not_quarantined.yml
@@ -23,7 +23,7 @@ Detection:
           To: SecretNotQuarantined
       Schedule:
         RateMinutes: 10
-        TimeoutMinutes: 2
+        TimeoutMinutes: 3
       LookbackWindowMinutes: 30
 Tests:
     - Name: Secret Found and Quarantied

--- a/correlation_rules/snowflake_data_exfiltration.yml
+++ b/correlation_rules/snowflake_data_exfiltration.yml
@@ -29,7 +29,7 @@ Detection:
           - On: stage
     Schedule:
       RateMinutes: 720
-      TimeoutMinutes: 2
+      TimeoutMinutes: 15
     LookbackWindowMinutes: 1440
 Tests:
     - Name: Data Exfiltration


### PR DESCRIPTION
### Background

Some customers were experiencing timeouts from some of the new OOTB Correlation Rules. This bumps the default timeout for some of the Correlation Rules with 1 hour+ lookback windows. In particular there was a two or three minute timeout for some Correlation Rules looking back at 12-24 hours of data.

### Changes

- For Correlation Rules with lookback windows over 1 hour, increase the default timeout
- Actually, bumped everything based on some feedback from users in high volume environments

### Testing

- pat test
