### PR TITLE
Add entity JSON object to Slack Privilege Escalation tests

### DIFF
--- a/rules/slack_rules/slack_user_privilege_escalation.yml
+++ b/rules/slack_rules/slack_user_privilege_escalation.yml
@@ -50,6 +50,17 @@ Tests:
               },
             "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
           },
+        "entity":
+          {
+            "type": "user",
+            "user":
+              {
+                "email": "user@example.com",
+                "id": "W012J3FEWAU",
+                "name": "primary-owner",
+                "team": "T01234N56GB",
+              },
+          },
       }
   - Name: Permissions Assigned
     ExpectedResult: true
@@ -78,6 +89,17 @@ Tests:
                 "type": "workspace",
               },
             "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
+          },
+        "entity":
+          {
+            "type": "user",
+            "user":
+              {
+                "email": "user@example.com",
+                "id": "W012J3FEWAU",
+                "name": "primary-owner",
+                "team": "T01234N56GB",
+              },
           },
       }
   - Name: Role Changed to Admin
@@ -108,6 +130,17 @@ Tests:
               },
             "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
           },
+        "entity":
+          {
+            "type": "user",
+            "user":
+              {
+                "email": "user@example.com",
+                "id": "W012J3FEWAU",
+                "name": "primary-owner",
+                "team": "T01234N56GB",
+              },
+          },
       }
   - Name: Role Changed to Owner
     ExpectedResult: true
@@ -136,6 +169,17 @@ Tests:
                 "type": "workspace",
               },
             "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
+          },
+        "entity":
+          {
+            "type": "user",
+            "user":
+              {
+                "email": "user@example.com",
+                "id": "W012J3FEWAU",
+                "name": "primary-owner",
+                "team": "T01234N56GB",
+              },
           },
       }
   - Name: User Logout


### PR DESCRIPTION
### Background
Noticed that the move from JSON to YAML had caused the addition of the `entity` block to be missed. The tests therefore show `unknown-actor` and `unknown-email`. This does not impact the functionality issue but could lead to confusion. 

```
Slack.AuditLogs.UserPrivilegeEscalation
	[PASS] Permissions Assigned
		[PASS] [rule] true
		[PASS] [title] Slack User Assigned Permissions <unknown-actor> (<unknown-email>)
		[PASS] [dedup] Slack User Assigned Permissions <unknown-actor> (<unknown-email>)
		[PASS] [alertContext] {"actor-name": "username", "actor-email": "user@example.com", "actor-ip": "1.2.3.4", "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"}
		[PASS] [severity] MEDIUM

	[PASS] Role Changed to Admin
		[PASS] [rule] true
		[PASS] [title] Slack User Made Admin <unknown-actor> (<unknown-email>)
		[PASS] [dedup] Slack User Made Admin <unknown-actor> (<unknown-email>)
		[PASS] [alertContext] {"actor-name": "username", "actor-email": "user@example.com", "actor-ip": "1.2.3.4", "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"}
		[PASS] [severity] CRITICAL

	[PASS] Role Changed to Owner
		[PASS] [rule] true
		[PASS] [title] Slack User Made Owner <unknown-actor> (<unknown-email>)
		[PASS] [dedup] Slack User Made Owner <unknown-actor> (<unknown-email>)
		[PASS] [alertContext] {"actor-name": "username", "actor-email": "user@example.com", "actor-ip": "1.2.3.4", "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"}
		[PASS] [severity] CRITICALunrestricted
```

### Changes
- Added the `entity` block in test JSON. 

### Testing

- `pipenv run panther_analysis_tool test --skip-disabled-tests --sort-test-results`

```
Slack.AuditLogs.UserPrivilegeEscalation
	[PASS] Permissions Assigned
		[PASS] [rule] true
		[PASS] [title] Slack User Assigned Permissions primary-owner (user@example.com)
		[PASS] [dedup] Slack User Assigned Permissions primary-owner (user@example.com)
		[PASS] [alertContext] {"actor-name": "username", "actor-email": "user@example.com", "actor-ip": "1.2.3.4", "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"}
		[PASS] [severity] MEDIUM

	[PASS] Role Changed to Admin
		[PASS] [rule] true
		[PASS] [title] Slack User Made Admin primary-owner (user@example.com)
		[PASS] [dedup] Slack User Made Admin primary-owner (user@example.com)
		[PASS] [alertContext] {"actor-name": "username", "actor-email": "user@example.com", "actor-ip": "1.2.3.4", "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"}
		[PASS] [severity] CRITICAL

	[PASS] Role Changed to Owner
		[PASS] [rule] true
		[PASS] [title] Slack User Made Owner primary-owner (user@example.com)
		[PASS] [dedup] Slack User Made Owner primary-owner (user@example.com)
		[PASS] [alertContext] {"actor-name": "username", "actor-email": "user@example.com", "actor-ip": "1.2.3.4", "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"}
		[PASS] [severity] CRITICAL

```