### PR TITLE
Update rule_jsonschema.json

### DIFF
--- a/.vscode/rule_jsonschema.json
+++ b/.vscode/rule_jsonschema.json
@@ -14,6 +14,9 @@
     "Enabled": {
       "$ref": "#/definitions/Enabled"
     },
+    "CreateAlert": {
+      "$ref": "#/definitions/CreateAlert"
+    },
     "Filename": {
       "$ref": "#/definitions/Filename"
     },
@@ -96,6 +99,11 @@
     },
     "Enabled": {
       "description": "Should this rule run automatically",
+      "type": "boolean",
+      "default": true
+    },
+    "CreateAlert": {
+      "description": "Whether the correlation rule should create an alert or not (default: true)",
       "type": "boolean",
       "default": true
     },


### PR DESCRIPTION
### Background

<High level overview here>
Added reference for CreateAlert, as discussed in this thread:

https://panther-labs.slack.com/archives/C0719AH18SV/p1721658614161399

It was initially brought up by Sentry: https://panther-labs.slack.com/archives/C02U2NZQ7RA/p1721657822931729

### Changes
- The two points that were be added are the following:
    "CreateAlert": {
      "description": "Whether the correlation rule should create an alert or not (default: true)",
      "type": "boolean",
      "default": true
    },
And the ref:
    "CreateAlert": {
      "$ref": "#/definitions/CreateAlert"
    },

### Testing

- <Testing steps>
