### PR TITLE
Update gcp_k8s_cron_job_created_or_modified.yml

### DIFF
--- a/rules/gcp_k8s_rules/gcp_k8s_cron_job_created_or_modified.yml
+++ b/rules/gcp_k8s_rules/gcp_k8s_cron_job_created_or_modified.yml
@@ -15,7 +15,7 @@ Reference: https://medium.com/snowflake/from-logs-to-detection-using-snowflake-a
 Runbook: Investigate a reason of creating or modifying a cron job in GKE. Create ticket if appropriate.
 Reports:
   MITRE ATT&CK:
-    - T1053.003 # Scheduled Task/Job: Cron
+    - T1053:003 # Scheduled Task/Job: Cron
 Tests:
   - Name: create
     ExpectedResult: true


### PR DESCRIPTION
### Background

RuleID: "GCP.GKE.Kubernetes.Cron.Job.Created.Or.Modified"
I believe there's an issue with the value of the field MITRE ATT&CK:
MITRE ATT&CK:
    - T1053.003
It should instead be:
MITRE ATT&CK:
    - T1053:003 
This is the customer ticket where this behavior was reported (Sigma): https://app.intercom.com/a/inbox/pgh5h4rf/inbox/view/95792/conversation/186787800017876?view=List

### Changes

I believe there's an issue with the value of the field MITRE ATT&CK:
MITRE ATT&CK:
    - T1053.003
It should instead be:
MITRE ATT&CK:
    - T1053:003 

### Testing

Steps to reproduce:
- Created a clone of our original rule "GCP.GKE.Kubernetes.Cron.Job.Created.Or.Modified" , with ID GCP.GKE.Kubernetes.Cron.Job.Created.Or.Modified.Cloned.By.Christina in [illustrious-seagull](https://panther-tse.runpanther.net/build/detections/rules/GCP.GKE.Kubernetes.Cron.Job.Created.Or.Modified.Cloned.By.Christina/) (Panther TSE Instance).
- Ingested via an S3 log source an event I created, in order to trigger an alert for this rule. I am attaching it here.
- The [alert](https://panther-tse.runpanther.net/alerts-and-errors/0242c48e5228fa3a241b31cf85f54553/) that was created has an issue, as shown in the attached screenshot. It says "the associated rule has been deleted" and shows None in the MITRE ATT&CK technique, even though the rule had a value there.
- Then, I changed the field MITRE ATT&CK to MITRE ATT&CK:T1053:003  , using : instead of ..
- The [alert](https://panther-tse.runpanther.net/alerts-and-errors/0242c48e5228fa3a241b31cf85f54553/) was then corrected and showed valid information and no error messages, as you'll see in the second screenshot.
[gcp_kubernetes_event.json](https://github.com/user-attachments/files/16493268/gcp_kubernetes_event.json)
![image (11)](https://github.com/user-attachments/assets/1460ce5a-bdff-4cb3-83a2-18cd3b09afd7)
![image (12)](https://github.com/user-attachments/assets/22411a0a-5bb6-4a96-b8ec-48c7ba07d168)

