### PR TITLE
CR upload fixes

### DIFF
--- a/correlation_rules/aws_potentially_compromised_service_role_cr.yml
+++ b/correlation_rules/aws_potentially_compromised_service_role_cr.yml
@@ -1,0 +1,55 @@
+AnalysisType: correlation_rule
+RuleID: "AWS.Potentially.Stolen.Service.Role"
+DisplayName: "DEPRECATED - AWS Potentially Stolen Service Role CR"
+Enabled: false
+Tags:
+    - AWS
+    - DEPRECATED
+Severity: Info
+Reports:
+  MITRE ATT&CK:
+    - T1528 # Steal Application Access Token
+Description: A role was assumed by an AWS service, followed by a user within 24 hours.  This could indicate a stolen or compromised AWS service role.
+Detection:
+  - Sequence:
+      - ID: Role Assumed by Service
+        RuleID: Role.Assumed.by.AWS.Service
+      - ID: Role Assumed by User
+        RuleID: Role.Assumed.by.User
+    Transitions:
+      - ID: Role Assumed by Service TO Role Assumed by User ON username
+        From: Role Assumed by Service
+        To: Role Assumed by User
+        Match:
+          - On: requestParameters.roleArn
+    Schedule:
+      RateMinutes: 1440
+      TimeoutMinutes: 20
+    LookbackWindowMinutes: 15
+Tests:
+  - Name: Role Assumed By Service, Followed By Different Role Assumed By User
+    ExpectedResult: false
+    RuleOutputs:
+    - ID: Role Assumed by Service
+      Matches:
+        requestParameters.roleArn:
+          FAKE_ROLE_ARN:
+            - 0
+    - ID: Role Assumed by User
+      Matches:
+        requestParameters.roleArn:
+          OTHER_ROLE_ARN:
+            - 2
+  - Name: Role Assumed By Service, Followed By Role Assumed By User
+    ExpectedResult: true
+    RuleOutputs:
+    - ID: Role Assumed by Service
+      Matches:
+        requestParameters.roleArn:
+          FAKE_ROLE_ARN:
+            - 0
+    - ID: Role Assumed by User
+      Matches:
+        requestParameters.roleArn:
+          FAKE_ROLE_ARN:
+            - 2

--- a/correlation_rules/github_advanced_security_change_not_followed_by_repo_archived.yml
+++ b/correlation_rules/github_advanced_security_change_not_followed_by_repo_archived.yml
@@ -6,19 +6,18 @@ Severity: Critical
 Description: Identifies when advances security change was made not to archive a repo. Eliminates false positives in the Advances Security Change Rule when the repo is archived.
 Reference: https://docs.github.com/en/code-security/getting-started/auditing-security-alerts
 Detection:
-  - Group:
+  - Sequence:
       - ID: GHASChange
         RuleID: GitHub.Advanced.Security.Change
       - ID: RepoArchived
         RuleID: Github.Repo.Archived
         Absence: true
-    MatchCriteria: 
-      field_name:
-      - GroupID: GHASChange
-        Match: p_alert_context.repo
-      - GroupID: RepoArchived
-        Match: p_alert_context.repo
-    EventEvaluationOrder: Chronological
+    Transitions:
+      - ID: GHASChange NOT FOLLOWED BY RepoArchived
+        From: RepoArchived
+        To: GHASChange
+        Match:
+          - On: p_alert_context.repo
     LookbackWindowMinutes: 90
     Schedule:
       RateMinutes: 60
@@ -38,7 +37,7 @@ Tests:
               my-org/example-repo:
                 - "2024-06-01T10:00:01Z"
     - Name: Repo Archived followed by GHAS change on same repo
-      ExpectedResult: false
+      ExpectedResult: true
       RuleOutputs:
         - ID: RepoArchived
           Matches:

--- a/queries/aws_queries/aws_potentially_compromised_service_role.yml
+++ b/queries/aws_queries/aws_potentially_compromised_service_role.yml
@@ -1,5 +1,5 @@
 AnalysisType: scheduled_rule
-RuleID: "AWS.Potentially.Stolen.Service.Role"
+RuleID: "AWS.Potentially.Stolen.Service.Role.Scheduled"
 DisplayName: "AWS Potentially Stolen Service Role"
 Enabled: true
 Tags:


### PR DESCRIPTION
### Background

Rules cannot be converted from one analysis type to another while keeping the same RuleID.

### Changes

- Reintroduces `AWS.Potentially.Stolen.Service.Role` as deprecated and changes RuleID of the new scheduled rule
- Reverts `GitHub.Advanced.Security.Change.NOT.FOLLOWED.BY.Repo.Archived` to Sequence CR with order reversed

### Testing

- pat validate
- pat upload
