### PR TITLE
Info Alerts are Signals

### DIFF
--- a/correlation_rules/aws_potentially_compromised_service_role_cr.yml
+++ b/correlation_rules/aws_potentially_compromised_service_role_cr.yml
@@ -6,6 +6,7 @@ Tags:
     - AWS
     - DEPRECATED
 Severity: Info
+CreateAlert: false
 Reports:
   MITRE ATT&CK:
     - T1528 # Steal Application Access Token

--- a/queries/snowflake_queries/snowflake_user_created.yml
+++ b/queries/snowflake_queries/snowflake_user_created.yml
@@ -8,6 +8,7 @@ Enabled: false
 ScheduledQueries:
   - Query.Snowflake.UserCreated
 Severity: Info
+CreateAlert: false
 Tags:
   - Snowflake
   - Persistence:Create Account

--- a/queries/snowflake_queries/snowflake_user_enabled.yml
+++ b/queries/snowflake_queries/snowflake_user_enabled.yml
@@ -8,6 +8,7 @@ Enabled: false
 ScheduledQueries:
   - Query.Snowflake.UserEnabled
 Severity: Info
+CreateAlert: false
 Tags:
   - Snowflake
   - Persistence:Create Account

--- a/rules/auth0_rules/auth0_integration_installed.yml
+++ b/rules/auth0_rules/auth0_integration_installed.yml
@@ -6,6 +6,7 @@ Filename: auth0_integration_installed.py
 Runbook: Assess if this was done by the user for a valid business reason. Be vigilant to re-enable this setting as it's in the best security interest for your organization's security posture.
 Reference: https://auth0.com/blog/actions-integrations-are-now-ga/
 Severity: Info
+CreateAlert: false
 Tests:
   - ExpectedResult: true
     Log:

--- a/rules/auth0_rules/auth0_mfa_factor_setting_enabled.yml
+++ b/rules/auth0_rules/auth0_mfa_factor_setting_enabled.yml
@@ -6,6 +6,7 @@ Filename: auth0_mfa_factor_setting_enabled.py
 Runbook: Assess if this was done by the user for a valid business reason. Be vigilant to re-enable this setting as it's in the best security interest for your organization's security posture.
 Reference: https://auth0.com/docs/secure/multi-factor-authentication/multi-factor-authentication-factors
 Severity: Info
+CreateAlert: false
 Tests:
   - ExpectedResult: true
     Log:

--- a/rules/auth0_rules/auth0_mfa_risk_assessment_enabled.yml
+++ b/rules/auth0_rules/auth0_mfa_risk_assessment_enabled.yml
@@ -6,6 +6,7 @@ Filename: auth0_mfa_risk_assessment_enabled.py
 Runbook: Assess if this was done by the user for a valid business reason. Be vigilant when enabling this setting as it's in the best security interest for your organization's security posture.
 Reference: https://auth0.com/docs/secure/multi-factor-authentication/enable-mfa#:~:text=Always%20policy%2C%20the-,MFA%20Risk%20Assessors,-section%20appears.%20By
 Severity: Info
+CreateAlert: false
 Tests:
   - ExpectedResult: false
     Log:

--- a/rules/auth0_rules/auth0_user_invitation_created.yml
+++ b/rules/auth0_rules/auth0_user_invitation_created.yml
@@ -4,6 +4,7 @@ Enabled: true
 Filename: auth0_user_invitation_created.py
 Reference: https://auth0.com/docs/manage-users/organizations/configure-organizations/invite-members
 Severity: Info
+CreateAlert: false
 Tests:
   - ExpectedResult: true
     Log:

--- a/rules/auth0_rules/auth0_user_joined_tenant.yml
+++ b/rules/auth0_rules/auth0_user_joined_tenant.yml
@@ -6,6 +6,7 @@ Filename: auth0_user_joined_tenant.py
 RuleID: Auth0.User.Joined.Tenant
 Reference: https://auth0.com/docs/manage-users/organizations/configure-organizations/invite-members#send-membership-invitations:~:text=.-,Send%20membership%20invitations,-You%20can
 Severity: Info
+CreateAlert: false
 LogTypes:
   - Auth0.Events
 Tests:

--- a/rules/aws_cloudtrail_rules/aws_cloudtrail_account_discovery.yml
+++ b/rules/aws_cloudtrail_rules/aws_cloudtrail_account_discovery.yml
@@ -8,6 +8,7 @@ Reports:
   MITRE ATT&CK:
     - TA0007:T1087
 Severity: Info
+CreateAlert: false
 Tests:
   - ExpectedResult: true
     Log:

--- a/rules/aws_cloudtrail_rules/aws_cloudtrail_created.yml
+++ b/rules/aws_cloudtrail_rules/aws_cloudtrail_created.yml
@@ -15,6 +15,7 @@ Reports:
   MITRE ATT&CK:
     - TA0007:T1538
 Severity: Info
+CreateAlert: false
 Description: >
   A CloudTrail Trail was created, updated, or enabled.
 Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-cloudtrail-modified

--- a/rules/aws_cloudtrail_rules/aws_cloudtrail_password_policy_discovery.yml
+++ b/rules/aws_cloudtrail_rules/aws_cloudtrail_password_policy_discovery.yml
@@ -8,6 +8,7 @@ Reports:
     - TA0007:T1201
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_account-policy.html
 Severity: Info
+CreateAlert: false
 Tests:
   - ExpectedResult: false
     Log:

--- a/rules/aws_cloudtrail_rules/aws_cloudtrail_useraccesskeyauth.yml
+++ b/rules/aws_cloudtrail_rules/aws_cloudtrail_useraccesskeyauth.yml
@@ -6,10 +6,9 @@ Enabled: true
 LogTypes:
     - AWS.CloudTrail
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 60
 Threshold: 1
-InlineFilters:
-    - All: []
 Tests:
     - Name: Access Key Action Failed
       ExpectedResult: false
@@ -275,4 +274,3 @@ Tests:
                     type: lambda
                 webIdFederationData: {}
             type: AssumedRole
-CreateAlert: false

--- a/rules/aws_cloudtrail_rules/aws_config_service_created.yml
+++ b/rules/aws_cloudtrail_rules/aws_config_service_created.yml
@@ -15,6 +15,7 @@ Reports:
   MITRE ATT&CK:
     - TA0007:T1526
 Severity: Info
+CreateAlert: false
 Description: >
   An AWS Config Recorder or Delivery Channel was created
 Runbook: >

--- a/rules/aws_cloudtrail_rules/aws_console_login.yml
+++ b/rules/aws_cloudtrail_rules/aws_console_login.yml
@@ -6,6 +6,6 @@ Enabled: true
 LogTypes:
     - AWS.CloudTrail
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 60
 Threshold: 1
-CreateAlert: false

--- a/rules/aws_cloudtrail_rules/aws_console_signin.yml
+++ b/rules/aws_cloudtrail_rules/aws_console_signin.yml
@@ -3,10 +3,10 @@ Filename: aws_console_signin.py
 RuleID: "AWS.Console.Sign-In"
 DisplayName: "SIGNAL - AWS Console SSO Sign-In"
 Enabled: true
-CreateAlert: false
 LogTypes:
     - AWS.CloudTrail
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 60
 Threshold: 1
 Tests:

--- a/rules/aws_cloudtrail_rules/aws_ec2_gateway_modified.yml
+++ b/rules/aws_cloudtrail_rules/aws_ec2_gateway_modified.yml
@@ -15,6 +15,7 @@ Reports:
   MITRE ATT&CK:
     - TA0005:T1562
 Severity: Info
+CreateAlert: false
 Description: An EC2 Network Gateway was modified.
 Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-ec2-gateway-modified
 Reference: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Internet_Gateway.html

--- a/rules/aws_cloudtrail_rules/aws_ec2_monitoring.yml
+++ b/rules/aws_cloudtrail_rules/aws_ec2_monitoring.yml
@@ -9,6 +9,7 @@ Reports:
 Runbook: Verify that the action was not taken by a malicious actor.
 Reference: https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2imagebuilder.html#amazonec2imagebuilder-actions-as-permissions
 Severity: Info
+CreateAlert: false
 Tags:
   - ec2
 Tests:

--- a/rules/aws_cloudtrail_rules/aws_ec2_network_acl_modified.yml
+++ b/rules/aws_cloudtrail_rules/aws_ec2_network_acl_modified.yml
@@ -15,6 +15,7 @@ Reports:
   MITRE ATT&CK:
     - TA0005:T1562
 Severity: Info
+CreateAlert: false
 Description: An EC2 Network ACL was modified.
 Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-ec2-network-acl-modified
 Reference: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html#nacl-tasks

--- a/rules/aws_cloudtrail_rules/aws_ec2_route_table_modified.yml
+++ b/rules/aws_cloudtrail_rules/aws_ec2_route_table_modified.yml
@@ -14,6 +14,7 @@ Reports:
   MITRE ATT&CK:
     - TA0010:T1048
 Severity: Info
+CreateAlert: false
 Description: An EC2 Route Table was modified.
 Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-ec2-route-table-modified
 Reference: https://docs.aws.amazon.com/vpc/latest/userguide/WorkWithRouteTables.html

--- a/rules/aws_cloudtrail_rules/aws_ec2_security_group_modified.yml
+++ b/rules/aws_cloudtrail_rules/aws_ec2_security_group_modified.yml
@@ -15,6 +15,7 @@ Reports:
   MITRE ATT&CK:
     - TA0005:T1562
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 720 # 12 hours
 Description: >
   An EC2 Security Group was modified.

--- a/rules/aws_cloudtrail_rules/aws_ec2_stopinstances.yml
+++ b/rules/aws_cloudtrail_rules/aws_ec2_stopinstances.yml
@@ -2,13 +2,13 @@ AnalysisType: rule
 RuleID: "AWS.EC2.StopInstances"
 DisplayName: "CloudTrail EC2 StopInstances"
 Enabled: true
-CreateAlert: false
 Filename: aws_ec2_stopinstances.py
 LogTypes:
   - AWS.CloudTrail
 Tags:
   - panther-signal
 Severity: Info
+CreateAlert: false
 Description: >
   A CloudTrail instances were stopped. It makes further changes of instances possible
 Reference: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-log-file-examples.html

--- a/rules/aws_cloudtrail_rules/aws_ec2_vpc_modified.yml
+++ b/rules/aws_cloudtrail_rules/aws_ec2_vpc_modified.yml
@@ -15,6 +15,7 @@ Reports:
   MITRE ATT&CK:
     - TA0005:T1562
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 720 # 12 hours
 Description: An EC2 VPC was modified.
 Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-ec2-vpc-modified

--- a/rules/aws_cloudtrail_rules/aws_iam_anything_changed.yml
+++ b/rules/aws_cloudtrail_rules/aws_iam_anything_changed.yml
@@ -9,6 +9,7 @@ Tags:
   - AWS
   - Identity and Access Management
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 720 # 12 hours
 Description: >
   A change occurred in the IAM configuration. This could be a resource being created, deleted, or modified. This is a high level view of changes, helfpul to indicate how dynamic a certain IAM environment is.

--- a/rules/aws_cloudtrail_rules/aws_iam_group_read_only_events.yml
+++ b/rules/aws_cloudtrail_rules/aws_iam_group_read_only_events.yml
@@ -6,6 +6,7 @@ Filename: aws_iam_group_read_only_events.py
 Reference: https://attack.mitre.org/techniques/T1069/
 Runbook: Examine other activities done by this user to determine whether or not activity is suspicious.
 Severity: Info
+CreateAlert: false
 Tags:
   - AWS
   - Cloudtrail

--- a/rules/aws_cloudtrail_rules/aws_iam_policy_modified.yml
+++ b/rules/aws_cloudtrail_rules/aws_iam_policy_modified.yml
@@ -15,6 +15,7 @@ Reports:
   MITRE ATT&CK:
     - TA0004:T1548
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 720 # 12 hours
 Description: >
   An IAM Policy was changed.

--- a/rules/aws_cloudtrail_rules/aws_iam_user_recon_denied.yml
+++ b/rules/aws_cloudtrail_rules/aws_iam_user_recon_denied.yml
@@ -12,6 +12,7 @@ Reports:
   MITRE ATT&CK:
     - TA0007:T1526
 Severity: Info
+CreateAlert: false
 Threshold: 15
 DedupPeriodMinutes: 10
 Description: An IAM user has a high volume of access denied API calls.

--- a/rules/aws_cloudtrail_rules/aws_kms_cmk_loss.yml
+++ b/rules/aws_cloudtrail_rules/aws_kms_cmk_loss.yml
@@ -15,6 +15,7 @@ Reports:
   MITRE ATT&CK:
     - TA0040:T1485
 Severity: Info
+CreateAlert: false
 Description: >
   A KMS Customer Managed Key was disabled or scheduled for deletion. This could potentially lead to permanent loss of encrypted data.
 Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-kms-cmk-loss

--- a/rules/aws_cloudtrail_rules/aws_s3_bucket_deleted.yml
+++ b/rules/aws_cloudtrail_rules/aws_s3_bucket_deleted.yml
@@ -12,6 +12,7 @@ Reports:
   MITRE ATT&CK:
     - TA0040:T1485
 Severity: Info
+CreateAlert: false
 Description: A S3 Bucket, Policy, or Website was deleted
 Runbook: Explore if this bucket deletion was potentially destructive
 Reference: https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjects.html

--- a/rules/aws_cloudtrail_rules/aws_s3_bucket_policy_modified.yml
+++ b/rules/aws_cloudtrail_rules/aws_s3_bucket_policy_modified.yml
@@ -15,6 +15,7 @@ Reports:
   MITRE ATT&CK:
     - TA0010:T1567
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 720 # 12 hours
 Description: >
   An S3 Bucket was modified.

--- a/rules/aws_cloudtrail_rules/aws_software_discovery.yml
+++ b/rules/aws_cloudtrail_rules/aws_software_discovery.yml
@@ -10,6 +10,7 @@ Reports:
   MITRE ATT&CK:
     - TA0007:T1518
 Severity: Info
+CreateAlert: false
 Tests:
   - ExpectedResult: true
     Log:

--- a/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.yml
+++ b/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.yml
@@ -15,6 +15,7 @@ Reports:
   MITRE ATT&CK:
     - TA0007:T1526
 Severity: Info
+CreateAlert: false
 Description: An unauthorized AWS API call was made
 Runbook: https://docs.runpanther.io/alert-runbooks/built-in-rules/aws-unauthorized-api-call
 Reference: https://amzn.to/3aOukaA

--- a/rules/aws_cloudtrail_rules/aws_update_credentials.yml
+++ b/rules/aws_cloudtrail_rules/aws_update_credentials.yml
@@ -13,6 +13,7 @@ Tags:
   - Identity & Access Management
   - Persistence:Account Manipulation
 Severity: Info
+CreateAlert: false
 Description: A console password, access key, or user has been created.
 Runbook: This rule is purely informational, there is no action needed.
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/list_identityandaccessmanagement.html

--- a/rules/aws_cloudtrail_rules/retrieve_sso_access_token.yml
+++ b/rules/aws_cloudtrail_rules/retrieve_sso_access_token.yml
@@ -3,10 +3,10 @@ Filename: retrieve_sso_access_token.py
 RuleID: "Retrieve.SSO.access.token"
 DisplayName: "SIGNAL - Retrieve SSO access token"
 Enabled: true
-CreateAlert: false
 LogTypes:
     - AWS.CloudTrail
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 60
 Threshold: 1
 Tests:

--- a/rules/aws_cloudtrail_rules/role_assumed_by_aws_service.yml
+++ b/rules/aws_cloudtrail_rules/role_assumed_by_aws_service.yml
@@ -3,10 +3,10 @@ Filename: role_assumed_by_aws_service.py
 RuleID: "Role.Assumed.by.AWS.Service"
 DisplayName: "SIGNAL - Role Assumed by AWS Service"
 Enabled: false
-CreateAlert: false
 LogTypes:
     - AWS.CloudTrail
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 60
 Threshold: 1
 Tests:

--- a/rules/aws_cloudtrail_rules/role_assumed_by_user.yml
+++ b/rules/aws_cloudtrail_rules/role_assumed_by_user.yml
@@ -3,10 +3,10 @@ Filename: role_assumed_by_user.py
 RuleID: "Role.Assumed.by.User"
 DisplayName: "SIGNAL - Role Assumed by User"
 Enabled: false
-CreateAlert: false
 LogTypes:
     - AWS.CloudTrail
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 60
 Threshold: 1
 Tests:

--- a/rules/aws_cloudtrail_rules/signin_with_aws_cli_prompt.yml
+++ b/rules/aws_cloudtrail_rules/signin_with_aws_cli_prompt.yml
@@ -3,10 +3,10 @@ Filename: signin_with_aws_cli_prompt.py
 RuleID: "Sign-in.with.AWS.CLI.prompt"
 DisplayName: "SIGNAL - Sign-in with AWS CLI prompt"
 Enabled: true
-CreateAlert: false
 LogTypes:
     - AWS.CloudTrail
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 60
 Threshold: 1
 Tests:

--- a/rules/aws_eks_rules/source_ip_multiple_403.yml
+++ b/rules/aws_eks_rules/source_ip_multiple_403.yml
@@ -12,6 +12,7 @@ Reports:
     - "TA0007:T1613"
 Reference: https://aws.github.io/aws-eks-best-practices/security/docs/detective/
 Severity: Info
+CreateAlert: false
 Description: > # (Optional)
   This detection identifies if a public sourceIP is generating multiple 403s
   with the Kubernetes API server.

--- a/rules/aws_eks_rules/system_namespace_public_ip.yml
+++ b/rules/aws_eks_rules/system_namespace_public_ip.yml
@@ -12,6 +12,7 @@ Reports:
     - "TA0027:T1475" # Tactic ID:Technique ID (https://attack.mitre.org/tactics/enterprise/)
 Reference: https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html
 Severity: Info
+CreateAlert: false
 Description: >
   This detection identifies if an activity is recorded in the Kubernetes audit log where
   the user:username attribute begins with "system:" or "eks:" and the requests originating

--- a/rules/aws_s3_rules/aws_s3_access_error.yml
+++ b/rules/aws_s3_rules/aws_s3_access_error.yml
@@ -15,6 +15,7 @@ Reports:
   MITRE ATT&CK:
     - TA0007:T1619
 Severity: Info
+CreateAlert: false
 Description: >
   Checks for errors during S3 Object access.
   This could be due to insufficient access permissions, non-existent buckets, or other reasons.

--- a/rules/box_rules/box_new_login.yml
+++ b/rules/box_rules/box_new_login.yml
@@ -12,6 +12,7 @@ Reports:
   MITRE ATT&CK:
     - TA0001:T1078
 Severity: Info
+CreateAlert: false
 Description: >
   A user logged in from a new device.
 Reference: https://support.box.com/hc/en-us/articles/360043691914-Controlling-Devices-Used-to-Access-Box

--- a/rules/box_rules/box_untrusted_device.yml
+++ b/rules/box_rules/box_untrusted_device.yml
@@ -12,6 +12,7 @@ Reports:
   MITRE ATT&CK:
     - TA0001:T1078
 Severity: Info
+CreateAlert: false
 Description: >
   A user attempted to login from an untrusted device.
 Reference: https://support.box.com/hc/en-us/articles/360044194993-Setting-Up-Device-Trust-Security-Requirements

--- a/rules/cloudflare_rules/cloudflare_firewall_high_volume_events_blocked_greynoise.yml
+++ b/rules/cloudflare_rules/cloudflare_firewall_high_volume_events_blocked_greynoise.yml
@@ -10,6 +10,7 @@ Tags:
   - GreyNoise
   - Deprecated
 Severity: Info
+CreateAlert: false
 Description: Monitors high volume events blocked from the same IP enriched with GreyNoise
 Runbook: Inspect and monitor internet-facing services for potential outages
 Reference: https://docs.greynoise.io/docs/understanding-greynoise-enrichments

--- a/rules/crowdstrike_rules/crowdstrike_lolbas.yml
+++ b/rules/crowdstrike_rules/crowdstrike_lolbas.yml
@@ -10,6 +10,7 @@ DedupPeriodMinutes: 1440
 Enabled: false
 Filename: crowdstrike_lolbas.py
 Severity: Info
+CreateAlert: false
 Tags:
   - Configuration Required
 Tests:

--- a/rules/gcp_audit_rules/gcp_bigquery_large_scan.yml
+++ b/rules/gcp_audit_rules/gcp_bigquery_large_scan.yml
@@ -5,6 +5,7 @@ Enabled: true
 Filename: gcp_bigquery_large_scan.py
 Reference: https://cloud.google.com/bigquery/docs/running-queries
 Severity: Info
+CreateAlert: false
 Tests:
   - ExpectedResult: false
     Log:

--- a/rules/gcp_audit_rules/gcp_destructive_queries.yml
+++ b/rules/gcp_audit_rules/gcp_destructive_queries.yml
@@ -5,6 +5,7 @@ Enabled: true
 Filename: gcp_destructive_queries.py
 Reference: https://cloud.google.com/bigquery/docs/managing-tables
 Severity: Info
+CreateAlert: false
 Tests:
   - ExpectedResult: true
     Log:

--- a/rules/gcp_audit_rules/gcp_iam_custom_role_changes.yml
+++ b/rules/gcp_audit_rules/gcp_iam_custom_role_changes.yml
@@ -16,6 +16,7 @@ Reports:
   MITRE ATT&CK:
     - TA0004:T1078
 Severity: Info
+CreateAlert: false
 Description: A custom role has been created, deleted, or updated.
 Runbook: No action needed, informational
 Reference: https://cloud.google.com/iam/docs/creating-custom-roles

--- a/rules/gcp_audit_rules/gcp_logging_sink_modified.yml
+++ b/rules/gcp_audit_rules/gcp_logging_sink_modified.yml
@@ -6,6 +6,7 @@ Enabled: true
 Filename: gcp_logging_sink_modified.py
 RuleID: "GCP.Logging.Sink.Modified"
 Severity: Info
+CreateAlert: false
 LogTypes:
   - GCP.AuditLog
 Tags:

--- a/rules/github_rules/github_org_modified.yml
+++ b/rules/github_rules/github_org_modified.yml
@@ -13,6 +13,7 @@ Reports:
     - TA0001:T1195
 Reference: https://docs.github.com/en/organizations/managing-membership-in-your-organization
 Severity: Info
+CreateAlert: false
 Description: Detects when a user is added or removed from a GitHub Org.
 Tests:
   - Name: GitHub - Team Deleted

--- a/rules/github_rules/github_repo_created.yml
+++ b/rules/github_rules/github_repo_created.yml
@@ -9,6 +9,7 @@ Tags:
   - GitHub
 Reference: https://docs.github.com/en/get-started/quickstart/create-a-repo
 Severity: Info
+CreateAlert: false
 Description: Detects when a repository is created.
 Tests:
   - Name: GitHub - Repo Created

--- a/rules/github_rules/github_repo_hook_modified.yml
+++ b/rules/github_rules/github_repo_hook_modified.yml
@@ -13,6 +13,7 @@ Reports:
     - TA0010:T1020
 Reference: https://docs.github.com/en/webhooks/about-webhooks
 Severity: Info
+CreateAlert: false
 Description: Detects when a web hook is added, modified, or deleted in an org repository.
 Tests:
   - Name: GitHub - Webhook Created

--- a/rules/github_rules/github_repo_initial_access.yml
+++ b/rules/github_rules/github_repo_initial_access.yml
@@ -9,6 +9,7 @@ Tags:
   - GitHub
 Reference: https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/managing-an-individuals-access-to-an-organization-repository
 Severity: Info
+CreateAlert: false
 Description: Detects when a user initially accesses a private organization repository.
 Tests:
   - Name: GitHub - Initial Access

--- a/rules/github_rules/github_team_modified.yml
+++ b/rules/github_rules/github_team_modified.yml
@@ -13,6 +13,7 @@ Reports:
     - TA0001:T1195
 Reference: https://docs.github.com/en/organizations/organizing-members-into-teams
 Severity: Info
+CreateAlert: false
 Description: Detects when a team is modified in some way, such as adding a new team, deleting a team, modifying members, or a change in repository control.
 Tests:
   - Name: GitHub - Team Deleted

--- a/rules/github_rules/github_user_access_key_created.yml
+++ b/rules/github_rules/github_user_access_key_created.yml
@@ -13,6 +13,7 @@ Reports:
     - TA0003:T1078
 Reference: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent
 Severity: Info
+CreateAlert: false
 Description: Detects when a GitHub user access key is created.
 Tests:
   - Name: GitHub - User Access Key Created

--- a/rules/gravitational_teleport_rules/teleport_lock_created.yml
+++ b/rules/gravitational_teleport_rules/teleport_lock_created.yml
@@ -8,6 +8,7 @@ LogTypes:
 Tags:
   - Teleport
 Severity: Info
+CreateAlert: false
 Description: A Teleport Lock was created
 DedupPeriodMinutes: 60
 Reference: https://goteleport.com/docs/management/admin/

--- a/rules/gsuite_activityevent_rules/gsuite_passthrough_rule.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_passthrough_rule.yml
@@ -8,6 +8,7 @@ LogTypes:
 Tags:
   - GSuite
 Severity: Info
+CreateAlert: false
 Description: >
   A GSuite rule was triggered.
 Reference: https://support.google.com/a/answer/9420866

--- a/rules/gsuite_reports_rules/gsuite_drive_overly_visible.yml
+++ b/rules/gsuite_reports_rules/gsuite_drive_overly_visible.yml
@@ -12,6 +12,7 @@ Reports:
   MITRE ATT&CK:
     - TA0009:T1213
 Severity: Info
+CreateAlert: false
 Description: >
   A Google drive resource that is overly visible has been modified.
 Reference: https://support.google.com/docs/answer/2494822?hl=en&co=GENIE.Platform%3DDesktop&sjid=864417124752637253-EU

--- a/rules/indicator_creation_rules/new_aws_account_logging.yml
+++ b/rules/indicator_creation_rules/new_aws_account_logging.yml
@@ -10,6 +10,7 @@ Tags:
   - Indicator Collection
   - Persistence:Create Account
 Severity: Info
+CreateAlert: false
 Reports:
   MITRE ATT&CK:
     - TA0003:T1136

--- a/rules/indicator_creation_rules/new_user_account_logging.yml
+++ b/rules/indicator_creation_rules/new_user_account_logging.yml
@@ -19,6 +19,7 @@ Tags:
   - OneLogin
   - Persistence:Create Account
 Severity: Info
+CreateAlert: false
 Reports:
   MITRE ATT&CK:
     - TA0003:T1136

--- a/rules/notion_rules/notion_workspace_settings_public_homepage_added.yml
+++ b/rules/notion_rules/notion_workspace_settings_public_homepage_added.yml
@@ -10,6 +10,7 @@ Tags:
   - Data Security
   - Information Disclosure
 Severity: Info
+CreateAlert: false
 Description: A Notion page was set to public in your worksace.
 DedupPeriodMinutes: 60
 Threshold: 1

--- a/rules/okta_rules/okta_admin_role_assigned.yml
+++ b/rules/okta_rules/okta_admin_role_assigned.yml
@@ -13,6 +13,7 @@ Reports:
   MITRE ATT&CK:
     - TA0004:T1078
 Severity: Info
+CreateAlert: false
 Description: A user has been granted administrative privileges in Okta
 Reference: https://help.okta.com/en/prod/Content/Topics/Security/administrators-admin-comparison.htm
 Runbook: Reach out to the user if needed to validate the activity

--- a/rules/okta_rules/okta_api_key_created.yml
+++ b/rules/okta_rules/okta_api_key_created.yml
@@ -13,6 +13,7 @@ Reports:
   MITRE ATT&CK:
     - TA0006:T1528
 Severity: Info
+CreateAlert: false
 Description: A user created an API Key in Okta
 Reference: https://help.okta.com/en/prod/Content/Topics/Security/API.htm
 Runbook: Reach out to the user if needed to validate the activity.

--- a/rules/okta_rules/okta_api_key_revoked.yml
+++ b/rules/okta_rules/okta_api_key_revoked.yml
@@ -9,6 +9,7 @@ Tags:
   - Identity & Access Management
   - Okta
 Severity: Info
+CreateAlert: false
 Description: A user has revoked an API Key in Okta
 Reference: https://help.okta.com/en/prod/Content/Topics/Security/API.htm
 Runbook: Validate this action was authorized.

--- a/rules/okta_rules/okta_login_signal.yml
+++ b/rules/okta_rules/okta_login_signal.yml
@@ -3,10 +3,10 @@ Filename: okta_login_signal.py
 RuleID: "Okta.Login.Success"
 DisplayName: "Okta Login Signal"
 Enabled: false
-CreateAlert: false
 LogTypes:
   - Okta.SystemLog
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 60
 Threshold: 1
 Tests:

--- a/rules/okta_rules/okta_sso_to_aws.yml
+++ b/rules/okta_rules/okta_sso_to_aws.yml
@@ -3,10 +3,10 @@ Filename: okta_sso_to_aws.py
 RuleID: "Okta.SSO.to.AWS"
 DisplayName: "SIGNAL - Okta SSO to AWS"
 Enabled: true
-CreateAlert: false
 LogTypes:
     - Okta.SystemLog
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 60
 Threshold: 1
 Tests:

--- a/rules/okta_rules/okta_user_mfa_reset.yml
+++ b/rules/okta_rules/okta_user_mfa_reset.yml
@@ -6,6 +6,7 @@ Enabled: true
 Filename: okta_user_mfa_reset.py
 Reference: https://support.okta.com/help/s/article/How-to-avoid-lockouts-and-reset-your-Multifactor-Authentication-MFA-for-Okta-Admins?language=en_US
 Severity: Info
+CreateAlert: false
 Tests:
   - ExpectedResult: true
     Name: User reset own MFA factor

--- a/rules/onelogin_rules/onelogin_password_changed.yml
+++ b/rules/onelogin_rules/onelogin_password_changed.yml
@@ -9,6 +9,7 @@ Tags:
   - OneLogin
   - Identity & Access Management
 Severity: Info
+CreateAlert: false
 Description: >
   A user password was updated.
 Reference: https://onelogin.service-now.com/kb_view_customer.do?sysparm_article=KB0010510

--- a/rules/osquery_rules/osquery_outdated.yml
+++ b/rules/osquery_rules/osquery_outdated.yml
@@ -9,6 +9,7 @@ Tags:
   - Osquery
   - Compliance
 Severity: Info
+CreateAlert: false
 Description: Keep track of osquery versions, current is 5.10.2.
 Runbook: Update the osquery agent.
 Reference: https://www.osquery.io/downloads/official/5.10.2

--- a/rules/panther_audit_rules/panther_detection_deleted.yml
+++ b/rules/panther_audit_rules/panther_detection_deleted.yml
@@ -6,6 +6,7 @@ Enabled: true
 LogTypes:
   - Panther.Audit
 Severity: Info
+CreateAlert: false
 Tags:
   - DataModel
   - Defense Evasion:Impair Defenses

--- a/rules/panther_ioc_rules/log4j_exploit_iocs.yml
+++ b/rules/panther_ioc_rules/log4j_exploit_iocs.yml
@@ -29,6 +29,7 @@ Reports:
   MITRE ATT&CK:
     - TA0002:T1203
 Severity: Info
+CreateAlert: false
 Description: >
   Monitors for potential exploit attempts agains CVE-2021-44228, Log4J remote code execution
 Reference: >

--- a/rules/push_security_rules/push_security_authorized_idp_login.yml
+++ b/rules/push_security_rules/push_security_authorized_idp_login.yml
@@ -3,18 +3,16 @@ Filename: push_security_authorized_idp_login.py
 RuleID: "Push.Security.Authorized.IdP.Login"
 DisplayName: "Push Security Authorized IdP Login"
 Enabled: false
-CreateAlert: false
 LogTypes:
   - PushSecurity.Activity
 Tags:
   - Configuration Required
 Severity: Info
+CreateAlert: false
 Description: Login to application with unauthorized identity provider which could indicate a SAMLjacking attack.
 DedupPeriodMinutes: 60
 Threshold: 1
 Reference: https://github.com/pushsecurity/saas-attacks/blob/main/techniques/samljacking/description.md
-InlineFilters:
-  - All: []
 Tests:
   - Name: Google Workspace Password Login
     ExpectedResult: false

--- a/rules/push_security_rules/push_security_mfa_method_changed.yml
+++ b/rules/push_security_rules/push_security_mfa_method_changed.yml
@@ -6,6 +6,7 @@ Enabled: true
 LogTypes:
   - PushSecurity.Entities
 Severity: Info
+CreateAlert: false
 Description: MFA method on SaaS app changed
 DedupPeriodMinutes: 60
 Threshold: 1

--- a/rules/push_security_rules/push_security_new_app_detected.yml
+++ b/rules/push_security_rules/push_security_new_app_detected.yml
@@ -6,6 +6,7 @@ Enabled: true
 LogTypes:
   - PushSecurity.Entities
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 60
 Threshold: 1
 Tests:

--- a/rules/push_security_rules/push_security_new_saas_account_created.yml
+++ b/rules/push_security_rules/push_security_new_saas_account_created.yml
@@ -6,6 +6,7 @@ Enabled: true
 LogTypes:
   - PushSecurity.Entities
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 60
 Threshold: 1
 Tests:

--- a/rules/push_security_rules/push_security_open_security_finding.yml
+++ b/rules/push_security_rules/push_security_open_security_finding.yml
@@ -6,6 +6,7 @@ Enabled: true
 LogTypes:
   - PushSecurity.Entities
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 60
 Threshold: 1
 Tests:

--- a/rules/push_security_rules/push_security_phishable_mfa_method.yml
+++ b/rules/push_security_rules/push_security_phishable_mfa_method.yml
@@ -6,6 +6,7 @@ Enabled: true
 LogTypes:
   - PushSecurity.Entities
 Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 60
 Threshold: 1
 Tests:

--- a/rules/salesforce_rules/salesforce_admin_login_as_user.yml
+++ b/rules/salesforce_rules/salesforce_admin_login_as_user.yml
@@ -6,6 +6,7 @@ Filename: salesforce_admin_login_as_user.py
 Runbook: "Please do an indicator search on USER_ID to find which user was assumed. "
 Reference: https://help.salesforce.com/s/articleView?id=sf.logging_in_as_another_user.htm&type=5
 Severity: Info
+CreateAlert: false
 Tests:
   - ExpectedResult: false
     Log:

--- a/rules/standard_rules/brute_force_by_ip.yml
+++ b/rules/standard_rules/brute_force_by_ip.yml
@@ -14,6 +14,7 @@ LogTypes:
   - OneLogin.Events
   - OnePassword.SignInAttempt
 Severity: Info
+CreateAlert: false
 Tags:
   - DataModel
   - Credential Access:Brute Force

--- a/rules/tines_rules/tines_story_items_destruction.yml
+++ b/rules/tines_rules/tines_story_items_destruction.yml
@@ -8,6 +8,7 @@ LogTypes:
 Tags:
   - Tines
 Severity: Info
+CreateAlert: false
 Description: "A user has destroyed a story item"
 Runbook: "Possible data destruction. Please reach out to the user and confirm this was done for valid business reasons."
 Reference: https://www.tines.com/docs/stories

--- a/rules/zendesk_rules/zendesk_user_role.yml
+++ b/rules/zendesk_rules/zendesk_user_role.yml
@@ -7,6 +7,7 @@ Enabled: true
 LogTypes:
   - Zendesk.Audit
 Severity: Info
+CreateAlert: false
 Description: A user's Zendesk role was changed
 Reference: https://support.zendesk.com/hc/en-us/articles/4408824375450-Setting-roles-and-access-in-Zendesk-Admin-Center
 SummaryAttributes:


### PR DESCRIPTION
### Background

Info severity alerts are auto-closed and primarily used as signal generators for correlation rules.  This change stores matches in the Signals table for correlations, while keeping them off the alert interface.

### Changes

- Set CreateAlert: false for Info severity rules

### Testing

- pat test
