### PR TITLE
Info Alerts are Signals, Nonrouted

### DIFF
--- a/rules/auth0_rules/auth0_user_invitation_created.yml
+++ b/rules/auth0_rules/auth0_user_invitation_created.yml
@@ -4,6 +4,7 @@ Enabled: true
 Filename: auth0_user_invitation_created.py
 Reference: https://auth0.com/docs/manage-users/organizations/configure-organizations/invite-members
 Severity: Info
+CreateAlert: false
 Tests:
   - ExpectedResult: true
     Log:

--- a/rules/auth0_rules/auth0_user_joined_tenant.yml
+++ b/rules/auth0_rules/auth0_user_joined_tenant.yml
@@ -6,6 +6,7 @@ Filename: auth0_user_joined_tenant.py
 RuleID: Auth0.User.Joined.Tenant
 Reference: https://auth0.com/docs/manage-users/organizations/configure-organizations/invite-members#send-membership-invitations:~:text=.-,Send%20membership%20invitations,-You%20can
 Severity: Info
+CreateAlert: false
 LogTypes:
   - Auth0.Events
 Tests:

--- a/rules/aws_cloudtrail_rules/aws_ecr_crud.yml
+++ b/rules/aws_cloudtrail_rules/aws_ecr_crud.yml
@@ -14,7 +14,8 @@ Reports:
     - 3.12
   MITRE ATT&CK:
     - TA0005:T1525
-Severity: High
+Severity: Info
+CreateAlert: false
 Description: Unauthorized ECR Create, Read, Update, or Delete event occurred.
 Runbook: https://docs.aws.amazon.com/AmazonECR/latest/userguide/logging-using-cloudtrail.html
 Reference: https://docs.aws.amazon.com/AmazonECR/latest/userguide/security-iam.html#security_iam_authentication

--- a/rules/aws_cloudtrail_rules/aws_ecr_events.yml
+++ b/rules/aws_cloudtrail_rules/aws_ecr_events.yml
@@ -12,7 +12,8 @@ Tags:
 Reports:
   MITRE ATT&CK:
     - TA0005:T1535
-Severity: Medium
+Severity: Info
+CreateAlert: false
 Description: An ECR event occurred outside of an expected account or region
 Runbook: https://docs.aws.amazon.com/AmazonECR/latest/userguide/logging-using-cloudtrail.html
 Reference: https://aws.amazon.com/blogs/containers/amazon-ecr-in-multi-account-and-multi-region-architectures/

--- a/rules/aws_cloudtrail_rules/aws_iam_group_read_only_events.yml
+++ b/rules/aws_cloudtrail_rules/aws_iam_group_read_only_events.yml
@@ -6,6 +6,7 @@ Filename: aws_iam_group_read_only_events.py
 Reference: https://attack.mitre.org/techniques/T1069/
 Runbook: Examine other activities done by this user to determine whether or not activity is suspicious.
 Severity: Info
+CreateAlert: false
 Tags:
   - AWS
   - Cloudtrail

--- a/rules/aws_cloudtrail_rules/aws_s3_activity_greynoise.yml
+++ b/rules/aws_cloudtrail_rules/aws_s3_activity_greynoise.yml
@@ -8,7 +8,8 @@ Reports:
   MITRE ATT&CK:
     - TA0009:T1530
 Runbook: Investigate all actions taken and validate that the ARN conducting the acitivty was not compromised
-Severity: High
+Severity: Info
+CreateAlert: false
 DedupPeriodMinutes: 60
 Threshold: 1
 SummaryAttributes:

--- a/rules/aws_cloudtrail_rules/aws_software_discovery.yml
+++ b/rules/aws_cloudtrail_rules/aws_software_discovery.yml
@@ -10,6 +10,7 @@ Reports:
   MITRE ATT&CK:
     - TA0007:T1518
 Severity: Info
+CreateAlert: false
 Tests:
   - ExpectedResult: true
     Log:
@@ -22,20 +23,20 @@ Tests:
       eventVersion: "1.08"
       managementEvent: true
       p_any_aws_account_ids:
-        - "853509373758"
+        - "123456789012"
       p_any_aws_arns:
-        - arn:aws:iam::853509373758:role/PantherAuditRole-us-east-2
-        - arn:aws:sts::853509373758:assumed-role/PantherAuditRole-us-east-2/1634605518650090138
+        - arn:aws:iam::123456789012:role/ExampleRole-us-east-2
+        - arn:aws:sts::123456789012:assumed-role/ExampleRole-us-east-2/153151351351351
       p_any_ip_addresses:
-        - 3.16.40.237
+        - 12.34.56.78
       p_event_time: "2021-10-19 01:06:59"
       p_log_type: AWS.CloudTrail
       p_parse_time: "2021-10-19 01:11:10.412"
       p_row_id: eabaceda7842c2b2e7a398f40cc150
       p_source_id: 5f9f0f60-9c56-4027-b93a-8bab3019f0f1
-      p_source_label: Hosted - Cloudtrail - KoS
+      p_source_label: Hosted - Cloudtrail - XYZ
       readOnly: true
-      recipientAccountId: "853509373758"
+      recipientAccountId: "123456789012"
       requestID: 43efad11-bb40-43df-ad25-c8e7f0bfdc7a
       requestParameters:
         filterSet: {}
@@ -43,23 +44,23 @@ Tests:
           items:
             - groupId: sg-01e29ae063f5f63a0
         securityGroupSet: {}
-      sourceIPAddress: 3.16.40.237
+      sourceIPAddress: 12.34.56.78
       userAgent: aws-sdk-go/1.40.21 (go1.17; linux; amd64) exec-env/AWS_Lambda_go1.x
       userIdentity:
-        accessKeyId: ASIA4NOI7P47DJPFAXF2
-        accountId: "853509373758"
-        arn: arn:aws:sts::853509373758:assumed-role/PantherAuditRole-us-east-2/1634605518650090138
-        principalId: AROA4NOI7P47OHH3NQORX:1634605518650090138
+        accessKeyId: ASIA153151351351351
+        accountId: "123456789012"
+        arn: arn:aws:sts::123456789012:assumed-role/ExampleRole-us-east-2/153151351351351
+        principalId: AROA4NOI7P47OHH3NQORX:153151351351351
         sessionContext:
           attributes:
             creationDate: "2021-10-19T01:05:18Z"
             mfaAuthenticated: "false"
           sessionIssuer:
-            accountId: "853509373758"
-            arn: arn:aws:iam::853509373758:role/PantherAuditRole-us-east-2
-            principalId: AROA4NOI7P47OHH3NQORX
+            accountId: "123456789012"
+            arn: arn:aws:iam::123456789012:role/ExampleRole-us-east-2
+            principalId: AROA153151351351351
             type: Role
-            userName: PantherAuditRole-us-east-2
+            userName: ExampleRole-us-east-2
           webIdFederationData: {}
         type: AssumedRole
     Name: Discovery Event Names

--- a/rules/box_rules/box_new_login.yml
+++ b/rules/box_rules/box_new_login.yml
@@ -12,6 +12,7 @@ Reports:
   MITRE ATT&CK:
     - TA0001:T1078
 Severity: Info
+CreateAlert: false
 Description: >
   A user logged in from a new device.
 Reference: https://support.box.com/hc/en-us/articles/360043691914-Controlling-Devices-Used-to-Access-Box

--- a/rules/box_rules/box_untrusted_device.yml
+++ b/rules/box_rules/box_untrusted_device.yml
@@ -12,6 +12,7 @@ Reports:
   MITRE ATT&CK:
     - TA0001:T1078
 Severity: Info
+CreateAlert: false
 Description: >
   A user attempted to login from an untrusted device.
 Reference: https://support.box.com/hc/en-us/articles/360044194993-Setting-Up-Device-Trust-Security-Requirements

--- a/rules/cloudflare_rules/cloudflare_firewall_high_volume_events_blocked_greynoise.yml
+++ b/rules/cloudflare_rules/cloudflare_firewall_high_volume_events_blocked_greynoise.yml
@@ -10,6 +10,7 @@ Tags:
   - GreyNoise
   - Deprecated
 Severity: Info
+CreateAlert: false
 Description: Monitors high volume events blocked from the same IP enriched with GreyNoise
 Runbook: Inspect and monitor internet-facing services for potential outages
 Reference: https://docs.greynoise.io/docs/understanding-greynoise-enrichments

--- a/rules/gcp_audit_rules/gcp_logging_sink_modified.yml
+++ b/rules/gcp_audit_rules/gcp_logging_sink_modified.yml
@@ -6,6 +6,7 @@ Enabled: true
 Filename: gcp_logging_sink_modified.py
 RuleID: "GCP.Logging.Sink.Modified"
 Severity: Info
+CreateAlert: false
 LogTypes:
   - GCP.AuditLog
 Tags:

--- a/rules/microsoft_rules/microsoft_graph_passthrough.py
+++ b/rules/microsoft_rules/microsoft_graph_passthrough.py
@@ -2,7 +2,9 @@ from panther_base_helpers import msft_graph_alert_context
 
 
 def rule(event):
-    return event.get("status") == "newAlert"
+    return (
+        event.get("status") == "newAlert" and event.get("severity", "").lower() != "informational"
+    )
 
 
 def title(event):

--- a/rules/okta_rules/okta_geo_improbable_access.yml
+++ b/rules/okta_rules/okta_geo_improbable_access.yml
@@ -12,7 +12,8 @@ Tags:
 Reports:
   MITRE ATT&CK:
     - TA0001:T1078
-Severity: High
+Severity: Info
+CreateAlert: false
 Description: A user has subsequent logins from two geographic locations that are very far apart
 Runbook: Reach out to the user if needed to validate the activity, then lock the account
 Reference: https://www.blinkops.com/blog/how-to-detect-and-remediate-okta-impossible-traveler-alerts


### PR DESCRIPTION
### Background

Related to #1327 , limited to info rules which are not currently being routed to alert destinations.

Info severity alerts are auto-closed and primarily used as signal generators for correlation rules.  This change stores matches in the Signals table for correlations, while keeping them off the alert interface.

### Changes

- Set CreateAlert: false for Info severity rules which are not currently being routed to alert destinations.

### Testing

- pat test
