### PR TITLE
Add Dynamic Severity to AWS.CloudTrail.SnapshotMadePublic

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_snapshot_made_public.yml
+++ b/rules/aws_cloudtrail_rules/aws_snapshot_made_public.yml
@@ -5,21 +5,22 @@ DisplayName: "AWS Snapshot Made Public"
 Enabled: true
 LogTypes:
   - AWS.CloudTrail
-Tags:
-  - AWS
-  - Exfiltration:Transfer Data to Cloud Account
+Severity: Medium
 Reports:
   MITRE ATT&CK:
     - TA0010:T1537
-Severity: Medium
 Description: An AWS storage snapshot was made public.
+Reference: 
+  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-modifying-snapshot-permissions.html
 Runbook: Adjust the snapshot configuration so that it is no longer public.
-Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-modifying-snapshot-permissions.html
 SummaryAttributes:
   - userAgent
   - sourceIpAddress
   - recipientAccountId
   - p_any_aws_arns
+Tags:
+  - AWS
+  - Exfiltration:Transfer Data to Cloud Account
 Tests:
   - Name: Snapshot Made Publicly Accessible
     ExpectedResult: true
@@ -34,41 +35,46 @@ Tests:
         "eventVersion": "1.05",
         "recipientAccountId": "123456789012",
         "requestID": "1111",
-        "requestParameters":
-          {
-            "attributeType": "CREATE_VOLUME_PERMISSION",
-            "createVolumePermission":
-              { "add": { "items": [{ "group": "all" }] } },
-            "snapshotId": "snap-1111",
+        "requestParameters": {
+          "attributeType": "CREATE_VOLUME_PERMISSION",
+          "createVolumePermission": {
+            "add": {
+              "items": [
+                {
+                  "group": "all"
+                }
+              ]
+            }
           },
-        "responseElements": { "_return": true, "requestId": "1111" },
+          "snapshotId": "snap-1111"
+        },
+        "responseElements": {
+          "_return": true,
+          "requestId": "1111"
+        },
         "sourceIPAddress": "111.111.111.111",
         "userAgent": "Mozilla/2.0 (compatible; NEWT ActiveX; Win32)",
-        "userIdentity":
-          {
-            "accessKeyId": "1111",
-            "accountId": "123456789012",
-            "arn": "arn:aws:sts::123456789012:assumed-role/example-role/example-user",
-            "principalId": "1111",
-            "sessionContext":
-              {
-                "attributes":
-                  {
-                    "creationDate": "2019-01-01T00:00:00Z",
-                    "mfaAuthenticated": "true",
-                  },
-                "sessionIssuer":
-                  {
-                    "accountId": "123456789012",
-                    "arn": "arn:aws:iam::123456789012:role/example-role",
-                    "principalId": "1111",
-                    "type": "Role",
-                    "userName": "example-role",
-                  },
-                "webIdFederationData": {},
-              },
-            "type": "AssumedRole",
+        "userIdentity": {
+          "accessKeyId": "1111",
+          "accountId": "123456789012",
+          "arn": "arn:aws:sts::123456789012:assumed-role/example-role/example-user",
+          "principalId": "1111",
+          "sessionContext": {
+            "attributes": {
+              "creationDate": "2019-01-01T00:00:00Z",
+              "mfaAuthenticated": "true"
+            },
+            "sessionIssuer": {
+              "accountId": "123456789012",
+              "arn": "arn:aws:iam::123456789012:role/example-role",
+              "principalId": "1111",
+              "type": "Role",
+              "userName": "example-role"
+            },
+            "webIdFederationData": {}
           },
+          "type": "AssumedRole"
+        }
       }
   - Name: Snapshot Not Made Publicly Accessible
     ExpectedResult: false
@@ -83,41 +89,46 @@ Tests:
         "eventVersion": "1.05",
         "recipientAccountId": "123456789012",
         "requestID": "1111",
-        "requestParameters":
-          {
-            "attributeType": "CREATE_VOLUME_PERMISSION",
-            "createVolumePermission":
-              { "add": { "items": [{ "group": "none" }] } },
-            "snapshotId": "snap-1111",
+        "requestParameters": {
+          "attributeType": "CREATE_VOLUME_PERMISSION",
+          "createVolumePermission": {
+            "add": {
+              "items": [
+                {
+                  "group": "none"
+                }
+              ]
+            }
           },
-        "responseElements": { "_return": true, "requestId": "1111" },
+          "snapshotId": "snap-1111"
+        },
+        "responseElements": {
+          "_return": true,
+          "requestId": "1111"
+        },
         "sourceIPAddress": "111.111.111.111",
         "userAgent": "Mozilla/2.0 (compatible; NEWT ActiveX; Win32)",
-        "userIdentity":
-          {
-            "accessKeyId": "1111",
-            "accountId": "123456789012",
-            "arn": "arn:aws:sts::123456789012:assumed-role/example-role/example-user",
-            "principalId": "1111",
-            "sessionContext":
-              {
-                "attributes":
-                  {
-                    "creationDate": "2019-01-01T00:00:00Z",
-                    "mfaAuthenticated": "true",
-                  },
-                "sessionIssuer":
-                  {
-                    "accountId": "123456789012",
-                    "arn": "arn:aws:iam::123456789012:role/example-role",
-                    "principalId": "1111",
-                    "type": "Role",
-                    "userName": "example-role",
-                  },
-                "webIdFederationData": {},
-              },
-            "type": "AssumedRole",
+        "userIdentity": {
+          "accessKeyId": "1111",
+          "accountId": "123456789012",
+          "arn": "arn:aws:sts::123456789012:assumed-role/example-role/example-user",
+          "principalId": "1111",
+          "sessionContext": {
+            "attributes": {
+              "creationDate": "2019-01-01T00:00:00Z",
+              "mfaAuthenticated": "true"
+            },
+            "sessionIssuer": {
+              "accountId": "123456789012",
+              "arn": "arn:aws:iam::123456789012:role/example-role",
+              "principalId": "1111",
+              "type": "Role",
+              "userName": "example-role"
+            },
+            "webIdFederationData": {}
           },
+          "type": "AssumedRole"
+        }
       }
   - Name: Error Making Snapshot Publicly Accessible
     ExpectedResult: false
@@ -133,39 +144,98 @@ Tests:
         "eventVersion": "1.05",
         "recipientAccountId": "123456789012",
         "requestID": "1111",
-        "requestParameters":
-          {
-            "attributeType": "CREATE_VOLUME_PERMISSION",
-            "createVolumePermission":
-              { "add": { "items": [{ "group": "all" }] } },
-            "snapshotId": "snap-1111",
+        "requestParameters": {
+          "attributeType": "CREATE_VOLUME_PERMISSION",
+          "createVolumePermission": {
+            "add": {
+              "items": [
+                {
+                  "group": "all"
+                }
+              ]
+            }
           },
-        "responseElements": { "_return": true, "requestId": "1111" },
+          "snapshotId": "snap-1111"
+        },
+        "responseElements": {
+          "_return": true,
+          "requestId": "1111"
+        },
         "sourceIPAddress": "111.111.111.111",
         "userAgent": "Mozilla/2.0 (compatible; NEWT ActiveX; Win32)",
-        "userIdentity":
-          {
-            "accessKeyId": "1111",
-            "accountId": "123456789012",
-            "arn": "arn:aws:sts::123456789012:assumed-role/example-role/example-user",
-            "principalId": "1111",
-            "sessionContext":
-              {
-                "attributes":
-                  {
-                    "creationDate": "2019-01-01T00:00:00Z",
-                    "mfaAuthenticated": "true",
-                  },
-                "sessionIssuer":
-                  {
-                    "accountId": "123456789012",
-                    "arn": "arn:aws:iam::123456789012:role/example-role",
-                    "principalId": "1111",
-                    "type": "Role",
-                    "userName": "example-role",
-                  },
-                "webIdFederationData": {},
-              },
-            "type": "AssumedRole",
+        "userIdentity": {
+          "accessKeyId": "1111",
+          "accountId": "123456789012",
+          "arn": "arn:aws:sts::123456789012:assumed-role/example-role/example-user",
+          "principalId": "1111",
+          "sessionContext": {
+            "attributes": {
+              "creationDate": "2019-01-01T00:00:00Z",
+              "mfaAuthenticated": "true"
+            },
+            "sessionIssuer": {
+              "accountId": "123456789012",
+              "arn": "arn:aws:iam::123456789012:role/example-role",
+              "principalId": "1111",
+              "type": "Role",
+              "userName": "example-role"
+            },
+            "webIdFederationData": {}
           },
+          "type": "AssumedRole"
+        }
+      }
+  - Name: Snapshot Mader Available to Single Person
+    ExpectedResult: true
+    Log:
+      {
+        "awsRegion": "us-west-2",
+        "eventID": "1111",
+        "eventName": "ModifySnapshotAttribute",
+        "eventSource": "ec2.amazonaws.com",
+        "eventTime": "2019-01-01T00:00:00Z",
+        "eventType": "AwsApiCall",
+        "eventVersion": "1.05",
+        "recipientAccountId": "123456789012",
+        "requestID": "1111",
+        "requestParameters": {
+          "attributeType": "CREATE_VOLUME_PERMISSION",
+          "createVolumePermission": {
+            "add": {
+              "items": [
+                {
+                  "userId": "111122223333"
+                }
+              ]
+            }
+          },
+          "snapshotId": "snap-1111"
+        },
+        "responseElements": {
+          "_return": true,
+          "requestId": "1111"
+        },
+        "sourceIPAddress": "111.111.111.111",
+        "userAgent": "Mozilla/2.0 (compatible; NEWT ActiveX; Win32)",
+        "userIdentity": {
+          "accessKeyId": "1111",
+          "accountId": "123456789012",
+          "arn": "arn:aws:sts::123456789012:assumed-role/example-role/example-user",
+          "principalId": "1111",
+          "sessionContext": {
+            "attributes": {
+              "creationDate": "2019-01-01T00:00:00Z",
+              "mfaAuthenticated": "true"
+            },
+            "sessionIssuer": {
+              "accountId": "123456789012",
+              "arn": "arn:aws:iam::123456789012:role/example-role",
+              "principalId": "1111",
+              "type": "Role",
+              "userName": "example-role"
+            },
+            "webIdFederationData": {}
+          },
+          "type": "AssumedRole"
+        }
       }


### PR DESCRIPTION
### Background

Customers have complained that a significant number of alerts from `AWS.CloudTrail.SnapshotMadePublic` are due to a Snapshot being shared with an individual user. Some would argue that "sharing with a single user" and "made public to all users" are 2 different actions entirely. This PR alters the rule to still track individual shares for reference, but only alert if a snapshot is truly made public.

### Changes

- Added a dynamic severity function to `AWS.CloudTrail.SnapshotMadePublic`, which returns `INFO` if the snapshot has only been shared with a single person, as opposed to a group.

### Testing

- Added a new unit test for a single-user share, and confirmed the alert is generated at INFO severity.
