### PR TITLE
Fix Unit Tests Failing in Pypanther

### DIFF
--- a/global_helpers/crowdstrike_event_streams_helpers.py
+++ b/global_helpers/crowdstrike_event_streams_helpers.py
@@ -14,6 +14,9 @@ def audit_keys_dict(event):
 def str_to_list(liststr: str) -> list[str]:
     """Several crowdstrike values are returned as a list like "[x y z]". This function convetrs
     such entries to Python list of strings, like: ["x", "y", "z"]."""
+    # Return empty list for empty string
+    if not liststr:
+        return []
     # Validate
     if liststr[0] != "[" or liststr[-1] != "]":
         raise ValueError(f"Invalid list string: {liststr}")

--- a/rules/crowdstrike_rules/event_stream_rules/crowdstrike_ip_allowlist_changed.py
+++ b/rules/crowdstrike_rules/event_stream_rules/crowdstrike_ip_allowlist_changed.py
@@ -56,10 +56,6 @@ def alert_context(event):
         case "CreateAllowlistGroup":
             added_cidrs = str_to_list(audit_keys.get("cidrs", []))
             added_contexts = str_to_list(audit_keys.get("contexts", []))
-        case _:
-            # Raise error if there's another operationname
-            #   This is in case we update the rule logic but forget to update this logic too
-            raise ValueError(f"Unepected Operation Name: {op_name}")
 
     context.update(
         {

--- a/rules/crowdstrike_rules/event_stream_rules/crowdstrike_single_ip_allowlisted.py
+++ b/rules/crowdstrike_rules/event_stream_rules/crowdstrike_single_ip_allowlisted.py
@@ -41,8 +41,10 @@ def title(event):
 
     # contexts_str: one of API, UI, or API & UI
     #   Also a more general case: API, UI, and XX (for if they add extra contexts in the future)
-    contexts = str_to_list(audit_keys_dict(event)["contexts"])
-    if len(contexts) == 1:
+    contexts = str_to_list(audit_keys_dict(event).get("contexts", ""))
+    if len(contexts) == 0:
+        contexts_str = "no contexts"
+    elif len(contexts) == 1:
         contexts_str = contexts[0]
     else:
         contexts_str = ", ".join(contexts[:-1]) + " & " + contexts[-1]


### PR DESCRIPTION
### Background

`pypanther`'s testing suite always runs the auxiliiary functions (`title`, `dedup`, `alert_context`, etc.) regardless of whether the unit test is expected to return True or False. This is different from PAT's behaviour, where those functions only run when the unit test has `ExpectedResult=True`. Due to this expectation, some rules have auxilliary functions designed in a way where they don't execute properly for all test logs. This PR addresses the problem with 2 of our rules.

### Changes

- Added logic to 2 rules to ensure they don't raise exceptions when processing log events for all tests

### Testing

- Confirmed that ALL tests pass when using both PAT and `pypanther`
