### PR TITLE
AWS SAML Activity Tuning

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_saml_activity.py
+++ b/rules/aws_cloudtrail_rules/aws_saml_activity.py
@@ -9,6 +9,9 @@ def rule(event):
         ":assumed-role/AWSServiceRoleForSSO/AWS-SSO"
     ):
         return False
+    # Don't alert on errors such as EntityAlreadyExistsException and NoSuchEntity
+    if event.get("errorCode"):
+        return False
     return (
         event.get("eventSource") == "iam.amazonaws.com" and event.get("eventName") in SAML_ACTIONS
     )


### PR DESCRIPTION
### Background

Automated tools can attempt to delete SAML providers multiple times, causing false positives.

### Changes

- Only alert when no errorCode is present in the log

### Testing

- pat test
