### PR TITLE
Update Pack Manifests with Data Models and Globals

### DIFF
--- a/packs/asana.yml
+++ b/packs/asana.yml
@@ -20,4 +20,6 @@ PackDefinition:
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
+    # Data Model
+    - Standard.Asana.Audit
 DisplayName: "Panther Asana Pack"

--- a/packs/asana.yml
+++ b/packs/asana.yml
@@ -20,6 +20,7 @@ PackDefinition:
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
+    - panther_event_type_helpers
     # Data Model
     - Standard.Asana.Audit
 DisplayName: "Panther Asana Pack"

--- a/packs/atlassian.yml
+++ b/packs/atlassian.yml
@@ -9,6 +9,7 @@ PackDefinition:
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
+    - panther_event_type_helpers
     # Data Model
     - Standard.Atlassian.Audit
 DisplayName: "Panther Atlassian Pack"

--- a/packs/atlassian.yml
+++ b/packs/atlassian.yml
@@ -9,4 +9,6 @@ PackDefinition:
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
+    # Data Model
+    - Standard.Atlassian.Audit
 DisplayName: "Panther Atlassian Pack"

--- a/packs/aws.yml
+++ b/packs/aws.yml
@@ -177,7 +177,9 @@ PackDefinition:
     # AWS DataModels
     - Standard.AWS.ALB
     - Standard.AWS.CloudTrail
+    - Standard.Amazon.EKS.Audit
     - Standard.AWS.S3ServerAccess
+    - Standard.AWS.VPCDns
     - Standard.AWS.VPCFlow
     - Standard.OCSF.NetworkActivity
     - Standard.OCSF.DnsActivity

--- a/packs/azure_signin.yml
+++ b/packs/azure_signin.yml
@@ -13,4 +13,6 @@ PackDefinition:
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
+    # Data Models
+    - Standard.Azure.Audit.SignIn
 DisplayName: "Panther Azure.Audit SignIn Pack"

--- a/packs/azure_signin.yml
+++ b/packs/azure_signin.yml
@@ -13,6 +13,7 @@ PackDefinition:
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
+    - panther_event_type_helpers
     # Data Models
     - Standard.Azure.Audit.SignIn
 DisplayName: "Panther Azure.Audit SignIn Pack"

--- a/packs/box.yml
+++ b/packs/box.yml
@@ -18,6 +18,7 @@ PackDefinition:
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
+    - panther_event_type_helpers
     # Data Models
     - Standard.Box.Event
 DisplayName: "Panther Box Pack"

--- a/packs/box.yml
+++ b/packs/box.yml
@@ -18,4 +18,6 @@ PackDefinition:
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
+    # Data Models
+    - Standard.Box.Event
 DisplayName: "Panther Box Pack"

--- a/packs/cisco_umbrella_dns.yml
+++ b/packs/cisco_umbrella_dns.yml
@@ -4,5 +4,6 @@ Description: Group of all Cisco Umbrella detections
 PackDefinition:
   IDs:
     - CiscoUmbrella.DNS.Blocked
-    # Globals used in these detections
+    # Data Model
+    - Standard.CiscoUmbrella.DNS
 DisplayName: "Panther Cisco Umbrella Pack"

--- a/packs/cloudflare.yml
+++ b/packs/cloudflare.yml
@@ -14,3 +14,6 @@ PackDefinition:
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
+    # Data Models
+    - Standard.Cloudflare.Firewall
+    - Standard.Cloudflare.HttpReq

--- a/packs/credential_security.yml
+++ b/packs/credential_security.yml
@@ -5,10 +5,16 @@ DisplayName: "Panther Credential Security Pack"
 PackDefinition:
   IDs:
     # Data Models
+    - Standard.Asana.Audit
     - Standard.Atlassian.Audit
+    - Standard.AWS.CloudTrail
+    - Standard.Crowdstrike.FDR
     - Standard.Github.Audit
     - Standard.Okta.SystemLog
+    - Standard.OneLogin.Events
+    - Standard.Slack.AuditLogs
     - Standard.Zendesk.AuditLog
+    - Standard.Zoom.Operation
     # Global Helpers
     - global_filter_auth0
     - global_filter_github

--- a/packs/crowdstrike.yml
+++ b/packs/crowdstrike.yml
@@ -24,5 +24,7 @@ PackDefinition:
     - panther_config_defaults
     - panther_config_overrides
     # Data models
+    - Standard.AWS.VPCDns
+    - Standard.CiscoUmbrella.DNS
     - Standard.Crowdstrike.FDR
 DisplayName: "Panther Crowdstrike Pack"

--- a/packs/crowdstrike_event_streams.yml
+++ b/packs/crowdstrike_event_streams.yml
@@ -5,6 +5,9 @@ PackDefinition:
   IDs:
     - crowdstrike_event_streams_helpers
     - panther_base_helpers
+    - panther_config
+    - panther_config_defaults
+    - panther_config_overrides
     
     - Crowdstrike.AdminRoleAssigned
     - Crowdstrike.AllowlistRemoved

--- a/packs/gsuite_reports.yml
+++ b/packs/gsuite_reports.yml
@@ -39,4 +39,6 @@ PackDefinition:
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
+    - panther_event_type_helpers
+    - panther_lookuptable_helpers
 DisplayName: "Panther GSuite Pack"

--- a/packs/multisource_correlations.yml
+++ b/packs/multisource_correlations.yml
@@ -22,3 +22,10 @@ PackDefinition:
     - Standard.Okta.SystemLog
     - Standard.Github.Audit
     - Standard.AWS.CloudTrail
+  
+  # Global Helpers
+    - panther_base_helpers
+    - panther_config
+    - panther_config_defaults
+    - panther_config_overrides
+    - panther_event_type_helpers

--- a/packs/multisource_correlations.yml
+++ b/packs/multisource_correlations.yml
@@ -17,3 +17,8 @@ PackDefinition:
     - Push.Security.Authorized.IdP.Login
     - Okta.Login.Without.Push.Marker
     - Push.Security.Phishing.Attack
+
+  # Data Models
+    - Standard.Okta.SystemLog
+    - Standard.Github.Audit
+    - Standard.AWS.CloudTrail

--- a/packs/notion.yml
+++ b/packs/notion.yml
@@ -18,13 +18,16 @@ PackDefinition:
     - Notion.SharingSettingsUpdated
     - Notion.TeamspaceOwnerAdded
     # Globals used in these detections
-    - panther_base_helpers
-    - panther_oss_helpers
-    - panther_notion_helpers
     - global_filter_notion
+    - panther_base_helpers
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
+    - panther_event_type_helpers
+    - panther_ipinfo_helpers
+    - panther_lookuptable_helpers
+    - panther_notion_helpers
+    - panther_oss_helpers
     # Data Model
     - Standard.Notion.AuditLogs
 DisplayName: "Panther Notion Pack"

--- a/packs/onelogin.yml
+++ b/packs/onelogin.yml
@@ -20,4 +20,6 @@ PackDefinition:
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
+    # Data Model
+    - Standard.OneLogin.Events
 DisplayName: "Panther OneLogin Pack"

--- a/packs/onelogin.yml
+++ b/packs/onelogin.yml
@@ -20,6 +20,7 @@ PackDefinition:
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
+    - panther_event_type_helpers
     # Data Model
     - Standard.OneLogin.Events
 DisplayName: "Panther OneLogin Pack"

--- a/packs/slack.yml
+++ b/packs/slack.yml
@@ -32,3 +32,5 @@ PackDefinition:
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
+    # Data Model
+    - Standard.Slack.AuditLogs

--- a/packs/standard_ruleset.yml
+++ b/packs/standard_ruleset.yml
@@ -27,6 +27,12 @@ PackDefinition:
     - Standard.NewAWSAccountCreated
     - Standard.NewUserAccountCreated
     # Global Helpers
-    - panther_event_type_helpers
-    - panther_oss_helpers
+    - panther_base_helpers
     - panther_default
+    - panther_config
+    - panther_config_defaults
+    - panther_config_overrides
+    - panther_event_type_helpers
+    - panther_ipinfo_helpers
+    - panther_lookuptable_helpers
+    - panther_oss_helpers

--- a/packs/wiz.yml
+++ b/packs/wiz.yml
@@ -5,3 +5,7 @@ DisplayName: "Panther Wiz Pack"
 PackDefinition:
   IDs:
     - Wiz.Alert.Passthrough
+    - panther_base_helpers
+    - panther_config
+    - panther_config_defaults
+    - panther_config_overrides

--- a/packs/zoom.yml
+++ b/packs/zoom.yml
@@ -16,8 +16,9 @@ PackDefinition:
     - Standard.Zoom.Operation
     # Globals used in these detections
     - panther_base_helpers
-    - panther_oss_helpers
-    - panther_zoom_helpers
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
+    - panther_event_type_helpers
+    - panther_oss_helpers
+    - panther_zoom_helpers


### PR DESCRIPTION
### Background

Some of the detections used in packs are generic (i.e. they can be used for other log types, and the use data models to do so). In such cases, the unit tests will fail if the data models for those log types aren't present. Additionally, some packs were missing global helpers (either because a new rule was added, or because the top-level helper was included in the pack, but it's dependencies weren't.)

For CI/CD users, these changes are moot, since they always upload the full repo, but for Console users, this can lead to missing dependencies when enabling packs.

For more information, [see this ticket in #ask](https://panther-labs.slack.com/archives/C0719AH18SV/p1725391042439389?thread_ts=1722285039.363829&cid=C0719AH18SV).

### Changes

- If a rule in a pack can be used for a certain log type, the data model for that log type is added to the pack
- Added additional helpers as needed by each pack

### Testing

- Wrote a script to look for missing pack items, and spot checked the findings. Looked good!
