### PR TITLE
added get_actor_user method to data model

### DIFF
--- a/data_models/gcp_data_model.py
+++ b/data_models/gcp_data_model.py
@@ -112,3 +112,10 @@ def get_verb(event):
     if deep_get(event, "protoPayload", "serviceName", default="") != "k8s.io":
         return ""
     return deep_get(event, "protoPayload", "methodName", default="").split(".")[-1]
+
+
+def get_actor_user(event):
+    authentication_info = deep_get(event, "protoPayload", "authenticationInfo", default={})
+    if principal_email := authentication_info.get("principalEmail"):
+        return principal_email
+    return authentication_info.get("principalSubject", "<UNKNOWN ACTOR USER>")

--- a/data_models/gcp_data_model.yml
+++ b/data_models/gcp_data_model.yml
@@ -7,7 +7,7 @@ Filename: gcp_data_model.py
 Enabled: true
 Mappings:
   - Name: actor_user
-    Path: $.protoPayload.authenticationInfo.principalEmail
+    Method: get_actor_user
   - Name: assigned_admin_role
     Method: get_iam_roles
   - Name: event_type
@@ -35,7 +35,7 @@ Mappings:
   - Name: sourceIPs
     Method: get_source_ips
   - Name: username
-    Path: $.protoPayload.authenticationInfo.principalEmail
+    Method: get_actor_user
   - Name: userAgent
     Path: $.protoPayload.requestMetadata.callerSuppliedUserAgent
   - Name: verb

--- a/rules/gcp_audit_rules/gcp_iam_service_accounts_get_access_token_privilege_escalation.py
+++ b/rules/gcp_audit_rules/gcp_iam_service_accounts_get_access_token_privilege_escalation.py
@@ -17,9 +17,7 @@ def rule(event):
 
 
 def title(event):
-    actor = deep_get(
-        event, "protoPayload", "authenticationInfo", "principalEmail", default="<ACTOR_NOT_FOUND>"
-    )
+    actor = event.udm("actor_user")
     operation = deep_get(event, "protoPayload", "methodName", default="<OPERATION_NOT_FOUND>")
     project_id = deep_get(event, "resource", "labels", "project_id", default="<PROJECT_NOT_FOUND>")
 

--- a/rules/gcp_audit_rules/gcp_iam_service_accounts_get_access_token_privilege_escalation.yml
+++ b/rules/gcp_audit_rules/gcp_iam_service_accounts_get_access_token_privilege_escalation.yml
@@ -18,6 +18,7 @@ Tests:
     ExpectedResult: true
     Log:
       {
+        "p_log_type": "GCP.AuditLog",
         "protoPayload":
           {
             "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
@@ -72,6 +73,7 @@ Tests:
     ExpectedResult: false
     Log:
       {
+        "p_log_type": "GCP.AuditLog",
         "protoPayload":
           {
             "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
@@ -122,3 +124,67 @@ Tests:
         "logName": "projects/some-project/logs/cloudaudit.googleapis.com%2Fdata_access",
         "receiveTimestamp": "2024-02-26T17:15:17.100020459Z",
       }
+  - Name: Principal Subject Used
+    ExpectedResult: true
+    Log:
+      {
+        "p_log_type": "GCP.AuditLog",
+        "insertId": "1dy9ihte4iyjz",
+        "logName": "projects/mylogs/logs/cloudaudit.googleapis.com%2Fdata_access",
+        "operation": {
+          "first": true,
+          "id": "10172500524907939495",
+          "last": true,
+          "producer": "­iamcredentials.googleapis.com"
+        },
+        "protoPayload": {
+          "at_sign_type": "­type.googleapis.com/google.cloud.audit.AuditLog",
+          "authenticationInfo": {
+            "principalSubject": "example_principal_subject",
+            "serviceAccountDelegationInfo": [
+              {}
+            ]
+          },
+          "authorizationInfo": [
+            {
+              "granted": true,
+              "permission": "iam.serviceAccounts.getAccessToken",
+              "resourceAttributes": {}
+            }
+          ],
+          "metadata": {
+            "identityDelegationChain": [
+              "projects/-/serviceAccounts/xxxxx.iam.gserviceaccount.com"
+            ]
+          },
+          "methodName": "GenerateAccessToken",
+          "request": {
+            "@type": "­type.googleapis.com/google.iam.credentials.v1.GenerateAccessTokenRequest",
+            "name": "projects/-/serviceAccounts/xxxxx.iam.gserviceaccount.com"
+          },
+          "requestMetadata": {
+            "callerIP": "gce-internal-ip",
+            "callerSuppliedUserAgent": "google-api-go-client/0.5 gke-metadata-server,gzip(gfe)",
+            "destinationAttributes": {},
+            "requestAttributes": {
+              "auth": {},
+              "time": "2024-08-29T19:30:36.353462175Z"
+            }
+          },
+          "resourceName": "projects/-/serviceAccounts/11111222223333444455",
+          "serviceName": "­iamcredentials.googleapis.com",
+          "status": {}
+        },
+        "receiveTimestamp": "2024-08-29 19:30:36.424542070",
+        "resource": {
+          "labels": {
+            "email_id": "sample@email.com",
+            "project_id": "sample_project_id",
+            "unique_id": "11111222223333444455"
+          },
+          "type": "service_account"
+        },
+        "severity": "INFO",
+        "timestamp": "2024-08-29 19:30:36.339983306"
+      }
+


### PR DESCRIPTION
### Background
A customer was receiving alerts from the out-of-the-box (OOTB) detection `GCP IAM serviceAccounts getAccessToken Privilege Escalation`. The alert message included `[GCP]: [<ACTOR_NOT_FOUND>] performed [GenerateAccessToken] on project`, which indicated that Panther's data model did not recognize the actor correctly.

Upon investigation, we found that the issue arose because the GCP Audit schema in Panther was only mapping the `principalEmail` field as the `actor_user`, while for third-party identity callers, GCP populates the `principalSubject` field instead of `principalEmail`. This behavior is confirmed by the [GCP documentation](https://cloud.google.com/logging/docs/reference/audit/auditlog/rest/Shared.Types/AuditLog#authenticationinfo).

### Changes
- Added a method `get_actor_user` to use `principalSubject` for `actor_user` field when `principalEmail` is not present
- Applied the `get_actor_user` method to 'username' field since it was also mapping to `principalEmail` previously
- Modified alert title of `GCP IAM serviceAccounts getAccessToken Privilege Escalation` to use the `actor_user` udm field

### Testing
- `make lint`, `make test`
- added the unit test `Principal Subject Used`
