### PR TITLE
Remove Multi-Table Queries from Packs

### DIFF
--- a/packs/aws.yml
+++ b/packs/aws.yml
@@ -132,7 +132,6 @@ PackDefinition:
     - AWS.WAF.Disassociation
     - AWS.WAF.HasXSSPredicate
     # Other rules
-    - AWS.Authentication.From.CrowdStrike.Unmanaged.Device
     - AWS.CloudTrail.Account.Discovery
     - AWS.CloudTrail.CloudWatchLogs
     - AWS.CloudTrail.LogEncryption
@@ -174,7 +173,6 @@ PackDefinition:
     - AWS.CloudTrail.LoginProfileCreatedOrModified
     - AWS.Console.Login
     # Queries
-    - AWS Authentication from CrowdStrike Unmanaged Device
     - Query.CloudTrail.Password.Spraying
     - Query.VPC.DNS.Tunneling
     - VPC Flow Port Scanning

--- a/packs/okta.yml
+++ b/packs/okta.yml
@@ -25,7 +25,6 @@ PackDefinition:
     - Okta.Phishing.Attempt.Blocked.FastPass
     - Okta.User.MFA.Reset.Single
     - Okta.PasswordAccess
-    - Okta.Login.From.CrowdStrike.Unmanaged.Device
     - Okta.PotentiallyStolenSession
     - Okta.Support.Reset
     # Globals used in these detections
@@ -35,8 +34,6 @@ PackDefinition:
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
-    # Queries
-    - Okta Login From CrowdStrike Unmanaged Device
     # Data Model
     - Standard.Okta.SystemLog
 DisplayName: "Panther Okta Pack"

--- a/packs/onepassword.yml
+++ b/packs/onepassword.yml
@@ -8,12 +8,9 @@ PackDefinition:
     - Standard.OnePassword.SignInAttempt
     # 1Password Specific Rules
     - OnePassword.Unusual.Client
-    - OnePassword.Login.From.CrowdStrike.Unmanaged.Device
     # Supporting Global Helpers
     - panther_base_helpers
     - panther_event_type_helpers
     - panther_config
     - panther_config_defaults
     - panther_config_overrides
-    # Queries
-    - 1Password Login From CrowdStrike Unmanaged Device Query

--- a/queries/aws_queries/AWS_Authentication_from_CrowdStrike_Unmanaged_Device_FDREvent.yml
+++ b/queries/aws_queries/AWS_Authentication_from_CrowdStrike_Unmanaged_Device_FDREvent.yml
@@ -20,3 +20,5 @@ QueryName: "AWS Authentication from CrowdStrike Unmanaged Device (crowdstrike_fd
 Schedule:
   RateMinutes: 1440
   TimeoutMinutes: 3
+Tags:
+  - Multi-Table Query

--- a/queries/crowdstrike_queries/AWS_Authentication_from_CrowdStrike_Unmanaged_Device_Query.yml
+++ b/queries/crowdstrike_queries/AWS_Authentication_from_CrowdStrike_Unmanaged_Device_Query.yml
@@ -17,3 +17,5 @@ QueryName: "AWS Authentication from CrowdStrike Unmanaged Device"
 Schedule:
   RateMinutes: 60
   TimeoutMinutes: 3
+Tags:
+  - Multi-Table Query

--- a/queries/crowdstrike_queries/Okta_Login_From_CrowdStrike_Unmanaged_Device_Query.yml
+++ b/queries/crowdstrike_queries/Okta_Login_From_CrowdStrike_Unmanaged_Device_Query.yml
@@ -19,3 +19,5 @@ QueryName: "Okta Login From CrowdStrike Unmanaged Device"
 Schedule:
   RateMinutes: 60
   TimeoutMinutes: 1
+Tags:
+  - Multi-Table Query

--- a/queries/crowdstrike_queries/onepass_login_from_crowdstrike_unmanaged_device_query.yml
+++ b/queries/crowdstrike_queries/onepass_login_from_crowdstrike_unmanaged_device_query.yml
@@ -20,3 +20,5 @@ QueryName: "1Password Login From CrowdStrike Unmanaged Device Query"
 Schedule:
   RateMinutes: 60
   TimeoutMinutes: 1
+Tags:
+  - Multi-Table Query

--- a/queries/okta_queries/Okta_Login_From_CrowdStrike_Unmanaged_Device_FDREvent.yml
+++ b/queries/okta_queries/Okta_Login_From_CrowdStrike_Unmanaged_Device_FDREvent.yml
@@ -22,3 +22,5 @@ QueryName: "Okta Login From CrowdStrike Unmanaged Device (crowdstrike_fdrevent t
 Schedule:
   RateMinutes: 1440
   TimeoutMinutes: 1
+Tags:
+  - Multi-Table Query

--- a/queries/onepassword_queries/onepass_login_from_crowdstrike_unmanaged_device_FDREvent.yml
+++ b/queries/onepassword_queries/onepass_login_from_crowdstrike_unmanaged_device_FDREvent.yml
@@ -23,3 +23,5 @@ QueryName: "1Password Login From CrowdStrike Unmanaged Device Query (crowdstrike
 Schedule:
   RateMinutes: 1440
   TimeoutMinutes: 1
+Tags:
+  - Multi-Table Query


### PR DESCRIPTION
### Background

Some of the queries recently added to packs involve more than one table, which may result in the pack failing to update if the customer has not ingested the corresponding log types yet.

Typically, each pack contains items focusing a single log type (or family of log types). When a customer creates a log source for those log types and ingests data, the data lake tables for those log types are also created. In some queries (namely the "Unauthorized Crowdstrike Device" queries), 2 tables are referenced: a crowdstrike table, and whichever log table the pack utilizes. If the customer hasn't previously ingested crowdstrike logs, the crowdstrike table won't exist, and the query will fail to compile (leading to the pack failing to update).

The same issue can happen if we move these queries to the Crowdstrike pack - the other tables may or may not exist. For the time being, we'll remove these queries from any packs until we can determine the best way to package them.

[For more context, review this Slack thread.](https://panther-labs.slack.com/archives/C0719AH18SV/p1726176673272719?thread_ts=1725633540.527299&cid=C0719AH18SV)

### Changes

Removed any Crowdstrike Unregistered Device queries (and their rules) from any packs. The items still exist in the repo itself.

### Testing

- `make test`
- `pat check-packs` still failed, but not with any new unexpected errors
