### PR TITLE
Filter out Intelsat satellite network plane wifi from Impossible Travel

### DIFF
--- a/rules/standard_rules/impossible_travel_login.py
+++ b/rules/standard_rules/impossible_travel_login.py
@@ -28,13 +28,13 @@ def gen_key(event):
 
 def rule(event):
     # too-many-return-statements due to error checking
-    # pylint: disable=global-statement,too-many-return-statements,too-complex
+    # pylint: disable=global-statement,too-many-return-statements,too-complex,too-many-statements
     global EVENT_CITY_TRACKING
     global CACHE_KEY
     global IS_VPN
     global IS_PRIVATE_RELAY
     global IS_SATELLITE_NETWORK
-    
+
     EVENT_CITY_TRACKING = {}
     CACHE_KEY = ""
     IS_VPN = False
@@ -91,7 +91,7 @@ def rule(event):
                 deep_get(ipinfo_privacy, "service", default="") != "",
             ]
         )
-    # Some satellite networks used during plane travel don't always 
+    # Some satellite networks used during plane travel don't always
     #   register properly as VPN's, so we have a separate check here.
     IS_SATELLITE_NETWORK = is_satellite_network(src_ip_enrichments)
     if IS_VPN or IS_PRIVATE_RELAY or IS_SATELLITE_NETWORK:

--- a/rules/standard_rules/impossible_travel_login.yml
+++ b/rules/standard_rules/impossible_travel_login.yml
@@ -826,7 +826,7 @@ Tests:
         "version": "0",
       }
   - Name: Okta sign-in with history and impossible travel, no VPN, Intelsat ASN
-    ExpectedResult: false
+    ExpectedResult: true
     Mocks:
       - objectName: put_string_set
         returnValue: ""
@@ -913,7 +913,7 @@ Tests:
                     "relay": false,
                     "service": "",
                     "tor": false,
-                    "vpn": true,
+                    "vpn": false,
                   },
               },
           },

--- a/rules/standard_rules/impossible_travel_login.yml
+++ b/rules/standard_rules/impossible_travel_login.yml
@@ -825,3 +825,107 @@ Tests:
         "uuid": "79999999-ffff-eeee-bbbb-222222222222",
         "version": "0",
       }
+  - Name: Okta sign-in with history and impossible travel, no VPN, Intelsat ASN
+    ExpectedResult: false
+    Mocks:
+      - objectName: put_string_set
+        returnValue: ""
+      - objectName: get_string_set
+        returnValue: >-
+          [
+           {
+            "p_event_time": "2023-05-26 18:14:51",
+            "city": "Los Angeles",
+            "country": "US",
+            "lat": "4.05223",
+            "lng": "-118.24368",
+            "postal_code": "90009",
+            "region": "California",
+            "region_code": "CA",
+            "timezone": "America/Los_Angeles"
+           }
+          ]
+    Log:
+      {
+        "actor":
+          {
+            "alternateId": "homer.simpson@company.com",
+            "displayName": "Homer Simpson",
+            "id": "00uwuwuwuwuwuwuwuwuw",
+            "type": "User",
+          },
+        "authenticationContext":
+          { "authenticationStep": 0, "externalSessionId": "idx1234" },
+        "client":
+          {
+            "device": "Computer",
+            "ipAddress": "164.86.38.26",
+            "userAgent":
+              {
+                "browser": "CHROME",
+                "os": "Mac OS X",
+                "rawUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36",
+              },
+            "zone": "null",
+          },
+        "debugContext": { "debugData": {} },
+        "device": {},
+        "displayMessage": "User login to Okta",
+        "eventType": "user.session.start",
+        "legacyEventType": "core.user_auth.login_success",
+        "outcome": { "result": "SUCCESS" },
+        "p_event_time": "2023-05-26 20:18:51",
+        "p_enrichment":
+          {
+            "ipinfo_asn":
+              {
+                "client.ipAddress":
+                  {
+                    "asn": "AS22351",
+                    "domain": "intelsat.com",
+                    "name": "INTELSAT GLOBAL SERVICE CORPORATION",
+                    "p_match": "164.86.38.26",
+                    "route": "164.86.38.0/23",
+                    "type": "isp",
+                  },
+              },
+            "ipinfo_location":
+              {
+                "client.ipAddress":
+                  {
+                    "city": "Tysons Corner",
+                    "country": "US",
+                    "lat": "38.953",
+                    "lng": "-77.2295",
+                    "p_match": "164.86.38.26",
+                    "postal_code": "22102",
+                    "region": "Virginia",
+                    "region_code": "VA",
+                    "timezone": "America/America/New_York",
+                  },
+              },
+            "ipinfo_privacy":
+              {
+                "client.ipAddress":
+                  {
+                    "hosting": false,
+                    "proxy": false,
+                    "relay": false,
+                    "service": "",
+                    "tor": false,
+                    "vpn": true,
+                  },
+              },
+          },
+        "p_log_type": "Okta.SystemLog",
+        "p_source_label": "Okta Logs",
+        "p_parse_time": "2023-05-26 20:22:51.888",
+        "published": "2023-05-26 20:18:51.888",
+        "request": { "ipChain": [] },
+        "securityContext": {},
+        "severity": "INFO",
+        "target": [],
+        "transaction": {},
+        "uuid": "79999999-ffff-eeee-bbbb-222222222222",
+        "version": "0",
+      }


### PR DESCRIPTION
### Background

[Intelsat](https://www.intelsat.com/) provides in-flight wifi for a number of airlines (American, Alaska, etc) among other mobile services but like any ASN provides geographic information for a fixed spot on the globe. This leads to false positives when persons using in-flight wifi have login activity shortly before or after a login from in-flight. An example:
- Login from LAX airport before boarding a flight at 17:00
- Login from Intelsat in-flight wifi at 17:30 tied to Tysons Landing, Virginia. 

### Changes

Adds a check on `ipinfo_asn` lookups and excludes Intelsat's ASN `AS22351` from triggering the rule or being included in `new_login_stats`. Any additional satellite network ASNs identified can be added to the `SATELLITE_NETWORK_ASNS `constant. 

### Testing

- New test for a true positive impossible travel event but from a IP in AS22351 results
- make lint
- pat test --filter RuleID=Standard.ImpossibleTravel.Login
