### PR TITLE
Add Unpacked Items to Packs

### DIFF
--- a/packs/auth0.yml
+++ b/packs/auth0.yml
@@ -3,6 +3,7 @@ PackID: PantherManaged.Auth0
 Description: Group of all Auth0 detections
 PackDefinition:
   IDs:
+    - Auth0.CIC.Credential.Stuffing
     - Auth0.Custom.Role.Created
     - Auth0.Integration.Installed
     - Auth0.MFA.Factor.Setting.Enabled

--- a/packs/aws.yml
+++ b/packs/aws.yml
@@ -73,6 +73,7 @@ PackDefinition:
     - AWS.PasswordPolicy.ComplexityGuidelines
     - AWS.PasswordPolicy.PasswordAgeLimit
     - AWS.PasswordPolicy.PasswordReuse
+    - AWS.Potentially.Stolen.Service.Role.Scheduled
     - AWS.Suspicious.SAML.Activity
     - AWS.User.Login.Profile.Modified
     # General Policies and Rules
@@ -165,6 +166,7 @@ PackDefinition:
     # Correlation Rules
     - AWS.Potentially.Stolen.Service.Role
     - AWS.Privilege.Escalation.Via.User.Compromise
+    - AWS.SSO.Access.Token.Retrieved.by.Unauthenticated.IP
     - AWS.User.Takeover.Via.Password.Reset
     # Signal Rules
     - Role.Assumed.by.AWS.Service
@@ -172,7 +174,10 @@ PackDefinition:
     - AWS.CloudTrail.UserAccessKeyAuth
     - AWS.CloudTrail.LoginProfileCreatedOrModified
     - AWS.Console.Login
+    - Retrieve.SSO.access.token
+    - Sign-in.with.AWS.CLI.prompt
     # Queries
+    - AWS Potentially Stolen Service Role
     - Query.CloudTrail.Password.Spraying
     - Query.VPC.DNS.Tunneling
     - VPC Flow Port Scanning

--- a/packs/gcp_audit.yml
+++ b/packs/gcp_audit.yml
@@ -27,7 +27,6 @@ PackDefinition:
     - GCP.iam.roles.update.Privilege.Escalation
     - GCP.iam.serviceAccountKeys.create
     - GCP.Inbound.SSO.Profile.Created
-    - GCP.K8s.New.Daemonset.Deployed
     - GCP.Log.Bucket.Or.Sink.Deleted
     - GCP.Logging.Settings.Modified
     - GCP.Logging.Sink.Modified

--- a/packs/gcp_k8.yml
+++ b/packs/gcp_k8.yml
@@ -7,6 +7,7 @@ PackDefinition:
     # DataModel
     - Standard.GCP.AuditLog
     # Rules
+    - GCP.K8s.New.Daemonset.Deployed
     - GCP.K8S.Pot.Create.Or.Modify.Host.Path.Volume.Mount
     - GCP.K8S.Privileged.Pod.Created
     - GCP.K8S.Service.Type.NodePort.Deployed

--- a/packs/gcp_k8.yml
+++ b/packs/gcp_k8.yml
@@ -1,0 +1,21 @@
+AnalysisType: pack
+PackID: PantherManaged.GCP.K8
+DisplayName: "Panther GCP Kubernetes Pack"
+Description: Group of all Google Cloud Platform (GCP) K8 detections
+PackDefinition:
+  IDs:
+    # DataModel
+    - Standard.GCP.AuditLog
+    # Rules
+    - GCP.K8S.Pot.Create.Or.Modify.Host.Path.Volume.Mount
+    - GCP.K8S.Privileged.Pod.Created
+    - GCP.K8S.Service.Type.NodePort.Deployed
+    - GCP.K8s.IOC.Activity
+    - GCP.K8s.Pod.Attached.To.Node.Host.Network
+    - GCP.K8s.Pod.Using.Host.PID.Namespace
+    # Globals
+    - gcp_base_helpers
+    - panther_base_helpers
+    - panther_config
+    - panther_config_defaults
+    - panther_config_overrides

--- a/packs/github.yml
+++ b/packs/github.yml
@@ -15,7 +15,6 @@ PackDefinition:
     - Github.Repo.Archived
     - Github.Repo.CollaboratorChange
     - Github.Repo.Created
-    #- GitHub.Repo.HookModified
     - GitHub.Repo.InitialAccess
     - Github.Repo.VisibilityChange
     - Github.Repo.VulnerabilityDismissed

--- a/packs/multisource_correlations.yml
+++ b/packs/multisource_correlations.yml
@@ -8,7 +8,9 @@ PackDefinition:
     - Secret.Exposed.and.not.Quarantined
     - GitHub.Secret.Scanning.Alert.Created
     - AWS.CloudTrail.IAMCompromisedKeyQuarantine
-    - global_filter_github
+    - Okta.SSO.to.AWS
+    - AWS.Console.Sign-In
+    - AWS.Console.Sign-In.NOT.PRECEDED.BY.Okta
 
   # Okta + Push Security
     - Okta.Login.Without.Push
@@ -24,6 +26,7 @@ PackDefinition:
     - Standard.AWS.CloudTrail
   
   # Global Helpers
+    - global_filter_github
     - panther_base_helpers
     - panther_config
     - panther_config_defaults

--- a/packs/snowflake.yml
+++ b/packs/snowflake.yml
@@ -18,7 +18,9 @@ PackDefinition:
     - Query.Snowflake.External.Shares
     - Query.Snowflake.FileDownloaded
     - Query.Snowflake.KeyUserPasswordLogin
+    - Query.Snowflake.MFALogin
     - Query.Snowflake.Multiple.Logins.Followed.By.Success
+    - Query.Snowflake.PublicRoleGrant
     - Query.Snowflake.SuspectedUserAccess
     - Query.Snowflake.TempStageCreated
     - Query.Snowflake.UserCreated
@@ -34,7 +36,9 @@ PackDefinition:
     - Snowflake.External.Shares
     - Snowflake.FileDownloaded
     - Snowflake.KeyUserPasswordLogin
+    - Snowflake.LoginWithoutMFA
     - Snowflake.Multiple.Failed.Logins.Followed.By.Success
+    - Snowflake.PublicRoleGrant
     - Snowflake.TempStageCreated
     - Snowflake.User.Access
     - Snowflake.UserCreated

--- a/queries/crowdstrike_queries/AWS_Authentication_from_CrowdStrike_Unmanaged_Device.yml
+++ b/queries/crowdstrike_queries/AWS_Authentication_from_CrowdStrike_Unmanaged_Device.yml
@@ -44,3 +44,5 @@ RuleID: "AWS.Authentication.From.CrowdStrike.Unmanaged.Device"
 Threshold: 1
 ScheduledQueries:
   - AWS Authentication from CrowdStrike Unmanaged Device
+Tags:
+  - Multi-Table Query

--- a/queries/crowdstrike_queries/Okta_Login_From_CrowdStrike_Unmanaged_Device.yml
+++ b/queries/crowdstrike_queries/Okta_Login_From_CrowdStrike_Unmanaged_Device.yml
@@ -162,3 +162,5 @@ RuleID: "Okta.Login.From.CrowdStrike.Unmanaged.Device"
 Threshold: 1
 ScheduledQueries:
   - Okta Login From CrowdStrike Unmanaged Device
+Tags:
+  - Multi-Table Query

--- a/queries/crowdstrike_queries/onepassword_login_from_crowdstrike_unmanaged_device.yml
+++ b/queries/crowdstrike_queries/onepassword_login_from_crowdstrike_unmanaged_device.yml
@@ -49,3 +49,5 @@ RuleID: "OnePassword.Login.From.CrowdStrike.Unmanaged.Device"
 Threshold: 1
 ScheduledQueries:
   - 1Password Login From CrowdStrike Unmanaged Device Query
+Tags:
+  - Multi-Table Query

--- a/queries/dropbox_queries/Dropbox_Many_Deletes.yml
+++ b/queries/dropbox_queries/Dropbox_Many_Deletes.yml
@@ -22,3 +22,5 @@ RuleID: "Dropbox.Many.Deletes"
 Threshold: 1
 ScheduledQueries:
   - Dropbox Many Deletes
+Tags:
+  - Configuration Required

--- a/queries/dropbox_queries/Dropbox_Many_Downloads.yml
+++ b/queries/dropbox_queries/Dropbox_Many_Downloads.yml
@@ -22,3 +22,5 @@ RuleID: "Dropbox.Many.Downloads"
 Threshold: 1
 ScheduledQueries:
   - Dropbox Many Downloads
+Tags:
+  - Configuration Required

--- a/rules/github_rules/github_repo_hook_modified.yml
+++ b/rules/github_rules/github_repo_hook_modified.yml
@@ -1,19 +1,20 @@
 AnalysisType: rule
 Filename: github_repo_hook_modified.py
 RuleID: "GitHub.Repo.HookModified"
-DisplayName: "GitHub Web Hook Modified"
+DisplayName: "DEPRECATED - GitHub Web Hook Modified"
 Enabled: false
 LogTypes:
   - GitHub.Audit
 Tags:
   - GitHub
   - Exfiltration:Automated Exfiltration
+  - Deprecated
 Reports:
   MITRE ATT&CK:
     - TA0010:T1020
 Reference: https://docs.github.com/en/webhooks/about-webhooks
 Severity: Info
-Description: Detects when a web hook is added, modified, or deleted in an org repository.
+Description: Deprecated. See GitHub.Webhook.Modified instead.
 Tests:
   - Name: GitHub - Webhook Created
     ExpectedResult: true

--- a/rules/gitlab_rules/gitlab_audit_password_reset_multiple_emails.yml
+++ b/rules/gitlab_rules/gitlab_audit_password_reset_multiple_emails.yml
@@ -8,6 +8,7 @@ LogTypes:
 Tags:
   - GitLab
   - CVE-2023-7028
+  - No Pack
 Reports:
   MITRE ATT&CK:
     - TA0001:T1195

--- a/rules/gitlab_rules/gitlab_production_password_reset_multiple_emails.yml
+++ b/rules/gitlab_rules/gitlab_production_password_reset_multiple_emails.yml
@@ -8,6 +8,7 @@ LogTypes:
 Tags:
   - GitLab
   - CVE-2023-7028
+  - No Pack
 Reports:
   MITRE ATT&CK:
     - TA0001:T1195

--- a/templates/example_scheduled_rule.yml
+++ b/templates/example_scheduled_rule.yml
@@ -7,6 +7,7 @@ ScheduledQueries:
   - My Query Name
 Tags:
   - Tag
+  - No Pack
 Severity: Medium
 Description: >
   An optional Description


### PR DESCRIPTION
### Background

After revamping the `check-packs` function in PAT, we discovered a number of rules that weren't assigned to any Packs. This PR either assigns them to a pack, or adds an exception tag to exclude them from the check.

### Changes

- Added a new pack for GCP K8s
- Added exceptions for the Crowdstrike Unmanaged Device rules
- A bunch of other rules got added or excluded from packs

### Testing

- `pat check-packs` passed, so there shouldn't be any issues with missing pack dependencies
- `pat validate` passed
- All of these rules have already existed in the repo, so if they have noise issues/bugs, we should know about them by now. They should be fine to add to packs.
