### PR TITLE
Clean up GitHub rule

### DIFF
--- a/rules/github_rules/github_action_failed.py
+++ b/rules/github_rules/github_action_failed.py
@@ -2,7 +2,7 @@ import json
 from unittest.mock import MagicMock
 
 from global_filter_github import filter_include_event
-from panther_base_helpers import deep_get, github_alert_context
+from panther_base_helpers import github_alert_context
 
 # The keys for MONITORED_ACTIONS are gh_org/repo_name
 # The values for MONITORED_ACTIONS are a list of ["action_names"]
@@ -15,22 +15,22 @@ def rule(event):
     global MONITORED_ACTIONS  # pylint: disable=global-statement
     if isinstance(MONITORED_ACTIONS, MagicMock):
         MONITORED_ACTIONS = json.loads(MONITORED_ACTIONS())  # pylint: disable=not-callable
-    repo = deep_get(event, "repo", default="")
-    action_name = deep_get(event, "name", default="")
+    repo = event.get("repo", "")
+    action_name = event.get("name", "")
     return all(
         [
-            deep_get(event, "action", default="") == "workflows.completed_workflow_run",
+            event.get("action", "") == "workflows.completed_workflow_run",
+            event.get("conclusion", "") == "failure",
             repo in MONITORED_ACTIONS,
             action_name in MONITORED_ACTIONS.get(repo, []),
-            deep_get(event, "conclusion", default="") == "failure",
         ]
     )
 
 
 def title(event):
-    repo = deep_get(event, "repo", default="<NO_REPO>")
-    action_name = deep_get(event, "name", default="<NO_ACTION_NAME>")
-    return f"The GitHub Action [{action_name}] in [{repo}] has failed"
+    repo = event.get("repo", "<NO_REPO>")
+    action_name = event.get("name", "<NO_ACTION_NAME>")
+    return f"GitHub Action [{action_name}] in [{repo}] has failed"
 
 
 def alert_context(event):


### PR DESCRIPTION
### Background

While prepping for the GitHub podcast, I ran across a few small QoL improvements to this rule

### Changes

- don't use deep_get for single-level nesting
- change the ordering of the `all()` call

### Testing

- locally
