### PR TITLE
Issue 1367: Reformat YAML to Always Use Literal Block for Query Text

### DIFF
--- a/queries/aws_queries/cloudtrail_password_spraying_query.yml
+++ b/queries/aws_queries/cloudtrail_password_spraying_query.yml
@@ -3,10 +3,10 @@ QueryName: "Query.CloudTrail.Password.Spraying"
 Enabled: false
 Description: >
   Detect password spraying in cloudtrail logs
-AthenaQuery: >
+AthenaQuery: |
   /* athena query not supported */
   SELECT count(1)
-SnowflakeQuery: >
+SnowflakeQuery: |
   SELECT
     -- this information will be in the alert events
     awsRegion as region,

--- a/queries/aws_queries/ec2_crud_activity_by_role_query.yml
+++ b/queries/aws_queries/ec2_crud_activity_by_role_query.yml
@@ -3,10 +3,10 @@ QueryName: "Query.EC2.CRUD.Activity.Role"
 Enabled: false
 Description: >
   This query searches for CRUD activity in EC2 by role arn. Activities from a role outside typical deployment processes may warrant investigation.
-AthenaQuery: >
+AthenaQuery: |
   /* athena query not supported */
   SELECT count(1)
-SnowflakeQuery: >
+SnowflakeQuery: |
   SELECT
     count(*) as num_logs,
     recipientAccountId,

--- a/queries/aws_queries/ec2_crud_activity_by_useragent_query.yml
+++ b/queries/aws_queries/ec2_crud_activity_by_useragent_query.yml
@@ -3,10 +3,10 @@ QueryName: "Query.EC2.CRUD.Activity.Useragent"
 Enabled: false
 Description: >
   This query searches for CRUD activity in EC2 by userAgent. A low count or previously unseen useragent may indicate that the action was not performed by an automated process.
-AthenaQuery: >
+AthenaQuery: |
   /* athena query not supported */
   SELECT count(1)
-SnowflakeQuery: >
+SnowflakeQuery: |
   SELECT
     count(*) as num_logs,
     recipientAccountId,

--- a/queries/aws_queries/vpc_dns_tunneling_query.yml
+++ b/queries/aws_queries/vpc_dns_tunneling_query.yml
@@ -3,10 +3,10 @@ QueryName: "Query.VPC.DNS.Tunneling"
 Enabled: false
 Description: >
   Detect activity similar to DNS tunneling traffic in AWS VPC Logs
-AthenaQuery: >
+AthenaQuery: |
   /* athena query not supported */
   SELECT count(1)
-SnowflakeQuery: >
+SnowflakeQuery: |
   SELECT
     account_id,
     region,

--- a/queries/kubernetes_queries/kubernetes_admission_controller_created_query.yml
+++ b/queries/kubernetes_queries/kubernetes_admission_controller_created_query.yml
@@ -5,7 +5,7 @@ Tags:
   - Optional
 Description: >
   This detection monitors for a new admission controller being created in the cluster. Admission controllers allows an attack to intercept all API requests made within a cluster, allowing for enumeration of resources and common actions. This can be a very powerful tool to understand where to pivot to next.
-Query: >
+Query: |
   SELECT *,
          IFF(sourceIPs[0] IS NOT null, sourceIPs[0], 'N/A') as X_FORWARDED_FOR_IP,
          IFF(sourceIPs[1] IS NOT null, sourceIPs[1], 'N/A') as X_Real_IP,

--- a/queries/kubernetes_queries/kubernetes_cron_job_created_or_modified_query.yml
+++ b/queries/kubernetes_queries/kubernetes_cron_job_created_or_modified_query.yml
@@ -5,7 +5,7 @@ Tags:
   - Optional
 Description: >
   This detection monitor for any modifications or creations of a cron job. Attackers may create or modify an existing scheduled job in order to achieve cluster persistence.
-Query: >
+Query: |
   SELECT *,
          IFF(sourceIPs[0] IS NOT null, sourceIPs[0], 'N/A') as X_FORWARDED_FOR_IP,
          IFF(sourceIPs[1] IS NOT null, sourceIPs[1], 'N/A') as X_Real_IP,

--- a/queries/kubernetes_queries/kubernetes_ioc_activity_query.yml
+++ b/queries/kubernetes_queries/kubernetes_ioc_activity_query.yml
@@ -5,7 +5,7 @@ Tags:
   - Optional
 Description: >
   This detection monitors for any kubernetes API Request originating from an Indicator of Compromise.
-Query: >
+Query: |
   SELECT *,
          VALUE as SRC_IP,
          THIS as IP_ADDRESS,

--- a/queries/kubernetes_queries/kubernetes_new_daemonset_deployed_query.yml
+++ b/queries/kubernetes_queries/kubernetes_new_daemonset_deployed_query.yml
@@ -5,7 +5,7 @@ Tags:
   - Optional
 Description: >
   This detection monitors for a new DaemonSet deployed to a kubernetes cluster. A daemonset is a workload that guarantees the presence of exactly one instance of a specific pod on every node in the cluster. This can be a very powerful tool for establishing peristence.
-Query: >
+Query: |
   SELECT *,
          IFF(sourceIPs[0] IS NOT null, sourceIPs[0], 'N/A') as X_FORWARDED_FOR_IP,
          IFF(sourceIPs[1] IS NOT null, sourceIPs[1], 'N/A') as X_Real_IP,

--- a/queries/kubernetes_queries/kubernetes_pod_attached_to_node_host_network_query.yml
+++ b/queries/kubernetes_queries/kubernetes_pod_attached_to_node_host_network_query.yml
@@ -5,7 +5,7 @@ Tags:
   - Optional
 Description: >
   This detection monitor for the creation of pods which are attached to the host's network. This allows a pod to listen to all network traffic for all deployed computer on that particular node and communicate with other compute on the network namespace. Attackers can use this to capture secrets passed in arguments or connections.
-Query: >
+Query: |
   SELECT *,
          IFF(sourceIPs[0] IS NOT null, sourceIPs[0], 'N/A') as X_FORWARDED_FOR_IP,
          IFF(sourceIPs[1] IS NOT null, sourceIPs[1], 'N/A') as X_Real_IP,

--- a/queries/kubernetes_queries/kubernetes_pod_create_or_modify_host_path_vol_mount_query.yml
+++ b/queries/kubernetes_queries/kubernetes_pod_create_or_modify_host_path_vol_mount_query.yml
@@ -5,7 +5,7 @@ Tags:
   - Optional
 Description: >
   This detection monitors for pod creation with a hostPath volume mount. The attachment to a node's volume can allow for privilege escalation through underlying vulnerabilities or it can open up possibilities for data exfiltration or unauthorized file access. It is very rare to see this being a pod requirement.
-Query: >
+Query: |
   SELECT *,
          IFF(sourceIPs[0] IS NOT null, sourceIPs[0], 'N/A') as X_FORWARDED_FOR_IP,
          IFF(sourceIPs[1] IS NOT null, sourceIPs[1], 'N/A') as X_Real_IP,

--- a/queries/kubernetes_queries/kubernetes_pod_in_default_name_space_query.yml
+++ b/queries/kubernetes_queries/kubernetes_pod_in_default_name_space_query.yml
@@ -5,7 +5,7 @@ Tags:
   - Optional
 Description: >
   This detection monitors for any pod created in pre-configured or default namespaces. Only Cluster Admins should be creating pods in the kube-system namespace, and it is best practice not to run any cluster critical infrastructure here. The kube-public namespace is intended to be readable by unauthenticated users. The default namespace is shipped with the cluster and it is best practice not to deploy production workloads here. These namespaces may be used to evade defenses or hide attacker infrastructure.
-Query: >
+Query: |
   SELECT *,
          IFF(sourceIPs[0] IS NOT null, sourceIPs[0], 'N/A') as X_FORWARDED_FOR_IP,
          IFF(sourceIPs[1] IS NOT null, sourceIPs[1], 'N/A') as X_Real_IP,

--- a/queries/kubernetes_queries/kubernetes_pod_using_host_ipc_namespace_query.yml
+++ b/queries/kubernetes_queries/kubernetes_pod_using_host_ipc_namespace_query.yml
@@ -5,7 +5,7 @@ Tags:
   - Optional
 Description: >
   This detection monitors for any pod creation or modification using the host IPC Namespace. Deploying pods in the Host IPC Namespace, breaks isolation between the pod and the underlying host meaning the pod has direct access to the same IPC objects and communications channels as the host system.
-Query: >
+Query: |
   SELECT *,
          IFF(sourceIPs[0] IS NOT null, sourceIPs[0], 'N/A') as X_FORWARDED_FOR_IP,
          IFF(sourceIPs[1] IS NOT null, sourceIPs[1], 'N/A') as X_Real_IP,

--- a/queries/kubernetes_queries/kubernetes_pod_using_host_pid_namespace_query.yml
+++ b/queries/kubernetes_queries/kubernetes_pod_using_host_pid_namespace_query.yml
@@ -5,7 +5,7 @@ Tags:
   - Optional
 Description: >
   This detection monitors for any pod creation or modification using the host PID namespace. The Host PID namespace enables a pod and its containers to have direct access and share the same view as of the host’s processes. This can offer a powerful escape hatch to the underlying host.
-Query: >
+Query: |
   SELECT *,
          IFF(sourceIPs[0] IS NOT null, sourceIPs[0], 'N/A') as X_FORWARDED_FOR_IP,
          IFF(sourceIPs[1] IS NOT null, sourceIPs[1], 'N/A') as X_Real_IP,

--- a/queries/kubernetes_queries/kubernetes_privileged_pod_created_query.yml
+++ b/queries/kubernetes_queries/kubernetes_privileged_pod_created_query.yml
@@ -5,7 +5,7 @@ Tags:
   - Optional
 Description: >
   This detection monitors for a privileged pod is created either by default or with permissions to run as root. These particular pods have full access to the hosts namespace and devices, ability to exploit the kernel, have dangerous linux capabilities, and can be a powerful launching point for further attacks.
-Query: >
+Query: |
   SELECT *,
          IFF(sourceIPs[0] IS NOT null, sourceIPs[0], 'N/A') as X_FORWARDED_FOR_IP,
          IFF(sourceIPs[1] IS NOT null, sourceIPs[1], 'N/A') as X_Real_IP,

--- a/queries/kubernetes_queries/kubernetes_service_type_node_port_deployed_query.yml
+++ b/queries/kubernetes_queries/kubernetes_service_type_node_port_deployed_query.yml
@@ -5,7 +5,7 @@ Tags:
   - Optional
 Description: >
   This detection monitors for any kubernetes service deployed with type node port. A Node Port service allows an attacker to expose a set of pods hosting the service to the internet by opening their port and redirecting traffic here. This can be used to bypass network controls and intercept traffic, creating a direct line to the outside network.
-Query: >
+Query: |
   SELECT *,
          objectRef:name as service,
          objectRef:namespace as namespace,

--- a/queries/kubernetes_queries/kubernetes_unauthenticated_api_request_query.yml
+++ b/queries/kubernetes_queries/kubernetes_unauthenticated_api_request_query.yml
@@ -5,7 +5,7 @@ Tags:
   - Optional
 Description: >
   This detection monitors for any unauthenticated kubernetes api request. Unauthenticated Requests are performed by the anonymous user and have unfederated access to the cluster.
-Query: >
+Query: |
   SELECT *,
          IFF(sourceIPs[0] IS NOT null, sourceIPs[0], 'N/A') as X_FORWARDED_FOR_IP,
          IFF(sourceIPs[1] IS NOT null, sourceIPs[1], 'N/A') as X_Real_IP,

--- a/queries/kubernetes_queries/kubernetes_unauthorized_pod_execution_query.yml
+++ b/queries/kubernetes_queries/kubernetes_unauthorized_pod_execution_query.yml
@@ -5,7 +5,7 @@ Tags:
   - Optional
 Description: >
   This detection monitors for any pod execution in a kubernetes cluster. Pod execution should never be done in a production cluster, and can indicate a user performing unauthorized actions.
-Query: >
+Query: |
   SELECT *,
          split(split(impersonatedUser:username,'remote-')[1],'-')[0] as src_user,
          SPLIT(requestURI,'exec?')[1] as command_executed,

--- a/queries/okta_queries/okta_activity_audit.yml
+++ b/queries/okta_queries/okta_activity_audit.yml
@@ -3,7 +3,7 @@ QueryName: "Okta Investigate User Activity"
 Enabled: false
 Description: >
   Audit user activity across your environment. Customize to filter on specific users, time ranges, etc
-AthenaQuery: >
+AthenaQuery: |
   SELECT actor.displayName AS actor_name, actor.alternateId AS actor_email, eventType, COUNT(*) AS activity_count
   FROM panther_logs.okta_systemlog
   WHERE p_occurs_since('7 days')
@@ -13,7 +13,7 @@ AthenaQuery: >
   -- and eventType = '<EVENTTYPE_GOES_HERE>'
   GROUP BY actor.displayName, actor.alternateId, eventType
   ORDER BY  actor_name, activity_count DESC
-SnowflakeQuery: >
+SnowflakeQuery: |
   SELECT actor:displayName AS actor_name, actor:alternateId AS actor_email, eventType, COUNT(*) AS activity_count
   FROM panther_logs.public.okta_systemlog
   WHERE p_occurs_since('7 days')

--- a/queries/okta_queries/okta_admin_access_granted.yml
+++ b/queries/okta_queries/okta_admin_access_granted.yml
@@ -3,7 +3,7 @@ QueryName: "Okta Admin Access Granted"
 Enabled: false
 Description: >
   Audit instances of admin access granted in your okta tenant
-AthenaQuery: >
+AthenaQuery: |
   SELECT
   p_event_time as event_time,
   actor.alternateid as actor_email,
@@ -26,7 +26,7 @@ AthenaQuery: >
   p_occurs_between('2022-01-14','2022-03-22')
   ORDER BY
   event_time desc
-SnowflakeQuery: >
+SnowflakeQuery: |
   SELECT
   p_event_time as event_time,
   actor:alternateId as actor_email,

--- a/queries/okta_queries/okta_mfa_password_reset_audit.yml
+++ b/queries/okta_queries/okta_mfa_password_reset_audit.yml
@@ -3,7 +3,7 @@ QueryName: "Okta Investigate MFA and Password resets"
 Enabled: false
 Description: >
   Investigate Password and MFA resets for the last 7 days
-AthenaQuery: >
+AthenaQuery: |
   SELECT p_event_time,actor.alternateId as actor_user,target[1].alternateId as target_user, eventType,client.ipAddress as ip_address
   FROM panther_logs.okta_systemlog
   WHERE eventType IN ('user.mfa.factor.reset_all', 'user.mfa.factor.deactivate', 'user.mfa.factor.suspend', 'user.account.reset_password', 'user.account.update_password')
@@ -11,7 +11,7 @@ AthenaQuery: >
   -- If you wish to investigate an individual user , uncomment this line and add their email here
   -- and actor:alternateId = '<EMAIL_GOES_HERE>'
   ORDER by p_event_time DESC
-SnowflakeQuery: >
+SnowflakeQuery: |
   SELECT p_event_time,actor:alternateId as actor_user,target[0]:alternateId as target_user, eventType,client:ipAddress as ip_address
   FROM panther_logs.public.okta_systemlog
   WHERE eventType IN ('user.mfa.factor.reset_all', 'user.mfa.factor.deactivate', 'user.mfa.factor.suspend', 'user.account.reset_password', 'user.account.update_password','user.mfa.factor.update')

--- a/queries/okta_queries/okta_session_id_audit.yml
+++ b/queries/okta_queries/okta_session_id_audit.yml
@@ -3,7 +3,7 @@ QueryName: "Okta Investigate Session ID Activity"
 Enabled: false
 Description: >
   Search for activity related to a specific SessionID in Okta panther_logs.okta_systemlog
-AthenaQuery: >
+AthenaQuery: |
   SELECT
     p_event_time as event_time,
     actor.alternateId as actor_email,
@@ -20,7 +20,7 @@ AthenaQuery: >
   -- Uncomment the line below and replace 'sessionId' with the sessionId you are investigating
   -- and authenticationContext:externalSessionId = '<SESSIONID_GOES_HERE>'
     ORDER BY event_time DESC
-SnowflakeQuery: >
+SnowflakeQuery: |
   SELECT
     p_event_time as event_time,
     actor:alternateId as actor_email,

--- a/queries/okta_queries/okta_support_access.yml
+++ b/queries/okta_queries/okta_support_access.yml
@@ -3,7 +3,7 @@ QueryName: "Okta Support Access"
 Enabled: false
 Description: >
   Show instances that Okta support was granted to your account
-AthenaQuery: >
+AthenaQuery: |
   SELECT
   p_event_time as event_time,
   actor.alternateid as actor_email,
@@ -23,7 +23,7 @@ AthenaQuery: >
   p_occurs_between('2022-01-14','2022-03-22')
   ORDER BY
     event_time desc
-SnowflakeQuery: >
+SnowflakeQuery: |
   SELECT
   p_event_time as event_time,
   actor:alternateId as actor_email,

--- a/queries/snowflake_queries/snowflake_0108977_configuration_drift_query.yml
+++ b/queries/snowflake_queries/snowflake_0108977_configuration_drift_query.yml
@@ -5,7 +5,7 @@ Description: >
   Monitor for configuration drift made by malicious actors as part of ongoing cyber threat activity reported May 31st, 2024
 Tags:
   - Configuration Required
-SnowflakeQuery: >
+SnowflakeQuery: |
   -- https://community.snowflake.com/s/article/Communication-ID-0108977-Additional-Information
 
   -- adjust query/limit to narrow as necessary

--- a/queries/snowflake_queries/snowflake_0108977_configuration_drift_threat_hunting.yml
+++ b/queries/snowflake_queries/snowflake_0108977_configuration_drift_threat_hunting.yml
@@ -2,7 +2,7 @@ AnalysisType: saved_query
 QueryName: "Query.Snowflake.ThreatHunting.ConfigurationDrift"
 Description: >
   Monitor for configuration drift made by malicious actors as part of ongoing cyber threat activity reported May 31st, 2024
-SnowflakeQuery: >
+SnowflakeQuery: |
   -- https://community.snowflake.com/s/article/Communication-ID-0108977-Additional-Information
 
   -- adjust query/limit to narrow as necessary

--- a/queries/snowflake_queries/snowflake_0108977_ip_query.yml
+++ b/queries/snowflake_queries/snowflake_0108977_ip_query.yml
@@ -3,7 +3,7 @@ Enabled: false
 QueryName: "Query.Snowflake.ClientIp"
 Description: >
   Monitor for malicious IPs interacting with Snowflake as part of ongoing cyber threat activity reported May 31st, 2024
-SnowflakeQuery: >
+SnowflakeQuery: |
   -- https://community.snowflake.com/s/article/Communication-ID-0108977-Additional-Information
 
   SELECT

--- a/queries/snowflake_queries/snowflake_0108977_ip_threat_hunting.yml
+++ b/queries/snowflake_queries/snowflake_0108977_ip_threat_hunting.yml
@@ -2,7 +2,7 @@ AnalysisType: saved_query
 QueryName: "Query.Snowflake.ThreatHunting.ClientIp"
 Description: >
   Monitor for malicious IPs interacting with Snowflake as part of ongoing cyber threat activity reported May 31st, 2024
-SnowflakeQuery: >
+SnowflakeQuery: |
   -- https://community.snowflake.com/s/article/Communication-ID-0108977-Additional-Information
 
   SELECT

--- a/queries/snowflake_queries/snowflake_0108977_suspected_user_access_query.yml
+++ b/queries/snowflake_queries/snowflake_0108977_suspected_user_access_query.yml
@@ -3,7 +3,7 @@ Enabled: false
 QueryName: "Query.Snowflake.SuspectedUserAccess"
 Description: >
   Return sessions of suspected clients as part of ongoing cyber threat activity reported May 31st, 2024
-SnowflakeQuery: >
+SnowflakeQuery: |
   -- https://community.snowflake.com/s/article/Communication-ID-0108977-Additional-Information
 
   SELECT

--- a/queries/snowflake_queries/snowflake_0108977_suspected_user_access_threat_hunting.yml
+++ b/queries/snowflake_queries/snowflake_0108977_suspected_user_access_threat_hunting.yml
@@ -2,7 +2,7 @@ AnalysisType: saved_query
 QueryName: "Query.Snowflake.ThreatHunting.SuspectedUserAccess"
 Description: >
   Return sessions of suspected clients as part of ongoing cyber threat activity reported May 31st, 2024
-SnowflakeQuery: >
+SnowflakeQuery: |
   -- https://community.snowflake.com/s/article/Communication-ID-0108977-Additional-Information
 
   SELECT

--- a/queries/snowflake_queries/snowflake_0108977_suspected_user_activity_threat_hunting.yml
+++ b/queries/snowflake_queries/snowflake_0108977_suspected_user_activity_threat_hunting.yml
@@ -2,7 +2,7 @@ AnalysisType: saved_query
 QueryName: "Query.Snowflake.ThreatHunting.SuspectedUserActivity"
 Description: >
   Return actions/queries made by suspected users as part of ongoing cyber threat activity reported May 31st, 2024
-SnowflakeQuery: >
+SnowflakeQuery: |
   -- https://community.snowflake.com/s/article/Communication-ID-0108977-Additional-Information
 
   -- replace <SUSPECTED_USER> with actual user name

--- a/queries/snowflake_queries/snowflake_account_admin_assigned_query.yml
+++ b/queries/snowflake_queries/snowflake_account_admin_assigned_query.yml
@@ -3,10 +3,10 @@ QueryName: "Query.Snowflake.AccountAdminGranted"
 Enabled: false
 Description: >
   Monitor and detect granting account admin role.
-AthenaQuery: >
+AthenaQuery: |
   /* athena query not supported */
   SELECT count(1)
-SnowflakeQuery: >
+SnowflakeQuery: |
   --return instances where active (not deleted) roles are granted within the last 24 hours
 
   --this was adapted from a Security Feature Checklist query

--- a/queries/snowflake_queries/snowflake_brute_force_ip_query.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_ip_query.yml
@@ -3,10 +3,10 @@ QueryName: "Query.Snowflake.BruteForceByIp"
 Enabled: false
 Description: >
   Detect brute force attempts by monitoring for failed logins to snowflake.
-AthenaQuery: >
+AthenaQuery: |
   /* athena query not supported */
   SELECT count(1)
-SnowflakeQuery: >
+SnowflakeQuery: |
   --return IPs with more than 5 failed logins in the previous 24 hours
 
   --this was adapted from a SnowAlert query

--- a/queries/snowflake_queries/snowflake_brute_force_username_query.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_username_query.yml
@@ -3,10 +3,10 @@ QueryName: "Query.Snowflake.BruteForceByUsername"
 Enabled: false
 Description: >
   Detect brute force attempts by monitoring for failed logins to snowflake.
-AthenaQuery: >
+AthenaQuery: |
   /* athena query not supported */
   SELECT count(1)
-SnowflakeQuery: >
+SnowflakeQuery: |
   --return users with more than 5 failed logins in the previous 24 hours
 
   --this was adapted from a SnowAlert query

--- a/queries/snowflake_queries/snowflake_external_shares_query.yml
+++ b/queries/snowflake_queries/snowflake_external_shares_query.yml
@@ -3,10 +3,10 @@ QueryName: "Query.Snowflake.External.Shares"
 Enabled: false
 Description: >
   Monitor for external shares from one cloud source to another.
-AthenaQuery: >
+AthenaQuery: |
   /* athena query not supported */
   SELECT count(1)
-SnowflakeQuery: >
+SnowflakeQuery: |
   --return external shares
 
   --this was adapted from a Security Feature Checklist query

--- a/queries/snowflake_queries/snowflake_file_downloaded_query.yml
+++ b/queries/snowflake_queries/snowflake_file_downloaded_query.yml
@@ -2,7 +2,7 @@ AnalysisType: scheduled_query
 QueryName: "Query.Snowflake.FileDownloaded"
 Enabled: true
 Description: https://cloud.google.com/blog/topics/threat-intelligence/unc5537-snowflake-data-theft-extortion/
-Query: >
+Query: |
     SELECT 
     user_name,
     role_name,

--- a/queries/snowflake_queries/snowflake_key_user_password_login_query.yml
+++ b/queries/snowflake_queries/snowflake_key_user_password_login_query.yml
@@ -3,10 +3,10 @@ QueryName: "Query.Snowflake.KeyUserPasswordLogin"
 Enabled: false
 Description: >
   Detects when a user with a configured RSA key logs in with a password
-AthenaQuery: >
+AthenaQuery: |
   /* athena query not supported */
   SELECT count(1)
-SnowflakeQuery: >
+SnowflakeQuery: |
   --return instances where a user who has key-based login configured logs in with a password
   --this was adapted from a Security Feature Checklist query
 

--- a/queries/snowflake_queries/snowflake_login_without_mfa_query.yml
+++ b/queries/snowflake_queries/snowflake_login_without_mfa_query.yml
@@ -3,10 +3,10 @@ QueryName: "Query.Snowflake.MFALogin"
 Enabled: false
 Description: >
   Monitor logins that are not using MFA.
-AthenaQuery: >
+AthenaQuery: |
   /* athena query not supported */
   SELECT count(1)
-SnowflakeQuery: >
+SnowflakeQuery: |
   --return instances where a user logs in without MFA
 
   --this was adapted from a Security Feature Checklist query

--- a/queries/snowflake_queries/snowflake_multiple_failed_logins_followed_by_success_query.yml
+++ b/queries/snowflake_queries/snowflake_multiple_failed_logins_followed_by_success_query.yml
@@ -3,10 +3,10 @@ QueryName: "Query.Snowflake.Multiple.Logins.Followed.By.Success"
 Enabled: false
 Description: >
   Monitor for brute force user activity.
-AthenaQuery: >
+AthenaQuery: |
   /* athena query not supported */
   SELECT count(1)
-SnowflakeQuery: >
+SnowflakeQuery: |
   --return multiple failed logins followed by a success
 
   WITH login_attempts as (

--- a/queries/snowflake_queries/snowflake_public_role_grant_query.yml
+++ b/queries/snowflake_queries/snowflake_public_role_grant_query.yml
@@ -3,10 +3,10 @@ QueryName: "Query.Snowflake.PublicRoleGrant"
 Enabled: false
 Description: >
   Monitor and detect alterations or grants to public role, which should be kept at a minimum.
-AthenaQuery: >
+AthenaQuery: |
   /* athena query not supported */
   SELECT count(1)
-SnowflakeQuery: >
+SnowflakeQuery: |
   --return instances of grants to the public role
 
   --this was adapted from a Security Feature Checklist query

--- a/queries/snowflake_queries/snowflake_table_copied_into_stage_query.yml
+++ b/queries/snowflake_queries/snowflake_table_copied_into_stage_query.yml
@@ -2,7 +2,7 @@ AnalysisType: scheduled_query
 QueryName: "Query.Snowflake.CopyIntoStage"
 Enabled: true
 Description: https://cloud.google.com/blog/topics/threat-intelligence/unc5537-snowflake-data-theft-extortion/
-Query: >
+Query: |
     SELECT 
     user_name,
     role_name,

--- a/queries/snowflake_queries/snowflake_temp_stage_created_query.yml
+++ b/queries/snowflake_queries/snowflake_temp_stage_created_query.yml
@@ -2,7 +2,7 @@ AnalysisType: scheduled_query
 QueryName: "Query.Snowflake.TempStageCreated"
 Enabled: true
 Description: https://cloud.google.com/blog/topics/threat-intelligence/unc5537-snowflake-data-theft-extortion/
-Query: > 
+Query: |
     SELECT 
     user_name,
     role_name,

--- a/queries/snowflake_queries/snowflake_user_created_query.yml
+++ b/queries/snowflake_queries/snowflake_user_created_query.yml
@@ -3,10 +3,10 @@ QueryName: "Query.Snowflake.UserCreated"
 Enabled: false
 Description: >
   Monitor for new users.
-AthenaQuery: >
+AthenaQuery: |
   /* athena query not supported */
   SELECT count(1)
-SnowflakeQuery: >
+SnowflakeQuery: |
   --return create user events
 
   --this was adapted from a Security Feature Checklist query

--- a/queries/snowflake_queries/snowflake_user_enabled_query.yml
+++ b/queries/snowflake_queries/snowflake_user_enabled_query.yml
@@ -3,10 +3,10 @@ QueryName: "Query.Snowflake.UserEnabled"
 Enabled: false
 Description: >
   Monitor for users that are being re-enabled.
-AthenaQuery: >
+AthenaQuery: |
   /* athena query not supported */
   SELECT count(1)
-SnowflakeQuery: >
+SnowflakeQuery: |
   --return enable user events
 
   --this was adapted from a Security Feature Checklist query


### PR DESCRIPTION
### Background

[Issue 1367](https://github.com/panther-labs/panther-analysis/issues/1367) raised the problem that using a folded block (`>`) when denoting SQL code in our YAML files can cause issues for some YAML parsers, since `>` allows the parser to insert line breaks where it find convenient, potentially breaking certain parts of the query. By using the literal block `|`, we ensure parsers maintain the current formatting of the SQL code.

### Changes

- change all SQL query blocks from folded `>` block style to literal `|` block style.

### Testing

- Linting passes, and a test upload found no problems.
