### PR TITLE
Configure `lint-mitre` to ignore schema test files

### DIFF
--- a/.scripts/mitre_mapping_check.py
+++ b/.scripts/mitre_mapping_check.py
@@ -13,8 +13,13 @@ MITRE_PATTERN = re.compile("^TA\d+\:T\d+(\.\d+)?$")
 
 
 def main(path: Path) -> bool:
+    # Ignore any schema test files
+    #   Schema tests can't be loaded by panther_analysis_tool because each file contains multiple
+    #   YAML documents.
+    ignore_files = list(path.glob("**/*_tests.y*ml"))
+
     # Load Repo
-    analysis_items = load_analysis_specs([path], ignore_files=[])
+    analysis_items = load_analysis_specs([path], ignore_files=ignore_files)
 
     items_with_invalid_mappings = []  # Record all items with bad tags
     for analysis_item in analysis_items:


### PR DESCRIPTION
### Background

Schema test files typically contain multiple documents, separated by dashes. The Analysis Spec loader used by Panther Analysis Tool doesn't support such files, and causes errors if they are present in the repo when `make lint-mitre` is run. Since schema tests do not contain MITRE mappings, we added an exclusion pattern to prevent schema test files from being loaded by the script.

### Changes

- Added a check to ignore any files with names matching `*_tests.y*ml` from the linting script

### Testing

- Tested script with several schema test files in repo, each containing multiple documents, and confirmed that no errors occurred
