### PR TITLE
Fix linter error in gsuite_workspace_calendar_external_sharing.py

### DIFF
--- a/.github/workflows/check-deprecated.yml
+++ b/.github/workflows/check-deprecated.yml
@@ -2,7 +2,7 @@ on:
   pull_request:
 
 permissions:
-    contents: read
+  contents: read
 
 jobs:
   check_removed_rules:
@@ -20,10 +20,10 @@ jobs:
             pypi.org:443
       - name: Checkout panther-analysis
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 #v4.2.1
-      
+
       - name: Fetch Release
         run: |
-          git fetch --depth=1 origin release
+          git fetch --depth=1 origin develop
 
       - name: Set python version
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 #v5.2.0
@@ -39,4 +39,4 @@ jobs:
       - name: Check for Removed Rules
         run: |
           pipenv run make check-deprecated
-  
+

--- a/.scripts/deleted_rules.py
+++ b/.scripts/deleted_rules.py
@@ -15,21 +15,21 @@ diff_pattern = re.compile(r'^-(?:RuleID|PolicyID|QueryName):\s*"?([\w.]+)"?')
 
 def get_deleted_ids() -> set[str]:
     # Run git diff, get output
-    result = subprocess.run(['git', 'diff', 'origin/release', 'HEAD'], capture_output=True)
+    result = subprocess.run(["git", "diff", "origin/develop", "HEAD"], capture_output=True)
     if result.stderr:
         raise Exception(result.stderr.decode("utf-8"))
-    
+
     ids = set()
     for line in result.stdout.decode("utf-8").split("\n"):
         if m := diff_pattern.match(line):
             # Add the ID to the list
             ids.add(m.group(1))
-    
+
     return ids
 
 
 def get_deprecated_ids() -> set[str]:
-    """ Returns all the IDs listed in `deprecated.txt`. """
+    """Returns all the IDs listed in `deprecated.txt`."""
     with open("deprecated.txt", "r") as f:
         return set(f.read().split("\n"))
 
@@ -42,6 +42,7 @@ def check(_):
         exit(1)
     else:
         print("✅ No unaccounted deletions found! You're in the clear! 👍")
+
 
 def remove(args):
     api_token = args.api_token or os.environ.get("PANTHER_API_TOKEN")
@@ -61,11 +62,7 @@ def remove(args):
     ids = list(get_deprecated_ids())
 
     pat_args = argparse.Namespace(
-        analysis_id = ids,
-        query_id = [],
-        confirm_bypass = True,
-        api_token = api_token,
-        api_host = api_host
+        analysis_id=ids, query_id=[], confirm_bypass=True, api_token=api_token, api_host=api_host
     )
 
     logging.basicConfig(

--- a/rules/gsuite_activityevent_rules/gsuite_workspace_calendar_external_sharing.py
+++ b/rules/gsuite_activityevent_rules/gsuite_workspace_calendar_external_sharing.py
@@ -17,6 +17,6 @@ def title(event):
     return (
         f"GSuite workspace setting for default calendar sharing was changed by "
         f"[{event.deep_get('actor', 'email', default='<UNKNOWN_EMAIL>')}] "
-        f"from [{event.deep_get('parameters', 'OLD_VALUE', default='<NO_OLD_SETTING_FOUND>')}] "
-        f"to [{event.deep_get('parameters', 'NEW_VALUE', default='<NO_NEW_SETTING_FOUND>')}]"
+        + f"from [{event.deep_get('parameters', 'OLD_VALUE', default='<NO_OLD_SETTING_FOUND>')}] "
+        + "to [{event.deep_get('parameters', 'NEW_VALUE', default='<NO_NEW_SETTING_FOUND>')}]"
     )


### PR DESCRIPTION
### Background

Linter in Github Action fails with:

```
rules/gsuite_activityevent_rules/gsuite_workspace_calendar_external_sharing.py:20:0: W1404: Implicit string concatenation found in call (implicit-str-concat)
```

### Changes

- Explicitly join the strings.
- Updates Check Removed Rules workflow to use the `develop` branch.
