### PR TITLE
Migrate `AthenaQuery` and `SnowflakeQuery` to just `Query`

### DIFF
--- a/queries/aws_queries/cloudtrail_password_spraying_query.yml
+++ b/queries/aws_queries/cloudtrail_password_spraying_query.yml
@@ -3,10 +3,7 @@ QueryName: "Query.CloudTrail.Password.Spraying"
 Enabled: false
 Description: >
   Detect password spraying in cloudtrail logs
-AthenaQuery: |
-  /* athena query not supported */
-  SELECT count(1)
-SnowflakeQuery: |
+Query: |
   SELECT
     -- this information will be in the alert events
     awsRegion as region,

--- a/queries/aws_queries/ec2_crud_activity_by_role_query.yml
+++ b/queries/aws_queries/ec2_crud_activity_by_role_query.yml
@@ -3,10 +3,7 @@ QueryName: "Query.EC2.CRUD.Activity.Role"
 Enabled: false
 Description: >
   This query searches for CRUD activity in EC2 by role arn. Activities from a role outside typical deployment processes may warrant investigation.
-AthenaQuery: |
-  /* athena query not supported */
-  SELECT count(1)
-SnowflakeQuery: |
+Query: |
   SELECT
     count(*) as num_logs,
     recipientAccountId,

--- a/queries/aws_queries/ec2_crud_activity_by_useragent_query.yml
+++ b/queries/aws_queries/ec2_crud_activity_by_useragent_query.yml
@@ -3,10 +3,7 @@ QueryName: "Query.EC2.CRUD.Activity.Useragent"
 Enabled: false
 Description: >
   This query searches for CRUD activity in EC2 by userAgent. A low count or previously unseen useragent may indicate that the action was not performed by an automated process.
-AthenaQuery: |
-  /* athena query not supported */
-  SELECT count(1)
-SnowflakeQuery: |
+Query: |
   SELECT
     count(*) as num_logs,
     recipientAccountId,

--- a/queries/aws_queries/vpc_dns_tunneling_query.yml
+++ b/queries/aws_queries/vpc_dns_tunneling_query.yml
@@ -3,10 +3,7 @@ QueryName: "Query.VPC.DNS.Tunneling"
 Enabled: false
 Description: >
   Detect activity similar to DNS tunneling traffic in AWS VPC Logs
-AthenaQuery: |
-  /* athena query not supported */
-  SELECT count(1)
-SnowflakeQuery: |
+Query: |
   SELECT
     account_id,
     region,

--- a/queries/okta_queries/okta_activity_audit.yml
+++ b/queries/okta_queries/okta_activity_audit.yml
@@ -3,17 +3,7 @@ QueryName: "Okta Investigate User Activity"
 Enabled: false
 Description: >
   Audit user activity across your environment. Customize to filter on specific users, time ranges, etc
-AthenaQuery: |
-  SELECT actor.displayName AS actor_name, actor.alternateId AS actor_email, eventType, COUNT(*) AS activity_count
-  FROM panther_logs.okta_systemlog
-  WHERE p_occurs_since('7 days')
-  AND actor.type = 'User'
-  -- Uncomment lines below to filter by user email and/or eventType
-  -- and actor_email = '<EMAIL_GOES_HERE>'
-  -- and eventType = '<EVENTTYPE_GOES_HERE>'
-  GROUP BY actor.displayName, actor.alternateId, eventType
-  ORDER BY  actor_name, activity_count DESC
-SnowflakeQuery: |
+Query: |
   SELECT actor:displayName AS actor_name, actor:alternateId AS actor_email, eventType, COUNT(*) AS activity_count
   FROM panther_logs.public.okta_systemlog
   WHERE p_occurs_since('7 days')

--- a/queries/okta_queries/okta_admin_access_granted.yml
+++ b/queries/okta_queries/okta_admin_access_granted.yml
@@ -3,30 +3,7 @@ QueryName: "Okta Admin Access Granted"
 Enabled: false
 Description: >
   Audit instances of admin access granted in your okta tenant
-AthenaQuery: |
-  SELECT
-  p_event_time as event_time,
-  actor.alternateid as actor_email,
-  actor.displayName as actor_name,
-  displayMessage,
-  eventType,
-  json_extract(debugcontext.debugdata, '$.privilegeGranted') as priv_granted,
-  target as target_name,
-  client.ipAddress as src_ip,
-  client.geographicalContext.city as city,
-  client.geographicalContext.country as country,
-  client.useragent.rawUserAgent as user_agent
-  FROM panther_logs.okta_systemlog
-  WHERE
-  (
-  eventType = 'user.account.privilege.grant' OR
-  eventType = 'group.privilege.grant' AND
-  cast(json_extract(debugcontext.debugdata, '$.privilegeGranted') as varchar) LIKE '%Admin%'
-  ) AND
-  p_occurs_between('2022-01-14','2022-03-22')
-  ORDER BY
-  event_time desc
-SnowflakeQuery: |
+Query: |
   SELECT
   p_event_time as event_time,
   actor:alternateId as actor_email,

--- a/queries/okta_queries/okta_mfa_password_reset_audit.yml
+++ b/queries/okta_queries/okta_mfa_password_reset_audit.yml
@@ -3,15 +3,7 @@ QueryName: "Okta Investigate MFA and Password resets"
 Enabled: false
 Description: >
   Investigate Password and MFA resets for the last 7 days
-AthenaQuery: |
-  SELECT p_event_time,actor.alternateId as actor_user,target[1].alternateId as target_user, eventType,client.ipAddress as ip_address
-  FROM panther_logs.okta_systemlog
-  WHERE eventType IN ('user.mfa.factor.reset_all', 'user.mfa.factor.deactivate', 'user.mfa.factor.suspend', 'user.account.reset_password', 'user.account.update_password')
-  and p_occurs_since('7 days')
-  -- If you wish to investigate an individual user , uncomment this line and add their email here
-  -- and actor:alternateId = '<EMAIL_GOES_HERE>'
-  ORDER by p_event_time DESC
-SnowflakeQuery: |
+Query: |
   SELECT p_event_time,actor:alternateId as actor_user,target[0]:alternateId as target_user, eventType,client:ipAddress as ip_address
   FROM panther_logs.public.okta_systemlog
   WHERE eventType IN ('user.mfa.factor.reset_all', 'user.mfa.factor.deactivate', 'user.mfa.factor.suspend', 'user.account.reset_password', 'user.account.update_password','user.mfa.factor.update')

--- a/queries/okta_queries/okta_session_id_audit.yml
+++ b/queries/okta_queries/okta_session_id_audit.yml
@@ -3,24 +3,7 @@ QueryName: "Okta Investigate Session ID Activity"
 Enabled: false
 Description: >
   Search for activity related to a specific SessionID in Okta panther_logs.okta_systemlog
-AthenaQuery: |
-  SELECT
-    p_event_time as event_time,
-    actor.alternateId as actor_email,
-    actor.displayName as actor_name,
-    authenticationContext.externalSessionId as sessionId,
-    displayMessage,
-    eventType,
-    client.ipAddress as src_ip,
-    client.geographicalContext.city as city,
-    client.geographicalContext.country as country,
-    client.userAgent.rawUserAgent as user_agent
-  FROM panther_logs.okta_systemlog
-  WHERE p_occurs_since('7 days')
-  -- Uncomment the line below and replace 'sessionId' with the sessionId you are investigating
-  -- and authenticationContext:externalSessionId = '<SESSIONID_GOES_HERE>'
-    ORDER BY event_time DESC
-SnowflakeQuery: |
+Query: |
   SELECT
     p_event_time as event_time,
     actor:alternateId as actor_email,

--- a/queries/okta_queries/okta_support_access.yml
+++ b/queries/okta_queries/okta_support_access.yml
@@ -3,27 +3,7 @@ QueryName: "Okta Support Access"
 Enabled: false
 Description: >
   Show instances that Okta support was granted to your account
-AthenaQuery: |
-  SELECT
-  p_event_time as event_time,
-  actor.alternateid as actor_email,
-  actor.displayName as actor_name,
-  displayMessage,
-  eventType,
-  client.ipAddress as src_ip,
-  client.geographicalContext.city as city,
-  client.geographicalContext.country as country,
-  client.useragent.rawUserAgent as user_agent
-  FROM panther_logs.okta_systemlog
-  WHERE
-  (
-  eventType = 'user.session.impersonation.grant' OR
-  eventType = 'user.session.impersonation.initiate'
-  ) and
-  p_occurs_between('2022-01-14','2022-03-22')
-  ORDER BY
-    event_time desc
-SnowflakeQuery: |
+Query: |
   SELECT
   p_event_time as event_time,
   actor:alternateId as actor_email,

--- a/queries/snowflake_queries/snowflake_0108977_configuration_drift_query.yml
+++ b/queries/snowflake_queries/snowflake_0108977_configuration_drift_query.yml
@@ -5,7 +5,7 @@ Description: >
   Monitor for configuration drift made by malicious actors as part of ongoing cyber threat activity reported May 31st, 2024
 Tags:
   - Configuration Required
-SnowflakeQuery: |
+Query: |
   -- https://community.snowflake.com/s/article/Communication-ID-0108977-Additional-Information
 
   -- adjust query/limit to narrow as necessary

--- a/queries/snowflake_queries/snowflake_0108977_configuration_drift_threat_hunting.yml
+++ b/queries/snowflake_queries/snowflake_0108977_configuration_drift_threat_hunting.yml
@@ -2,7 +2,7 @@ AnalysisType: saved_query
 QueryName: "Query.Snowflake.ThreatHunting.ConfigurationDrift"
 Description: >
   Monitor for configuration drift made by malicious actors as part of ongoing cyber threat activity reported May 31st, 2024
-SnowflakeQuery: |
+Query: |
   -- https://community.snowflake.com/s/article/Communication-ID-0108977-Additional-Information
 
   -- adjust query/limit to narrow as necessary

--- a/queries/snowflake_queries/snowflake_0108977_ip_query.yml
+++ b/queries/snowflake_queries/snowflake_0108977_ip_query.yml
@@ -3,7 +3,7 @@ Enabled: false
 QueryName: "Query.Snowflake.ClientIp"
 Description: >
   Monitor for malicious IPs interacting with Snowflake as part of ongoing cyber threat activity reported May 31st, 2024
-SnowflakeQuery: |
+Query: |
   -- https://community.snowflake.com/s/article/Communication-ID-0108977-Additional-Information
 
   SELECT

--- a/queries/snowflake_queries/snowflake_0108977_ip_threat_hunting.yml
+++ b/queries/snowflake_queries/snowflake_0108977_ip_threat_hunting.yml
@@ -2,7 +2,7 @@ AnalysisType: saved_query
 QueryName: "Query.Snowflake.ThreatHunting.ClientIp"
 Description: >
   Monitor for malicious IPs interacting with Snowflake as part of ongoing cyber threat activity reported May 31st, 2024
-SnowflakeQuery: |
+Query: |
   -- https://community.snowflake.com/s/article/Communication-ID-0108977-Additional-Information
 
   SELECT

--- a/queries/snowflake_queries/snowflake_0108977_suspected_user_access_query.yml
+++ b/queries/snowflake_queries/snowflake_0108977_suspected_user_access_query.yml
@@ -3,7 +3,7 @@ Enabled: false
 QueryName: "Query.Snowflake.SuspectedUserAccess"
 Description: >
   Return sessions of suspected clients as part of ongoing cyber threat activity reported May 31st, 2024
-SnowflakeQuery: |
+Query: |
   -- https://community.snowflake.com/s/article/Communication-ID-0108977-Additional-Information
 
   SELECT

--- a/queries/snowflake_queries/snowflake_0108977_suspected_user_access_threat_hunting.yml
+++ b/queries/snowflake_queries/snowflake_0108977_suspected_user_access_threat_hunting.yml
@@ -2,7 +2,7 @@ AnalysisType: saved_query
 QueryName: "Query.Snowflake.ThreatHunting.SuspectedUserAccess"
 Description: >
   Return sessions of suspected clients as part of ongoing cyber threat activity reported May 31st, 2024
-SnowflakeQuery: |
+Query: |
   -- https://community.snowflake.com/s/article/Communication-ID-0108977-Additional-Information
 
   SELECT

--- a/queries/snowflake_queries/snowflake_0108977_suspected_user_activity_threat_hunting.yml
+++ b/queries/snowflake_queries/snowflake_0108977_suspected_user_activity_threat_hunting.yml
@@ -2,7 +2,7 @@ AnalysisType: saved_query
 QueryName: "Query.Snowflake.ThreatHunting.SuspectedUserActivity"
 Description: >
   Return actions/queries made by suspected users as part of ongoing cyber threat activity reported May 31st, 2024
-SnowflakeQuery: |
+Query: |
   -- https://community.snowflake.com/s/article/Communication-ID-0108977-Additional-Information
 
   -- replace <SUSPECTED_USER> with actual user name

--- a/queries/snowflake_queries/snowflake_account_admin_assigned_query.yml
+++ b/queries/snowflake_queries/snowflake_account_admin_assigned_query.yml
@@ -3,10 +3,7 @@ QueryName: "Query.Snowflake.AccountAdminGranted"
 Enabled: false
 Description: >
   Monitor and detect granting account admin role.
-AthenaQuery: |
-  /* athena query not supported */
-  SELECT count(1)
-SnowflakeQuery: |
+Query: |
   --return instances where active (not deleted) roles are granted within the last 24 hours
 
   --this was adapted from a Security Feature Checklist query

--- a/queries/snowflake_queries/snowflake_brute_force_ip_query.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_ip_query.yml
@@ -3,10 +3,7 @@ QueryName: "Query.Snowflake.BruteForceByIp"
 Enabled: false
 Description: >
   Detect brute force attempts by monitoring for failed logins to snowflake.
-AthenaQuery: |
-  /* athena query not supported */
-  SELECT count(1)
-SnowflakeQuery: |
+Query: |
   --return IPs with more than 5 failed logins in the previous 24 hours
 
   --this was adapted from a SnowAlert query

--- a/queries/snowflake_queries/snowflake_brute_force_username_query.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_username_query.yml
@@ -3,10 +3,7 @@ QueryName: "Query.Snowflake.BruteForceByUsername"
 Enabled: false
 Description: >
   Detect brute force attempts by monitoring for failed logins to snowflake.
-AthenaQuery: |
-  /* athena query not supported */
-  SELECT count(1)
-SnowflakeQuery: |
+Query: |
   --return users with more than 5 failed logins in the previous 24 hours
 
   --this was adapted from a SnowAlert query

--- a/queries/snowflake_queries/snowflake_external_shares_query.yml
+++ b/queries/snowflake_queries/snowflake_external_shares_query.yml
@@ -3,10 +3,7 @@ QueryName: "Query.Snowflake.External.Shares"
 Enabled: false
 Description: >
   Monitor for external shares from one cloud source to another.
-AthenaQuery: |
-  /* athena query not supported */
-  SELECT count(1)
-SnowflakeQuery: |
+Query: |
   --return external shares
 
   --this was adapted from a Security Feature Checklist query

--- a/queries/snowflake_queries/snowflake_key_user_password_login_query.yml
+++ b/queries/snowflake_queries/snowflake_key_user_password_login_query.yml
@@ -3,10 +3,7 @@ QueryName: "Query.Snowflake.KeyUserPasswordLogin"
 Enabled: false
 Description: >
   Detects when a user with a configured RSA key logs in with a password
-AthenaQuery: |
-  /* athena query not supported */
-  SELECT count(1)
-SnowflakeQuery: |
+Query: |
   --return instances where a user who has key-based login configured logs in with a password
   --this was adapted from a Security Feature Checklist query
 

--- a/queries/snowflake_queries/snowflake_login_without_mfa_query.yml
+++ b/queries/snowflake_queries/snowflake_login_without_mfa_query.yml
@@ -3,10 +3,7 @@ QueryName: "Query.Snowflake.MFALogin"
 Enabled: false
 Description: >
   Monitor logins that are not using MFA.
-AthenaQuery: |
-  /* athena query not supported */
-  SELECT count(1)
-SnowflakeQuery: |
+Query: |
   --return instances where a user logs in without MFA
 
   --this was adapted from a Security Feature Checklist query

--- a/queries/snowflake_queries/snowflake_multiple_failed_logins_followed_by_success_query.yml
+++ b/queries/snowflake_queries/snowflake_multiple_failed_logins_followed_by_success_query.yml
@@ -3,10 +3,7 @@ QueryName: "Query.Snowflake.Multiple.Logins.Followed.By.Success"
 Enabled: false
 Description: >
   Monitor for brute force user activity.
-AthenaQuery: |
-  /* athena query not supported */
-  SELECT count(1)
-SnowflakeQuery: |
+Query: |
   --return multiple failed logins followed by a success
 
   WITH login_attempts as (

--- a/queries/snowflake_queries/snowflake_user_created_query.yml
+++ b/queries/snowflake_queries/snowflake_user_created_query.yml
@@ -3,10 +3,7 @@ QueryName: "Query.Snowflake.UserCreated"
 Enabled: false
 Description: >
   Monitor for new users.
-AthenaQuery: |
-  /* athena query not supported */
-  SELECT count(1)
-SnowflakeQuery: |
+Query: |
   --return create user events
 
   --this was adapted from a Security Feature Checklist query

--- a/queries/snowflake_queries/snowflake_user_enabled_query.yml
+++ b/queries/snowflake_queries/snowflake_user_enabled_query.yml
@@ -3,10 +3,7 @@ QueryName: "Query.Snowflake.UserEnabled"
 Enabled: false
 Description: >
   Monitor for users that are being re-enabled.
-AthenaQuery: |
-  /* athena query not supported */
-  SELECT count(1)
-SnowflakeQuery: |
+Query: |
   --return enable user events
 
   --this was adapted from a Security Feature Checklist query

--- a/templates/example_scheduled_query.yml
+++ b/templates/example_scheduled_query.yml
@@ -6,12 +6,7 @@ Tags:
   - Tags
 Description: >
   An optional Description
-# Note: Use this parameter if the query includes generic syntax
-Query: "SELECT * FROM panther_logs.aws_cloudtrail LIMIT 10"
-# Note: Use this parameter if the query includes Snowflake-specific syntax
 Query: "SELECT * FROM panther_logs.public.aws_cloudtrail LIMIT 10"
-# Note: Use this parameter if the query includes Athena-specific syntax
-AthenaQuery: "SELECT * FROM panther_logs.aws_cloudtrail LIMIT 10"
 Schedule:
   # Note: CronExpression and RateMinutes are mutually exclusive, only
   # configure one or the other

--- a/templates/example_scheduled_query.yml
+++ b/templates/example_scheduled_query.yml
@@ -9,7 +9,7 @@ Description: >
 # Note: Use this parameter if the query includes generic syntax
 Query: "SELECT * FROM panther_logs.aws_cloudtrail LIMIT 10"
 # Note: Use this parameter if the query includes Snowflake-specific syntax
-SnowflakeQuery: "SELECT * FROM panther_logs.public.aws_cloudtrail LIMIT 10"
+Query: "SELECT * FROM panther_logs.public.aws_cloudtrail LIMIT 10"
 # Note: Use this parameter if the query includes Athena-specific syntax
 AthenaQuery: "SELECT * FROM panther_logs.aws_cloudtrail LIMIT 10"
 Schedule:


### PR DESCRIPTION
### Background

Panther no longer supports a different backend than Snowflake, and having multiple different fields to specify a scheduled query's SQL body has caused confusion. By pruning all references to `AthenaQuery` and `SnowflakeQuery`, we can make our repo consistent with our recommended best practices for customers.

### Changes

- removed all `AthenaQuery` fields
- renamed all `SnowflakeQuery` fields to `Query`

### Testing

- `pat validate` passes
