### PR TITLE
Add AWS WAF Logging Configured Policy

### DIFF
--- a/packs/aws.yml
+++ b/packs/aws.yml
@@ -132,6 +132,7 @@ PackDefinition:
     - AWS.VPC.FlowLogs
     - AWS.WAF.Disassociation
     - AWS.WAF.HasXSSPredicate
+    - AWS.WAF.LoggingConfigured
     # Other rules
     - AWS.CloudTrail.Account.Discovery
     - AWS.CloudTrail.CloudWatchLogs

--- a/policies/aws_waf_policies/aws_waf_logging_configured.py
+++ b/policies/aws_waf_policies/aws_waf_logging_configured.py
@@ -1,0 +1,29 @@
+def is_valid_arn(arn, service):
+    if service == "logs":
+        return arn.startswith("arn:aws:logs:") and ":log-group:" in arn
+    if service == "s3":
+        return arn.startswith("arn:aws:s3:::") and len(arn.split(":")) == 6
+    if service == "firehose":
+        return arn.startswith("arn:aws:firehose:") and ":deliverystream/" in arn
+    return False
+
+
+def policy(resource):
+    # Check if WAF logging configuration exists
+    logging_config = resource.get("LoggingConfiguration")
+    if not logging_config:
+        return False
+
+    # Get the logging destinations
+    destinations = logging_config.get("LogDestinationConfigs", [])
+
+    # Validate the ARNs for CloudWatch Logs, S3, or Kinesis Firehose
+    for destination in destinations:
+        if (
+            is_valid_arn(destination, "logs")
+            or is_valid_arn(destination, "s3")
+            or is_valid_arn(destination, "firehose")
+        ):
+            return True
+
+    return False

--- a/policies/aws_waf_policies/aws_waf_logging_configured.yml
+++ b/policies/aws_waf_policies/aws_waf_logging_configured.yml
@@ -1,0 +1,91 @@
+AnalysisType: policy
+Filename: aws_waf_logging_configured.py
+PolicyID: "AWS.WAF.LoggingConfigured"
+DisplayName: "AWS WAF Logging Configured"
+Enabled: true
+ResourceTypes:
+  - AWS.WAF.Regional.WebACL
+  - AWS.WAF.WebACL
+Tags:
+  - AWS
+  - Monitoring
+  - Logging
+  - Security Control
+  - Defense Evasion:Impair Defenses
+Reports:
+  PCI:
+    - 10.5.5
+  MITRE ATT&CK:
+    - TA0005:T1562
+Severity: High
+Description: >
+  Ensures that AWS WAF logging is enabled and that the logs are being sent to a valid destination (S3, CloudWatch, or Kinesis Firehose). Without logging, visibility into WAF activity is severely limited, increasing the risk of undetected attacks.
+Runbook: >
+  Ensure AWS WAF logging is configured to at least one valid destination such as an Amazon S3 bucket, Amazon CloudWatch Logs, or Amazon Kinesis Data Firehose. Refer to the AWS WAF logging documentation for setup instructions.
+Reference: https://docs.aws.amazon.com/waf/latest/developerguide/logging.html
+Tests:
+  - Name: WAF Logging Configured to CloudWatch Logs
+    ExpectedResult: true
+    Resource:
+      LoggingConfiguration:
+        LogDestinationConfigs:
+          - "arn:aws:logs:us-west-2:123456789012:log-group:example-log-group"
+        RedactedFields: null
+
+  - Name: WAF Logging Configured to S3
+    ExpectedResult: true
+    Resource:
+      LoggingConfiguration:
+        LogDestinationConfigs:
+          - "arn:aws:s3:::example-bucket/waf-logs/"
+        RedactedFields: null
+
+  - Name: WAF Logging Configured to Kinesis Firehose
+    ExpectedResult: true
+    Resource:
+      LoggingConfiguration:
+        LogDestinationConfigs:
+          - "arn:aws:firehose:us-west-2:123456789012:deliverystream/example-firehose"
+        RedactedFields: null
+
+  - Name: WAF Logging Not Configured
+    ExpectedResult: false
+    Resource:
+      LoggingConfiguration: null
+
+  # Edge Case 1: Malformed CloudWatch Logs ARN
+  - Name: WAF Logging Configured with Malformed CloudWatch Logs ARN
+    ExpectedResult: false
+    Resource:
+      LoggingConfiguration:
+        LogDestinationConfigs:
+          - "arn:aws:logs:us-west-2:123456789012"  # Incorrect ARN format
+        RedactedFields: null
+
+  # Edge Case 2: Malformed S3 ARN
+  - Name: WAF Logging Configured with Malformed S3 ARN
+    ExpectedResult: false
+    Resource:
+      LoggingConfiguration:
+        LogDestinationConfigs:
+          - "arn:aws:s3::example-bucket-wrong-format"  # Incorrect ARN format
+        RedactedFields: null
+
+  # Edge Case 3: Multiple Valid Logging Destinations (S3 and Kinesis Firehose)
+  - Name: WAF Logging Configured to Both S3 and Kinesis Firehose
+    ExpectedResult: true
+    Resource:
+      LoggingConfiguration:
+        LogDestinationConfigs:
+          - "arn:aws:s3:::example-bucket/waf-logs/"
+          - "arn:aws:firehose:us-west-2:123456789012:deliverystream/example-firehose"
+        RedactedFields: null
+
+  # Edge Case 4: Malformed Kinesis Firehose ARN
+  - Name: WAF Logging Configured with Malformed Kinesis Firehose ARN
+    ExpectedResult: false
+    Resource:
+      LoggingConfiguration:
+        LogDestinationConfigs:
+          - "arn:aws:firehose:us-west-2"  # Incorrect ARN format
+        RedactedFields: null


### PR DESCRIPTION
### Background

This PR adds a new detection rule that ensures AWS WAF (Web Application Firewall) logging is configured and sending logs to valid destinations, such as Amazon S3, CloudWatch Logs, or Kinesis Firehose. Proper logging is essential for monitoring AWS WAF activity.
### Changes
Python policy file: aws_waf_logging_configured.py
This file contains logic to validate if AWS WAF logging is configured to a valid destination (S3, CloudWatch Logs, or Kinesis Firehose).
It checks the LoggingConfiguration field in AWS WAF resources and validates the destination ARNs.
Metadata file: aws_waf_logging_configured.yml
Adds metadata for the new rule, specifying:
PolicyID: "AWS.WAF.LoggingConfigured"
Severity: High
Tags for easier categorization
Includes test cases for different logging configurations (e.g., valid/invalid ARNs, multiple valid destinations).

### Testing

Ran the following test cases using Panther’s panther_analysis_tool:
WAF Logging Configured to CloudWatch Logs
WAF Logging Configured to S3
WAF Logging Configured to Kinesis Firehose
WAF Logging Not Configured
Edge cases (Malformed ARNs for CloudWatch, S3, Kinesis)
Multiple Valid Logging Destinations (S3 and Kinesis)
