### PR TITLE
Allow 'applicationName=login` for `GSuite.ExternalMailForwarding`

### DIFF
--- a/rules/gsuite_activityevent_rules/gsuite_external_forwarding.py
+++ b/rules/gsuite_activityevent_rules/gsuite_external_forwarding.py
@@ -2,7 +2,7 @@ from panther_config import config
 
 
 def rule(event):
-    if event.deep_get("id", "applicationName") != "user_accounts":
+    if event.deep_get("id", "applicationName") not in ("user_accounts", "login"):
         return False
 
     if event.get("name") == "email_forwarding_out_of_domain":

--- a/rules/gsuite_activityevent_rules/gsuite_external_forwarding.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_external_forwarding.yml
@@ -21,7 +21,7 @@ Runbook: >
 SummaryAttributes:
   - p_any_emails
 Tests:
-  - Name: Forwarding to External Address
+  - Name: Forwarding to External Address - applicationName = user_accounts
     ExpectedResult: true
     Log:
       {
@@ -31,6 +31,17 @@ Tests:
         "name": "email_forwarding_out_of_domain",
         "parameters":
           { "email_forwarding_destination_address": "HSimpson@gmail.com" },
+      }
+
+  - Name: Forwarding to External Address - applicationName = login
+    ExpectedResult: true
+    Log:
+      {
+        "id": { "applicationName": "login", "customerId": "D12345" },
+        "actor": { "email": "homer.simpson@springfield.io" },
+        "type": "email_forwarding_change",
+        "name": "email_forwarding_out_of_domain",
+        "parameters": { "email_forwarding_destination_address": "HSimpsone@gmail.com" }
       }
 
   - Name: Forwarding to External Address - Allowed Domain


### PR DESCRIPTION
### Background

A customer raised an issue with the current detection - email forwarding change events can come from applications with name `user_accoutns` or `login`. They observed events where `applicationName=login` did not raise alerts. We confirmed this behaviour and updated the rule.

### Changes

- restrict `applicationName` to `login` or `user_accounts` instead of just `user_accounts`

### Testing

- used a recent email forwarding event from our own logs as a test case
