### PR TITLE
feat: add requestParameters

### DIFF
--- a/global_helpers/panther_aws_helpers.py
+++ b/global_helpers/panther_aws_helpers.py
@@ -35,6 +35,7 @@ def aws_rule_context(event: dict):
         "eventSource": event.get("eventSource", "<MISSING_ACCOUNT_ID>"),
         "awsRegion": event.get("awsRegion", "<MISSING_AWS_REGION>"),
         "recipientAccountId": event.get("recipientAccountId", "<MISSING_ACCOUNT_ID>"),
+        "requestParameters": event.get("requestParameters", "<MISSING_REQUEST_PARAMETERS>"),
         "sourceIPAddress": event.get("sourceIPAddress", "<MISSING_SOURCE_IP>"),
         "userAgent": event.get("userAgent", "<MISSING_USER_AGENT>"),
         "userIdentity": event.get("userIdentity", "<MISSING_USER_IDENTITY>"),


### PR DESCRIPTION
Closes #1401

### Background

`requestParameters` contains critical information for incident responders that should be surfaced as part of the alert context.

### Changes

- Adds `requestParameters` to the dict returned by `aws_rule_context()` helper function

### Testing
