### PR TITLE
feat: include accountId in aws_guardduty_context

### DIFF
--- a/global_helpers/panther_aws_helpers.py
+++ b/global_helpers/panther_aws_helpers.py
@@ -49,6 +49,7 @@ def aws_guardduty_context(event: dict):
         "type": event.get("type", "<MISSING TYPE>"),
         "resource": event.get("resource", {}),
         "service": event.get("service", {}),
+        "accountId": event.get("accountId", "<MISSING ACCOUNT ID>"),
     }
 
 


### PR DESCRIPTION
Closes #1403

### Background

`aws_guardduty_context` helper function does not include `accountId` in the alert context

### Changes

- Includes `accountId` in the dict returned by `aws_guardduty_context`

### Testing