### PR TITLE
fix typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-dirs := $(shell ls | egrep 'policies|rules|helpers|models|templates|queries' | xargs)
+dirs := $(shell ls | egrep 'policies|rules|global_helpers|models|templates|queries' | xargs)
 UNAME := $(shell uname)
 TEST_ARGS :=
 


### PR DESCRIPTION
This pull request includes a small change to the `Makefile`. The change updates the list of directories to include `global_helpers` instead of `helpers`.

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R1): Updated the `dirs` variable to include `global_helpers` instead of `helpers`.