### PR TITLE
Fix event dict typing

### DIFF
--- a/global_helpers/panther_aws_helpers.py
+++ b/global_helpers/panther_aws_helpers.py
@@ -29,7 +29,7 @@ def aws_strip_role_session_id(user_identity_arn):
     return user_identity_arn
 
 
-def aws_rule_context(event: dict):
+def aws_rule_context(event):
     return {
         "eventName": event.get("eventName", "<MISSING_EVENT_NAME>"),
         "eventSource": event.get("eventSource", "<MISSING_ACCOUNT_ID>"),
@@ -41,7 +41,7 @@ def aws_rule_context(event: dict):
     }
 
 
-def aws_guardduty_context(event: dict):
+def aws_guardduty_context(event):
     return {
         "description": event.get("description", "<MISSING DESCRIPTION>"),
         "severity": event.get("severity", "<MISSING SEVERITY>"),

--- a/global_helpers/panther_box_helpers.py
+++ b/global_helpers/panther_box_helpers.py
@@ -139,7 +139,7 @@ def build_jwt_settings(response: dict) -> dict:
 
 # 'additional_details' from box logs varies by event_type.
 # This helper wraps the process of extracting those details.
-def box_parse_additional_details(event: dict):
+def box_parse_additional_details(event):
     additional_details = event.get("additional_details", {})
     if isinstance(additional_details, (str, bytes)):
         try:

--- a/global_helpers/panther_cloudflare_helpers.py
+++ b/global_helpers/panther_cloudflare_helpers.py
@@ -38,7 +38,7 @@ def map_source_to_name(event: Any) -> str:
     )
 
 
-def cloudflare_fw_alert_context(event: dict = None):
+def cloudflare_fw_alert_context(event=None):
     keep_keys = [
         "Action",
         "ClientIP",
@@ -57,7 +57,7 @@ def cloudflare_fw_alert_context(event: dict = None):
     return context_dict
 
 
-def cloudflare_http_alert_context(event: dict = None):
+def cloudflare_http_alert_context(event=None):
     keep_keys = [
         "BotScore",
         "BotScoreSrc",

--- a/global_helpers/panther_crowdstrike_fdr_helpers.py
+++ b/global_helpers/panther_crowdstrike_fdr_helpers.py
@@ -1,4 +1,4 @@
-def crowdstrike_detection_alert_context(event: dict):
+def crowdstrike_detection_alert_context(event):
     """Returns common context for Crowdstrike detections"""
     return {
         "aid": get_crowdstrike_field(event, "aid", default=""),
@@ -13,7 +13,7 @@ def crowdstrike_detection_alert_context(event: dict):
     }
 
 
-def crowdstrike_process_alert_context(event: dict):
+def crowdstrike_process_alert_context(event):
     """Returns common process context for Crowdstrike detections"""
     return {
         "aid": get_crowdstrike_field(event, "aid", default=""),
@@ -28,7 +28,7 @@ def crowdstrike_process_alert_context(event: dict):
     }
 
 
-def crowdstrike_network_detection_alert_context(event: dict):
+def crowdstrike_network_detection_alert_context(event):
     """Returns common network context for Crowdstrike detections"""
     return {
         "LocalAddressIP4": get_crowdstrike_field(event, "LocalAddressIP4", default=""),

--- a/global_helpers/panther_duo_helpers.py
+++ b/global_helpers/panther_duo_helpers.py
@@ -2,7 +2,7 @@ import json
 from json import JSONDecodeError
 
 
-def deserialize_administrator_log_event_description(event: dict) -> dict:
+def deserialize_administrator_log_event_description(event) -> dict:
     """Intelligently try and decode a field that is usually stringified json into a python dict.
 
     This description field seems to take the form of stringified json, So this function

--- a/global_helpers/panther_lookuptable_helpers.py
+++ b/global_helpers/panther_lookuptable_helpers.py
@@ -27,7 +27,7 @@ class LookupTableMatches:
     def p_matched(self):
         return self._p_matched
 
-    def p_matches(self, event: dict, p_match: str = "") -> dict:
+    def p_matches(self, event, p_match: str = "") -> dict:
         """Collect enrichments by searching for a value match in the p_match field
 
         Parameters:

--- a/global_helpers/panther_okta_helpers.py
+++ b/global_helpers/panther_okta_helpers.py
@@ -1,4 +1,4 @@
-def okta_alert_context(event: dict):
+def okta_alert_context(event):
     """Returns common context for automation of Okta alerts"""
     return {
         "event_type": event.get("eventtype", ""),


### PR DESCRIPTION
### Background

Some alert context helpers were erroneously typing `event: dict`.   This breaks some things after PyPanther conversion because events are type PantherEvent.

### Changes

- Remove dict typing from alert context helpers

### Testing

- make test
