### PR TITLE
Fix Wiz Audit Log Titles for Service Account Actors

### DIFF
--- a/global_helpers/panther_wiz_helpers.py
+++ b/global_helpers/panther_wiz_helpers.py
@@ -7,9 +7,33 @@ def wiz_success(event):
 def wiz_alert_context(event):
     return {
         "action": event.get("action", ""),
-        "user": event.get("user", ""),
+        "actor": wiz_actor(event),
         "source_ip": event.get("sourceip", ""),
         "event_id": event.get("id", ""),
-        "service_account": event.get("serviceaccount", ""),
         "action_parameters": event.get("actionparameters", ""),
+    }
+
+
+def wiz_actor(event):
+    user = event.get("user")
+    serviceaccount = event.get("serviceAccount")
+
+    if user is not None:
+        return {
+            "type": "user",
+            "id": user.get("id"),
+            "name": user.get("name"),
+        }
+
+    if serviceaccount is not None:
+        return {
+            "type": "serviceaccount",
+            "id": serviceaccount.get("id"),
+            "name": serviceaccount.get("name"),
+        }
+
+    return {
+        "type": "unknown",
+        "id": "<Unknown ID>",
+        "name": "<Unknown Name>",
     }

--- a/rules/wiz_rules/wiz_cicd_scan_policy_updated_or_deleted.py
+++ b/rules/wiz_rules/wiz_cicd_scan_policy_updated_or_deleted.py
@@ -1,4 +1,4 @@
-from panther_wiz_helpers import wiz_alert_context, wiz_success
+from panther_wiz_helpers import wiz_actor, wiz_alert_context, wiz_success
 
 SUSPICIOUS_ACTIONS = ["DeleteCICDScanPolicy", "UpdateCICDScanPolicy"]
 
@@ -10,9 +10,11 @@ def rule(event):
 
 
 def title(event):
+    actor = wiz_actor(event)
+
     return (
         f"[Wiz]: [{event.get('action', 'ACTION_NOT_FOUND')}] action "
-        f"performed by user [{event.deep_get('user', 'name', default='USER_NAME_NOT_FOUND')}]"
+        f"performed by {actor.get('type')} [{actor.get('name')}]"
     )
 
 

--- a/rules/wiz_rules/wiz_connector_updated_or_deleted.py
+++ b/rules/wiz_rules/wiz_connector_updated_or_deleted.py
@@ -1,4 +1,4 @@
-from panther_wiz_helpers import wiz_alert_context, wiz_success
+from panther_wiz_helpers import wiz_actor, wiz_alert_context, wiz_success
 
 SUSPICIOUS_ACTIONS = ["DeleteConnector", "UpdateConnector"]
 
@@ -10,9 +10,11 @@ def rule(event):
 
 
 def title(event):
+    actor = wiz_actor(event)
+
     return (
         f"[Wiz]: [{event.get('action', 'ACTION_NOT_FOUND')}] action "
-        f"performed by user [{event.deep_get('user', 'name', default='USER_NAME_NOT_FOUND')}]"
+        f"performed by {actor.get('type')} [{actor.get('name')}]"
     )
 
 

--- a/rules/wiz_rules/wiz_data_classifier_updated_or_deleted.py
+++ b/rules/wiz_rules/wiz_data_classifier_updated_or_deleted.py
@@ -1,4 +1,4 @@
-from panther_wiz_helpers import wiz_alert_context, wiz_success
+from panther_wiz_helpers import wiz_actor, wiz_alert_context, wiz_success
 
 SUSPICIOUS_ACTIONS = ["DeleteDataClassifier", "UpdateDataClassifier"]
 
@@ -10,9 +10,11 @@ def rule(event):
 
 
 def title(event):
+    actor = wiz_actor(event)
+
     return (
         f"[Wiz]: [{event.get('action', 'ACTION_NOT_FOUND')}] action "
-        f"performed by user [{event.deep_get('user', 'name', default='USER_NAME_NOT_FOUND')}]"
+        f"performed by {actor.get('type')} [{actor.get('name')}]"
     )
 
 

--- a/rules/wiz_rules/wiz_image_integrity_validator_updated_or_deleted.py
+++ b/rules/wiz_rules/wiz_image_integrity_validator_updated_or_deleted.py
@@ -1,4 +1,4 @@
-from panther_wiz_helpers import wiz_alert_context, wiz_success
+from panther_wiz_helpers import wiz_actor, wiz_alert_context, wiz_success
 
 SUSPICIOUS_ACTIONS = ["DeleteImageIntegrityValidator", "UpdateImageIntegrityValidator"]
 
@@ -10,9 +10,11 @@ def rule(event):
 
 
 def title(event):
+    actor = wiz_actor(event)
+
     return (
         f"[Wiz]: [{event.get('action', 'ACTION_NOT_FOUND')}] action "
-        f"performed by user [{event.deep_get('user', 'name', default='USER_NAME_NOT_FOUND')}]"
+        f"performed by {actor.get('type')} [{actor.get('name')}]"
     )
 
 

--- a/rules/wiz_rules/wiz_integration_updated_or_deleted.py
+++ b/rules/wiz_rules/wiz_integration_updated_or_deleted.py
@@ -1,4 +1,4 @@
-from panther_wiz_helpers import wiz_alert_context, wiz_success
+from panther_wiz_helpers import wiz_actor, wiz_alert_context, wiz_success
 
 SUSPICIOUS_ACTIONS = ["DeleteIntegration", "UpdateIntegration"]
 
@@ -10,9 +10,11 @@ def rule(event):
 
 
 def title(event):
+    actor = wiz_actor(event)
+
     return (
         f"[Wiz]: [{event.get('action', 'ACTION_NOT_FOUND')}] action "
-        f"performed by user [{event.deep_get('user', 'name', default='USER_NAME_NOT_FOUND')}]"
+        f"performed by {actor.get('type')} [{actor.get('name')}]"
     )
 
 

--- a/rules/wiz_rules/wiz_revoke_user_sessions.py
+++ b/rules/wiz_rules/wiz_revoke_user_sessions.py
@@ -1,4 +1,4 @@
-from panther_wiz_helpers import wiz_alert_context, wiz_success
+from panther_wiz_helpers import wiz_actor, wiz_alert_context, wiz_success
 
 
 def rule(event):
@@ -8,9 +8,11 @@ def rule(event):
 
 
 def title(event):
+    actor = wiz_actor(event)
+
     return (
         f"[Wiz]: [{event.get('action', 'ACTION_NOT_FOUND')}] action "
-        f"performed by user [{event.deep_get('user', 'name', default='USER_NAME_NOT_FOUND')}]"
+        f"performed by {actor.get('type')} [{actor.get('name')}]"
     )
 
 

--- a/rules/wiz_rules/wiz_rotate_service_account_secret.py
+++ b/rules/wiz_rules/wiz_rotate_service_account_secret.py
@@ -1,4 +1,4 @@
-from panther_wiz_helpers import wiz_alert_context, wiz_success
+from panther_wiz_helpers import wiz_actor, wiz_alert_context, wiz_success
 
 
 def rule(event):
@@ -8,9 +8,11 @@ def rule(event):
 
 
 def title(event):
+    actor = wiz_actor(event)
+
     return (
         f"[Wiz]: [{event.get('action', 'ACTION_NOT_FOUND')}] action "
-        f"performed by user [{event.deep_get('user', 'name', default='USER_NAME_NOT_FOUND')}]"
+        f"performed by {actor.get('type')} [{actor.get('name')}]"
     )
 
 

--- a/rules/wiz_rules/wiz_rule_change.py
+++ b/rules/wiz_rules/wiz_rule_change.py
@@ -1,4 +1,4 @@
-from panther_wiz_helpers import wiz_alert_context, wiz_success
+from panther_wiz_helpers import wiz_actor, wiz_alert_context, wiz_success
 
 SUSPICIOUS_ACTIONS = [
     "DeleteAutomationRule",
@@ -24,9 +24,11 @@ def rule(event):
 
 
 def title(event):
+    actor = wiz_actor(event)
+
     return (
         f"[Wiz]: [{event.get('action', 'ACTION_NOT_FOUND')}] action "
-        f"performed by user [{event.deep_get('user', 'name', default='USER_NAME_NOT_FOUND')}]"
+        f"performed by {actor.get('type')} [{actor.get('name')}]"
     )
 
 

--- a/rules/wiz_rules/wiz_saml_identity_provider_change.py
+++ b/rules/wiz_rules/wiz_saml_identity_provider_change.py
@@ -1,4 +1,4 @@
-from panther_wiz_helpers import wiz_alert_context, wiz_success
+from panther_wiz_helpers import wiz_actor, wiz_alert_context, wiz_success
 
 SUSPICIOUS_ACTIONS = [
     "UpdateSAMLIdentityProvider",
@@ -15,9 +15,11 @@ def rule(event):
 
 
 def title(event):
+    actor = wiz_actor(event)
+
     return (
         f"[Wiz]: [{event.get('action', 'ACTION_NOT_FOUND')}] action "
-        f"performed by user [{event.deep_get('user', 'name', default='USER_NAME_NOT_FOUND')}]"
+        f"performed by {actor.get('type')} [{actor.get('name')}]"
     )
 
 

--- a/rules/wiz_rules/wiz_service_account_change.py
+++ b/rules/wiz_rules/wiz_service_account_change.py
@@ -1,4 +1,4 @@
-from panther_wiz_helpers import wiz_alert_context, wiz_success
+from panther_wiz_helpers import wiz_actor, wiz_alert_context, wiz_success
 
 SUSPICIOUS_ACTIONS = [
     "CreateServiceAccount",
@@ -14,9 +14,11 @@ def rule(event):
 
 
 def title(event):
+    actor = wiz_actor(event)
+
     return (
         f"[Wiz]: [{event.get('action', 'ACTION_NOT_FOUND')}] action "
-        f"performed by user [{event.deep_get('user', 'name', default='USER_NAME_NOT_FOUND')}]"
+        f"performed by {actor.get('type')} [{actor.get('name')}]"
     )
 
 

--- a/rules/wiz_rules/wiz_update_ip_restrictions.py
+++ b/rules/wiz_rules/wiz_update_ip_restrictions.py
@@ -1,4 +1,4 @@
-from panther_wiz_helpers import wiz_alert_context, wiz_success
+from panther_wiz_helpers import wiz_actor, wiz_alert_context, wiz_success
 
 
 def rule(event):
@@ -8,9 +8,11 @@ def rule(event):
 
 
 def title(event):
+    actor = wiz_actor(event)
+
     return (
         f"[Wiz]: [{event.get('action', 'ACTION_NOT_FOUND')}] action "
-        f"performed by user [{event.deep_get('user', 'name', default='USER_NAME_NOT_FOUND')}]"
+        f"performed by {actor.get('type')} [{actor.get('name')}]"
     )
 
 

--- a/rules/wiz_rules/wiz_update_login_settings.py
+++ b/rules/wiz_rules/wiz_update_login_settings.py
@@ -1,4 +1,4 @@
-from panther_wiz_helpers import wiz_alert_context, wiz_success
+from panther_wiz_helpers import wiz_actor, wiz_alert_context, wiz_success
 
 
 def rule(event):
@@ -8,9 +8,11 @@ def rule(event):
 
 
 def title(event):
+    actor = wiz_actor(event)
+
     return (
         f"[Wiz]: [{event.get('action', 'ACTION_NOT_FOUND')}] action "
-        f"performed by user [{event.deep_get('user', 'name', default='USER_NAME_NOT_FOUND')}]"
+        f"performed by {actor.get('type')} [{actor.get('name')}]"
     )
 
 

--- a/rules/wiz_rules/wiz_update_scanner_settings.py
+++ b/rules/wiz_rules/wiz_update_scanner_settings.py
@@ -1,4 +1,4 @@
-from panther_wiz_helpers import wiz_alert_context, wiz_success
+from panther_wiz_helpers import wiz_actor, wiz_alert_context, wiz_success
 
 
 def rule(event):
@@ -8,9 +8,11 @@ def rule(event):
 
 
 def title(event):
+    actor = wiz_actor(event)
+
     return (
         f"[Wiz]: [{event.get('action', 'ACTION_NOT_FOUND')}] action "
-        f"performed by user [{event.deep_get('user', 'name', default='USER_NAME_NOT_FOUND')}]"
+        f"performed by {actor.get('type')} [{actor.get('name')}]"
     )
 
 

--- a/rules/wiz_rules/wiz_update_support_contact_list.py
+++ b/rules/wiz_rules/wiz_update_support_contact_list.py
@@ -1,4 +1,4 @@
-from panther_wiz_helpers import wiz_alert_context, wiz_success
+from panther_wiz_helpers import wiz_actor, wiz_alert_context, wiz_success
 
 
 def rule(event):
@@ -8,9 +8,11 @@ def rule(event):
 
 
 def title(event):
+    actor = wiz_actor(event)
+
     return (
         f"[Wiz]: [{event.get('action', 'ACTION_NOT_FOUND')}] action "
-        f"performed by user [{event.deep_get('user', 'name', default='USER_NAME_NOT_FOUND')}]"
+        f"performed by {actor.get('type')} [{actor.get('name')}]"
     )
 
 

--- a/rules/wiz_rules/wiz_user_created_or_deleted.py
+++ b/rules/wiz_rules/wiz_user_created_or_deleted.py
@@ -1,4 +1,4 @@
-from panther_wiz_helpers import wiz_alert_context, wiz_success
+from panther_wiz_helpers import wiz_actor, wiz_alert_context, wiz_success
 
 SUSPICIOUS_ACTIONS = ["CreateUser", "DeleteUser"]
 
@@ -10,9 +10,11 @@ def rule(event):
 
 
 def title(event):
+    actor = wiz_actor(event)
+
     return (
         f"[Wiz]: [{event.get('action', 'ACTION_NOT_FOUND')}] action "
-        f"performed by user [{event.deep_get('user', 'name', default='USER_NAME_NOT_FOUND')}]"
+        f"performed by {actor.get('type')} [{actor.get('name')}]"
     )
 
 

--- a/rules/wiz_rules/wiz_user_role_updated_or_deleted.py
+++ b/rules/wiz_rules/wiz_user_role_updated_or_deleted.py
@@ -1,4 +1,4 @@
-from panther_wiz_helpers import wiz_alert_context, wiz_success
+from panther_wiz_helpers import wiz_actor, wiz_alert_context, wiz_success
 
 SUSPICIOUS_ACTIONS = ["DeleteUserRole", "UpdateUserRole"]
 
@@ -10,9 +10,11 @@ def rule(event):
 
 
 def title(event):
+    actor = wiz_actor(event)
+
     return (
         f"[Wiz]: [{event.get('action', 'ACTION_NOT_FOUND')}] action "
-        f"performed by user [{event.deep_get('user', 'name', default='USER_NAME_NOT_FOUND')}]"
+        f"performed by {actor.get('type')} [{actor.get('name')}]"
     )
 
 


### PR DESCRIPTION
### Background

Wiz audit logs events can have a service account as an actor. This isn't currently reflected properly in alert titles.

### Changes

- Add a helper function to determine if the actor is a user or service account.
- Update all rules to use this logic in their titles.

### Testing

- These changes have been tested on a Wiz log source for the last few weeks.
