### PR TITLE
Adjust CR Schedules and Lookbacks

### DIFF
--- a/correlation_rules/aws_cloudtrail_stopinstance_followed_by_modifyinstanceattributes.yml
+++ b/correlation_rules/aws_cloudtrail_stopinstance_followed_by_modifyinstanceattributes.yml
@@ -18,11 +18,12 @@ Detection:
         - ID: StopInstance FOLLOWED BY StartupScriptChange
           From: StopInstance
           To: StartupScriptChange
+          WithinTimeFrameMinutes: 90
           Match:
             - On: p_alert_context.instance_ids
-      LookbackWindowMinutes: 90
+      LookbackWindowMinutes: 2160
       Schedule:
-        RateMinutes: 60
+        RateMinutes: 1440
         TimeoutMinutes: 5
 Tests:
     - Name: Instance Stopped, Followed By Script Change

--- a/correlation_rules/aws_console_sign-in_without_okta.yml
+++ b/correlation_rules/aws_console_sign-in_without_okta.yml
@@ -26,7 +26,7 @@ Detection:
       Schedule:
         RateMinutes: 1440
         TimeoutMinutes: 5
-      LookbackWindowMinutes: 1440
+      LookbackWindowMinutes: 2160
 Tests:
   - Name: AWS Console Sign-In PRECEDED BY Okta Redirect
     ExpectedResult: false

--- a/correlation_rules/aws_privilege_escalation_via_user_compromise.yml
+++ b/correlation_rules/aws_privilege_escalation_via_user_compromise.yml
@@ -16,12 +16,13 @@ Detection:
         - ID: User Backdoored TO User Accessed ON IP Addr
           From: User Backdoored
           To: User Accessed
+          WithinTimeFrameMinutes: 60
           Match:
             - On: p_alert_context.ip_accessKeyId
       Schedule:
-        RateMinutes: 60
+        RateMinutes: 1440
         TimeoutMinutes: 10
-      LookbackWindowMinutes: 90
+      LookbackWindowMinutes: 2160
 Tests:
     - Name: Access Key Created and Used from Same IP
       ExpectedResult: true

--- a/correlation_rules/aws_sso_access_token_retrieved_by_unauthenticated_ip.yml
+++ b/correlation_rules/aws_sso_access_token_retrieved_by_unauthenticated_ip.yml
@@ -25,7 +25,7 @@ Detection:
       Schedule:
         RateMinutes: 1440
         TimeoutMinutes: 5
-      LookbackWindowMinutes: 1440
+      LookbackWindowMinutes: 2160
 Tests:
   - Name: AWS SSO Access Token Retrieved by Authenticated IP
     ExpectedResult: false

--- a/correlation_rules/aws_user_takeover_via_password_reset.yml
+++ b/correlation_rules/aws_user_takeover_via_password_reset.yml
@@ -16,12 +16,13 @@ Detection:
         - ID: Password Reset TO Login ON IP Addr
           From: Password Reset
           To: Login
+          WithinTimeFrameMinutes: 60
           Match:
             - On: p_alert_context.ip_and_username
       Schedule:
-        RateMinutes: 60
+        RateMinutes: 1440
         TimeoutMinutes: 10
-      LookbackWindowMinutes: 90
+      LookbackWindowMinutes: 2160
 Tests:
     - Name: Password Reset, Then Login From Same IP
       ExpectedResult: true

--- a/correlation_rules/gcp_cloud_run_service_create_followed_by_set_iam_policy.yml
+++ b/correlation_rules/gcp_cloud_run_service_create_followed_by_set_iam_policy.yml
@@ -21,11 +21,12 @@ Detection:
         - ID: ServiceCreated FOLLOWED BY SetIAMPolicy
           From: ServiceCreated
           To: SetIAMPolicy
+          WithinTimeFrameMinutes: 90
           Match:
             - On: p_alert_context.caller_ip
-      LookbackWindowMinutes: 90
+      LookbackWindowMinutes: 2160
       Schedule:
-        RateMinutes: 60 
+        RateMinutes: 1440 
         TimeoutMinutes: 5
 Tests:
     - Name: GCP Service Run, Followed By IAM Policy Change From Same IP

--- a/correlation_rules/github_advanced_security_change_not_followed_by_repo_archived.yml
+++ b/correlation_rules/github_advanced_security_change_not_followed_by_repo_archived.yml
@@ -16,11 +16,12 @@ Detection:
       - ID: GHASChange NOT FOLLOWED BY RepoArchived
         From: RepoArchived
         To: GHASChange
+        WithinTimeFrameMinutes: 60
         Match:
           - On: p_alert_context.repo
-    LookbackWindowMinutes: 90
+    LookbackWindowMinutes: 2160
     Schedule:
-      RateMinutes: 60
+      RateMinutes: 1440
       TimeoutMinutes: 10
 Tests:
     - Name: Security Change on Repo, Followed By Same Repo Archived

--- a/correlation_rules/notion_login_followed_by_account_change.yml
+++ b/correlation_rules/notion_login_followed_by_account_change.yml
@@ -22,7 +22,7 @@ Detection:
           WithinTimeFrameMinutes: 15
           Match:
             - On: p_alert_context.actor_id
-      LookbackWindowMinutes: 1440
+      LookbackWindowMinutes: 2160
       Schedule:
         RateMinutes: 1440
         TimeoutMinutes: 5

--- a/correlation_rules/okta_login_without_push.yml
+++ b/correlation_rules/okta_login_without_push.yml
@@ -21,13 +21,14 @@ Detection:
       - ID: Okta to Push
         From: Okta
         To: Push
+        WithinTimeFrameMinutes: 60
         Match:
           - From: actor.alternateId
             To: new.email
     Schedule:
-      RateMinutes: 60
+      RateMinutes: 1440
       TimeoutMinutes: 10
-    LookbackWindowMinutes: 90
+    LookbackWindowMinutes: 2160
 Tests:
   - Name: Okta Login, Followed By Push Authorized Login
     ExpectedResult: false

--- a/correlation_rules/onelogin_successful_login_after_high_risk_failed_login.yml
+++ b/correlation_rules/onelogin_successful_login_after_high_risk_failed_login.yml
@@ -22,7 +22,7 @@ Detection:
           WithinTimeFrameMinutes: 15
           Match:
             - On: user_name
-      LookbackWindowMinutes: 1440
+      LookbackWindowMinutes: 2160
       Schedule:
         RateMinutes: 1440
         TimeoutMinutes: 5

--- a/correlation_rules/potential_compromised_okta_credentials.yml
+++ b/correlation_rules/potential_compromised_okta_credentials.yml
@@ -20,13 +20,14 @@ Detection:
       - ID: Match on user
         From: Login Without Push Marker
         To: Push Phishing
+        WithinTimeFrameMinutes: 60
         Match:
           - From: actor.alternateId
             To: new.employee.email
     Schedule:
-      RateMinutes: 60
+      RateMinutes: 1440
       TimeoutMinutes: 10
-    LookbackWindowMinutes: 90
+    LookbackWindowMinutes: 2160
 Tests:
   - Name: Login Without Marker, Followed By Phishing Detection
     ExpectedResult: true

--- a/correlation_rules/secret_exposed_and_not_quarantined.yml
+++ b/correlation_rules/secret_exposed_and_not_quarantined.yml
@@ -21,10 +21,11 @@ Detection:
         - ID: SecretFound TO SecretNotQuarantined
           From: SecretFound
           To: SecretNotQuarantined
+          WithinTimeFrameMinutes: 60
       Schedule:
-        RateMinutes: 60
+        RateMinutes: 1440
         TimeoutMinutes: 10
-      LookbackWindowMinutes: 90
+      LookbackWindowMinutes: 2160
 Tests:
     - Name: Secret Found and Quarantied
       ExpectedResult: false

--- a/correlation_rules/snowflake_data_exfiltration.yml
+++ b/correlation_rules/snowflake_data_exfiltration.yml
@@ -28,9 +28,9 @@ Detection:
         Match:
           - On: stage
     Schedule:
-      RateMinutes: 720
+      RateMinutes: 1440
       TimeoutMinutes: 15
-    LookbackWindowMinutes: 1440
+    LookbackWindowMinutes: 2160
 Tests:
     - Name: Data Exfiltration
       ExpectedResult: true

--- a/rules/crowdstrike_rules/event_stream_rules/crowdstrike_ephemeral_user_account.yml
+++ b/rules/crowdstrike_rules/event_stream_rules/crowdstrike_ephemeral_user_account.yml
@@ -19,11 +19,12 @@ Detection:
       - ID: User Created FOLLOWED BY User Deleted
         From: AccountCreated
         To: AccountDeleted
+        WithinTimeFrameMinutes: 720 # 12 hours
         Match:
           - On: p_alert_context.target_name
-    LookbackWindowMinutes: 720 # 12 hours
+    LookbackWindowMinutes: 2160
     Schedule:
-      RateMinutes: 480 # 8 hours
+      RateMinutes: 1440
       TimeoutMinutes: 1
 Tests:
   - Name: User Creation, Followed By Deletion

--- a/rules/crowdstrike_rules/event_stream_rules/crowdstrike_new_admin_user_created.yml
+++ b/rules/crowdstrike_rules/event_stream_rules/crowdstrike_new_admin_user_created.yml
@@ -19,11 +19,12 @@ Detection:
       - ID: AcountCreated FOLLOWED BY AdminRoleAssigned ON target AND actor
         From: AccountCreated
         To: AdminRoleAssigned
+        WithinTimeFrameMinutes: 45
         Match:
           - On: p_alert_context.actor_target
-    LookbackWindowMinutes: 45
+    LookbackWindowMinutes: 2160
     Schedule:
-      RateMinutes: 30
+      RateMinutes: 1440
       TimeoutMinutes: 1
 Tests:
   - Name: User Creation, Followed By Role Assignment


### PR DESCRIPTION
### Background

Correlation rules that run too frequently are very cost-ineffective. This PR defaults all managed CRs to running once per day and looking back over the past 36 hours (while respecting the relative time constraints between events using `WithinTimeFrameMinutes`.

### Changes

- adjusted all CR schedule `RateMinutes` to 1440 (24 hours)
- adjusted all CR `LookbackWindowMinutes` to 2160 (36 hours) to allow for log latency
- added `WithinTimeFrameMinutes` to transitions to preserve the original lookback window

### Testing

- `make test`
- `pat validate`
