### PR TITLE
fixing ruleID typo on gcp_k8s_pod_create_or_modify_host_path_vol_mount.yml

### DIFF
--- a/deprecated.txt
+++ b/deprecated.txt
@@ -34,3 +34,4 @@ Okta.GeographicallyImprobableAccess
 Okta.BruteForceLogins
 Query.Snowflake.PublicRoleGrant
 Snowflake.PublicRoleGrant
+GCP.K8S.Pot.Create.Or.Modify.Host.Path.Volume.Mount

--- a/packs/gcp_k8.yml
+++ b/packs/gcp_k8.yml
@@ -8,7 +8,7 @@ PackDefinition:
     - Standard.GCP.AuditLog
     # Rules
     - GCP.K8s.New.Daemonset.Deployed
-    - GCP.K8S.Pot.Create.Or.Modify.Host.Path.Volume.Mount
+    - GCP.K8S.Pod.Create.Or.Modify.Host.Path.Volume.Mount
     - GCP.K8S.Privileged.Pod.Created
     - GCP.K8S.Service.Type.NodePort.Deployed
     - GCP.K8s.IOC.Activity

--- a/rules/gcp_k8s_rules/gcp_k8s_pod_create_or_modify_host_path_vol_mount.yml
+++ b/rules/gcp_k8s_rules/gcp_k8s_pod_create_or_modify_host_path_vol_mount.yml
@@ -1,6 +1,6 @@
 AnalysisType: rule
-RuleID: "GCP.K8S.Pot.Create.Or.Modify.Host.Path.Volume.Mount"
-DisplayName: "GCP K8S Pot Create Or Modify Host Path Volume Mount"
+RuleID: "GCP.K8S.Pod.Create.Or.Modify.Host.Path.Volume.Mount"
+DisplayName: "GCP K8S Pod Create Or Modify Host Path Volume Mount"
 Enabled: true
 LogTypes:
   - GCP.AuditLog


### PR DESCRIPTION
fixing typo pot -> pod

### Background

<High level overview here>

### Changes

- <Describe changes here>

### Testing

- <Testing steps>
