### PR TITLE
Okta AD/LDAP Delegated Authentication - Username Above 52 Characters Security Advisory

### DIFF
--- a/queries/okta_queries/okta_52_char_username_threat_hunt.yml
+++ b/queries/okta_queries/okta_52_char_username_threat_hunt.yml
@@ -1,0 +1,20 @@
+AnalysisType: saved_query
+QueryName: "Okta Username Above 52 Characters Security Advisory"
+Description: >
+  On October 30, 2024, a vulnerability was internally identified in generating the cache key for AD/LDAP DelAuth. The Bcrypt algorithm was used to generate the cache key where we hash a combined string of userId + username + password. Under a specific set of conditions, listed below, this could allow users to authenticate by providing the username with the stored cache key of a previous successful authentication.
+  Customers meeting the pre-conditions should investigate their Okta System Log for unexpected authentications from usernames greater than 52 characters between the period of July 23rd, 2024 to October 30th, 2024.
+  https://trust.okta.com/security-advisories/okta-ad-ldap-delegated-authentication-username/
+Query: |
+  SELECT
+    p_event_time as p_timeline,
+    *
+  FROM
+    panther_logs.public.okta_systemlog
+  WHERE
+    p_occurs_between('2024-07-22 00:00:00Z','2024-11-01 00:00:00Z')
+    AND actor:type = 'User'
+    AND eventType = 'user.session.start'
+    AND outcome:result = 'SUCCESS'
+    AND LEN(actor:alternateId) >= 52
+  ORDER by p_event_time ASC NULLS LAST
+  LIMIT 100


### PR DESCRIPTION
### Background

On October 30, 2024, a vulnerability was internally identified in generating the cache key for AD/LDAP DelAuth. The Bcrypt algorithm was used to generate the cache key where we hash a combined string of userId + username + password. Under a specific set of conditions, listed below, this could allow users to authenticate by providing the username with the stored cache key of a previous successful authentication.

Customers meeting the pre-conditions should investigate their Okta System Log for unexpected authentications from usernames greater than 52 characters between the period of July 23rd, 2024 to October 30th, 2024. 

### Changes

- Saved query to investigate unexpected authentications from usernames greater than 52 characters between the period of July 23rd, 2024 to October 30th, 2024.

### Testing

- tested in production Okta environment
