### PR TITLE
Wiz.Alert.Passthrough: New Dedup Logic

### DIFF
--- a/rules/wiz_rules/wiz_alert_passthrough.py
+++ b/rules/wiz_rules/wiz_alert_passthrough.py
@@ -13,12 +13,17 @@ def title(event):
 
 
 def severity(event):
-    # if event.get("severity") == "INFORMATIONAL":
-    #     return "INFO"
     return event.get("severity")
 
 
 def dedup(event):
+    # For lower-severity events, dedup based on specific source rule to reduce overall alert volume
+    if event.get("severity") in ("INFO", "LOW"):
+        dedup_str = str(event.deep_get("sourceRule", "id"))
+        if dedup_str:
+            return dedup_str
+    # If the severity is higher, or for some reason we couldn't generate a dedup string based on
+    #   the source rule, then use the alert severity + the resource ID itself.
     return event.deep_get(
         "entitySnapshot", "externalId", default="<RESOURCE_NOT_FOUND>"
     ) + event.get("severity", "<SEVERITY_NOT_FOUND>")

--- a/rules/wiz_rules/wiz_alert_passthrough.yml
+++ b/rules/wiz_rules/wiz_alert_passthrough.yml
@@ -78,6 +78,72 @@ Tests:
           "type": "TOXIC_COMBINATION",
           "updatedAt": "2024-06-04 02:28:06.763277000"
       }
+  - Name: Low-Severity Open Alert
+    ExpectedResult: true
+    Log:
+      {
+          "createdAt": "2024-06-04 02:28:06.763277000",
+          "entitySnapshot": {
+              "cloudProviderURL": "",
+              "externalId": "someExternalId",
+              "id": "12345",
+              "name": "someName",
+              "nativeType": "",
+              "providerId": "someProviderId",
+              "region": "",
+              "resourceGroupExternalId": "",
+              "subscriptionExternalId": "",
+              "subscriptionName": "",
+              "tags": { },
+              "type": "DATA_FINDING"
+          },
+          "id": "54321",
+          "notes": [ ],
+          "projects": [
+              {
+                  "businessUnit": "",
+                  "id": "45678",
+                  "name": "Project 2",
+                  "riskProfile": {
+                      "businessImpact": "MBI"
+                  },
+                  "slug": "project-2"
+              },
+          ],
+          "serviceTickets": [ ],
+          "severity": "LOW",
+          "sourceRule": {
+              "__typename": "Control",
+              "controlDescription": "Alert Description",
+              "id": "12345",
+              "name": "Alert Name",
+              "resolutionRecommendation": "Alert Resolution Recommendation",
+              "securitySubCategories": [
+                {
+                  "category": {
+                    "framework": {
+                      "name": "Wiz for Risk Assessment"
+                    },
+                    "name": "High Profile Threats"
+                  },
+                  "title": "High-profile vulnerability exploited in the wild"
+                },
+                {
+                  "category": {
+                    "framework": {
+                      "name": "MITRE ATT&CK Matrix"
+                    },
+                    "name": "TA0001 Initial Access"
+                  },
+                  "title": "T1190 Exploit Public-Facing Application"
+                },
+              ]
+          },
+          "status": "OPEN",
+          "statusChangedAt": "2024-06-04 02:28:06.597355000",
+          "type": "TOXIC_COMBINATION",
+          "updatedAt": "2024-06-04 02:28:06.763277000"
+      }
   - Name: Resolved Alert
     ExpectedResult: false
     Log:


### PR DESCRIPTION
### Background

We've observed large numbers of low-level alerts for some customers, due to a handful of Wiz rules failing for a large number of resources. The current dedup behaviour of the Panther rule is to group based on the resource ID. This PR alters the behaviour to dedup low-level alerts based on the Wiz rule ID instead, ensuring that low-severity policies that fail against many resources don't generate alert storms.

This should be more useful to Panther customers as well, since they get 1 alert informing them that many resources have failed the policy.

Simulations testing this against alert metadata from several volunteering customers say alert reductions between 10%-50%

### Changes

- add alternative dedup logic for low-severity Wiz alerts to group based on the Rule ID instead of the Resource ID

### Testing

- tested an alert simulation using new dedup logic
- dedup string output for unit tests matches expected value
