### PR TITLE
Important changes to CloudTrail events for AWS IAM Identity Center

### DIFF
--- a/global_helpers/panther_aws_helpers.py
+++ b/global_helpers/panther_aws_helpers.py
@@ -38,6 +38,7 @@ def aws_rule_context(event):
         "sourceIPAddress": event.get("sourceIPAddress", "<MISSING_SOURCE_IP>"),
         "userAgent": event.get("userAgent", "<MISSING_USER_AGENT>"),
         "userIdentity": event.get("userIdentity", "<MISSING_USER_IDENTITY>"),
+        "additionalEventData": event.get("additionalEventData", "<MISSING_ADDITIONAL_EVENT_DATA>"),
     }
 
 

--- a/queries/aws_queries/anomalous_role_assume_query.yml
+++ b/queries/aws_queries/anomalous_role_assume_query.yml
@@ -4,7 +4,7 @@ Enabled: false
 Query: |
   SELECT
     requestParameters:roleArn as roleArn,
-    userIdentity:principalId as principalId,
+    userIdentity:credentialId as credentialId,
     count(DISTINCT userAgent) as distinctUserAgents
   FROM
     panther_logs.public.aws_cloudtrail
@@ -12,10 +12,10 @@ Query: |
     eventSource = 'sts.amazonaws.com'
     and eventName = 'AssumeRole'
     and p_occurs_since('1 days')
-    and userIdentity:principalId != 'null'
+    and userIdentity:credentialId != 'null'
     and userAgent != 'AWS Internal'
     and requestParameters:roleArn != 'null'
-  GROUP BY requestParameters:roleArn, userIdentity:principalId
+  GROUP BY requestParameters:roleArn, userIdentity:credentialId
   HAVING count(DISTINCT userAgent) > 1
   ORDER BY count(DISTINCT userAgent) DESC
 QueryName: "RoleAssumes by Multiple Useragents"

--- a/queries/aws_queries/aws_potentially_compromised_service_role_query.yml
+++ b/queries/aws_queries/aws_potentially_compromised_service_role_query.yml
@@ -4,7 +4,7 @@ Enabled: false
 Query: |
   SELECT
     requestParameters:roleArn AS role,
-    ARRAY_AGG(distinct userIdentity:principalId) AS users,
+    ARRAY_AGG(distinct userIdentity:credentialId) AS users,
     ARRAY_AGG(distinct userIdentity:type) AS types
   FROM
     panther_logs.public.aws_cloudtrail

--- a/rules/aws_cloudtrail_rules/aws_cloudtrail_unsuccessful_mfa_attempt.py
+++ b/rules/aws_cloudtrail_rules/aws_cloudtrail_unsuccessful_mfa_attempt.py
@@ -18,7 +18,7 @@ def rule(event):
 
 def title(event):
     arn = event.deep_get("userIdenity", "arn", default="No ARN")
-    username = event.deep_get("userIdentity", "userName", default="No Username")
+    username = event.deep_get("additionalEventData", "UserName", default="No Username")
 
     return f"Failed MFA login from [{arn}] [{username}]"
 

--- a/rules/aws_cloudtrail_rules/aws_console_login.py
+++ b/rules/aws_cloudtrail_rules/aws_console_login.py
@@ -6,5 +6,5 @@ def alert_context(event):
     context = {}
     context["ip_and_username"] = event.get(
         "sourceIPAddress", "<MISSING_SOURCE_IP>"
-    ) + event.deep_get("userIdentity", "userName", default="<MISSING_USER_NAME>")
+    ) + event.deep_get("additionalEventData", "UserName", default="<MISSING_USER_NAME>")
     return context

--- a/rules/aws_cloudtrail_rules/aws_console_login_without_mfa.py
+++ b/rules/aws_cloudtrail_rules/aws_console_login_without_mfa.py
@@ -42,7 +42,7 @@ def rule(event):
     new_user_string = (
         event.deep_get("additionalEventData", "UserName", default="<MISSING_USER_NAME>")
         + "-"
-        + event.deep_get("userIdentity", "principalId", default="<MISSING_ID>")
+        + event.deep_get("userIdentity", "credentialId", default="<MISSING_ID>")
     )
     is_new_user = check_account_age(new_user_string)
     if isinstance(is_new_user, str):

--- a/rules/aws_cloudtrail_rules/aws_console_login_without_mfa.py
+++ b/rules/aws_cloudtrail_rules/aws_console_login_without_mfa.py
@@ -40,7 +40,7 @@ def rule(event):
     # This functionality is not enabled by default, in order to start logging new user creations
     # Enable indicator_creation_rules/new_account_logging to start logging new users
     new_user_string = (
-        event.deep_get("userIdentity", "userName", default="<MISSING_USER_NAME>")
+        event.deep_get("additionalEventData", "UserName", default="<MISSING_USER_NAME>")
         + "-"
         + event.deep_get("userIdentity", "principalId", default="<MISSING_ID>")
     )
@@ -81,7 +81,7 @@ def title(event):
     if event.deep_get("userIdentity", "type") == "Root":
         user_string = "the root user"
     else:
-        user = event.deep_get("userIdentity", "userName") or event.deep_get(
+        user = event.deep_get("additionalEventData", "UserName") or event.deep_get(
             "userIdentity", "sessionContext", "sessionIssuer", "userName"
         )
         type_ = event.deep_get(

--- a/rules/aws_cloudtrail_rules/aws_iam_user_recon_denied.py
+++ b/rules/aws_cloudtrail_rules/aws_iam_user_recon_denied.py
@@ -46,7 +46,7 @@ def dedup(event):
 def title(event):
     user_type = event.deep_get("userIdentity", "type")
     if user_type == "IAMUser":
-        user = event.deep_get("userIdentity", "userName")
+        user = event.deep_get("additionalEventData", "UserName")
     # root user
     elif user_type == "Root":
         user = user_type

--- a/rules/aws_cloudtrail_rules/aws_key_compromised.py
+++ b/rules/aws_cloudtrail_rules/aws_key_compromised.py
@@ -14,7 +14,7 @@ def rule(event):
 
 
 def dedup(event):
-    return event.deep_get("additionalEventData", "UserName")
+    return event.deep_get("additionalEventData", "UserName", default="<NO_USERNAME>")
 
 
 def title(event):

--- a/rules/aws_cloudtrail_rules/aws_key_compromised.py
+++ b/rules/aws_cloudtrail_rules/aws_key_compromised.py
@@ -14,7 +14,7 @@ def rule(event):
 
 
 def dedup(event):
-    return event.deep_get("userIdentity", "userName")
+    return event.deep_get("additionalEventData", "UserName")
 
 
 def title(event):

--- a/rules/aws_cloudtrail_rules/aws_key_compromised.yml
+++ b/rules/aws_cloudtrail_rules/aws_key_compromised.yml
@@ -32,6 +32,11 @@ Tests:
             "arn": "arn:aws:iam::123456789012:user/compromised_user",
             "accountId": "123456789012",
           },
+        "additionalEventData": 
+          {
+            "CredentialType": "PASSWORD",
+            "UserName": "anyuser"
+          },
         "eventName": "PutUserPolicy",
         "eventVersion": "1.05",
         "userAgent": "aws-internal/3 aws-sdk-java/1.11.706 Linux/4.9.184-0.1.ac.235.83.329.metal1.x86_64 OpenJDK_64-Bit_Server_VM/25.242-b08 java/1.8.0_242 vendor/Oracle_Corporation",

--- a/rules/aws_cloudtrail_rules/aws_resource_made_public.py
+++ b/rules/aws_cloudtrail_rules/aws_resource_made_public.py
@@ -70,7 +70,7 @@ def rule(event):
 
 def title(event):
     # TODO(): Update this rule to use data models
-    user = event.deep_get("userIdentity", "userName") or event.deep_get(
+    user = event.deep_get("additionalEventData", "UserName") or event.deep_get(
         "userIdentity",
         "sessionContext",
         "sessionIssuer",

--- a/rules/aws_cloudtrail_rules/aws_security_configuration_change.py
+++ b/rules/aws_cloudtrail_rules/aws_security_configuration_change.py
@@ -52,7 +52,7 @@ def rule(event):
 
 
 def title(event):
-    user = event.deep_get("userIdentity", "userName") or event.deep_get(
+    user = event.deep_get("additionalEventData", "UserName") or event.deep_get(
         "userIdentity", "sessionContext", "sessionIssuer", "userName"
     )
 

--- a/rules/aws_cloudtrail_rules/aws_software_discovery.py
+++ b/rules/aws_cloudtrail_rules/aws_software_discovery.py
@@ -29,14 +29,14 @@ def rule(event):
 
 def title(event):
     return (
-        f"User [{event.deep_get('userIdentity', 'principalId')}] "
+        f"User [{event.deep_get('additionalEventData', 'UserName')}] "
         f"performed a [{event.get('eventName')}] "
         f"action in AWS account [{event.get('recipientAccountId')}]."
     )
 
 
 def dedup(event):
-    return event.deep_get("userIdentity", "principalId", default="NO_PRINCIPAL_ID_FOUND")
+    return event.deep_get("additionalEventData", "UserName", default="NO_USERNAME_FOUND")
 
 
 def alert_context(event):

--- a/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.py
+++ b/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.py
@@ -23,7 +23,7 @@ def rule(event):
 
 
 def dedup(event):
-    return event.deep_get("userIdentity", "principalId", default="<UNKNOWN_PRINCIPAL>")
+    return event.deep_get("userIdentity", "credentialId", default="<UNKNOWN_CREDENTIAL>")
 
 
 def title(event):

--- a/rules/aws_cloudtrail_rules/aws_update_credentials.py
+++ b/rules/aws_cloudtrail_rules/aws_update_credentials.py
@@ -8,7 +8,7 @@ def rule(event):
 
 
 def dedup(event):
-    return event.deep_get("userIdentity", "userName", default="<UNKNOWN_USER>")
+    return event.deep_get("additionalEventData", "UserName", default="<UNKNOWN_USER>")
 
 
 def title(event):

--- a/rules/aws_cloudtrail_rules/aws_waf_disassociation.py
+++ b/rules/aws_cloudtrail_rules/aws_waf_disassociation.py
@@ -16,5 +16,5 @@ def alert_context(event):
         "recipientAccountId": event.get("recipientAccountId"),
         "requestID": event.get("requestID"),
         "requestParameters": event.deep_get("requestParameters", "resourceArn"),
-        "userIdentity": event.deep_get("userIdentity", "principalId"),
+        "UserName": event.deep_get("additionalEventData", "UserName"),
     }


### PR DESCRIPTION
### Background

[Important changes to CloudTrail events for AWS IAM Identity Center](https://aws.amazon.com/blogs/security/modifications-to-aws-cloudtrail-event-data-of-iam-identity-center/)

Effective January 13, 2025, IAM Identity Center will stop emitting userName and principalId fields under the [user identity element](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-user-identity.html) in CloudTrail events. These fields will be excluded from the CloudTrail events that are initiated when users sign in to IAM Identity Center, use the [AWS access portal](https://docs.aws.amazon.com/singlesignon/latest/userguide/using-the-portal.html), and access AWS accounts through the [AWS CLI](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/configure/sso.html). Instead, IAM Identity Center now emits user ID and Identity Store Amazon Resource Name (ARN) fields to replace the userName and principalId fields, simplifying user identification. IAM Identity Center CloudTrail events will also specify IdentityCenterUser as the [identity](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-user-identity.html) type instead of Unknown, providing a clear identifier for users. Additionally, IAM Identity Center will omit the value of a [group’s displayName](https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_Group.html) in CloudTrail events when you [create](https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_CreateGroup.html) or [update](https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_UpdateGroup.html) a group.

### Changes

- userIdentity.userName -> additionalEventData.UserName
- principalId -> credentialId or additionalEventData.UserName

### Testing

- updated unit tests with new fields
