### PR TITLE
Add get_user to AWS datamodel

### DIFF
--- a/data_models/aws_cloudtrail_data_model.py
+++ b/data_models/aws_cloudtrail_data_model.py
@@ -56,7 +56,12 @@ def get_actor_user(event):
         actor_user = deep_get(event, "userIdentity", "userName", default=f"Unknown{user_type}")
     elif user_type in ("AssumedRole", "Role", "FederatedUser"):
         actor_user = deep_get(
-            event, "sessionContext", "sessionIssuer", "userName", default=f"Unknown{user_type}"
+            event,
+            "userIdentity",
+            "sessionContext",
+            "sessionIssuer",
+            "userName",
+            default=f"Unknown{user_type}",
         )
     elif user_type == "IdentityCenterUser":
         actor_user = deep_get(

--- a/data_models/aws_cloudtrail_data_model.py
+++ b/data_models/aws_cloudtrail_data_model.py
@@ -39,22 +39,23 @@ def load_ip_address(event):
     return source_ip
 
 
-def get_user(event):
-    user_type = event.deep_get("userIdentity", "type")
+def get_actor_user(event):
+    user_type = deep_get(event, "userIdentity", "type")
     if event.get("eventType") == "AwsServiceEvent":
-        return event.deep_get("userIdentity", "invokedBy", default="Unknown")
+        return deep_get(event, "userIdentity", "invokedBy", default="Unknown")
     if user_type == "Root":
-        return event.deep_get(
+        return deep_get(
+            event,
             "userIdentity",
             "userName",
-            default=event.deep_get("userIdentity", "accountId"),
+            default=deep_get(event, "userIdentity", "accountId"),
         )
     if user_type in ("IAMUser", "Directory", "Unknown", "SAMLUser", "WebIdentityUser"):
-        return event.deep_get("userIdentity", "userName", default="Unknown")
+        return deep_get(event, "userIdentity", "userName", default="Unknown")
     if user_type in ("AssumedRole", "Role", "FederatedUser"):
-        return event.deep_get("sessionContext", "sessionIssuer", "userName", default="Unknown")
+        return deep_get(event, "sessionContext", "sessionIssuer", "userName", default="Unknown")
     if user_type == "IdentityCenterUser":
-        return event.deep_get("additionalEventData", "UserName", default="Unknown")
+        return deep_get(event, "additionalEventData", "UserName", default="Unknown")
     if user_type in ("AWSService", "AWSAccount"):
         return event.get("sourceIdentity", "Unknown")
     return "Unknown"

--- a/data_models/aws_cloudtrail_data_model.py
+++ b/data_models/aws_cloudtrail_data_model.py
@@ -41,6 +41,8 @@ def load_ip_address(event):
 
 def get_user(event):
     user_type = event.deep_get("userIdentity", "type")
+    if event.get("eventType") == "AwsServiceEvent":
+        return event.deep_get("userIdentity", "invokedBy", default="Unknown")
     if user_type == "Root":
         return event.deep_get(
             "userIdentity",

--- a/data_models/aws_cloudtrail_data_model.py
+++ b/data_models/aws_cloudtrail_data_model.py
@@ -37,3 +37,22 @@ def load_ip_address(event):
         except ipaddress.AddressValueError:
             return None
     return source_ip
+
+
+def get_user(event):
+    user_type = event.deep_get("userIdentity", "type")
+    if user_type == "Root":
+        return event.deep_get(
+            "userIdentity",
+            "userName",
+            default=event.deep_get("userIdentity", "accountId"),
+        )
+    if user_type in ("IAMUser", "Directory", "Unknown", "SAMLUser", "WebIdentityUser"):
+        return event.deep_get("userIdentity", "userName", default="Unknown")
+    if user_type in ("AssumedRole", "Role", "FederatedUser"):
+        return event.deep_get("sessionContext", "sessionIssuer", "userName", default="Unknown")
+    if user_type == "IdentityCenterUser":
+        return event.deep_get("additionalEventData", "UserName", default="Unknown")
+    if user_type in ("AWSService", "AWSAccount"):
+        return event.get("sourceIdentity", "Unknown")
+    return "Unknown"

--- a/data_models/aws_cloudtrail_data_model.py
+++ b/data_models/aws_cloudtrail_data_model.py
@@ -42,24 +42,26 @@ def load_ip_address(event):
 def get_actor_user(event):
     user_type = deep_get(event, "userIdentity", "type")
     if event.get("eventType") == "AwsServiceEvent":
-        actor_user = deep_get(event, "userIdentity", "invokedBy", default="Unknown")
+        actor_user = deep_get(event, "userIdentity", "invokedBy", default="UnknownAwsServiceEvent")
     elif user_type == "Root":
         actor_user = deep_get(
             event,
             "userIdentity",
             "userName",
-            default=deep_get(event, "userIdentity", "accountId"),
+            default=deep_get(event, "userIdentity", "accountId", default="UnknownRootUser"),
         )
     elif user_type in ("IAMUser", "Directory", "Unknown", "SAMLUser", "WebIdentityUser"):
-        actor_user = deep_get(event, "userIdentity", "userName", default="Unknown")
+        actor_user = deep_get(event, "userIdentity", "userName", default=f"Unknown{user_type}")
     elif user_type in ("AssumedRole", "Role", "FederatedUser"):
         actor_user = deep_get(
-            event, "sessionContext", "sessionIssuer", "userName", default="Unknown"
+            event, "sessionContext", "sessionIssuer", "userName", default=f"Unknown{user_type}"
         )
     elif user_type == "IdentityCenterUser":
-        actor_user = deep_get(event, "additionalEventData", "UserName", default="Unknown")
+        actor_user = deep_get(
+            event, "additionalEventData", "UserName", default=f"Unknown{user_type}"
+        )
     elif user_type in ("AWSService", "AWSAccount"):
-        actor_user = event.get("sourceIdentity", "Unknown")
+        actor_user = event.get("sourceIdentity", f"Unknown{user_type}")
     else:
-        actor_user = "Unknown"
+        actor_user = "UnknownUser"
     return actor_user

--- a/data_models/aws_cloudtrail_data_model.py
+++ b/data_models/aws_cloudtrail_data_model.py
@@ -39,6 +39,8 @@ def load_ip_address(event):
     return source_ip
 
 
+# get actor user from correct field based on identity type
+# https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-user-identity.html#cloudtrail-event-reference-user-identity-fields
 def get_actor_user(event):
     user_type = deep_get(event, "userIdentity", "type")
     if event.get("eventType") == "AwsServiceEvent":

--- a/data_models/aws_cloudtrail_data_model.py
+++ b/data_models/aws_cloudtrail_data_model.py
@@ -42,20 +42,24 @@ def load_ip_address(event):
 def get_actor_user(event):
     user_type = deep_get(event, "userIdentity", "type")
     if event.get("eventType") == "AwsServiceEvent":
-        return deep_get(event, "userIdentity", "invokedBy", default="Unknown")
-    if user_type == "Root":
-        return deep_get(
+        actor_user = deep_get(event, "userIdentity", "invokedBy", default="Unknown")
+    elif user_type == "Root":
+        actor_user = deep_get(
             event,
             "userIdentity",
             "userName",
             default=deep_get(event, "userIdentity", "accountId"),
         )
-    if user_type in ("IAMUser", "Directory", "Unknown", "SAMLUser", "WebIdentityUser"):
-        return deep_get(event, "userIdentity", "userName", default="Unknown")
-    if user_type in ("AssumedRole", "Role", "FederatedUser"):
-        return deep_get(event, "sessionContext", "sessionIssuer", "userName", default="Unknown")
-    if user_type == "IdentityCenterUser":
-        return deep_get(event, "additionalEventData", "UserName", default="Unknown")
-    if user_type in ("AWSService", "AWSAccount"):
-        return event.get("sourceIdentity", "Unknown")
-    return "Unknown"
+    elif user_type in ("IAMUser", "Directory", "Unknown", "SAMLUser", "WebIdentityUser"):
+        actor_user = deep_get(event, "userIdentity", "userName", default="Unknown")
+    elif user_type in ("AssumedRole", "Role", "FederatedUser"):
+        actor_user = deep_get(
+            event, "sessionContext", "sessionIssuer", "userName", default="Unknown"
+        )
+    elif user_type == "IdentityCenterUser":
+        actor_user = deep_get(event, "additionalEventData", "UserName", default="Unknown")
+    elif user_type in ("AWSService", "AWSAccount"):
+        actor_user = event.get("sourceIdentity", "Unknown")
+    else:
+        actor_user = "Unknown"
+    return actor_user

--- a/data_models/aws_cloudtrail_data_model.yml
+++ b/data_models/aws_cloudtrail_data_model.yml
@@ -15,6 +15,8 @@ Mappings:
   - Name: user_agent
     Path: userAgent
   - Name: user
+    Path: $.responseElements.user.userName
+  - Name: username
     Method: get_user
   - Name: user_account_id
     Path: $.responseElements.user.userId

--- a/data_models/aws_cloudtrail_data_model.yml
+++ b/data_models/aws_cloudtrail_data_model.yml
@@ -7,7 +7,7 @@ Filename: aws_cloudtrail_data_model.py
 Enabled: true
 Mappings:
   - Name: actor_user
-    Path: $.userIdentity..userName
+    Method: get_actor_user
   - Name: event_type
     Method: get_event_type
   - Name: source_ip
@@ -16,7 +16,5 @@ Mappings:
     Path: userAgent
   - Name: user
     Path: $.responseElements.user.userName
-  - Name: username
-    Method: get_user
   - Name: user_account_id
     Path: $.responseElements.user.userId

--- a/data_models/aws_cloudtrail_data_model.yml
+++ b/data_models/aws_cloudtrail_data_model.yml
@@ -15,6 +15,6 @@ Mappings:
   - Name: user_agent
     Path: userAgent
   - Name: user
-    Path: $.responseElements.user.userName
+    Method: get_user
   - Name: user_account_id
     Path: $.responseElements.user.userId


### PR DESCRIPTION
### Background

In preparation for https://github.com/panther-labs/panther-analysis/pull/1439 creating a get_user datamodel for AWS to correctly identify the username depending on user type.

### Changes

- add get_user to datamodel

### Testing

- validated against [documentation](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-user-identity.html#cloudtrail-event-reference-user-identity-fields)
- will update unit tests after applying event.udm('user') in subsequent PR
