### PR TITLE
Add policy for AWS KMS Key Confused Deputy Protection

### DIFF
--- a/packs/aws.yml
+++ b/packs/aws.yml
@@ -15,6 +15,7 @@ PackDefinition:
     - AWS.IAM.AccessKeyCompromised
     - AWS.KMS.CustomerManagedKeyLoss
     - AWS.KMS.RestrictsUsage
+    - AWS.KMS.ConfusedDeputyProtection
     - AWS.Macie.Evasion
     - AWS.RDS.Instance.PublicAccess
     - AWS.RDS.Instance.SnapshotPublicAccess

--- a/policies/aws_kms_policies/aws_kms_confused_deputy_protection.py
+++ b/policies/aws_kms_policies/aws_kms_confused_deputy_protection.py
@@ -1,0 +1,27 @@
+import json
+
+REQUIRED_CONDITIONS = {
+    "aws:SourceArn",
+    "aws:SourceAccount",
+    "aws:SourceOrgID",
+    "aws:SourceOrgPaths",
+}
+
+def policy(resource):
+    key_policy = resource.get("Policy")
+    policy_statements = json.loads(key_policy).get("Statement", [])
+    for statement in policy_statements:
+        # Check if the statement allows access and includes a service principal
+        principal = statement.get("Principal", {})
+        if "Service" in principal and statement.get("Effect") == "Allow":
+            conditions = statement.get("Condition", {})
+            # Flatten nested condition keys (e.g., inside "StringEquals")
+            flat_condition_keys = set()
+            for condition in conditions.values():
+                if isinstance(condition, dict):
+                    flat_condition_keys.update(condition.keys())
+            # Check if any required condition key is present
+            if not REQUIRED_CONDITIONS.intersection(flat_condition_keys):
+                return False
+
+    return True

--- a/policies/aws_kms_policies/aws_kms_confused_deputy_protection.yml
+++ b/policies/aws_kms_policies/aws_kms_confused_deputy_protection.yml
@@ -1,0 +1,79 @@
+AnalysisType: policy
+Filename: aws_kms_confused_deputy_protection.py
+PolicyID: "AWS.KMS.ConfusedDeputyProtection"
+DisplayName: "AWS KMS Key Confused Deputy Protection"
+Enabled: true
+ResourceTypes:
+  - AWS.KMS.Key
+Tags:
+  - AWS
+  - Security Control
+  - Best Practices
+Severity: Medium
+Description: >
+  Ensures that KMS Key Policies include conditions such as `aws:SourceArn`, 
+  `aws:SourceAccount`, `aws:SourceOrgID`, or `aws:SourceOrgPaths` to prevent 
+  the confused deputy problem when using service principals.
+Runbook: >
+  Update the KMS Key Policy to include one or more of the following conditions: 
+  `aws:SourceArn`, `aws:SourceAccount`, `aws:SourceOrgID`, or `aws:SourceOrgPaths`. 
+  Refer to AWS documentation for examples of secure KMS Key Policies.
+Reference: >
+  https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-examples.html#key-policy-cdp
+Tests:
+  - Name: KMS Key Policy Without Required Conditions
+    ExpectedResult: false
+    Resource:
+      {
+        "Policy": '{
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {"Service": "cloudtrail.amazonaws.com"},
+              "Action": "kms:Encrypt",
+              "Resource": "*"
+            }
+          ]
+        }'
+      }
+
+  - Name: KMS Key Policy With Required Conditions
+    ExpectedResult: true
+    Resource:
+      {
+        "Policy": '{
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {"Service": "cloudtrail.amazonaws.com"},
+              "Action": "kms:Encrypt",
+              "Resource": "*",
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceArn": "arn:aws:cloudtrail:us-east-1:123456789012:trail/MyCloudTrail",
+                  "aws:SourceAccount": "123456789012"
+                }
+              }
+            }
+          ]
+        }'
+      }
+
+  - Name: KMS Key Policy Without Service Principal
+    ExpectedResult: true
+    Resource:
+      {
+        "Policy": '{
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+              "Action": "kms:Encrypt",
+              "Resource": "*"
+            }
+          ]
+        }'
+      }


### PR DESCRIPTION
### Background

This policy ensures that AWS KMS Key policies with service principals include conditions to prevent cross-service confused deputy issues. Without these conditions (such as aws:SourceArn, aws:SourceAccount, aws:SourceOrgID, or aws:SourceOrgPaths), attackers may exploit the policy to misuse KMS keys by impersonating trusted services.
https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html

### Changes

Added a new policy: AWS.KMS.ConfusedDeputyProtection to verify that AWS KMS Key policies containing service principals include at least one of the required conditions to prevent cross-service abuse.

### Testing

KMS Key Policy Without Required Conditions:

    A key policy with a service principal but no required conditions.
    Expected Result: Fail.

KMS Key Policy With Required Conditions:

    A key policy with a service principal and at least one valid condition.
    Expected Result: Pass.

KMS Key Policy Without Service Principal:

    A key policy without any service principal.
    Expected Result: Pass.
