### PR TITLE
AWS CloudWatch Log Resource Policy Confused Deputy Protection

### DIFF
--- a/packs/aws.yml
+++ b/packs/aws.yml
@@ -99,6 +99,7 @@ PackDefinition:
     - AWS.CloudTrail.UnauthorizedAPICall
     - AWS.CloudWatchLogs.DataRetention1Year
     - AWS.CloudWatchLogs.Encrypted
+    - AWS.CloudWatchLog.ConfusedDeputyProtection
     - AWS.Config.GlobalResources
     - AWS.Config.RecordAllResourceTypes
     - AWS.Config.RecordingEnabled

--- a/policies/aws_cloudwatch_policies/aws_cloudwatch_log_confused_deputy.py
+++ b/policies/aws_cloudwatch_policies/aws_cloudwatch_log_confused_deputy.py
@@ -1,0 +1,31 @@
+import json
+
+REQUIRED_CONDITIONS = {
+    "aws:SourceArn",
+    "aws:SourceAccount",
+    "aws:SourceOrgID",
+    "aws:SourceOrgPaths",
+}
+
+
+def policy(resource):
+    policy_document = resource.get("Policy")
+    if not policy_document:
+        return True  # Pass if there is no policy document
+
+    policy_statements = json.loads(policy_document).get("Statement", [])
+    for statement in policy_statements:
+        # Check if the statement allows access and includes a service principal
+        principal = statement.get("Principal", {})
+        if "Service" in principal and statement.get("Effect") == "Allow":
+            conditions = statement.get("Condition", {})
+            # Flatten nested condition keys (e.g., inside "StringEquals")
+            flat_condition_keys = set()
+            for condition in conditions.values():
+                if isinstance(condition, dict):
+                    flat_condition_keys.update(condition.keys())
+            # Check if any required condition key is present
+            if not REQUIRED_CONDITIONS.intersection(flat_condition_keys):
+                return False
+
+    return True

--- a/policies/aws_cloudwatch_policies/aws_cloudwatch_log_confused_deputy.yml
+++ b/policies/aws_cloudwatch_policies/aws_cloudwatch_log_confused_deputy.yml
@@ -1,0 +1,37 @@
+AnalysisType: policy
+Filename: aws_cloudwatch_log_confused_deputy.py
+PolicyID: "AWS.CloudWatchLog.ConfusedDeputyProtection"
+DisplayName: "AWS CloudWatch Log Resource Policy Confused Deputy Protection"
+Enabled: true
+ResourceTypes:
+  - AWS.CloudWatch.LogGroup
+Tags:
+  - AWS
+  - Security Control
+  - Panther
+Severity: High
+Description: >
+  Ensures that AWS CloudWatch Log resource policies with service principals contain conditions to prevent cross-service confused deputy issues. Without these conditions (such as aws:SourceArn, aws:SourceAccount, aws:SourceOrgID, or aws:SourceOrgPaths), attackers may exploit the policy to gain unauthorized access to resources.
+Runbook: >
+  Update the CloudWatch Log resource policy to include at least one of the following conditions for service principals:
+  aws:SourceArn, aws:SourceAccount, aws:SourceOrgID, or aws:SourceOrgPaths. Refer to AWS documentation for proper usage.
+Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html
+Tests:
+  - Name: Log Policy Without Required Conditions
+    ExpectedResult: false
+    Resource:
+      {
+        "Policy": '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"logs:PutLogEvents","Resource":"arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/my-function:*"}]}',
+      }
+  - Name: Log Policy With Required Conditions
+    ExpectedResult: true
+    Resource:
+      {
+        "Policy": '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"logs:PutLogEvents","Resource":"arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/my-function:*","Condition":{"ArnLike":{"aws:SourceArn":"arn:aws:lambda:us-east-1:123456789012:function:my-function"}}}]}',
+      }
+  - Name: Log Policy Without Service Principal
+    ExpectedResult: true
+    Resource:
+      {
+        "Policy": '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::123456789012:role/MyRole"},"Action":"logs:PutLogEvents","Resource":"arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/my-function:*"}]}',
+      }

--- a/policies/aws_cloudwatch_policies/aws_cloudwatch_log_confused_deputy.yml
+++ b/policies/aws_cloudwatch_policies/aws_cloudwatch_log_confused_deputy.yml
@@ -9,7 +9,7 @@ Tags:
   - AWS
   - Security Control
   - Panther
-Severity: High
+Severity: Medium
 Description: >
   Ensures that AWS CloudWatch Log resource policies with service principals contain conditions to prevent cross-service confused deputy issues. Without these conditions (such as aws:SourceArn, aws:SourceAccount, aws:SourceOrgID, or aws:SourceOrgPaths), attackers may exploit the policy to gain unauthorized access to resources.
 Runbook: >


### PR DESCRIPTION
### Background

This policy ensures that AWS CloudWatch Log Resource Policies with service principals contain conditions to prevent cross-service confused deputy issues. Without these conditions (such as aws:SourceArn, aws:SourceAccount, aws:SourceOrgID, or aws:SourceOrgPaths), attackers may be able to exploit the resource policy to gain unauthorized access or misuse the service.

### Changes

Added a new policy, AWS.CloudWatchLog.ConfusedDeputyProtection, to validate that CloudWatch Log Resource Policies containing service principals include at least one of the required conditions to mitigate the risk of confused deputy attacks.

### Testing

Log Policy Without Required Conditions: Tests a policy with a service principal but no conditions (expected to fail).
Log Policy With Required Conditions: Tests a policy with a service principal and valid conditions (expected to pass).
Log Policy Without Service Principal: Tests a policy without a service principal (expected to pass).
