### PR TITLE
THREAT-427: Fix 'check-deprecated' Script

### DIFF
--- a/.scripts/deleted_rules.py
+++ b/.scripts/deleted_rules.py
@@ -10,7 +10,7 @@ import subprocess
 import panther_analysis_tool.command.bulk_delete as pat_delete
 import panther_analysis_tool.util as pat_util
 
-diff_pattern = re.compile(r'^-(?:RuleID|PolicyID|QueryName):\s*"?([\w.]+)"?')
+diff_pattern = re.compile(r'^-(?:RuleID|PolicyID|QueryName):\s*"?(.+?)["\n]')
 
 
 def get_deleted_ids() -> set[str]:


### PR DESCRIPTION
### Background

Our `check-deprecated` script was failing to work properly in cases where a space was present in the query name. We observed this behaviour in our own PRs, and customers have also reported it.

### Changes

- Adjusted the regex used to scan gif diffs for removed items

### Testing

- Tested new regex pattern against all files in repo, and confirmed that all RuleIDs, PolicyIDs, and Query Names match
