### PR TITLE
Create Github.Repo.RulesetModified rule

### DIFF
--- a/packs/github.yml
+++ b/packs/github.yml
@@ -16,6 +16,7 @@ PackDefinition:
     - Github.Repo.CollaboratorChange
     - Github.Repo.Created
     - GitHub.Repo.InitialAccess
+    - GitHub.Repo.RulesetModified
     - Github.Repo.VisibilityChange
     - Github.Repo.VulnerabilityDismissed
     - GitHub.Secret.Scanning.Alert.Created

--- a/rules/github_rules/github_repo_ruleset_modified.py
+++ b/rules/github_rules/github_repo_ruleset_modified.py
@@ -1,0 +1,49 @@
+from global_filter_github import filter_include_event
+from panther_github_helpers import github_alert_context
+
+
+def rule(event):
+    if not filter_include_event(event):
+        return False
+    return event.get("action").startswith("repository_ruleset.")
+
+
+def title(event):
+    action = "modified"
+    if event.get("action").endswith("destroy"):
+        action = "deleted"
+    elif event.get("action").endswith("create"):
+        action = "created"
+
+    title_str = (
+        f"Github repository ruleset for [{event.get('repo', '<UNKNOWN_REPO>')}]"
+        f" {action} by [{event.get('actor','<UNKNOWN_ACTOR>')}]"
+    )
+    return title_str
+
+
+def dedup(event):
+    return event.get("_document_id", "")
+
+
+def severity(event):
+    if event.get("action").endswith("create"):
+        return "INFO"
+    if event.get("action").endswith("update"):
+        return "MEDIUM"
+    if event.get("action").endswith("destroy"):
+        return "HIGH"
+    return "INFO"
+
+
+def alert_context(event):
+    ctx = github_alert_context(event)
+    ctx["actor_is_bot"] = event.get("actor_is_bot", "")
+    ctx["actor_user_agent"] = event.get("user_agent", "")
+    ctx["business"] = event.get("business", "")
+    ctx["public_repo"] = event.get("public_repo", "")
+    ctx["operation_type"] = event.get("operation_type", "")
+    ctx["ruleset_bypass_actors"] = event.deep_walk("ruleset_bypass_actors")
+    ctx["ruleset_conditions"] = event.deep_walk("ruleset_conditions")
+    ctx["ruleset_rules"] = event.deep_walk("ruleset_rules")
+    return ctx

--- a/rules/github_rules/github_repo_ruleset_modified.py
+++ b/rules/github_rules/github_repo_ruleset_modified.py
@@ -33,7 +33,7 @@ def severity(event):
         return "MEDIUM"
     if event.get("action").endswith("destroy"):
         return "HIGH"
-    return "INFO"
+    return "DEFAULT"
 
 
 def alert_context(event):

--- a/rules/github_rules/github_repo_ruleset_modified.yml
+++ b/rules/github_rules/github_repo_ruleset_modified.yml
@@ -12,7 +12,7 @@ Tags:
   - Disable or Modify Tools
 Reports:
   MITRE ATT&CK:
-    - TA0005:T1562:001 # Impair Defenses: Disable or Modify Tools
+    - TA0005:T1562 # Impair Defenses: Disable or Modify Tools
 Reference: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets
 Severity: Info
 Description: Disabling repository ruleset controls could indicate malicious use of admin credentials in an attempt to hide activity.

--- a/rules/github_rules/github_repo_ruleset_modified.yml
+++ b/rules/github_rules/github_repo_ruleset_modified.yml
@@ -9,7 +9,7 @@ Tags:
   - GitHub
 Reports:
   MITRE ATT&CK:
-    - TA0001:T1195
+    - TA0005:T1562:001 # Impair Defenses: Disable or Modify Tools
 Reference: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets
 Severity: Info
 Description: Disabling repository ruleset controls could indicate malicious use of admin credentials in an attempt to hide activity.

--- a/rules/github_rules/github_repo_ruleset_modified.yml
+++ b/rules/github_rules/github_repo_ruleset_modified.yml
@@ -1,0 +1,248 @@
+AnalysisType: rule
+Filename: github_repo_ruleset_modified.py
+RuleID: "GitHub.Repo.RulesetModified"
+DisplayName: "GitHub Repository Ruleset Modified"
+Enabled: true
+LogTypes:
+  - GitHub.Audit
+Tags:
+  - GitHub
+Reports:
+  MITRE ATT&CK:
+    - TA0001:T1195
+Reference: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets
+Severity: Info
+Description: Disabling repository ruleset controls could indicate malicious use of admin credentials in an attempt to hide activity.
+DedupPeriodMinutes: 60
+Threshold: 1
+Runbook: Verify that ruleset modifications are intended and authorized.
+Tests:
+  - Name: GitHub - Ruleset Created
+    ExpectedResult: true
+    Log:
+      {
+        "action": "repository_ruleset.create",
+        "actor": "dog",
+        "actor_id": "999999999",
+        "actor_is_bot": false,
+        "actor_location": { "country_code": "US" },
+        "business": "bizname",
+        "business_id": "12345",
+        "created_at": "2024-12-17 00:00:00000000",
+        "operation_type": "create",
+        "org": "some-org",
+        "org_id": 12345678,
+        "public_repo": true,
+        "repo": "some-org/ruleset-repo",
+        "repo_id": 123456789,
+        "ruleset_bypass_actors":
+          [
+            {
+              "actor_id": 123456,
+              "actor_type": "Integration",
+              "bypass_mode": "always",
+              "id": 123456,
+            },
+            {
+              "actor_id": 123456,
+              "actor_type": "Team",
+              "bypass_mode": "always",
+              "id": 1234567,
+            },
+          ],
+        "ruleset_conditions":
+          [
+            {
+              "id": 1234567,
+              "parameters": { "exclude": [], "include": ["~DEFAULT_BRANCH"] },
+              "target": "ref_name",
+            },
+          ],
+        "ruleset_enforcement": "enabled",
+        "ruleset_id": "1234567",
+        "ruleset_name": "a-ruleset-name",
+        "ruleset_rules":
+          [
+            {
+              "id": 12345678,
+              "parameters":
+                {
+                  "allowed_merge_methods": ["merge", "squash", "rebase"],
+                  "authorized_dismissal_actors_only": false,
+                  "automatic_copilot_code_review_enabled": false,
+                  "dismiss_stale_reviews_on_push": false,
+                  "ignore_approvals_from_contributors": false,
+                  "require_code_owner_review": false,
+                  "require_last_push_approval": false,
+                  "required_approving_review_count": 1,
+                  "required_review_thread_resolution": false,
+                  "required_reviewers": [],
+                },
+              "type": "pull_request",
+            },
+            { "id": 12345678, "parameters": {}, "type": "deletion" },
+            { "id": 12345678, "parameters": {}, "type": "non_fast_forward" },
+          ],
+        "ruleset_source_type": "Repository",
+        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+      }
+  - Name: GitHub - Ruleset Deleted
+    ExpectedResult: true
+    Log:
+      {
+        "action": "repository_ruleset.destroy",
+        "actor": "dog",
+        "actor_id": "999999999",
+        "actor_is_bot": false,
+        "actor_location": { "country_code": "US" },
+        "business": "bizname",
+        "business_id": "12345",
+        "created_at": "2024-12-17 00:00:00000000",
+        "operation_type": "remove",
+        "org": "some-org",
+        "org_id": 12345678,
+        "public_repo": false,
+        "repo": "some-org/ruleset-repo",
+        "repo_id": 123456789,
+        "ruleset_bypass_actors":
+          [
+            {
+              "actor_id": 123456,
+              "actor_type": "Integration",
+              "bypass_mode": "always",
+              "id": 123456,
+            },
+            {
+              "actor_id": 123456,
+              "actor_type": "Team",
+              "bypass_mode": "always",
+              "id": 1234567,
+            },
+          ],
+        "ruleset_conditions":
+          [
+            {
+              "id": 1234567,
+              "parameters": { "exclude": [], "include": ["~DEFAULT_BRANCH"] },
+              "target": "ref_name",
+            },
+          ],
+        "ruleset_enforcement": "enabled",
+        "ruleset_id": "1234567",
+        "ruleset_name": "a-ruleset-name",
+        "ruleset_rules":
+          [
+            {
+              "id": 10994218,
+              "parameters":
+                {
+                  "allowed_merge_methods": ["merge", "squash", "rebase"],
+                  "authorized_dismissal_actors_only": false,
+                  "automatic_copilot_code_review_enabled": true,
+                  "dismiss_stale_reviews_on_push": false,
+                  "ignore_approvals_from_contributors": false,
+                  "require_code_owner_review": false,
+                  "require_last_push_approval": false,
+                  "required_approving_review_count": 1,
+                  "required_review_thread_resolution": false,
+                  "required_reviewers": [],
+                },
+              "type": "pull_request",
+            },
+            { "id": 10994219, "parameters": {}, "type": "deletion" },
+            { "id": 10994220, "parameters": {}, "type": "non_fast_forward" },
+          ],
+        "ruleset_source_type": "Repository",
+        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+      }
+
+  - Name: GitHub - Non Webhook Event
+    ExpectedResult: false
+    Log:
+      {
+        "actor": "cat",
+        "action": "org.invite_member",
+        "org": "my-org",
+        "p_log_type": "GitHub.Audit",
+        "repo": "my-org/my-repo",
+      }
+  - Name: Github - Ruleset Modified
+    ExpectedResult: true
+    Log:
+      {
+        "action": "repository_ruleset.update",
+        "actor": "dog",
+        "actor_id": "999999999",
+        "actor_is_bot": false,
+        "actor_location": { "country_code": "US" },
+        "business": "bizname",
+        "business_id": "12345",
+        "created_at": "2024-12-17 00:00:00000000",
+        "operation_type": "modify",
+        "org": "some-org",
+        "org_id": 12345678,
+        "public_repo": false,
+        "repo": "some-org/ruleset-repo",
+        "repo_id": 123456789,
+        "ruleset_bypass_actors":
+          [
+            {
+              "actor_id": 123456,
+              "actor_type": "Integration",
+              "bypass_mode": "always",
+              "id": 123456,
+            },
+            {
+              "actor_id": 123456,
+              "actor_type": "Team",
+              "bypass_mode": "always",
+              "id": 1234567,
+            },
+          ],
+        "ruleset_conditions":
+          [
+            {
+              "id": 1234567,
+              "parameters": { "exclude": [], "include": ["~DEFAULT_BRANCH"] },
+              "target": "ref_name",
+            },
+          ],
+        "ruleset_enforcement": "enabled",
+        "ruleset_id": "1234567",
+        "ruleset_name": "a-ruleset-name",
+        "ruleset_rules_updated":
+          [
+            {
+              "id": 12345678,
+              "old_parameters":
+                {
+                  "allowed_merge_methods": ["merge", "squash", "rebase"],
+                  "authorized_dismissal_actors_only": false,
+                  "automatic_copilot_code_review_enabled": false,
+                  "dismiss_stale_reviews_on_push": false,
+                  "ignore_approvals_from_contributors": false,
+                  "require_code_owner_review": false,
+                  "require_last_push_approval": false,
+                  "required_approving_review_count": 1,
+                  "required_review_thread_resolution": false,
+                  "required_reviewers": [],
+                },
+              "parameters":
+                {
+                  "allowed_merge_methods": ["merge", "squash", "rebase"],
+                  "authorized_dismissal_actors_only": false,
+                  "automatic_copilot_code_review_enabled": true,
+                  "dismiss_stale_reviews_on_push": false,
+                  "ignore_approvals_from_contributors": false,
+                  "require_code_owner_review": false,
+                  "require_last_push_approval": false,
+                  "required_approving_review_count": 1,
+                  "required_review_thread_resolution": false,
+                  "required_reviewers": [],
+                },
+              "type": "pull_request",
+            },
+          ],
+        "ruleset_source_type": "Repository",
+        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+      }

--- a/rules/github_rules/github_repo_ruleset_modified.yml
+++ b/rules/github_rules/github_repo_ruleset_modified.yml
@@ -7,6 +7,9 @@ LogTypes:
   - GitHub.Audit
 Tags:
   - GitHub
+  - Defense Evasion
+  - Impair Defenses
+  - Disable or Modify Tools
 Reports:
   MITRE ATT&CK:
     - TA0005:T1562:001 # Impair Defenses: Disable or Modify Tools


### PR DESCRIPTION
### Background

The cool kidz these days are using ruleset instead of or in combination with branch protection rules. This rule alerts to modifications (update, destroy) of rulesets and adds an INFO-level signal for ruleset creations if desired for future correlation rules. Filters can be applied in global_filter_github and the github_alert_context is enriched specific to repo ruleset changes.

[1] https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets

### Changes

- Create GitHub.Repo.RulsetModified rule
- Tests for each create/update/destroy event type
- Update the github.yml pack

### Testing

pat test, make lint