### PR TITLE
Github Actions OIDC IAM Role Trust Relation

### DIFF
--- a/packs/aws.yml
+++ b/packs/aws.yml
@@ -70,6 +70,7 @@ PackDefinition:
     - AWS.IAM.PolicyModified
     - AWS.IAM.User.MFA
     - AWS.IAMUser.ReconAccessDenied
+    - AWS.IAM.Role.GitHubActionsTrust
     - AWS.Password.Unused
     - AWS.PasswordPolicy.ComplexityGuidelines
     - AWS.PasswordPolicy.PasswordAgeLimit

--- a/policies/aws_iam_policies/aws_iam_role_github_actions_trust.py
+++ b/policies/aws_iam_policies/aws_iam_role_github_actions_trust.py
@@ -1,37 +1,37 @@
 def policy(resource):
     assume_role_policy = resource.get("AssumeRolePolicyDocument", {}).get("Statement", [])
-    
-    # Iterate through each statement in the trust policy
+    is_valid = False
+
     for statement in assume_role_policy:
-        # Check if the statement allows sts:AssumeRoleWithWebIdentity
-        if statement.get("Effect") == "Allow" and "sts:AssumeRoleWithWebIdentity" in statement.get("Action", []):
-            # Validate the Principal
-            principal = statement.get("Principal", {}).get("Federated")
-            if not principal:
-                return False  # Invalid Principal
-            if principal == "*":
-                return False  # Wildcard in Principal is insecure
-            if "oidc-provider/token.actions.githubusercontent.com" not in principal:
-                continue  # Skip non-GitHub-related Principals
-            
-            # Validate the conditions only if the Principal is valid for GitHub Actions
-            conditions = statement.get("Condition", {})
-            
-            # Check if the aud is correctly set
-            audience = conditions.get("StringEquals", {}).get("token.actions.githubusercontent.com:aud")
-            if audience != "sts.amazonaws.com":
-                return False
-            
-            # Check if the sub is properly restricted
-            subject = conditions.get("StringLike", {}).get("token.actions.githubusercontent.com:sub", "") or \
-                      conditions.get("StringEquals", {}).get("token.actions.githubusercontent.com:sub", "")
-            
-            if not subject.startswith("repo:"):
-                return False  # Ensure sub references a repository
-            
-            if "*" in subject and not subject.startswith("repo:org/repo:*"):
-                return False  # Disallow overly permissive wildcards
-            
-            return True  # Valid GitHub Actions config
-    
-    return False  # No valid statements found
+        if (
+            statement.get("Effect") != "Allow"
+            or "sts:AssumeRoleWithWebIdentity" not in statement.get("Action", [])
+        ):
+            continue
+
+        principal = statement.get("Principal", {}).get("Federated")
+        if not principal or principal == "*":
+            return False
+        if "oidc-provider/token.actions.githubusercontent.com" not in principal:
+            continue
+
+        # Validate the conditions only if the Principal is valid for GitHub Actions
+        conditions = statement.get("Condition", {})
+        audience = conditions.get("StringEquals", {}).get(
+            "token.actions.githubusercontent.com:aud"
+        )
+        subject = (
+            conditions.get("StringLike", {}).get("token.actions.githubusercontent.com:sub", "")
+            or conditions.get("StringEquals", {}).get("token.actions.githubusercontent.com:sub", "")
+        )
+
+        if (
+            audience != "sts.amazonaws.com"
+            or not subject.startswith("repo:")
+            or ("*" in subject and not subject.startswith("repo:org/repo:*"))
+        ):
+            return False
+
+        is_valid = True  # Mark as valid if all checks pass
+
+    return is_valid

--- a/policies/aws_iam_policies/aws_iam_role_github_actions_trust.py
+++ b/policies/aws_iam_policies/aws_iam_role_github_actions_trust.py
@@ -1,0 +1,37 @@
+def policy(resource):
+    assume_role_policy = resource.get("AssumeRolePolicyDocument", {}).get("Statement", [])
+    
+    # Iterate through each statement in the trust policy
+    for statement in assume_role_policy:
+        # Check if the statement allows sts:AssumeRoleWithWebIdentity
+        if statement.get("Effect") == "Allow" and "sts:AssumeRoleWithWebIdentity" in statement.get("Action", []):
+            # Validate the Principal
+            principal = statement.get("Principal", {}).get("Federated")
+            if not principal:
+                return False  # Invalid Principal
+            if principal == "*":
+                return False  # Wildcard in Principal is insecure
+            if "oidc-provider/token.actions.githubusercontent.com" not in principal:
+                continue  # Skip non-GitHub-related Principals
+            
+            # Validate the conditions only if the Principal is valid for GitHub Actions
+            conditions = statement.get("Condition", {})
+            
+            # Check if the aud is correctly set
+            audience = conditions.get("StringEquals", {}).get("token.actions.githubusercontent.com:aud")
+            if audience != "sts.amazonaws.com":
+                return False
+            
+            # Check if the sub is properly restricted
+            subject = conditions.get("StringLike", {}).get("token.actions.githubusercontent.com:sub", "") or \
+                      conditions.get("StringEquals", {}).get("token.actions.githubusercontent.com:sub", "")
+            
+            if not subject.startswith("repo:"):
+                return False  # Ensure sub references a repository
+            
+            if "*" in subject and not subject.startswith("repo:org/repo:*"):
+                return False  # Disallow overly permissive wildcards
+            
+            return True  # Valid GitHub Actions config
+    
+    return False  # No valid statements found

--- a/policies/aws_iam_policies/aws_iam_role_github_actions_trust.py
+++ b/policies/aws_iam_policies/aws_iam_role_github_actions_trust.py
@@ -3,10 +3,9 @@ def policy(resource):
     is_valid = False
 
     for statement in assume_role_policy:
-        if (
-            statement.get("Effect") != "Allow"
-            or "sts:AssumeRoleWithWebIdentity" not in statement.get("Action", [])
-        ):
+        if statement.get(
+            "Effect"
+        ) != "Allow" or "sts:AssumeRoleWithWebIdentity" not in statement.get("Action", []):
             continue
 
         principal = statement.get("Principal", {}).get("Federated")
@@ -17,13 +16,10 @@ def policy(resource):
 
         # Validate the conditions only if the Principal is valid for GitHub Actions
         conditions = statement.get("Condition", {})
-        audience = conditions.get("StringEquals", {}).get(
-            "token.actions.githubusercontent.com:aud"
-        )
-        subject = (
-            conditions.get("StringLike", {}).get("token.actions.githubusercontent.com:sub", "")
-            or conditions.get("StringEquals", {}).get("token.actions.githubusercontent.com:sub", "")
-        )
+        audience = conditions.get("StringEquals", {}).get("token.actions.githubusercontent.com:aud")
+        subject = conditions.get("StringLike", {}).get(
+            "token.actions.githubusercontent.com:sub", ""
+        ) or conditions.get("StringEquals", {}).get("token.actions.githubusercontent.com:sub", "")
 
         if (
             audience != "sts.amazonaws.com"

--- a/policies/aws_iam_policies/aws_iam_role_github_actions_trust.py
+++ b/policies/aws_iam_policies/aws_iam_role_github_actions_trust.py
@@ -1,5 +1,8 @@
+from panther_base_helpers import deep_get
+
+
 def policy(resource):
-    assume_role_policy = resource.get("AssumeRolePolicyDocument", {}).get("Statement", [])
+    assume_role_policy = deep_get(resource, "AssumeRolePolicyDocument", "Statement", default=[])
     is_valid = False
 
     for statement in assume_role_policy:
@@ -8,7 +11,7 @@ def policy(resource):
         ) != "Allow" or "sts:AssumeRoleWithWebIdentity" not in statement.get("Action", []):
             continue
 
-        principal = statement.get("Principal", {}).get("Federated")
+        principal = deep_get(statement, "Principal", "Federated")
         if not principal or principal == "*":
             return False
         if "oidc-provider/token.actions.githubusercontent.com" not in principal:
@@ -16,10 +19,12 @@ def policy(resource):
 
         # Validate the conditions only if the Principal is valid for GitHub Actions
         conditions = statement.get("Condition", {})
-        audience = conditions.get("StringEquals", {}).get("token.actions.githubusercontent.com:aud")
-        subject = conditions.get("StringLike", {}).get(
-            "token.actions.githubusercontent.com:sub", ""
-        ) or conditions.get("StringEquals", {}).get("token.actions.githubusercontent.com:sub", "")
+        audience = deep_get(conditions, "StringEquals", "token.actions.githubusercontent.com:aud")
+        subject = deep_get(
+            conditions, "StringLike", "token.actions.githubusercontent.com:sub", default=""
+        ) or deep_get(
+            conditions, "StringEquals", "token.actions.githubusercontent.com:sub", default=""
+        )
 
         if (
             audience != "sts.amazonaws.com"

--- a/policies/aws_iam_policies/aws_iam_role_github_actions_trust.yml
+++ b/policies/aws_iam_policies/aws_iam_role_github_actions_trust.yml
@@ -1,0 +1,202 @@
+AnalysisType: policy
+Filename: aws_iam_role_github_actions_trust.py
+PolicyID: "AWS.IAM.Role.GitHubActionsTrust"
+DisplayName: "AWS IAM Role Trust Relationship for GitHub Actions"
+Enabled: true
+ResourceTypes:
+  - AWS.IAM.Role
+Tags:
+  - AWS
+  - GitHub Actions
+  - Identity & Access Management
+Severity: High
+Description: >
+  This policy ensures that IAM roles used with GitHub Actions are securely configured to prevent unauthorized access to AWS resources. 
+  It validates trust relationships by checking for proper audience (aud) restrictions, ensuring it is set to sts.amazonaws.com, and subject (sub) conditions, 
+  confirming they are scoped to specific repositories or environments. Misconfigurations, such as overly permissive wildcards or missing conditions, 
+  can allow unauthorized repositories to assume roles, leading to potential data breaches or compliance violations. 
+  By enforcing these checks, the policy mitigates risks of exploitation, enhances security posture, and protects critical AWS resources from external threats.
+Runbook: >
+  To fix roles flagged by this policy:
+  1. Update the trust relationship of the flagged IAM role in the AWS Management Console or CLI.
+  2. Add a Condition block with 'StringLike' or 'StringEquals' for 'token.actions.githubusercontent.com:sub'.
+  3. Ensure the audience is set to 'sts.amazonaws.com'.
+  4. Avoid overly permissive wildcards in the sub condition.
+Reference: >
+  - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html
+  - https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers
+  - https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
+Tests:
+  - Name: Valid GitHub Actions Trust Relationship
+    ExpectedResult: true
+    Resource:
+      {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Principal": {
+                "Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+              },
+              "Condition": {
+                "StringEquals": {
+                  "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+                },
+                "StringLike": {
+                  "token.actions.githubusercontent.com:sub": "repo:org/repo:*"
+                }
+              }
+            }
+          ]
+        }
+      }
+
+  - Name: Missing Audience Condition
+    ExpectedResult: false
+    Resource:
+      {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Principal": {
+                "Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+              },
+              "Condition": {
+                "StringLike": {
+                  "token.actions.githubusercontent.com:sub": "repo:org/repo:*"
+                }
+              }
+            }
+          ]
+        }
+      }
+
+  - Name: Missing Subject Restriction
+    ExpectedResult: false
+    Resource:
+      {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Principal": {
+                "Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+              },
+              "Condition": {
+                "StringEquals": {
+                  "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+                }
+              }
+            }
+          ]
+        }
+      }
+
+  - Name: Overly Permissive Wildcard in Subject
+    ExpectedResult: false
+    Resource:
+      {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Principal": {
+                "Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+              },
+              "Condition": {
+                "StringEquals": {
+                  "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+                },
+                "StringLike": {
+                  "token.actions.githubusercontent.com:sub": "*"
+                }
+              }
+            }
+          ]
+        }
+      }
+
+  - Name: Valid Subject Restriction with Specific Environment
+    ExpectedResult: true
+    Resource:
+      {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Principal": {
+                "Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+              },
+              "Condition": {
+                "StringEquals": {
+                  "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                  "token.actions.githubusercontent.com:sub": "repo:org/repo:environment:prod"
+                }
+              }
+            }
+          ]
+        }
+      }
+
+  - Name: Invalid Principal as Wildcard
+    ExpectedResult: false
+    Resource:
+      {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Principal": {
+                "Federated": "*"
+              },
+              "Condition": {
+                "StringEquals": {
+                  "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+                },
+                "StringLike": {
+                  "token.actions.githubusercontent.com:sub": "repo:org/repo:*"
+                }
+              }
+            }
+          ]
+        }
+      }
+
+  - Name: Non-GitHub OIDC Principal
+    ExpectedResult: false
+    Resource:
+      {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Principal": {
+                "Federated": "arn:aws:iam::123456789012:oidc-provider/accounts.google.com"
+              },
+              "Condition": {
+                "StringEquals": {
+                  "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+                },
+                "StringLike": {
+                  "token.actions.githubusercontent.com:sub": "repo:org/repo:*"
+                }
+              }
+            }
+          ]
+        }
+      }


### PR DESCRIPTION
### Background

This policy ensures secure configuration of AWS IAM roles used with GitHub Actions by validating trust relationships. It enforces restrictions on the Principal, aud (audience), and sub (subject) conditions to prevent unauthorized access to AWS resources. Misconfigurations such as wildcards in the Principal or overly permissive sub conditions can lead to potential exploitation, so this policy mitigates such risks by enforcing proper validation rules.

### Changes

- Validates the Principal.Federated field to ensure it is either GitHub's OIDC provider (oidc- provider/token.actions.githubusercontent.com) or skips validation for non-GitHub principals. It rejects wildcards as insecure.
- Ensures Condition.StringEquals for aud is correctly set to sts.amazonaws.com.
- Enforces scoping of Condition.StringLike or Condition.StringEquals for sub to specific repositories or environments.
Disallows overly permissive wildcards in sub.

### Testing

- Valid GitHub Actions Trust Relationship: Passes for properly configured GitHub Actions trust relationships.
- Missing Audience Condition: Fails when aud condition is missing.
- Missing Subject Restriction: Fails when sub condition is absent.
- Overly Permissive Wildcard in Subject: Flags overly permissive sub wildcards.
- Valid Subject Restriction with Specific Environment: Passes for correctly scoped sub with environments.
- Invalid Principal as Wildcard: Fails when Principal.Federated is a wildcard (*).
- Non-GitHub OIDC Principal: Ignore non-GitHub OIDC providers like accounts.google.com/cognito

I have added scenarios I could think of, let me know if any additional test cases are required. 
