### PR TITLE
Okta New Behaviors Acessing Admin Console — jsonify logOnlySecurityData string

### DIFF
--- a/rules/okta_rules/okta_new_behavior_accessing_admin_console.py
+++ b/rules/okta_rules/okta_new_behavior_accessing_admin_console.py
@@ -15,11 +15,11 @@ def rule(event):
     if behaviors:
         return "New Device=POSITIVE" in behaviors and "New IP=POSITIVE" in behaviors
 
-    log_only_security_data = event.deep_get(
-            "debugContext", "debugData", "logOnlySecurityData")
+    log_only_security_data = event.deep_get("debugContext", "debugData", "logOnlySecurityData")
     if type(log_only_security_data) is str:
         log_only_security_data = json.loads(log_only_security_data)
-    return (deep_get(log_only_security_data, "behaviors", "New Device") == "POSITIVE"
+    return (
+        deep_get(log_only_security_data, "behaviors", "New Device") == "POSITIVE"
         and deep_get(log_only_security_data, "behaviors", "New IP") == "POSITIVE"
     )
 

--- a/rules/okta_rules/okta_new_behavior_accessing_admin_console.py
+++ b/rules/okta_rules/okta_new_behavior_accessing_admin_console.py
@@ -1,3 +1,6 @@
+import json
+
+from panther_base_helpers import deep_get
 from panther_okta_helpers import okta_alert_context
 
 
@@ -12,15 +15,12 @@ def rule(event):
     if behaviors:
         return "New Device=POSITIVE" in behaviors and "New IP=POSITIVE" in behaviors
 
-    return (
-        event.deep_get(
-            "debugContext", "debugData", "logOnlySecurityData", "behaviors", "New Device"
-        )
-        == "POSITIVE"
-        and event.deep_get(
-            "debugContext", "debugData", "logOnlySecurityData", "behaviors", "New IP"
-        )
-        == "POSITIVE"
+    log_only_security_data = event.deep_get(
+            "debugContext", "debugData", "logOnlySecurityData")
+    if type(log_only_security_data) is str:
+        log_only_security_data = json.loads(log_only_security_data)
+    return (deep_get(log_only_security_data, "behaviors", "New Device") == "POSITIVE"
+        and deep_get(log_only_security_data, "behaviors", "New IP") == "POSITIVE"
     )
 
 

--- a/rules/okta_rules/okta_new_behavior_accessing_admin_console.py
+++ b/rules/okta_rules/okta_new_behavior_accessing_admin_console.py
@@ -16,7 +16,7 @@ def rule(event):
         return "New Device=POSITIVE" in behaviors and "New IP=POSITIVE" in behaviors
 
     log_only_security_data = event.deep_get("debugContext", "debugData", "logOnlySecurityData")
-    if type(log_only_security_data) is str:
+    if isinstance(log_only_security_data, str):
         log_only_security_data = json.loads(log_only_security_data)
     return (
         deep_get(log_only_security_data, "behaviors", "New Device") == "POSITIVE"

--- a/rules/okta_rules/okta_new_behavior_accessing_admin_console.yml
+++ b/rules/okta_rules/okta_new_behavior_accessing_admin_console.yml
@@ -23,255 +23,329 @@ Tests:
   - Name: New Behavior Accessing Admin Console (behavior)
     ExpectedResult: true
     Log:
-      actor:
-        alternateId: homer.simpson@duff.com
-        displayName: Homer Simpson
-        id: 00abc123
-        type: User
-      authenticationcontext:
-        authenticationStep: 0
-        externalSessionId: 100-abc-9999
-      client:
-        device: Computer
-        geographicalContext:
-          city: Springfield
-          country: United States
-          geolocation:
-            lat: 20
-            lon: -25
-          postalCode: "12345"
-          state: Ohio
-        ipAddress: 1.3.2.4
-        userAgent:
-          browser: CHROME
-          os: Mac OS X
-          rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36
-        zone: "null"
-      device:
-        name: Evil Computer
-      debugcontext:
-        debugData:
-          requestId: AbCdEf12G
-          requestUri: /api/v1/users/AbCdEfG/lifecycle/reset_factors
-          url: /api/v1/users/AbCdEfG/lifecycle/reset_factors?
-          behaviors:
-            {
-              New Geo-Location=NEGATIVE,
-              New Device=POSITIVE,
-              New IP=POSITIVE,
-              New State=NEGATIVE,
-              New Country=NEGATIVE,
-              Velocity=NEGATIVE,
-              New City=NEGATIVE,
-            }
-      displaymessage: Evaluation of sign-on policy
-      eventtype: policy.evaluate_sign_on
-      outcome:
-        reason: Sign-on policy evaluation resulted in CHALLENGE
-        result: CHALLENGE
-      published: "2022-06-22 18:18:29.015"
-      request:
-        ipChain:
-          - geographicalContext:
-              city: Springfield
-              country: United States
-              geolocation:
-                lat: 20
-                lon: -25
-              postalCode: "12345"
-              state: Ohio
-              ip: 1.3.2.4
-              version: V4
-      securitycontext:
-        asNumber: 701
-        asOrg: verizon
-        domain: verizon.net
-        isProxy: false
-        isp: verizon
-      severity: INFO
-      target:
-        - alternateId: Okta Admin Console
-          displayName: Okta Admin Console
-          type: AppInstance
-        - alternateId: peter.griffin@company.com
-          displayName: Peter Griffin
-          id: 0002222AAAA
-          type: User
-      transaction:
-        detail: {}
-        id: ABcDeFgG
-        type: WEB
-      uuid: AbC-123-XyZ
-      version: "0"
+      { actor:
+          { alternateId: homer.simpson@duff.com,
+            displayName: Homer Simpson,
+            id: 00abc123,
+            type: User },
+        authenticationcontext:
+          { authenticationStep: 0,
+            externalSessionId: 100-abc-9999 },
+        client:
+          { device: Computer,
+            geographicalContext:
+              { city: Springfield,
+                country: United States,
+                geolocation:
+                  { lat: 20,
+                    lon: -25 },
+                postalCode: "12345",
+                state: Ohio },
+            ipAddress: 1.3.2.4,
+            userAgent:
+              { browser: CHROME,
+                os: Mac OS X,
+                rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36 },
+            zone: "null" },
+        device:
+          { name: Evil Computer },
+        debugcontext:
+          { debugData:
+              { requestId: AbCdEf12G,
+                requestUri: /api/v1/users/AbCdEfG/lifecycle/reset_factors,
+                url: '/api/v1/users/AbCdEfG/lifecycle/reset_factors?',
+                behaviors:
+                  [
+                    New Geo-Location=NEGATIVE,
+                    New Device=POSITIVE,
+                    New IP=POSITIVE,
+                    New State=NEGATIVE,
+                    New Country=NEGATIVE,
+                    Velocity=NEGATIVE,
+                    New City=NEGATIVE,
+                  ] }, },
+        displaymessage: Evaluation of sign-on policy,
+          eventtype: policy.evaluate_sign_on,
+          outcome:
+            { reason: Sign-on policy evaluation resulted in CHALLENGE,
+              result: CHALLENGE },
+        published: "2022-06-22 18:18:29.015",
+          request:
+            { ipChain:
+                [ { geographicalContext:
+                      { city: Springfield,
+                        country: United States,
+                        geolocation:
+                          { lat: 20,
+                            lon: -25 },
+                        postalCode: "12345",
+                        state: Ohio,
+                        ip: 1.3.2.4,
+                        version: V4 }, } ] },
+        securitycontext:
+          { asNumber: 701,
+            asOrg: verizon,
+            domain: verizon.net,
+            isProxy: false,
+            isp: verizon },
+        severity: INFO,
+        target:
+          [ { alternateId: Okta Admin Console,
+              displayName: Okta Admin Console,
+              type: AppInstance },
+            { alternateId: peter.griffin@company.com,
+              displayName: Peter Griffin,
+              id: 0002222AAAA,
+              type: User }, ],
+        transaction:
+          { detail: { },
+            id: ABcDeFgG,
+            type: WEB },
+      uuid: AbC-123-XyZ,
+        version: "0" }
   - Name: New Behavior Accessing Admin Console (logSecurityDataOnly)
     ExpectedResult: true
     Log:
-      actor:
-        alternateId: homer.simpson@duff.com
-        displayName: Homer Simpson
-        id: 00abc123
-        type: User
-      authenticationcontext:
-        authenticationStep: 0
-        externalSessionId: 100-abc-9999
-      client:
-        device: Computer
-        geographicalContext:
-          city: Springfield
-          country: United States
-          geolocation:
-            lat: 20
-            lon: -25
-          postalCode: "12345"
-          state: Ohio
-        ipAddress: 1.3.2.4
-        userAgent:
-          browser: CHROME
-          os: Mac OS X
-          rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36
-        zone: "null"
-      device:
-        name: Evil Computer
-      debugcontext:
-        debugData:
-          requestId: AbCdEf12G
-          requestUri: /api/v1/users/AbCdEfG/lifecycle/reset_factors
-          url: /api/v1/users/AbCdEfG/lifecycle/reset_factors?
-          logOnlySecurityData:
-            {
-              "risk": { "level": "LOW" },
-              "behaviors":
-                {
-                  "New Geo-Location": "NEGATIVE",
-                  "New Device": "POSITIVE",
-                  "New IP": "POSITIVE",
-                  "New State": "NEGATIVE",
-                  "New Country": "NEGATIVE",
-                  "Velocity": "NEGATIVE",
-                  "New City": "NEGATIVE",
-                },
-            }
-      displaymessage: Evaluation of sign-on policy
-      eventtype: policy.evaluate_sign_on
-      outcome:
-        reason: Sign-on policy evaluation resulted in CHALLENGE
-        result: CHALLENGE
-      published: "2022-06-22 18:18:29.015"
-      request:
-        ipChain:
-          - geographicalContext:
-              city: Springfield
-              country: United States
-              geolocation:
-                lat: 20
-                lon: -25
-              postalCode: "12345"
-              state: Ohio
-              ip: 1.3.2.4
-              version: V4
-      securitycontext:
-        asNumber: 701
-        asOrg: verizon
-        domain: verizon.net
-        isProxy: false
-        isp: verizon
-      severity: INFO
-      target:
-        - alternateId: Okta Admin Console
-          displayName: Okta Admin Console
-          type: AppInstance
-        - alternateId: peter.griffin@company.com
-          displayName: Peter Griffin
-          id: 0002222AAAA
-          type: User
-      transaction:
-        detail: {}
-        id: ABcDeFgG
-        type: WEB
-      uuid: AbC-123-XyZ
-      version: "0"
+      { actor:
+          { alternateId: homer.simpson@duff.com,
+            displayName: Homer Simpson,
+            id: 00abc123,
+            type: User },
+        authenticationcontext:
+          { authenticationStep: 0,
+            externalSessionId: 100-abc-9999 },
+        client:
+          { device: Computer,
+            geographicalContext:
+              { city: Springfield,
+                country: United States,
+                geolocation:
+                  { lat: 20,
+                    lon: -25 },
+                postalCode: "12345",
+                state: Ohio },
+            ipAddress: 1.3.2.4,
+            userAgent:
+              { browser: CHROME,
+                os: Mac OS X,
+                rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36 },
+            zone: "null" },
+        device:
+          { name: Evil Computer },
+        debugcontext:
+          { debugData:
+              { requestId: AbCdEf12G,
+                requestUri: /api/v1/users/AbCdEfG/lifecycle/reset_factors,
+                url: '/api/v1/users/AbCdEfG/lifecycle/reset_factors?',
+                logOnlySecurityData:
+                  {
+                    "risk": { "level": "LOW" },
+                    "behaviors":
+                      {
+                        "New Geo-Location": "NEGATIVE",
+                        "New Device": "POSITIVE",
+                        "New IP": "POSITIVE",
+                        "New State": "NEGATIVE",
+                        "New Country": "NEGATIVE",
+                        "Velocity": "NEGATIVE",
+                        "New City": "NEGATIVE",
+                      },
+                  } } },
+        displaymessage: Evaluation of sign-on policy,
+          eventtype: policy.evaluate_sign_on,
+          outcome:
+            { reason: Sign-on policy evaluation resulted in CHALLENGE,
+              result: CHALLENGE },
+        published: "2022-06-22 18:18:29.015",
+          request:
+            { ipChain:
+                [ { geographicalContext:
+                      { city: Springfield,
+                        country: United States,
+                        geolocation:
+                          { lat: 20,
+                            lon: -25 },
+                        postalCode: "12345",
+                        state: Ohio,
+                        ip: 1.3.2.4,
+                        version: V4 } } ] },
+        securitycontext:
+          { asNumber: 701,
+            asOrg: verizon,
+            domain: verizon.net,
+            isProxy: false,
+            isp: verizon },
+        severity: INFO,
+          target:
+            [ { alternateId: Okta Admin Console,
+                displayName: Okta Admin Console,
+                type: AppInstance },
+              { alternateId: peter.griffin@company.com,
+                displayName: Peter Griffin,
+                id: 0002222AAAA,
+                type: User } ],
+        transaction:
+          { detail: { },
+            id: ABcDeFgG,
+            type: WEB },
+        uuid: AbC-123-XyZ,
+          version: "0" }
   - Name: Not New Behavior
     ExpectedResult: false
     Log:
-      actor:
-        alternateId: homer.simpson@duff.com
-        displayName: Homer Simpson
-        id: 00abc123
-        type: User
-      authenticationcontext:
-        authenticationStep: 0
-        externalSessionId: 100-abc-9999
-      client:
-        device: Computer
-        geographicalContext:
-          city: Springfield
-          country: United States
-          geolocation:
-            lat: 20
-            lon: -25
-          postalCode: "12345"
-          state: Ohio
-        ipAddress: 1.3.2.4
-        userAgent:
-          browser: CHROME
-          os: Mac OS X
-          rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36
-        zone: "null"
-      debugcontext:
-        debugData:
-          requestId: AbCdEf12G
-          requestUri: /api/v1/users/AbCdEfG/lifecycle/reset_factors
-          url: /api/v1/users/AbCdEfG/lifecycle/reset_factors?
-          logOnlySecurityData:
-            {
-              "risk": { "level": "LOW" },
-              "behaviors":
-                {
-                  "New Geo-Location": "NEGATIVE",
-                  "New Device": "NEGATIVE",
-                  "New IP": "NEGATIVE",
-                  "New State": "NEGATIVE",
-                  "New Country": "NEGATIVE",
-                  "Velocity": "NEGATIVE",
-                  "New City": "NEGATIVE",
-                },
-            }
-      displaymessage: Evaluation of sign-on policy
-      eventtype: policy.evaluate_sign_on
-      outcome:
-        reason: Sign-on policy evaluation resulted in CHALLENGE
-        result: CHALLENGE
-      published: "2022-06-22 18:18:29.015"
-      request:
-        ipChain:
-          - geographicalContext:
-              city: Springfield
-              country: United States
-              geolocation:
-                lat: 20
-                lon: -25
-              postalCode: "12345"
-              state: Ohio
-              ip: 1.3.2.4
-              version: V4
-      securitycontext:
-        asNumber: 701
-        asOrg: verizon
-        domain: verizon.net
-        isProxy: false
-        isp: verizon
-      severity: INFO
-      target:
-        - alternateId: Okta Admin Console
-          displayName: Okta Admin Console
-          type: AppInstance
-        - alternateId: peter.griffin@company.com
-          displayName: Peter Griffin
-          id: 0002222AAAA
-          type: User
-      transaction:
-        detail: {}
-        id: ABcDeFgG
-        type: WEB
-      uuid: AbC-123-XyZ
-      version: "0"
+      { actor:
+          { alternateId: homer.simpson@duff.com,
+              displayName: Homer Simpson,
+              id: 00abc123,
+              type: User },
+          authenticationcontext:
+            { authenticationStep: 0,
+                externalSessionId: 100-abc-9999 },
+          client:
+            { device: Computer,
+                geographicalContext:
+                  { city: Springfield,
+                      country: United States,
+                      geolocation:
+                        { lat: 20,
+                            lon: -25 },
+                      postalCode: "12345",
+                      state: Ohio },
+                ipAddress: 1.3.2.4,
+                userAgent:
+                  { browser: CHROME,
+                      os: Mac OS X,
+                      rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36 },
+              zone: "null" },
+          debugcontext:
+            { debugData:
+                { requestId: AbCdEf12G,
+                    requestUri: /api/v1/users/AbCdEfG/lifecycle/reset_factors,
+                    url: '/api/v1/users/AbCdEfG/lifecycle/reset_factors?',
+                    logOnlySecurityData:
+                      {
+                        "risk": { "level": "LOW" },
+                        "behaviors":
+                          {
+                            "New Geo-Location": "NEGATIVE",
+                            "New Device": "NEGATIVE",
+                            "New IP": "NEGATIVE",
+                            "New State": "NEGATIVE",
+                            "New Country": "NEGATIVE",
+                            "Velocity": "NEGATIVE",
+                            "New City": "NEGATIVE",
+                          },
+                      } } },
+          displaymessage: Evaluation of sign-on policy,
+          eventtype: policy.evaluate_sign_on,
+          outcome:
+            { reason: Sign-on policy evaluation resulted in CHALLENGE,
+                result: CHALLENGE },
+          published: "2022-06-22 18:18:29.015",
+          request:
+            { ipChain:
+                [ { geographicalContext:
+                      { city: Springfield,
+                          country: United States,
+                          geolocation:
+                            { lat: 20,
+                                lon: -25 },
+                          postalCode: "12345",
+                          state: Ohio,
+                          ip: 1.3.2.4,
+                          version: V4 } } ] },
+          securitycontext:
+            { asNumber: 701,
+                asOrg: verizon,
+                domain: verizon.net,
+                isProxy: false,
+                isp: verizon },
+          severity: INFO,
+          target:
+            [ { alternateId: Okta Admin Console,
+                  displayName: Okta Admin Console,
+                  type: AppInstance },
+              { alternateId: peter.griffin@company.com,
+                  displayName: Peter Griffin,
+                  id: 0002222AAAA,
+                  type: User } ],
+          transaction:
+            { detail: { },
+                id: ABcDeFgG,
+                type: WEB },
+          uuid: AbC-123-XyZ,
+          version: "0" }
+  - Name: New Behavior Accessing Admin Console (logSecurityDataOnly) - not jsonified string
+    ExpectedResult: true
+    Log:
+      { actor:
+          { alternateId: homer.simpson@duff.com,
+            displayName: Homer Simpson,
+            id: 00abc123,
+            type: User },
+        authenticationcontext:
+          { authenticationStep: 0,
+            externalSessionId: 100-abc-9999 },
+        client:
+          { device: Computer,
+            geographicalContext:
+              { city: Springfield,
+                country: United States,
+                geolocation:
+                  { lat: 20,
+                    lon: -25 },
+                postalCode: "12345",
+                state: Ohio },
+            ipAddress: 1.3.2.4,
+            userAgent:
+              { browser: CHROME,
+                os: Mac OS X,
+                rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36 },
+            zone: "null" },
+        device:
+          { name: Evil Computer },
+        debugcontext:
+          { debugData:
+              { requestId: AbCdEf12G,
+                requestUri: /api/v1/users/AbCdEfG/lifecycle/reset_factors,
+                url: '/api/v1/users/AbCdEfG/lifecycle/reset_factors?',
+                logOnlySecurityData: "{\"risk\":{\"level\":\"LOW\"},\"behaviors\":{\"New Geo-Location\":\"NEGATIVE\",\"New Device\":\"POSITIVE\",\"New IP\":\"POSITIVE\",\"New State\":\"NEGATIVE\",\"New Country\":\"NEGATIVE\",\"Velocity\":\"NEGATIVE\",\"New City\":\"NEGATIVE\"}}" }},
+            displaymessage: Evaluation of sign-on policy,
+            eventtype: policy.evaluate_sign_on,
+            outcome:
+              { reason: Sign-on policy evaluation resulted in CHALLENGE,
+                result: CHALLENGE },
+            published: "2022-06-22 18:18:29.015",
+            request:
+              { ipChain:
+                  [ { geographicalContext:
+                        { city: Springfield,
+                          country: United States,
+                          geolocation:
+                            { lat: 20,
+                              lon: -25 },
+                          postalCode: "12345",
+                          state: Ohio,
+                          ip: 1.3.2.4,
+                          version: V4 } } ] },
+            securitycontext:
+              { asNumber: 701,
+                asOrg: verizon,
+                domain: verizon.net,
+                isProxy: false,
+                isp: verizon },
+            severity: INFO,
+            target:
+              [ { alternateId: Okta Admin Console,
+                  displayName: Okta Admin Console,
+                  type: AppInstance },
+                { alternateId: peter.griffin@company.com,
+                  displayName: Peter Griffin,
+                  id: 0002222AAAA,
+                  type: User } ],
+            transaction:
+              { detail: { },
+                id: ABcDeFgG,
+                type: WEB },
+            uuid: AbC-123-XyZ,
+            version: "0" }


### PR DESCRIPTION
### Background

If Okta field `debugContext.debugData.logOnlySecurityData` came as a string instead of json, there was no alert for `Okta New Behaviors Acessing Admin Console` rule

### Changes

- added check for type of `debugContext.debugData.logOnlySecurityData` and jsonification if needed
- changed tests' format from yml to json

### Testing

pat test
