### PR TITLE
Patch AWS.S3.ServerAccess.IPWhitelist to work with IPv6

### DIFF
--- a/rules/aws_s3_rules/aws_s3_access_ip_allowlist.yml
+++ b/rules/aws_s3_rules/aws_s3_access_ip_allowlist.yml
@@ -31,3 +31,6 @@ Tests:
   - Name: Access From Unapproved IP
     ExpectedResult: true
     Log: { "remoteip": "11.0.0.1", "bucket": "my-test-bucket" }
+  - Name: Access From IPv6
+    ExpectedResult: true
+    Log: { "remoteip": "2600:1ffe:8140::a47:a85a", "bucket": "my-test-bucket" }


### PR DESCRIPTION
### Background

`AWS.S3.ServerAccess.IPWhitelist` would raise an error if the version of the accessing IP was different from the version of the allowed CIDR range. I added an additional check to confirm whether the addresses are both IPv4 or IPv6, and return `False` if they are not.

### Changes

- add `is_subnet` function to rule, which allows comparison of IPv4 and IPv6 networks

### Testing

- Manual testing passed the vibe check
- New unit test also passes
