### PR TITLE
fix: default release workflow to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Panther Analysis Release
 
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to release from"
+        required: true
+        default: "main"
 
 permissions:
   contents: read


### PR DESCRIPTION
### Background

Makes the Release workflow to default to the `main` branch instead of the repository's default (`develop`).
