### PR TITLE
Test GHA runs unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: test
         run: |
+          make data-models-unit-test global-helpers-unit-test
           pipenv run panther_analysis_tool test --show-failures-only
 
   test-authenticated:


### PR DESCRIPTION
### Background

The test GHA currently runs PAT test but not make test, which misses the unit tests for global helpers and data models.

### Changes

- Add `make data-models-unit-test global-helpers-unit-test` step to test workflow

### Testing

- GHA test
