### PR TITLE
Snowflake Brute Force Tuning

### DIFF
--- a/rules/snowflake_rules/snowflake_stream_brute_force_by_ip.py
+++ b/rules/snowflake_rules/snowflake_stream_brute_force_by_ip.py
@@ -1,7 +1,12 @@
 def rule(event):
     # Return true for any login attempt; Let Panther's dedup and threshold handle the brute force
     #   detection.
-    return event.get("EVENT_TYPE") == "LOGIN" and event.get("IS_SUCCESS") == "NO"
+    return (
+        event.get("EVENT_TYPE") == "LOGIN"
+        and event.get("IS_SUCCESS") == "NO"
+        and event.get("ERROR_MESSAGE") != "OVERFLOW_FAILURE_EVENTS_ELIDED"
+        # ^^ OVERFLOW_FAILURE_EVENTS_ELIDED are placeholder logs -> no point in alerting
+    )
 
 
 def title(event):
@@ -10,6 +15,14 @@ def title(event):
         f"{event.get('CLIENT_IP', '<UNKNOWN IP>')} "
         "have exceeded the failed logins threshold"
     )
+
+
+def severity(event):
+    # If the error appears to be caused by an automation issue, downgrade to INFO
+    common_errors = {"JWT_TOKEN_INVALID_PUBLIC_KEY_FINGERPRINT_MISMATCH"}
+    if event.get("ERROR_MESSAGE") in common_errors:
+        return "INFO"
+    return "DEFAULT"
 
 
 def dedup(event):

--- a/rules/snowflake_rules/snowflake_stream_brute_force_by_ip.yml
+++ b/rules/snowflake_rules/snowflake_stream_brute_force_by_ip.yml
@@ -54,3 +54,42 @@ Tests:
         "REPORTED_CLIENT_VERSION": "1.11.1",
         "USER_NAME": "luthor@lexcorp.com"
       }
+  - Name: Unsuccessful Login due to Invalid JWT Fingerprint
+    ExpectedResult: true
+    Log:
+      {
+        "p_event_time": "2024-10-08 14:38:46.061000000",
+        "p_log_type": "Snowflake.LoginHistory",
+        "p_source_label": "Snowflake Prod",
+        "CLIENT_IP": "1.2.3.4",
+        "ERROR_CODE": 394304,
+        "ERROR_MESSAGE": "JWT_TOKEN_INVALID_PUBLIC_KEY_FINGERPRINT_MISMATCH",
+        "EVENT_ID": "393754014361778",
+        "EVENT_TIMESTAMP": "2024-10-08 14:38:46.061000000",
+        "EVENT_TYPE": "LOGIN",
+        "FIRST_AUTHENTICATION_FACTOR": "PASSWORD",
+        "IS_SUCCESS": "NO",
+        "RELATED_EVENT_ID": "0",
+        "REPORTED_CLIENT_TYPE": "OTHER",
+        "REPORTED_CLIENT_VERSION": "1.11.1",
+        "USER_NAME": "luthor@lexcorp.com"
+      }
+  - Name: Overflow Failure
+    ExpectedResult: false
+    Log:
+      {
+        "p_event_time": "2024-11-15 00:12:24.288000000",
+        "p_log_type": "Snowflake.LoginHistory",
+        "p_parse_time": "2024-11-15 02:46:25.862374468",
+        "CLIENT_IP": "0.0.0.0",
+        "ERROR_CODE": 390156,
+        "ERROR_MESSAGE": "OVERFLOW_FAILURE_EVENTS_ELIDED",
+        "EVENT_ID": "16592193114297018",
+        "EVENT_TIMESTAMP": "2024-11-15 00:12:24.288000000",
+        "EVENT_TYPE": "LOGIN",
+        "IS_SUCCESS": "NO",
+        "RELATED_EVENT_ID": "0",
+        "REPORTED_CLIENT_TYPE": "OTHER",
+        "REPORTED_CLIENT_VERSION": "0",
+        "USER_NAME": "luthor@lexcorp.com"
+      }

--- a/rules/snowflake_rules/snowflake_stream_brute_force_by_username.py
+++ b/rules/snowflake_rules/snowflake_stream_brute_force_by_username.py
@@ -1,13 +1,26 @@
 def rule(event):
     # Return true for any login attempt; Let Panther's dedup and threshold handle the brute force
     #   detection.
-    return event.get("EVENT_TYPE") == "LOGIN" and event.get("IS_SUCCESS") == "NO"
+    return (
+        event.get("EVENT_TYPE") == "LOGIN"
+        and event.get("IS_SUCCESS") == "NO"
+        and event.get("ERROR_MESSAGE") != "OVERFLOW_FAILURE_EVENTS_ELIDED"
+        # ^^ OVERFLOW_FAILURE_EVENTS_ELIDED are placeholder logs -> no point in alerting
+    )
 
 
 def title(event):
     return (
         f"User {event.get('USER_NAME', '<UNKNOWN USER>')} has exceeded the failed logins threshold"
     )
+
+
+def severity(event):
+    # If the error appears to be caused by an automation issue, downgrade to INFO
+    common_errors = {"JWT_TOKEN_INVALID_PUBLIC_KEY_FINGERPRINT_MISMATCH"}
+    if event.get("ERROR_MESSAGE") in common_errors:
+        return "INFO"
+    return "DEFAULT"
 
 
 def dedup(event):

--- a/rules/snowflake_rules/snowflake_stream_brute_force_by_username.yml
+++ b/rules/snowflake_rules/snowflake_stream_brute_force_by_username.yml
@@ -54,3 +54,42 @@ Tests:
         "REPORTED_CLIENT_VERSION": "1.11.1",
         "USER_NAME": "luthor@lexcorp.com"
       }
+  - Name: Unsuccessful Login due to Invalid JWT Fingerprint
+    ExpectedResult: true
+    Log:
+      {
+        "p_event_time": "2024-10-08 14:38:46.061000000",
+        "p_log_type": "Snowflake.LoginHistory",
+        "p_source_label": "Snowflake Prod",
+        "CLIENT_IP": "1.2.3.4",
+        "ERROR_CODE": 394304,
+        "ERROR_MESSAGE": "JWT_TOKEN_INVALID_PUBLIC_KEY_FINGERPRINT_MISMATCH",
+        "EVENT_ID": "393754014361778",
+        "EVENT_TIMESTAMP": "2024-10-08 14:38:46.061000000",
+        "EVENT_TYPE": "LOGIN",
+        "FIRST_AUTHENTICATION_FACTOR": "PASSWORD",
+        "IS_SUCCESS": "NO",
+        "RELATED_EVENT_ID": "0",
+        "REPORTED_CLIENT_TYPE": "OTHER",
+        "REPORTED_CLIENT_VERSION": "1.11.1",
+        "USER_NAME": "luthor@lexcorp.com"
+      }
+  - Name: Overflow Failure
+    ExpectedResult: false
+    Log:
+      {
+        "p_event_time": "2024-11-15 00:12:24.288000000",
+        "p_log_type": "Snowflake.LoginHistory",
+        "p_parse_time": "2024-11-15 02:46:25.862374468",
+        "CLIENT_IP": "0.0.0.0",
+        "ERROR_CODE": 390156,
+        "ERROR_MESSAGE": "OVERFLOW_FAILURE_EVENTS_ELIDED",
+        "EVENT_ID": "16592193114297018",
+        "EVENT_TIMESTAMP": "2024-11-15 00:12:24.288000000",
+        "EVENT_TYPE": "LOGIN",
+        "IS_SUCCESS": "NO",
+        "RELATED_EVENT_ID": "0",
+        "REPORTED_CLIENT_TYPE": "OTHER",
+        "REPORTED_CLIENT_VERSION": "0",
+        "USER_NAME": "luthor@lexcorp.com"
+      }


### PR DESCRIPTION
### Background

We've observed a high number of alerts caused by JWT validation issues from our automations rotating tokens, and this PR will fix that.

### Changes

- Failed logins due to JWT issues are now signals
- Failed logins logs due to event overflow are ignored; these events are generated only when we've had a bunch of previous failed logins, so we will already have alerted if we start seeing these

### Testing

- Added new unit tests for both types of error message
