### PR TITLE
Add comments for check-deprecated and remove-deprecated in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,11 @@ install:
 test: global-helpers-unit-test data-models-unit-test
 	pipenv run panther_analysis_tool test $(TEST_ARGS)
 
+# Used by Panther team to update deprecated.txt
 check-deprecated:
 	pipenv run python3 ./.scripts/deleted_rules.py check
 
+# Used by Panther customers to delete detection content in deprecated.txt from their Panther instance
 remove-deprecated:
 	pipenv run python3 ./.scripts/deleted_rules.py remove
 


### PR DESCRIPTION
### Background

In [this docs change request](https://app.gitbook.com/o/-LgddDaIOc7MA4mxoaPa/s/-LgdiSWdyJcXPahGi9Rs-2910905616/~/changes/2924/panther-developer-workflows/ci-cd/detections-repo/~/comments/HZTP8nl23iNZyMnfruxZ?node=sr7cV5P1qs1Q#working-with-deprecated-rules) that adds info on working with deprecated detection content, after I suggested not mentioning make check-deprecated, @ben-githubs said, "My concern was that, if it isn't documented, we will get questions about it."

What do you think about adding code comments like this?

### Changes

Added a comment for both check-deprecated and remove-deprecated

### Testing

n/a
