### PR TITLE
Update aws_cloudtrail_event_selectors_disabled.yml DisplayName

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_cloudtrail_event_selectors_disabled.yml
+++ b/rules/aws_cloudtrail_rules/aws_cloudtrail_event_selectors_disabled.yml
@@ -1,7 +1,7 @@
 AnalysisType: rule
 Filename: aws_cloudtrail_event_selectors_disabled.py
 RuleID: "AWS.CloudTrail.EventSelectorsDisabled"
-DisplayName: "CloudTrail Event Delectors Disabled"
+DisplayName: "CloudTrail Event Selectors Disabled"
 Enabled: true
 LogTypes:
   - AWS.CloudTrail


### PR DESCRIPTION

### Background

SPS-Commerce noticed that we have a small typo in the `DisplayName` of the rule. Here is the corresponding thread: https://panther-labs.slack.com/archives/C060Z8KNGJ3/p1738008281806559

### Changes

The DisplayName of the rule was updated to "CloudTrail Event Selectors Disabled". Initially, it was "CloudTrail Event Delectors Disabled".
