### PR TITLE
[Tuning] Public Lambda Policy Tuning

### DIFF
--- a/policies/aws_lambda_policies/aws_lambda_public_access.py
+++ b/policies/aws_lambda_policies/aws_lambda_public_access.py
@@ -4,12 +4,26 @@ from panther_base_helpers import deep_get
 
 
 def policy(resource):
-    json_policy = json.loads(deep_get(resource, "Policy", "Policy"))
+    json_policy = json.loads(deep_get(resource, "Policy", "Policy", default="{}"))
     if any(
         (statement.get("Principal") == "*" or deep_get(statement, "Principal", "AWS") == "*")
         and statement.get("Effect") == "Allow"
-        and statement.get("Condition", {}) == {}
-        for statement in json_policy.get("Statement")
+        and (
+            statement.get("Condition", {}) == {}
+            or deep_get(statement, "Condition", "StringEquals", "lambda:FunctionUrlAuthType")
+            == "NONE"
+        )
+        for statement in json_policy.get("Statement", [])
     ):
         return False
     return True
+
+
+def severity(resource):
+    json_policy = json.loads(deep_get(resource, "Policy", "Policy", default="{}"))
+    if not any(
+        deep_get(statement, "Condition", "StringEquals", "lambda:FunctionUrlAuthType") == "NONE"
+        for statement in json_policy.get("Statement", [])
+    ):
+        return "LOW"
+    return "DEFAULT"

--- a/policies/aws_lambda_policies/aws_lambda_public_access.yml
+++ b/policies/aws_lambda_policies/aws_lambda_public_access.yml
@@ -104,3 +104,44 @@ Tests:
       Role: arn:aws:iam::123456789:role/some-name
       Timeout: 10
       Version: $LATEST
+  - Name: AWS Lambda No Policy
+    ExpectedResult: true
+    Resource:
+      AccountId: "123456789"
+      Arn: arn:aws:lambda:us-west-2:123456789:function:some-name
+      CodeSha256: azertyuiopqsdfghjklm
+      CodeSize: 1234
+      Description: Some description
+      Handler: some-name.lambda_handler
+      LastModified: 2024-09-13T15:23:51.000+0000
+      MemorySize: 128
+      Name: some-name
+      Region: us-west-2
+      ResourceId: arn:aws:lambda:us-west-2:123456789:function:some-name
+      ResourceType: AWS.Lambda.Function
+      RevisionId: 123456789-1234-1234-1234-123456789123
+      Role: arn:aws:iam::123456789:role/some-name
+      Timeout: 10
+      Version: $LATEST
+  - Name: AWS Lambda Unauthenticated Public Access 
+    ExpectedResult: false
+    Resource:
+      AccountId: "123456789"
+      Arn: arn:aws:lambda:us-west-2:123456789:function:some-name
+      CodeSha256: azertyuiopqsdfghjklm
+      CodeSize: 1234
+      Description: Some description
+      Handler: some-name.lambda_handler
+      LastModified: 2024-09-13T15:23:51.000+0000
+      MemorySize: 128
+      Name: some-name
+      Policy:
+        Policy: '{"Version":"2012-10-17","Id":"default","Statement":[{"Sid":"AllowExecutionFromCloudWatch","Effect":"Allow","Principal":{"AWS":"*"},"Action":"lambda:InvokeFunction","Resource":"arn:aws:lambda:us-west-2:123456789:function:some-name","Condition":{"StringEquals":{"lambda:FunctionUrlAuthType":"NONE"}}}]}'
+        RevisionId: 123456789-1234-1234-1234-123456789123
+      Region: us-west-2
+      ResourceId: arn:aws:lambda:us-west-2:123456789:function:some-name
+      ResourceType: AWS.Lambda.Function
+      RevisionId: 123456789-1234-1234-1234-123456789123
+      Role: arn:aws:iam::123456789:role/some-name
+      Timeout: 10
+      Version: $LATEST


### PR DESCRIPTION
### Background

Lack of default return values was causing lambdas without policies to trigger false positives.  There was also an issue where conditions to allow [unauthenticated public access](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html#urls-auth-none) would cause false negatives.

### Changes

- add default values to get and deep_get
- add logic and severity function for unauthenticated public access

### Testing

- new unit tests
