### PR TITLE
Fix GitHub.Repo.RulesetModified title and context

### DIFF
--- a/rules/github_rules/github_repo_ruleset_modified.py
+++ b/rules/github_rules/github_repo_ruleset_modified.py
@@ -15,6 +15,11 @@ def title(event):
     elif event.get("action").endswith("create"):
         action = "created"
 
+    title_str = (
+        f"Github repository ruleset for [{event.get('repo', '<UNKNOWN_REPO>')}]"
+        f" {action} by [{event.get('actor','<UNKNOWN_ACTOR>')}]"
+    )
+
     if event.get("ruleset_source_type", default="<UNKNOWN_SOURCE_TYPE>") == "Organization":
         title_str = (
             f"Github repository ruleset for Organization [{event.get('org', '<UNKNOWN_ORG>')}]"

--- a/rules/github_rules/github_repo_ruleset_modified.py
+++ b/rules/github_rules/github_repo_ruleset_modified.py
@@ -15,10 +15,11 @@ def title(event):
     elif event.get("action").endswith("create"):
         action = "created"
 
-    title_str = (
-        f"Github repository ruleset for [{event.get('repo', '<UNKNOWN_REPO>')}]"
-        f" {action} by [{event.get('actor','<UNKNOWN_ACTOR>')}]"
-    )
+    if event.get("ruleset_source_type", default="<UNKNOWN_SOURCE_TYPE>") == "Organization":
+        title_str = (
+            f"Github repository ruleset for Organization [{event.get('org', '<UNKNOWN_ORG>')}]"
+            f" {action} by [{event.get('actor','<UNKNOWN_ACTOR>')}]"
+        )
     return title_str
 
 
@@ -38,6 +39,7 @@ def severity(event):
 
 def alert_context(event):
     ctx = github_alert_context(event)
+    ctx["user"] = event.get("actor", "")
     ctx["actor_is_bot"] = event.get("actor_is_bot", "")
     ctx["actor_user_agent"] = event.get("user_agent", "")
     ctx["business"] = event.get("business", "")

--- a/rules/github_rules/github_repo_ruleset_modified.yml
+++ b/rules/github_rules/github_repo_ruleset_modified.yml
@@ -249,3 +249,25 @@ Tests:
         "ruleset_source_type": "Repository",
         "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
       }
+  - Name: Github - Ruleset Modified for entire Organization
+    ExpectedResult: true
+    Log:
+      {
+        "action": "repository_ruleset.update",
+        "actor": "dog",
+        "actor_id": "999999999",
+        "actor_is_bot": false,
+        "actor_location": { "country_code": "US" },
+        "business": "bizname",
+        "business_id": "12345",
+        "created_at": "2024-12-17 00:00:00000000",
+        "operation_type": "modify",
+        "org": "some-org",
+        "org_id": 12345678,
+        "ruleset_enforcement": "disabled",
+        "ruleset_id": "1082915",
+        "ruleset_name": "Name of org-wide ruleset",
+        "ruleset_old_enforcement": "evaluate",
+        "ruleset_source_type": "Organization",
+        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36",
+      }


### PR DESCRIPTION
### Background

My initial rule neglected to account for Org-wide ruleset in the title and used the default github_alert_context for the user field, which is inappropriate for repo ruleset changes. 

### Changes

- Ensure title reflects organization-wide ruleset changes
- Add test for that title change
- Overwrite user field in alert_context it's the actor field as the default in github_alert_context is the user field

### Testing

- pat test
- make lint
