### PR TITLE
ASK-1387 Tuning AWS.IAM.Role.GitHubActionsTrust policy to be more flexible

### DIFF
--- a/policies/aws_iam_policies/aws_iam_role_github_actions_trust.py
+++ b/policies/aws_iam_policies/aws_iam_role_github_actions_trust.py
@@ -3,6 +3,9 @@ import json
 from panther_base_helpers import deep_get
 
 
+ALLOWED_ORG_REPO_PAIRS = ["org/repo", "allowed-org-example/allowed-repo-example"]
+
+
 def policy(resource):
     # check if resource.AssumRolePolicyDocument is a string, and if so convert to json
     if isinstance(resource.get("AssumeRolePolicyDocument"), str):
@@ -43,7 +46,13 @@ def policy(resource):
                 [
                     "oidc-provider/token.actions.githubusercontent.com" not in principal,
                     audience != "sts.amazonaws.com",
-                    ("*" in subject and not subject.startswith("repo:org/repo:*")),
+                    (
+                        "*" in subject
+                        and not any(
+                            subject.startswith(f"repo:{org_repo}:*")
+                            for org_repo in ALLOWED_ORG_REPO_PAIRS
+                        )
+                    ),
                 ]
             ):
                 return False

--- a/policies/aws_iam_policies/aws_iam_role_github_actions_trust.py
+++ b/policies/aws_iam_policies/aws_iam_role_github_actions_trust.py
@@ -2,7 +2,6 @@ import json
 
 from panther_base_helpers import deep_get
 
-
 ALLOWED_ORG_REPO_PAIRS = ["org/repo", "allowed-org-example/allowed-repo-example"]
 
 

--- a/policies/aws_iam_policies/aws_iam_role_github_actions_trust.yml
+++ b/policies/aws_iam_policies/aws_iam_role_github_actions_trust.yml
@@ -222,3 +222,26 @@ Tests:
       "ResourceType": "AWS.IAM.Role",
       "TimeCreated": "2023-11-08T23:50:46Z"
     }
+  - Name: Allowed repo
+    ExpectedResult: true
+    Resource:
+      {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Principal": {
+                "Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+              },
+              "Condition": {
+                "StringEquals": {
+                  "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                  "token.actions.githubusercontent.com:sub": "repo:allowed-org-example/allowed-repo-example:*"
+                }
+              }
+            }
+          ]
+        }
+      }


### PR DESCRIPTION
### Background

`AWS.IAM.Role.GitHubActionsTrust` policy had `token.actions.githubusercontent.com:sub` hardcoded to need exactly one possible beginning of value containing `*` (`repo:org/repo:*`), which could cause the policy to fail even when `org` and `repo` were trusted but named differently.

### Changes

- Added the possibility to add trusted org/repo pairs

### Testing

- pat test
