### PR TITLE
[Tuning] VPC Healthy Log Status

### DIFF
--- a/data_models/aws_vpcflow_data_model.yml
+++ b/data_models/aws_vpcflow_data_model.yml
@@ -16,4 +16,4 @@ Mappings:
   - Name: user_agent
     Path: userAgent
   - Name: log_status
-    Path: log-status
+    Path: status

--- a/rules/aws_vpc_flow_rules/aws_vpc_healthy_log_status.yml
+++ b/rules/aws_vpc_flow_rules/aws_vpc_healthy_log_status.yml
@@ -10,19 +10,21 @@ Tags:
   - AWS
   - DataModel
   - Security Control
-Severity: Low
+Severity: Info
+CreateAlert: false
+DedupPeriodMinutes: 1440
 Description: >
-  Checks for the log status `SKIP-DATA`, which indicates that data was lost either to an internal server error or due to capacity constraints.
-Reference: https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html#flow-log-records
+  Checks for the log status `SKIPDATA`, which indicates that data was lost either to an internal server error or due to capacity constraints.
+Reference: https://www.reddit.com/r/aws/comments/zt1xhg/vpc_flow_logs_when_is_logstatus_skipdata_a_concern/?rdt=41505
 Runbook: >
   Determine if the cause of the issue is capacity constraints, and consider adjusting VPC Flow Log configurations accordingly.
 Tests:
   - Name: Healthy Log Status
     ExpectedResult: false
-    Log: { "log-status": "OK", "p_log_type": "AWS.VPCFlow" }
+    Log: { "status": "OK", "p_log_type": "AWS.VPCFlow" }
   - Name: Unhealthy Log Status
     ExpectedResult: true
-    Log: { "log-status": "SKIPDATA", "p_log_type": "AWS.VPCFlow" }
+    Log: { "status": "SKIPDATA", "p_log_type": "AWS.VPCFlow" }
   - Name: Healthy Log Status - OCSF
     ExpectedResult: false
     Log: { "status_code": "OK", "p_log_type": "OCSF.NetworkActivity" }


### PR DESCRIPTION
### Background

Noticed an issue with the VPC Flow data model referencing the wrong field.  Also noticed that these SKIPDATA VPC logs [are non-actionable](https://www.reddit.com/r/aws/comments/zt1xhg/vpc_flow_logs_when_is_logstatus_skipdata_a_concern/?rdt=41505), so converted the rule to a signal.

### Changes

- Fix data model
- Convert to signal

### Testing

- Updated unit tests
