### PR TITLE
stop deduping info-level alerts

### DIFF
--- a/rules/aws_eks_rules/anonymous_api_access.py
+++ b/rules/aws_eks_rules/anonymous_api_access.py
@@ -15,6 +15,9 @@ def rule(event):
 
 
 def title(event):
+    # For INFO-level events, just group them all together since they're not that interesting
+    if severity(event) == "INFO":
+        return "Failed Annonymous EKS Acces Attempt(s) Detected"
     p_eks = eks_panther_obj_ref(event)
     return (
         f"Anonymous API access detected on Kubernetes API server "
@@ -32,6 +35,9 @@ def severity(event):
 
 
 def dedup(event):
+    # For INFO-level events, just group them all together since they're not that interesting
+    if severity(event) == "INFO":
+        return "no dedup"
     p_eks = eks_panther_obj_ref(event)
     return f"anonymous_access_{p_eks.get('p_source_label')}_{event.get('userAgent')}"
 


### PR DESCRIPTION
### Background

Making some tuning changes to prevent a bunch of low-level alerts, while preserving the signals

### Changes

- Adjusted dedup logic to only apply to alerts higher than INFO severity

### Testing

- Tests all pass; ran it through a data replay for a noisy timespan and reduced alerts by 50%
