### PR TITLE
Update aws_console_login_without_saml.yml

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_console_login_without_saml.yml
+++ b/rules/aws_cloudtrail_rules/aws_console_login_without_saml.yml
@@ -77,7 +77,7 @@ Tests:
         "sourceIPAddress": "111.111.111.111",
         "userAgent": "Mozilla",
         "requestParameters": null,
-        "responseElements": { "ConsoleLogin": "Failure" },
+        "responseElements": { "ConsoleLogin": "Success" },
         "additionalEventData":
           {
             "LoginTo": "https://console.aws.amazon.com/console/",


### PR DESCRIPTION
Background
The ConsoleLogin is expected to be "Success" since it's a Normal Login.

Changes
Update aws_console_login_without_saml.yml, change "ConsoleLogin" value to "Success" in the Normal Login unit test.

Customer ticket:

https://panther-labs.slack.com/archives/C02ESLFUAUQ/p1739252735737349?thread_ts=1739252735.737349&cid=C02ESLFUAUQ