### PR TITLE
fix: Index stability for scheduled rules vs. scheduled queries

### DIFF
--- a/.scripts/generate_indexes.py
+++ b/.scripts/generate_indexes.py
@@ -201,11 +201,11 @@ def extract_log_types_from_yaml(yaml, query_lookup, logtype_lookup):
 # We use this to prefer showing the Scheduled Rules over their associated Query when they share the same name
 def entry_scoring(entry):
     score = 0
-    if entry['AnalysisType'] == 'Scheduled Query':
+    if entry['AnalysisType'] in ('Scheduled Query', 'scheduled_query'):
         score += 3
-    if entry['AnalysisType'] == 'Scheduled Rule':
+    if entry['AnalysisType'] in ('Scheduled Rule', 'scheduled_rule'):
         score += 2
-    if entry['AnalysisType'] == 'Rule':
+    if entry['AnalysisType'] in ('Rule', 'rule'):
         score += 1
     return score
 
@@ -214,7 +214,8 @@ def group_by(iterable, key=None):
     if key is None:
         key = lambda x: x
     result = {}
-    groups = itertools.groupby(iterable, key=key)
+    data = sorted(iterable, key=key)
+    groups = itertools.groupby(data, key=key)
     for k, g in groups:
         result[k] = list(g)
     return result
@@ -282,7 +283,7 @@ def write_alpha_index(detections, query_lookup, logtype_lookup, root_dir):
         valid_detections.append(json_slice)
 
     # Dedupe detections by DisplayName
-    name_map = group_by(valid_detections, key=lambda x: x['DisplayName'].lower())
+    name_map = group_by(valid_detections, key=lambda x: x['DisplayName'].lower().strip())
     standard_rules = []
     json_export = []
     for name in name_map:


### PR DESCRIPTION
### Background

It was brought to my attention that seemingly unrelated changes were being written to the indexes. The index script is meant to always produce the same output for the same input, so there should be no changes written when rules aren't substantially changed. It looked like scheduled rules were being randomly exchanged for their scheduled queries ([commit 1](https://github.com/panther-labs/panther-analysis/commit/7e8015fb16c981d847b64ca022028aedcfb715c3) & [commit 2](https://github.com/panther-labs/panther-analysis/commit/af113a13c7a3fd05dbb1a28ce01a4691cf5a0c36)) when the intent is to always show the query.

### Changes

- Fix the name deduplication logic by checking for pretty and raw `AnalysisTypes` and fixing a logic error with how I was using `itertools.groupby`. I didn't realize there was a requirement for the data to be sorted for this function.

### Testing

- I tested locally to confirm that the script was no longer drifting in output when executed multiple times and that scheduled queries were being preferred over scheduled rules.
