### PR TITLE
Fixing Slack permission expanded problem

### DIFF
--- a/rules/slack_rules/slack_app_access_expanded.py
+++ b/rules/slack_rules/slack_app_access_expanded.py
@@ -27,7 +27,7 @@ def alert_context(event):
     prv_scopes = event.deep_get("details", "previous_scopes", default=[])
 
     context["scopes_added"] = [x for x in new_scopes if x not in prv_scopes]
-    context["scoped_removed"] = [x for x in prv_scopes if x not in new_scopes]
+    context["scopes_removed"] = [x for x in prv_scopes if x not in new_scopes]
 
     return context
 


### PR DESCRIPTION
### Background

Slack permissions gets triggered even though they're not changed. After checking the code, I found a typo in the code: one single character

### Changes

At `rules/slack_rules/slack_app_access_expanded.py` line 30:

`context["scoped_removed"] = [x for x in prv_scopes if x not in new_scopes]`

Should be:

`context["scopes_removed"] = [x for x in prv_scopes if x not in new_scopes]`


