### PR TITLE
Azure.Audit.RoleChangedPIM: Ensure Every Event is a Separate Alert

### DIFF
--- a/rules/azure_signin_rules/azure_role_changed_pim.py
+++ b/rules/azure_signin_rules/azure_role_changed_pim.py
@@ -21,5 +21,10 @@ def title(event):
     return f"{actor_name} added {target_name} as {role} successfully with {operation_name}"
 
 
+def dedup(event):
+    # Ensure every event is a separate alert
+    return event.get("p_row_id", "<UNKNWON_ROW_ID>")
+
+
 def alert_context(event):
     return azure_rule_context(event)

--- a/rules/azure_signin_rules/azure_role_changed_pim.yml
+++ b/rules/azure_signin_rules/azure_role_changed_pim.yml
@@ -6,7 +6,7 @@ Enabled: true
 LogTypes:
   - Azure.Audit
 Severity: Medium
-DedupPeriodMinutes: 0
+DedupPeriodMinutes: 5
 Description: >
   This detection looks for a change in member's PIM roles in EntraID
 Reports:

--- a/rules/azure_signin_rules/azure_role_changed_pim.yml
+++ b/rules/azure_signin_rules/azure_role_changed_pim.yml
@@ -25,6 +25,7 @@ Tests:
     ExpectedResult: true
     Log:
         {
+            "p_row_id": "2316902d-b9a4-4f37-a1a5-5ed03993110f",
             "category": "AuditLogs",
             "correlationId": "1234155",
             "durationMs": 0,


### PR DESCRIPTION
### Background

The rule `Azure.Audit.RoleChangedPIM` originally had a `DedupPeriodMinutes` value of 0, but our rule engine doesn't allow values smaller than 5. I adjusted the value to 5, and introduced a `dedup` function to the rule which ensures that each event is a separate alert (which is the assumed intent of setting the dedup period to 0).

### Changes

- changed `DedupPeriodMinutes` to 5
- set rule to dedup based on `p_row_id` which is unique for every event

### Testing

- linting and unit tests all pass
