### PR TITLE
ASK 1969 - Tuning Snowflake.BruteForceBy* Rules

### DIFF
--- a/packs/snowflake.yml
+++ b/packs/snowflake.yml
@@ -16,6 +16,7 @@ PackDefinition:
     - Query.Snowflake.ConfigurationDrift
     - Query.Snowflake.CopyIntoStage
     - Query.Snowflake.External.Shares
+    - Query.Snowflake.FailedLogins
     - Query.Snowflake.FileDownloaded
     - Query.Snowflake.KeyUserPasswordLogin
     - Query.Snowflake.MFALogin

--- a/queries/snowflake_queries/snowflake_brute_force_ip.py
+++ b/queries/snowflake_queries/snowflake_brute_force_ip.py
@@ -4,7 +4,19 @@ def rule(_):
 
 def title(event):
     return (
-        "Login attempts from IP "
-        f"[{event.get('client_ip','<UNKNOWN_USER>')}] "
-        "have exceeded the failed logins threshold"
+        f"Snowflake: {event.get('count_by_ip', 'many')} failed login attempts from IP "
+        f"[{event.get('client_ip','<UNKNOWN_USER>')}]"
     )
+
+
+def severity(event):
+    # If the error appears to be caused by an automation issue, downgrade to INFO
+    common_errors = {"JWT_TOKEN_INVALID_PUBLIC_KEY_FINGERPRINT_MISMATCH"}
+    if event.get("ERROR_MESSAGE") in common_errors:
+        return "INFO"
+    return "DEFAULT"
+
+
+def dedup(event):
+    # Dedup on title and severity
+    return f"[{severity(event)}] {title(event)}"

--- a/queries/snowflake_queries/snowflake_brute_force_ip.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_ip.yml
@@ -1,21 +1,34 @@
 AnalysisType: scheduled_rule
 Filename: snowflake_brute_force_ip.py
 RuleID: "Snowflake.BruteForceByIp"
-Description: >
-  Detect brute force attacks by monitoring for failed logins from the same IP address
 DisplayName: "Snowflake Brute Force Attacks by IP"
 Enabled: false
 ScheduledQueries:
-  - Query.Snowflake.BruteForceByIp
-Tags:
-  - Snowflake
-  - Credential Access:Brute Force
+  - Query.Snowflake.FailedLogins
+Severity: Medium
 Reports:
   MITRE ATT&CK:
     - TA0006:T1110
-Severity: Medium
+Description: >
+  Detect brute force attacks by monitoring for failed logins from the same IP address
+Threshold: 5
+SummaryAttributes:
+  - error_message
+  - error_code
+  - reported_client_type
+  - user_name
+Tags:
+  - Snowflake
+  - Credential Access:Brute Force
 Tests:
   - Name: Value Returned By Query
     ExpectedResult: true
     Log:
       client_ip: 1.2.3.4
+      count_by_ip: 100
+  - Name: Common Error
+    ExpectedResult: true
+    Log:
+      client_ip: 1.2.3.4
+      error_message: JWT_TOKEN_INVALID_PUBLIC_KEY_FINGERPRINT_MISMATCH
+      count_by_ip: 100

--- a/queries/snowflake_queries/snowflake_brute_force_username.py
+++ b/queries/snowflake_queries/snowflake_brute_force_username.py
@@ -4,5 +4,19 @@ def rule(_):
 
 def title(event):
     return (
-        f"User [{event.get('user_name','<UNKNOWN_USER>')}] has exceeded the failed logins threshold"
+        f"Snowflake: {event.get('counts_by_user', 'many')} failed login attempts by user "
+        f"[{event.get('user_name','<UNKNOWN_USER>')}]"
     )
+
+
+def severity(event):
+    # If the error appears to be caused by an automation issue, downgrade to INFO
+    common_errors = {"JWT_TOKEN_INVALID_PUBLIC_KEY_FINGERPRINT_MISMATCH"}
+    if event.get("ERROR_MESSAGE") in common_errors:
+        return "INFO"
+    return "DEFAULT"
+
+
+def dedup(event):
+    # Dedup on title and severity
+    return f"[{severity(event)}] {title(event)}"

--- a/queries/snowflake_queries/snowflake_brute_force_username.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_username.yml
@@ -6,7 +6,7 @@ Description: >
 DisplayName: "Snowflake Brute Force Attacks by Username"
 Enabled: false
 ScheduledQueries:
-  - Query.Snowflake.BruteForceByUsername
+  - Query.Snowflake.FailedLogins
 Tags:
   - Snowflake
   - Credential Access:Brute Force
@@ -14,8 +14,20 @@ Reports:
   MITRE ATT&CK:
     - TA0006:T1110
 Severity: Medium
+SummaryAttributes:
+  - client_ip
+  - error_message
+  - error_code
+  - reported_client_type
 Tests:
   - Name: Value Returned By Query
     ExpectedResult: true
     Log:
       user_name: "testuser"
+      error_message: JWT_TOKEN_INVALID_PUBLIC_KEY_FINGERPRINT_MISMATCH
+      count_by_username: 100
+  - Name: Common Error Message
+    ExpectedResult: true
+    Log:
+      user_name: "testuser"
+      count_by_username: 100

--- a/queries/snowflake_queries/snowflake_brute_force_username.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_username.yml
@@ -14,6 +14,7 @@ Reports:
   MITRE ATT&CK:
     - TA0006:T1110
 Severity: Medium
+Threshold: 5
 SummaryAttributes:
   - client_ip
   - error_message

--- a/queries/snowflake_queries/snowflake_failed_logins_query.yml
+++ b/queries/snowflake_queries/snowflake_failed_logins_query.yml
@@ -1,0 +1,26 @@
+AnalysisType: scheduled_query
+QueryName: "Query.Snowflake.FailedLogins"
+Enabled: false
+Description: >
+  Detect brute force attempts by monitoring for failed logins to snowflake.
+Query: |
+  --return all failed failed logins in the previous 24 hours
+
+  --this was adapted from a SnowAlert query
+
+  SELECT
+    client_ip,
+    user_name,
+    reported_client_type,
+    error_code,
+    error_message,
+    count(distinct event_id) over (partition by client_ip) as count_by_ip,
+    count(distinct event_id) over (partition by user_name) as count_by_username
+  FROM snowflake.account_usage.login_history
+  WHERE
+    p_occurs_since(1d, , event_timestamp)
+    AND event_type = 'LOGIN'
+    AND error_code is NOT NULL
+Schedule:
+  RateMinutes: 1440
+  TimeoutMinutes: 2


### PR DESCRIPTION
### Background

I've adjusted the brute force scheduled rules to make them more reliable, and also added some QoL improvements as well.

### Changes

- filter common error messages due to token rotations to be signals instead of alerts
- changed the rules to use a new query that returns events instead of aggregates, and allow the threshold to be adjustable in the rule YAML spec
- add the number of failed logins to the alert title
- add summary attributes to better understand the distribution of indicators at a glance

### Testing

- after adding new fields to the unit tests, all tests pass
