### PR TITLE
AWS.EC2.LaunchUnusualEC2Instances: Add support for dictionary 'instanceType' values

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_ec2_launch_unusual_ec2_instances.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_launch_unusual_ec2_instances.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping
+
 from panther_aws_helpers import aws_cloudtrail_success, aws_rule_context, lookup_aws_account_name
 from panther_core import PantherEvent
 
@@ -10,7 +12,7 @@ UNUSUAL_INSTANCE_TYPES = {
 
 
 def rule(event: PantherEvent) -> bool:
-    instance_type = event.deep_get("requestParameters", "instanceType")
+    instance_type = get_instance_type(event)
     return all(
         (
             event.get("eventName") == "RunInstances",
@@ -23,7 +25,7 @@ def rule(event: PantherEvent) -> bool:
 def title(event: PantherEvent) -> str:
     # The actor in these events is always AutoScalingService
     account = lookup_aws_account_name(event.get("recipientAccountId"))
-    instance_type = event.deep_get("requestParameters", "instanceType")
+    instance_type = get_instance_type(event)
     return f"EC2 instance with a suspicious type '{instance_type}' was launched in in {account}"
 
 
@@ -35,10 +37,21 @@ def severity(event: PantherEvent) -> str:
 
 def alert_context(event: PantherEvent) -> dict:
     context = aws_rule_context(event)
-    context["instanceType"] = event.deep_get("requestParameters", "instanceType")
+    context["instanceType"] = get_instance_type(event)
     return context
 
 
-def get_unusual_instance_types() -> bool:
+def get_unusual_instance_types() -> set[str]:
     # Making this a separate function allows us to mock it during unit tests for reliable testing!
     return UNUSUAL_INSTANCE_TYPES
+
+
+def get_instance_type(event: PantherEvent) -> str:
+    # Return the type of the instance that was launch
+    instance_type = event.deep_get(
+        "requestParameters", "instanceType", default="<UNKNOWN INSTANCE TYPE>"
+    )
+    # instanceType could be a string or a dict
+    if isinstance(instance_type, Mapping):
+        instance_type = instance_type.get("value", "<UNKNOWN INSTANCE TYPE>")
+    return instance_type

--- a/rules/aws_cloudtrail_rules/aws_ec2_launch_unusual_ec2_instances.yml
+++ b/rules/aws_cloudtrail_rules/aws_ec2_launch_unusual_ec2_instances.yml
@@ -352,3 +352,257 @@ Tests:
           "type": "AssumedRole"
         }
       }
+  - Name: Successful Unusual EC2 (Dictionary)
+    ExpectedResult: true
+    Mocks:
+      - objectName: get_unusual_instance_types
+        returnValue: "p2.xlarge"
+    Log:
+      {
+        "awsRegion": "us-west-2",
+        "eventCategory": "Management",
+        "eventID": "41fab871-150b-43ad-b42a-39fff3f2ca4e",
+        "eventName": "RunInstances",
+        "eventSource": "ec2.amazonaws.com",
+        "eventTime": "2024-12-16 18:41:07.000000000",
+        "eventType": "AwsApiCall",
+        "eventVersion": "1.10",
+        "managementEvent": true,
+        "readOnly": false,
+        "recipientAccountId": "111122223333",
+        "requestID": "95cdbe4d-8ff7-4111-8f08-44f510371035",
+        "requestParameters": {
+          "availabilityZone": "us-west-2a",
+          "blockDeviceMapping": {},
+          "clientToken": "fleet-180da986-0bb4-c936-0c9a-0e20a0c6d1aa-0",
+          "disableApiStop": false,
+          "disableApiTermination": false,
+          "instanceType": {
+              "value": "p2.xlarge"
+          },
+          "instancesSet": {
+            "items": [
+              {
+                "maxCount": 1,
+                "minCount": 1
+              }
+            ]
+          },
+          "monitoring": {
+            "enabled": false
+          },
+          "subnetId": "subnet-083e5906ef2809ac2"
+        },
+        "responseElements": {
+          "groupSet": {},
+          "instancesSet": {
+            "items": [
+              {
+                "amiLaunchIndex": 0,
+                "architecture": "arm64",
+                "blockDeviceMapping": {},
+                "bootMode": "uefi",
+                "capacityReservationSpecification": {
+                  "capacityReservationPreference": "open"
+                },
+                "clientToken": "fleet-180da986-0bb4-c936-0c9a-0e20a0c6d1aa-0",
+                "cpuOptions": {
+                  "coreCount": 2,
+                  "threadsPerCore": 1
+                },
+                "currentInstanceBootMode": "uefi",
+                "ebsOptimized": false,
+                "enaSupport": true,
+                "enclaveOptions": {
+                  "enabled": false
+                },
+                "groupSet": {
+                  "items": [
+                    {
+                      "groupId": "sg-03d704b35372e74e8",
+                      "groupName": "my-group"
+                    }
+                  ]
+                },
+                "hypervisor": "xen",
+                "iamInstanceProfile": {
+                  "arn": "arn:aws:iam::111122223333:instance-profile/profile-id",
+                  "id": "PROFILE_ID"
+                },
+                "imageId": "ami-013e7d3a6659f358d",
+                "instanceId": "i-07d06021b0da55115",
+                "instanceState": {
+                  "code": 0,
+                  "name": "pending"
+                },
+                "instanceType": "p2.xlarge",
+                "launchTime": 1734374467000,
+                "maintenanceOptions": {
+                  "autoRecovery": "default"
+                },
+                "metadataOptions": {
+                  "httpEndpoint": "enabled",
+                  "httpProtocolIpv4": "enabled",
+                  "httpProtocolIpv6": "disabled",
+                  "httpPutResponseHopLimit": 2,
+                  "httpTokens": "required",
+                  "instanceMetadataTags": "disabled",
+                  "state": "pending"
+                },
+                "monitoring": {
+                  "state": "disabled"
+                },
+                "networkInterfaceSet": {
+                  "items": [
+                    {
+                      "attachment": {
+                        "attachTime": 1734374467000,
+                        "attachmentId": "eni-attach-022e4a3077e096442",
+                        "deleteOnTermination": true,
+                        "deviceIndex": 0,
+                        "networkCardIndex": 0,
+                        "status": "attaching"
+                      },
+                      "groupSet": {
+                        "items": [
+                          {
+                            "groupId": "sg-03d704b35372e74e8",
+                            "groupName": "eks-cluster-sg-k8s-goat-cluster-816437967"
+                          }
+                        ]
+                      },
+                      "interfaceType": "interface",
+                      "ipv6AddressesSet": {},
+                      "macAddress": "02:fc:9a:8a:db:c3",
+                      "networkInterfaceId": "eni-03ac9043f76fab96c",
+                      "operator": {
+                        "managed": false
+                      },
+                      "ownerId": "111122223333",
+                      "privateDnsName": "ip-192-168-1-95.us-west-2.compute.internal",
+                      "privateIpAddress": "192.168.1.95",
+                      "privateIpAddressesSet": {
+                        "item": [
+                          {
+                            "primary": true,
+                            "privateDnsName": "ip-192-168-1-95.us-west-2.compute.internal",
+                            "privateIpAddress": "192.168.1.95"
+                          }
+                        ]
+                      },
+                      "sourceDestCheck": true,
+                      "status": "in-use",
+                      "subnetId": "subnet-083e5906ef2809ac2",
+                      "tagSet": {},
+                      "vpcId": "vpc-0330bfd33da75b36e"
+                    }
+                  ]
+                },
+                "operator": {
+                  "managed": false
+                },
+                "placement": {
+                  "availabilityZone": "us-west-2a",
+                  "tenancy": "default"
+                },
+                "privateDnsName": "ip-192-168-1-95.us-west-2.compute.internal",
+                "privateDnsNameOptions": {
+                  "enableResourceNameDnsAAAARecord": false,
+                  "enableResourceNameDnsARecord": false,
+                  "hostnameType": "ip-name"
+                },
+                "privateIpAddress": "192.168.1.95",
+                "productCodes": {},
+                "rootDeviceName": "/dev/xvda",
+                "rootDeviceType": "ebs",
+                "sourceDestCheck": true,
+                "stateReason": {
+                  "code": "pending",
+                  "message": "pending"
+                },
+                "subnetId": "subnet-083e5906ef2809ac2",
+                "tagSet": {
+                  "items": [
+                    {
+                      "key": "k8s.io/cluster-autoscaler/enabled",
+                      "value": "true"
+                    },
+                    {
+                      "key": "aws:autoscaling:groupName",
+                      "value": "eks-ng-0ca246e9-cac9e862-bfd9-a821-c9fd-9916df5654eb"
+                    },
+                    {
+                      "key": "aws:ec2:fleet-id",
+                      "value": "fleet-180da986-0bb4-c936-0c9a-0e20a0c6d1aa"
+                    },
+                    {
+                      "key": "eks:cluster-name",
+                      "value": "k8s-goat-cluster"
+                    },
+                    {
+                      "key": "eks:nodegroup-name",
+                      "value": "ng-0ca246e9"
+                    },
+                    {
+                      "key": "alpha.eksctl.io/nodegroup-name",
+                      "value": "ng-0ca246e9"
+                    },
+                    {
+                      "key": "alpha.eksctl.io/nodegroup-type",
+                      "value": "managed"
+                    },
+                    {
+                      "key": "k8s.io/cluster-autoscaler/k8s-goat-cluster",
+                      "value": "owned"
+                    },
+                    {
+                      "key": "aws:ec2launchtemplate:id",
+                      "value": "lt-07a0b5cea4ece8ffd"
+                    },
+                    {
+                      "key": "aws:ec2launchtemplate:version",
+                      "value": "1"
+                    },
+                    {
+                      "key": "Name",
+                      "value": "k8s-goat-cluster-ng-0ca246e9-Node"
+                    },
+                    {
+                      "key": "kubernetes.io/cluster/k8s-goat-cluster",
+                      "value": "owned"
+                    }
+                  ]
+                },
+                "virtualizationType": "hvm",
+                "vpcId": "vpc-0330bfd33da75b36e"
+              }
+            ]
+          },
+          "ownerId": "111122223333",
+          "requestId": "95cdbe4d-8ff7-4111-8f08-44f510371035",
+          "requesterId": "414886084714",
+          "reservationId": "r-0ff0b006325a10345"
+        },
+        "sourceIPAddress": "autoscaling.amazonaws.com",
+        "userAgent": "autoscaling.amazonaws.com",
+        "userIdentity": {
+          "accountId": "111122223333",
+          "arn": "arn:aws:sts::111122223333:assumed-role/AWSServiceRoleForAutoScaling/AutoScaling",
+          "invokedBy": "autoscaling.amazonaws.com",
+          "principalId": "PRINCIPAL_ID:AutoScaling",
+          "sessionContext": {
+            "attributes": {
+              "creationDate": "2024-12-16T18:41:05Z",
+              "mfaAuthenticated": "false"
+            },
+            "sessionIssuer": {
+              "accountId": "111122223333",
+              "arn": "arn:aws:iam::111122223333:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+              "principalId": "PRINCIPAL_ID",
+              "type": "Role",
+              "userName": "AWSServiceRoleForAutoScaling"
+            }
+          },
+          "type": "AssumedRole"
+        }
+      }


### PR DESCRIPTION
### Background

A customer reported receiving the following error when running this rule:
```
TypeError("unhashable type: 'ImmutableCaseInsensitiveDict'")
``` 
It was determined that their incoming events have an unexpected value for `instanceType`:
```json
"instanceType": {
    "value": "g5.8xlarge"
}
```

### Changes

- fix logic to work in cases where `instanceType` is a string and also when it is an object

### Testing

- added new unit test
