### PR TITLE
THREAT-477 [Tuning] aws_ec2_multi_instance_connect.py

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_ec2_multi_instance_connect.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_multi_instance_connect.py
@@ -1,9 +1,24 @@
+import json
+
 from panther_aws_helpers import aws_cloudtrail_success, aws_rule_context, lookup_aws_account_name
 from panther_core import PantherEvent
+from panther_detection_helpers.caching import get_string_set, put_string_set
 
 
 def rule(event: PantherEvent) -> bool:
-    return aws_cloudtrail_success(event) and event.get("eventName") == "SendSSHPublicKey"
+    if not (aws_cloudtrail_success(event) and event.get("eventName") == "SendSSHPublicKey"):
+        return False
+
+    key = event.deep_get("requestParameters", "sSHPublicKey")
+    cached_instance_ids = get_cached_instance_ids(key)
+    if len(cached_instance_ids) == 0:
+        return False
+    target_instance_id = event.deep_get("requestParameters", "instanceId")
+    if target_instance_id not in cached_instance_ids:
+        cached_instance_ids.add(target_instance_id)
+        put_string_set(key, cached_instance_ids, epoch_seconds=3600)
+        return True
+    return False
 
 
 def title(event: PantherEvent) -> str:
@@ -23,3 +38,13 @@ def alert_context(event: PantherEvent) -> dict:
         "requestParameters", "instanceId", default="<UNKNOWN EC2 INSTANCE ID>"
     )
     return context
+
+
+def get_cached_instance_ids(key: str) -> set[str]:
+    """Get any previously cached parameter names. Included automatic converstion from string in
+    the case of a unit test mock."""
+    cached_ids = get_string_set(key, force_ttl_check=True)
+    if isinstance(cached_ids, str):
+        # This is a unit test
+        cached_ids = set(json.loads(cached_ids))
+    return cached_ids

--- a/rules/aws_cloudtrail_rules/aws_ec2_multi_instance_connect.yml
+++ b/rules/aws_cloudtrail_rules/aws_ec2_multi_instance_connect.yml
@@ -29,7 +29,12 @@ Tags:
   - SSH
   - Lateral Movement:Remote Services
 Tests:
-  - Name: Public SSH Key Sent Successfully
+  - Name: Public SSH Key Sent Successfully to Multiple Instances
+    Mocks:
+      - objectName: get_string_set
+        returnValue: '["i-other-id"]'
+      - objectName: put_string_set
+        returnValue: ''
     ExpectedResult: true
     Log:
       {
@@ -82,6 +87,68 @@ Tests:
               "userName": "SampleRole"
             },
             "webIdFederationData": {}
+          },
+          "type": "AssumedRole"
+        }
+      }
+  - Name: Public SSH Key Sent Successfully to Same Instance
+    Mocks:
+      - objectName: get_string_set
+        returnValue: '["i-abcdef01234567890"]'
+      - objectName: put_string_set
+        returnValue: ''
+    ExpectedResult: false
+    Log:
+      {
+        "p_event_time": "2025-01-13 19:58:59.000000000",
+        "p_log_type": "AWS.CloudTrail",
+        "p_parse_time": "2025-01-13 20:05:54.575569351",
+        "awsRegion": "us-west-2",
+        "eventCategory": "Management",
+        "eventID": "d6d05dd2-d03d-4dce-a88c-02b6a567d889",
+        "eventName": "SendSSHPublicKey",
+        "eventSource": "ec2-instance-connect.amazonaws.com",
+        "eventTime": "2025-01-13 19:58:59.000000000",
+        "eventType": "AwsApiCall",
+        "eventVersion": "1.08",
+        "managementEvent": true,
+        "readOnly": false,
+        "recipientAccountId": "111122223333",
+        "requestID": "25eac5d1-cd24-4156-a49b-f2bf3a20ec9d",
+        "requestParameters": {
+          "instanceId": "i-abcdef01234567890",
+          "instanceOSUser": "ec2-user",
+          "sSHPublicKey": "ssh-ed25519 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        },
+        "responseElements": {
+          "requestId": "25eac5d1-cd24-4156-a49b-f2bf3a20ec9d",
+          "success": true
+        },
+        "sourceIPAddress": "1.2.3.4",
+        "tlsDetails": {
+          "cipherSuite": "TLS_AES_128_GCM_SHA256",
+          "clientProvidedHostHeader": "ec2-instance-connect.us-west-2.amazonaws.com",
+          "tlsVersion": "TLSv1.3"
+        },
+        "userAgent": "stratus-red-team_8b255a24-d33d-4750-bd4b-4007124741df",
+        "userIdentity": {
+          "accessKeyId": "SAMPLE_ACCESS_KEY",
+          "accountId": "111122223333",
+          "arn": "arn:aws:sts::111122223333:assumed-role/SampleRole/bobson.dugnutt",
+          "principalId": "SAMPLE_PRINCIPAL_ID:bobson.dugnutt",
+          "sessionContext": {
+            "attributes": {
+              "creationDate": "2025-01-13T19:21:25Z",
+              "mfaAuthenticated": "false"
+            },
+            "sessionIssuer": {
+              "accountId": "111122223333",
+              "arn": "arn:aws:iam::111122223333:role/aws-reserved/sso.amazonaws.com/us-west-2/SampleRole",
+              "principalId": "SAMPLE_PRINCIPAL_ID",
+              "type": "Role",
+              "userName": "SampleRole"
+            },
+            "webIdFederationData": { }
           },
           "type": "AssumedRole"
         }


### PR DESCRIPTION
### Background

This alert is very noisy, because it triggers if someone access the same instance with the same public key two or more times during the deduplication period. That seems at odds with the intent of the alert, because the intent is for this to trigger on different instances.

### Changes

- Added caching to check if the key is being pushed to the same instance or not

### Testing

pat test
