### PR TITLE
Github.Repo.VulnerabilityDismissed: Remove duplicate unit test

### DIFF
--- a/rules/github_rules/github_repo_vulnerability_dismissed.yml
+++ b/rules/github_rules/github_repo_vulnerability_dismissed.yml
@@ -10,15 +10,6 @@ Description: >
 LogTypes:
   - GitHub.Audit
 Tests:
-  - Name: GitHub Dependabot Vulnerability Dismissed
-    LogType: GitHub.Audit
-    ExpectedResult: true
-    Log:
-      {
-        "action": "repository_vulnerability_alert.dismiss",
-        "alert_number": 1, 
-        "repo": "panther-labs/panther-analysis",
-      }
   - Name: Not GitHub Dependabot Vulnerability Dismissed
     LogType: GitHub.Audit
     ExpectedResult: false


### PR DESCRIPTION
### Background

The rule had 2 unit tests with the same name and similar payload. This causes issues when trying to upload using PyPanther. I removed one of them.

### Changes

- remove unit test from `github_repo_vulnerability_dismissed.yml`

### Testing

- Tests still pass
