### PR TITLE
update comp keys rule

### DIFF
--- a/indexes/alpha-index.md
+++ b/indexes/alpha-index.md
@@ -74,8 +74,6 @@
   - An Amazon Machine Image (AMI) was modified to allow it to be launched by anyone. Any sensitive configuration or application data stored in the AMI's block devices is at risk.
 - [Anomalous AccessDenied Requests](../queries/aws_queries/anomalous_access_denied_query.yml)
   - ARNs with a high Access Denied error rate could indicate an error or compromised credentials attempting to perform reconnaissance.
-- [AWS Access Key Uploaded to Github](../rules/aws_cloudtrail_rules/aws_key_compromised.yml)
-  - A users static AWS API key was uploaded to a public github repo.
 - [AWS Authentication from CrowdStrike Unmanaged Device](../queries/crowdstrike_queries/AWS_Authentication_from_CrowdStrike_Unmanaged_Device_Query.yml)
   - Detects AWS Authentication events with IP Addresses not found in CrowdStrike's AIP List
 - [AWS Authentication from CrowdStrike Unmanaged Device (crowdstrike_fdrevent table)](../queries/aws_queries/AWS_Authentication_from_CrowdStrike_Unmanaged_Device_FDREvent.yml)
@@ -152,6 +150,8 @@
   - Detecting EC2 instances launched with AMIs containing potentially vulnerable versions of XZ (CVE-2024-3094)
 - [AWS ECR Events](../rules/aws_cloudtrail_rules/aws_ecr_events.yml)
   - An ECR event occurred outside of an expected account or region
+- [AWS IAM Access Key Compromise Detection](../rules/aws_cloudtrail_rules/aws_key_compromised.yml)
+  - This alert occurs when AWS has detected exposed credentials. It attaches a policy to deny certain actions, effectively quarantining those credentials, and is accompanied by a support case with instructions for detaching the policy.
 - [AWS IAM Group Read Only Events](../rules/aws_cloudtrail_rules/aws_iam_group_read_only_events.yml)
   - This rule captures multiple read/list events related to IAM group management in AWS Cloudtrail.
 - [AWS Macie Disabled/Updated](../rules/aws_cloudtrail_rules/aws_macie_evasion.yml)

--- a/indexes/aws.md
+++ b/indexes/aws.md
@@ -28,8 +28,6 @@
   - An Amazon Machine Image (AMI) was modified to allow it to be launched by anyone. Any sensitive configuration or application data stored in the AMI's block devices is at risk.
 - [Anomalous AccessDenied Requests](../queries/aws_queries/anomalous_access_denied_query.yml)
   - ARNs with a high Access Denied error rate could indicate an error or compromised credentials attempting to perform reconnaissance.
-- [AWS Access Key Uploaded to Github](../rules/aws_cloudtrail_rules/aws_key_compromised.yml)
-  - A users static AWS API key was uploaded to a public github repo.
 - [AWS Authentication from CrowdStrike Unmanaged Device](../queries/crowdstrike_queries/AWS_Authentication_from_CrowdStrike_Unmanaged_Device_Query.yml)
   - Detects AWS Authentication events with IP Addresses not found in CrowdStrike's AIP List
 - [AWS Authentication from CrowdStrike Unmanaged Device (crowdstrike_fdrevent table)](../queries/aws_queries/AWS_Authentication_from_CrowdStrike_Unmanaged_Device_FDREvent.yml)
@@ -106,6 +104,8 @@
   - Detecting EC2 instances launched with AMIs containing potentially vulnerable versions of XZ (CVE-2024-3094)
 - [AWS ECR Events](../rules/aws_cloudtrail_rules/aws_ecr_events.yml)
   - An ECR event occurred outside of an expected account or region
+- [AWS IAM Access Key Compromise Detection](../rules/aws_cloudtrail_rules/aws_key_compromised.yml)
+  - This alert occurs when AWS has detected exposed credentials. It attaches a policy to deny certain actions, effectively quarantining those credentials, and is accompanied by a support case with instructions for detaching the policy.
 - [AWS IAM Group Read Only Events](../rules/aws_cloudtrail_rules/aws_iam_group_read_only_events.yml)
   - This rule captures multiple read/list events related to IAM group management in AWS Cloudtrail.
 - [AWS Macie Disabled/Updated](../rules/aws_cloudtrail_rules/aws_macie_evasion.yml)

--- a/indexes/detection-coverage.json
+++ b/indexes/detection-coverage.json
@@ -442,15 +442,6 @@
         "YAMLPath": "policies/aws_iam_policies/aws_access_key_rotation.yml"
     },
     {
-        "AnalysisType": "Rule",
-        "Description": "A users static AWS API key was uploaded to a public github repo.",
-        "DisplayName": "AWS Access Key Uploaded to Github",
-        "LogTypes": [
-            "AWS.CloudTrail"
-        ],
-        "YAMLPath": "rules/aws_cloudtrail_rules/aws_key_compromised.yml"
-    },
-    {
         "AnalysisType": "Policy",
         "Description": "This policy validates that AWS IAM user accounts do not have access keys that were created during account creation. This results in excess keys being generated, and unnecessary management work in auditing and rotating these keys.",
         "DisplayName": "AWS Access Keys At Account Creation",
@@ -1192,6 +1183,15 @@
             "AWS.GuardDuty"
         ],
         "YAMLPath": "rules/aws_guardduty_rules/aws_guardduty_med_sev_findings.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "This alert occurs when AWS has detected exposed credentials. It attaches a policy to deny certain actions, effectively quarantining those credentials, and is accompanied by a support case with instructions for detaching the policy.",
+        "DisplayName": "AWS IAM Access Key Compromise Detection",
+        "LogTypes": [
+            "AWS.CloudTrail"
+        ],
+        "YAMLPath": "rules/aws_cloudtrail_rules/aws_key_compromised.yml"
     },
     {
         "AnalysisType": "Rule",

--- a/rules/aws_cloudtrail_rules/aws_key_compromised.py
+++ b/rules/aws_cloudtrail_rules/aws_key_compromised.py
@@ -12,7 +12,7 @@ def rule(event):
     if event.get("eventName") != "PutUserPolicy":
         return False
 
-    request_params = event.get("requestParameters") or {}
+    request_params = event.get("requestParameters", {})
     if request_params.get("policyName") not in EXPOSED_CRED_POLICIES:
         return False
     return True

--- a/rules/aws_cloudtrail_rules/aws_key_compromised.py
+++ b/rules/aws_cloudtrail_rules/aws_key_compromised.py
@@ -12,7 +12,7 @@ def rule(event):
     if event.get("eventName") != "PutUserPolicy":
         return False
 
-    request_params = event.get("requestParameters", {})
+    request_params = event.get("requestParameters") or {}
     if request_params.get("policyName") not in EXPOSED_CRED_POLICIES:
         return False
     return True

--- a/rules/aws_cloudtrail_rules/aws_key_compromised.yml
+++ b/rules/aws_cloudtrail_rules/aws_key_compromised.yml
@@ -1,7 +1,7 @@
 AnalysisType: rule
 Filename: aws_key_compromised.py
 RuleID: "AWS.IAM.AccessKeyCompromised"
-DisplayName: "AWS Access Key Uploaded to Github"
+DisplayName: "AWS IAM Access Key Compromise Detection"
 Enabled: true
 LogTypes:
   - AWS.CloudTrail
@@ -12,11 +12,11 @@ Tags:
   - AWS
   - Credential Access:Unsecured Credentials
 Severity: High
-Description: A users static AWS API key was uploaded to a public github repo.
-Runbook: Determine the key owner, disable/delete key, and delete the user to resolve the AWS case. If user needs a new IAM give them a stern talking to first.
+Description: This alert occurs when AWS has detected exposed credentials. It attaches a policy to deny certain actions, effectively quarantining those credentials, and is accompanied by a support case with instructions for detaching the policy.
+Runbook: Determine the IAM user who owns the key, rotate/disable/delete the key, and then investigate which actions were taken by the compromised key to determine scope and if any remediation is needed.
 Reference: https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning
 Tests:
-  - Name: An AWS Access Key was Uploaded to Github
+  - Name: An AWS IAM Access Key was Compromised
     ExpectedResult: true
     Log:
       {
@@ -39,7 +39,7 @@ Tests:
           {
             "policyDocument": '{"Version":"2012-10-17","Statement":[{"Sid":"Stmt1538161409","Effect":"Deny","Action":["lambda:CreateFunction","iam:AttachUserPolicy","iam:PutUserPolicy","organizations:InviteAccountToOrganization","ec2:RunInstances","iam:DetachUserPolicy","iam:CreateUser","lightsail:Create*","lightsail:Update*","ec2:StartInstances","ec2:RequestSpotInstances","iam:ChangePassword","iam:CreateLoginProfile","organizations:CreateOrganization","organizations:CreateAccount","lightsail:Delete*","iam:AttachGroupPolicy","iam:CreateAccessKey","iam:UpdateUser","iam:UpdateAccountPasswordPolicy","iam:DeleteUserPolicy","iam:PutUserPermissionsBoundary","iam:UpdateAccessKey","lightsail:DownloadDefaultKeyPair","iam:CreateInstanceProfile","lightsail:Start*","lightsail:GetInstanceAccessDetails","iam:CreateRole","iam:PutGroupPolicy","iam:AttachRolePolicy"],"Resource":["*"]}]}',
             "userName": "compromised_user",
-            "policyName": "AWSExposedCredentialPolicy_DO_NOT_REMOVE",
+            "policyName": "AWSCompromisedKeyQuarantineV3",
           },
         "eventID": "1c2a53d1-58cc-41b3-85b8-bd7565370e0d",
         "eventType": "AwsApiCall",


### PR DESCRIPTION
### Background
AWS has added a few changes to the monitored policy since it was initially committed.

### Changes
Check one of the new policies attached (OG through v3)
Remove custom dedup function. We should remember that if the interpolation values differ from the title, there will be odd side-effects around merging alerts that don't match the title.
Simplified rule logic
Updated tests
### Testing
Updated and ran tests