### PR TITLE
Fix regression in GCP.IAM.CorporateEmail for Service Agent Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ dist/
 # VSCode
 .vscode/launch.json
 .vscode/settings.json
+.vscode/*_bak.json
 
 #mac files
 .DS_Store

--- a/rules/gcp_audit_rules/gcp_iam_corp_email.py
+++ b/rules/gcp_audit_rules/gcp_iam_corp_email.py
@@ -18,11 +18,23 @@ def rule(event):
     if not binding_deltas:
         return False
 
+    all_service_accounts = True
+
     for delta in binding_deltas:
-        if delta.get("action") != "ADD":
-            continue
-        if delta.get("member", "").endswith(f"@{expected_domain}"):
+        member = delta.get("member", "")
+        if delta.get("action") == "ADD" and member.endswith(f"@{expected_domain}"):
             return False
+
+        if not (
+            member.startswith("serviceAccount:")
+            and "@gcp-sa-" in member
+            and member.endswith(".iam.gserviceaccount.com")
+        ):
+            all_service_accounts = False
+
+    if authenticated == "service-agent-manager@system.gserviceaccount.com" and all_service_accounts:
+        return False
+
     return True
 
 

--- a/rules/gcp_audit_rules/gcp_iam_corp_email.yml
+++ b/rules/gcp_audit_rules/gcp_iam_corp_email.yml
@@ -24,6 +24,194 @@ SummaryAttributes:
   - p_any_ip_addresses
   - p_any_domain_names
 Tests:
+  - Name: Expected GCP service account added by Service Agent Manager
+    ExpectedResult: false
+    Log:
+      {
+        "protoPayload":
+          {
+            "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+            "status": {},
+            "authenticationInfo":
+              {
+                "principalEmail": "service-agent-manager@system.gserviceaccount.com",
+              },
+            "requestMetadata":
+              {
+                "callerIp": "136.24.229.58",
+                "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36,gzip(gfe)",
+                "requestAttributes": {},
+                "destinationAttributes": {},
+              },
+            "serviceName": "cloudresourcemanager.googleapis.com",
+            "methodName": "SetIamPolicy",
+            "authorizationInfo":
+              [
+                {
+                  "resource": "projects/western-verve-123456",
+                  "permission": "resourcemanager.projects.setIamPolicy",
+                  "granted": true,
+                  "resourceAttributes": {},
+                },
+                {
+                  "resource": "projects/western-verve-123456",
+                  "permission": "resourcemanager.projects.setIamPolicy",
+                  "granted": true,
+                  "resourceAttributes": {},
+                },
+              ],
+            "resourceName": "projects/western-verve-123456",
+            "serviceData":
+              {
+                "@type": "type.googleapis.com/google.iam.v1.logging.AuditData",
+                "policyDelta":
+                  {
+                    "bindingDeltas":
+                      [
+                        {
+                          "action": "ADD",
+                          "role": "roles/logging.serviceAgent",
+                          "member": "serviceAccount:service-951849100836@gcp-sa-logging.iam.gserviceaccount.com",
+                        },
+                      ],
+                  },
+              },
+            "request":
+              {
+                "resource": "western-verve-123456",
+                "@type": "type.googleapis.com/google.iam.v1.SetIamPolicyRequest",
+                "policy":
+                  {
+                    "bindings":
+                      [
+                        {
+                          "members": ["user:user-two@gmail.com"],
+                          "role": "roles/appengine.serviceAdmin",
+                        },
+                        {
+                          "members":
+                            [
+                              "serviceAccount:service-951849100836@compute-system.iam.gserviceaccount.com",
+                            ],
+                          "role": "roles/compute.serviceAgent",
+                        },
+                        {
+                          "role": "roles/editor",
+                          "members":
+                            [
+                              "serviceAccount:951849100836-compute@developer.gserviceaccount.com",
+                              "serviceAccount:951849100836@cloudservices.gserviceaccount.com",
+                            ],
+                        },
+                        {
+                          "members": ["user:test@runpanther.com"],
+                          "role": "roles/owner",
+                        },
+                        {
+                          "members": ["user:user-two@gmail.com"],
+                          "role": "roles/pubsub.admin",
+                        },
+                        {
+                          "members":
+                            [
+                              "serviceAccount:pubsub-reader@western-verve-123456.iam.gserviceaccount.com",
+                            ],
+                          "role": "roles/pubsub.subscriber",
+                        },
+                        {
+                          "members":
+                            [
+                              "serviceAccount:pubsub-reader@western-verve-123456.iam.gserviceaccount.com",
+                            ],
+                          "role": "roles/pubsub.viewer",
+                        },
+                        {
+                          "role": "roles/resourcemanager.organizationAdmin",
+                          "members": ["user:test@runpanther.com"],
+                        },
+                        {
+                          "members":
+                            [
+                              "serviceAccount:service-951849100836@gcp-sa-logging.iam.gserviceaccount.com",
+                            ],
+                          "role": "roles/logging.ServiceAgent",
+                        },
+                      ],
+                    "etag": "BwWk8zJlg2o=",
+                  },
+              },
+            "response":
+              {
+                "etag": "BwWlp7rH6tY=",
+                "bindings":
+                  [
+                    {
+                      "members": ["user:user-two@gmail.com"],
+                      "role": "roles/appengine.serviceAdmin",
+                    },
+                    {
+                      "members":
+                        [
+                          "serviceAccount:service-951849100836@compute-system.iam.gserviceaccount.com",
+                        ],
+                      "role": "roles/compute.serviceAgent",
+                    },
+                    {
+                      "members":
+                        [
+                          "serviceAccount:951849100836-compute@developer.gserviceaccount.com",
+                          "serviceAccount:951849100836@cloudservices.gserviceaccount.com",
+                        ],
+                      "role": "roles/editor",
+                    },
+                    {
+                      "members": ["user:test@runpanther.com"],
+                      "role": "roles/owner",
+                    },
+                    {
+                      "role": "roles/pubsub.admin",
+                      "members": ["user:user-two@gmail.com"],
+                    },
+                    {
+                      "role": "roles/pubsub.subscriber",
+                      "members":
+                        [
+                          "serviceAccount:pubsub-reader@western-verve-123456.iam.gserviceaccount.com",
+                        ],
+                    },
+                    {
+                      "members":
+                        [
+                          "serviceAccount:pubsub-reader@western-verve-123456.iam.gserviceaccount.com",
+                        ],
+                      "role": "roles/pubsub.viewer",
+                    },
+                    {
+                      "members": ["user:test@runpanther.com"],
+                      "role": "roles/resourcemanager.organizationAdmin",
+                    },
+                    {
+                      "members":
+                        [
+                          "serviceAccount:service-951849100836@gcp-sa-logging.iam.gserviceaccount.com",
+                        ],
+                      "role": "roles/logging.ServiceAgent",
+                    },
+                  ],
+                "@type": "type.googleapis.com/google.iam.v1.Policy",
+              },
+          },
+        "insertId": "mrbji0dal80",
+        "resource":
+          {
+            "type": "project",
+            "labels": { "project_id": "western-verve-123456" },
+          },
+        "timestamp": "2020-05-15T03:51:35.019Z",
+        "severity": "NOTICE",
+        "logName": "projects/western-verve-123456/logs/cloudaudit.googleapis.com%2Factivity",
+        "receiveTimestamp": "2020-05-15T03:51:35.977314225Z",
+      }
   - Name: Gmail account added
     ExpectedResult: true
     Log:


### PR DESCRIPTION
### Background

This fixes a regression in `GCP.IAM.CorporateEmail` introduced in https://github.com/panther-labs/panther-analysis/pull/1527 rule such that any domain mismatches between a `principalEmail` and any `service_data.policyDelta.bindingDeltas[].member` would trigger the rule. However this overlooked common GCP activity like how the [Service Agent Manager](https://cloud.google.com/iam/docs/service-agents) is used in production environments. For example, when the Service Agent Manager adds an expected service account:


```
"authenticationInfo": {
	"principalEmail": "service-agent-manager@system.gserviceaccount.com"
},
[...]
"serviceData": {
	"@type": "type.googleapis.com/google.iam.v1.logging.AuditData",
	"policyDelta": {
		"bindingDeltas": [
			{
				"action": "ADD",
				"member": "serviceAccount:service-[project-number]@gcp-sa-logging.iam.gserviceaccount.com",
				"role": "roles/logging.serviceAgent"
			}
		]
	}
}
```

So if the Service Agent Manager principal adds only expected GCP service accounts, we can ignore them. The logic should be structured well enough to add other patterns of expected activity if they're found later.

Also https://github.com/panther-labs/panther-analysis/pull/1547 had end users run a fresh `make vscode-config` which creates `.vscode/*_bak.json` backup files, so I tagged on a quick change for it,

### Changes

- If the Service Agent Manager adds only expected GCP service accounts, return false
- New test added for `GCP.IAM.CorporateEmail`
- gitignore `.vscode/*_bak.json`

### Testing

- pat test
- make lint
