### PR TITLE
fix: turn Lambda Update alerts into signals

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_add_malicious_lambda_extension.yml
+++ b/rules/aws_cloudtrail_rules/aws_add_malicious_lambda_extension.yml
@@ -9,6 +9,7 @@ Reports:
   MITRE ATT&CK:
     - TA0007:T1078
 Severity: Medium
+CreateAlert: false
 Description: >
   Identifies when a Lambda function configuration is updated with layers, which could indicate a potential security risk.
 Runbook: Make sure that the Lambda function configuration update is expected and authorized. If not, investigate the event further.

--- a/rules/aws_cloudtrail_rules/aws_overwrite_lambda_code.yml
+++ b/rules/aws_cloudtrail_rules/aws_overwrite_lambda_code.yml
@@ -3,6 +3,7 @@ Filename: aws_overwrite_lambda_code.py
 RuleID: "AWS.Lambda.UpdateFunctionCode"
 DisplayName: "Lambda Update Function Code"
 Enabled: true
+CreateAlert: false
 LogTypes:
   - AWS.CloudTrail
 Reports:


### PR DESCRIPTION
### Background

Turns `AWS.Lambda.UpdateFunctionCode` and `AWS.Lambda.UpdateFunctionConfiguration` into signals.

### Testing

- `make test`
