### PR TITLE
Turn Lambda Update alerts into signals (3.75.1 patch) 

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_add_malicious_lambda_extension.yml
+++ b/rules/aws_cloudtrail_rules/aws_add_malicious_lambda_extension.yml
@@ -9,6 +9,7 @@ Reports:
   MITRE ATT&CK:
     - TA0007:T1078
 Severity: Medium
+CreateAlert: false
 Description: >
   Identifies when a Lambda function configuration is updated with layers, which could indicate a potential security risk.
 Runbook: Make sure that the Lambda function configuration update is expected and authorized. If not, investigate the event further.

--- a/rules/aws_cloudtrail_rules/aws_overwrite_lambda_code.yml
+++ b/rules/aws_cloudtrail_rules/aws_overwrite_lambda_code.yml
@@ -9,6 +9,7 @@ Reports:
   MITRE ATT&CK:
     - TA0007:T1078
 Severity: Medium
+CreateAlert: false
 Description: >
   Identifies when the code of a Lambda function is updated, which could indicate a potential security risk.
 Runbook: Verify the event details and the user that triggered the event. If the event is expected, no action is required. If the event is unexpected, investigate the user and the function that was updated.


### PR DESCRIPTION
### Background

Turns `Lambda Update Function Code` and `AWS.Lambda.UpdateFunctionConfiguration` into signals.

### Testing

- `make test`
