### PR TITLE
Unusual EC2 launch logic fixup

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_ec2_launch_unusual_ec2_instances.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_launch_unusual_ec2_instances.py
@@ -12,13 +12,10 @@ UNUSUAL_INSTANCE_TYPES = {
 
 
 def rule(event: PantherEvent) -> bool:
-    instance_type = get_instance_type(event)
-    return all(
-        (
-            event.get("eventName") == "RunInstances",
-            event.get("eventSource") == "ec2.amazonaws.com",
-            instance_type in get_unusual_instance_types(),
-        )
+    return (
+            event.get("eventSource") == "ec2.amazonaws.com" and
+            event.get("eventName") == "RunInstances" and
+            get_instance_type(event) in get_unusual_instance_types()
     )
 
 

--- a/rules/aws_cloudtrail_rules/aws_ec2_launch_unusual_ec2_instances.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_launch_unusual_ec2_instances.py
@@ -13,9 +13,9 @@ UNUSUAL_INSTANCE_TYPES = {
 
 def rule(event: PantherEvent) -> bool:
     return (
-            event.get("eventSource") == "ec2.amazonaws.com" and
-            event.get("eventName") == "RunInstances" and
-            get_instance_type(event) in get_unusual_instance_types()
+        event.get("eventSource") == "ec2.amazonaws.com"
+        and event.get("eventName") == "RunInstances"
+        and get_instance_type(event) in get_unusual_instance_types()
     )
 
 


### PR DESCRIPTION
### Background

The EC2 unusual launch detection currently returns an error if the instanceType lookup returns a dictionary. The lookup function fixes this error, but the instance type function being called is unnecessary unless the eventSource and eventName are appropriate.

### Changes

Change return logic to use `and` to return false faster.
Move lookup of instance type into return logic to avoid unnecessary event processing.

### Testing

Local PAT testing passes
```
Test Summary
        Path: ./rules/aws_cloudtrail_rules
        Passed: 1
        Skipped: 0
        Failed: 0
        Invalid: 0
```
