### PR TITLE
Change phrasing in AWS.SecretsManager.RetrieveSecrets

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_secretsmanager_retrieve_secrets.py
+++ b/rules/aws_cloudtrail_rules/aws_secretsmanager_retrieve_secrets.py
@@ -13,7 +13,7 @@ def rule(event):
 
 def title(event):
     user = event.udm("actor_user")
-    return f"[{user}] attempted to retrieve a large number of secrets from AWS Secrets Manager"
+    return f"[{user}] attempted to retrieve a secret from AWS Secrets Manager"
 
 
 def alert_context(event):

--- a/rules/aws_cloudtrail_rules/aws_secretsmanager_retrieve_secrets.yml
+++ b/rules/aws_cloudtrail_rules/aws_secretsmanager_retrieve_secrets.yml
@@ -13,7 +13,7 @@ Reports:
   MITRE ATT&CK:
     - TA0006:T1552 # Credentials from Password Stores 
 Severity: Medium
-Description: An attacker attempted to retrieve a high number of Secrets Manager secrets, through secretsmanager:GetSecretValue.
+Description: An attacker attempted to retrieve a Secrets Manager secret, through secretsmanager:GetSecretValue.
 Runbook: https://permiso.io/blog/lucr-3-scattered-spider-getting-saas-y-in-the-cloud
 Reference: https://stratus-red-team.cloud/attack-techniques/AWS/aws.credential-access.secretsmanager-retrieve-secrets/
 Threshold: 20


### PR DESCRIPTION

Background

When an attacker attempts to hit secretsmanager:GetSecretValue, the alert's title is "attempted to retrieve a large number of secrets from AWS Secrets Manager" which is I think copy/pasted from AWS.SecretsManager.RetrieveSecrets.MultiRegion
Changes

I just changed the phrasing: Plural to singular. I changed this because clients freak out when they see "$USER attempted to retrieve a large number of secrets from AWS Secrets Manager"
