### PR TITLE
[fix] ASK-1780 Snowflake. DataTransferHistory rule using non-existent field

### DIFF
--- a/rules/snowflake_rules/snowflake_stream_external_shares.py
+++ b/rules/snowflake_rules/snowflake_stream_external_shares.py
@@ -1,16 +1,6 @@
-# CONFIGURATION REQUIRED
-#   Be sure to add code to exclude any transfers from acounts designed to host data shares. Either
-#   add those account names to the set below, or add a rule filter to exclude events with those
-#   account names.
-DATA_SHARE_HOSTING_ACCOUNTS = {
-    # Add account names here
-}
-
-
 def rule(event):
     return all(
         [
-            event.get("ACCOUNT_NAME") not in get_data_share_hosting_accounts(),
             event.get("SOURCE_CLOUD"),
             event.get("TARGET_CLOUD"),
             event.get("BYTES_TRANSFERRED", 0) > 0,
@@ -20,8 +10,7 @@ def rule(event):
 
 def title(event):
     return (
-        f"{event.get('ORGANIZATION_NAME', '<UNKNOWN ORGANIZATION>')}: "
-        "A data export has been initiated from source cloud "
+        f"A data export has been initiated from source cloud "
         f"{event.get('SOURCE_CLOUD', '<UNKNOWN SOURCE CLOUD>')} "
         f"in source region {event.get('SOURCE_REGION', '<UNKNOWN SOURCE REGION>')} "
         f"to target cloud {event.get('TARGET_CLOUD', '<UNKNOWN TARGET CLOUD>')} "
@@ -29,8 +18,3 @@ def title(event):
         f"with transfer type {event.get('TRANSFER_TYPE', '<UNKNOWN TRANSFER TYPE>')} "
         f"for {event.get('BYTES_TRANSFERRED', '<UNKNOWN VOLUME>')} bytes"
     )
-
-
-def get_data_share_hosting_accounts():
-    """Getter function. Used so we can mock during unit tests."""
-    return DATA_SHARE_HOSTING_ACCOUNTS

--- a/rules/snowflake_rules/snowflake_stream_external_shares.yml
+++ b/rules/snowflake_rules/snowflake_stream_external_shares.yml
@@ -13,37 +13,26 @@ Description: Detect when an external share has been initiated from one source cl
   to another target cloud.
 Runbook: Determine if this occurred as a result of a valid business request.
 Tags:
-  - Configuration Required
   - Snowflake
   - '[MITRE] Exfiltration'
   - '[MITRE] Transfer Data to Cloud Account'
 Tests:
-  - Name: Allowed Share
+  - Name: Zero byte transfer
     ExpectedResult: false
-    Mocks:
-      - objectName: get_data_share_hosting_accounts
-        returnValue: '{DP_EUROPE}, {DP_ASIA}, {DP_AMERICA}'
     Log:
       {
-        "ORGANIZATION_NAME": "DAILY_PLANET",
-        "ACCOUNT_NAME": "DP_EUROPE",
         "REGION": "US-EAST-2",
         "SOURCE_CLOUD": "AWS",
         "SOURCE_REGION": "US-EAST-2",
         "TARGET_CLOUD": "AWS",
         "TARGET_REGION": "EU-WEST-1",
-        "BYTES_TRANSFERRED": 61235879,
+        "BYTES_TRANSFERRED": 0,
         "TRANSFER_TYPE": "COPY"
       }
   - Name: Disallowed Share
     ExpectedResult: true
-    Mocks:
-      - objectName: get_data_share_hosting_accounts
-        returnValue: '{DP_EUROPE}, {DP_ASIA}, {DP_AMERICA}'
     Log:
       {
-        "ORGANIZATION_NAME": "LEXCORP",
-        "ACCOUNT_NAME": "LEX_SECRET_ACCOUNT",
         "REGION": "US-EAST-2",
         "SOURCE_CLOUD": "AWS",
         "SOURCE_REGION": "US-EAST-2",


### PR DESCRIPTION
### Background

A mismatch between the Panther-managed Snowflake.DataTransferHistory schema and the log messages coming from Snowflake — specifically around the ACCOUNT_NAME field.

### Changes

- Dropped non-existent fields from rule logic and tests

### Testing

pat test
