### PR TITLE
Fiixing list conversion in AWS.CloudTrail.EventSelectorsDisabled

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_cloudtrail_event_selectors_disabled.py
+++ b/rules/aws_cloudtrail_rules/aws_cloudtrail_event_selectors_disabled.py
@@ -12,7 +12,7 @@ def rule(event):
     #    deep_walk only returns a list if there's more than 1 entry in the nested array, so we must
     #    enforce it to be a list.
     includes = event.deep_walk("requestParameters", "eventSelectors", "includeManagementEvents")
-    
+
     if includes is None:
         includes = []
 

--- a/rules/aws_cloudtrail_rules/aws_cloudtrail_event_selectors_disabled.py
+++ b/rules/aws_cloudtrail_rules/aws_cloudtrail_event_selectors_disabled.py
@@ -12,6 +12,10 @@ def rule(event):
     #    deep_walk only returns a list if there's more than 1 entry in the nested array, so we must
     #    enforce it to be a list.
     includes = event.deep_walk("requestParameters", "eventSelectors", "includeManagementEvents")
+    
+    if includes is None:
+        includes = []
+
     if not isinstance(includes, list):
         includes = [includes]
 


### PR DESCRIPTION
### Background

the current code does not work in intended way.

the logic below fails if `includes` is `None`.

```python
if not isinstance(includes, list):
        includes = [includes]
```

and this rule will always return true

### Changes

i added custom check for None.

```python
    if includes is None:
        includes = []
```

### Testing

```python
 includes = deep_walk({}, "requestParameters", "eventSelectors", "include
       ⋮ ManagementEvents")
assert includes is None
includes = [includes]
print(includes)
# > [None]
result = not all(includes)
print(result)
# > True
```
