### PR TITLE
THREAT 490: Add Dynamic Reference to Wiz Passthrough

### DIFF
--- a/rules/wiz_rules/wiz_alert_passthrough.py
+++ b/rules/wiz_rules/wiz_alert_passthrough.py
@@ -33,6 +33,10 @@ def description(event):
     return event.deep_get("sourceRule", "controlDescription", default="<DESCRIPTION_NOT_FOUND>")
 
 
+def reference(event):
+    return get_issue_url(event) or "DEFAULT"
+
+
 def runbook(event):
     return event.deep_get(
         "sourceRule", "resolutionRecommendation", default="<RECOMMENDATION_NOT_FOUND>"
@@ -45,9 +49,24 @@ def alert_context(event):
         "id": event.get("id", "<ID_NOT_FOUND>"),
         "type": event.get("type", "<TYPE_NOT_FOUND>"),
         "entity_snapshot": event.get("entitySnapshot", {}),
+        "entity_url": get_entity_url(event),
         "mitre_attack_categories": [
             subcategory
             for subcategory in security_subcategories
             if deep_get(subcategory, "category", "framework", "name") == "MITRE ATT&CK Matrix"
         ],
     }
+
+
+def get_issue_url(event):
+    if issue_id := event.get("id"):
+        return f"https://app.wiz.io/issues#~(issue~'{issue_id})"
+    return None  # Return None if there's no issue ID
+
+
+def get_entity_url(event):
+    entity_id = event.deep_get("entitySnapshot", "id")
+    entity_type = event.deep_get("entitySnapshot", "type")
+    if entity_id and entity_type:
+        return f"https://app.wiz.io/issues#~(entity~(~'{entity_id}*2c{entity_type}))"
+    return None  # Return None if we're missing the ID or type


### PR DESCRIPTION
### Background

Wiz provides all the information needed to construct a backlink to the Issue in the Wiz console in their alerts. This PR adds URLs linking to the specific issue this alert corresponds to, and also to the entity involved in the issue.

### Changes

- add two new URLs, one to the issue and another to the entity

### Testing

- unit tests added the URLs as expected
- plan to let this bake in pre-alpha and make sure the URLs are actually working
