### PR TITLE
Add mcp.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ dist/
 
 # panther settings
 .panther_settings.yml
+
+# Cursor MCP configuratios
+.cursor/mcp.json


### PR DESCRIPTION
### Background

Adding mcp.json to gitignore so that we (and customers) can set up an MCP server without having our API credentials stored in the repo 😳 

### Changes

- add mcp.json to gitignore

### Testing

- I looked and mcp.json was ignored
