### PR TITLE
Cloudflare.Firewall.L7DDoS: Remove deduplication

### DIFF
--- a/rules/cloudflare_rules/cloudflare_firewall_ddos.py
+++ b/rules/cloudflare_rules/cloudflare_firewall_ddos.py
@@ -8,13 +8,8 @@ def rule(event):
     return event.get("Source", "") == "l7ddos"
 
 
-def title(event):
-    return (
-        "Cloudflare: Detected L7 DDoS"
-        f"from [{event.get('ClientIP', '<NO_CLIENTIP>')}] "
-        f"to [{event.get('ClientRequestHost', '<NO_REQ_HOST>')}] "
-        f"and took action [{event.get('Action', '<NO_ACTION>')}]"
-    )
+def title(_):
+    return "Cloudflare: Detected L7 DDoS"
 
 
 def alert_context(event):


### PR DESCRIPTION
### Background

Previously the rule was deduping based on client IP and resource requested, which doesn't make sense since DDoS attacks are distributed across many clients. The result was a lot of alerts generated for a single attack, where only one would do.

See [ASK-1840](https://panther-labs.atlassian.net/jira/servicedesk/projects/ASK/queues/custom/47/ASK-1840) for additional context.

### Changes

- remove `dedup` function

### Testing

- make test baby
