### PR TITLE
THREAT-431 Update AWS rules to use new `get_actor_user` udm

### DIFF
--- a/data_models/aws_cloudtrail_data_model.py
+++ b/data_models/aws_cloudtrail_data_model.py
@@ -1,7 +1,7 @@
 import ipaddress
 
 import panther_event_type_helpers as event_type
-from panther_aws_helpers import get_actor_user  # pylint: disable=unused-import
+from panther_aws_helpers import get_actor_user as aws_helpers_get_actor_user
 from panther_base_helpers import deep_get
 
 
@@ -38,3 +38,6 @@ def load_ip_address(event):
         except ipaddress.AddressValueError:
             return None
     return source_ip
+
+def get_actor_user(event):
+    return aws_helpers_get_actor_user(event)


### PR DESCRIPTION
### Changes

- Updated AWS CloudTrail data model to use `get_actor_user` from aws_helpers
