### PR TITLE
Google.Workspace.ManyDocsDownloaded: Fix typos and move to beta status

### DIFF
--- a/rules/gsuite_activityevent_rules/google_workspace_many_docs_downloaded.py
+++ b/rules/gsuite_activityevent_rules/google_workspace_many_docs_downloaded.py
@@ -6,8 +6,8 @@ def rule(event: PantherEvent) -> bool:
 
 
 def title(event: PantherEvent) -> str:
-    actor = event.deep_get("actor", "email", default="<UNKNWON ACTOR>")
-    return f"{actor} downloaded an escessive number of documents."
+    actor = event.deep_get("actor", "email", default="<UNKNOWN ACTOR>")
+    return f"{actor} downloaded an excessive number of documents."
 
 
 def alert_context(event: PantherEvent) -> dict:

--- a/rules/gsuite_activityevent_rules/google_workspace_many_docs_downloaded.yml
+++ b/rules/gsuite_activityevent_rules/google_workspace_many_docs_downloaded.yml
@@ -5,7 +5,7 @@ DisplayName: Google Workspace Many Docs Downloaded
 Enabled: true
 LogTypes:
   - GSuite.ActivityEvent
-Severity: Medium
+Severity: Info
 Reports:
   MITRE ATT&CK:
     - TA0010:T1567
@@ -20,6 +20,7 @@ SummaryAttributes:
   - parameters:doc_title
 Tags:
   - GSuite ActivityEvent
+  - Beta
 Tests:
   - Name: Document Downloaded
     ExpectedResult: true


### PR DESCRIPTION
### Background

Customer identified a couple typos and experienced excessive alerts. This PR fixes the types and moves the rule to Beta statis (INFO severity) to stem the bleeding while we fix the issues.

### Changes

- add `Beta` tag
- spelling fixes

### Testing

- N/A
