### PR TITLE
Fix schema

### DIFF
--- a/.vscode/schemas/correlation_rule.json
+++ b/.vscode/schemas/correlation_rule.json
@@ -25,7 +25,10 @@
       "type": "boolean"
     },
     "Detection": {
-      "type": "object"
+      "type": ["array"],
+      "items": {
+        "type": "object"
+      }
     },
     "Severity": {
       "oneOf": [


### PR DESCRIPTION
### Background

Correlation rule schema was incorrectly categorizing the Detection field as an object when it should be a list.

### Changes

- Schema update

### Testing

- Validated that VScode passes schema checks for all Correlation Rules

ASK-1782
