### PR TITLE
GCP.Destructive.Queries: More tuning

### DIFF
--- a/rules/gcp_audit_rules/gcp_destructive_queries.py
+++ b/rules/gcp_audit_rules/gcp_destructive_queries.py
@@ -47,16 +47,36 @@ def title(event):
         "statementType",
         default="<STATEMENT_NOT_FOUND>",
     )
-    table = event.deep_get(
+    if (
+        event.deep_get("protoPayload", "metadata", "jobChange", "job", "jobConfig", "type")
+        == "QUERY"
+    ):
+        return f"GCP: [{actor}] performed a destructive BigQuery [{statement}] query"
+
+    if event.deep_get("protoPayload", "metadata", "tableDeletion"):
+        return f"GCP: [{actor}] deleted a table in BigQuery"
+
+    if event.deep_get("protoPayload", "metadata", "datasetDeletion"):
+        return f"GCP: [{actor}] deleted a dataset in BigQuery"
+
+    # Default return value
+    return f"GCP: [{actor}] performed a destructive BigQuery query"
+
+
+def severity(event):
+    statement = event.deep_get(
         "protoPayload",
         "metadata",
         "jobChange",
         "job",
         "jobConfig",
         "queryConfig",
-        "destinationTable",
-    ) or event.deep_get("protoPayload", "metadata", "resourceName", default="<TABLE_NOT_FOUND>")
-    return f"GCP: [{actor}] performed a destructive BigQuery [{statement}] query on [{table}]."
+        "statementType",
+        default="<STATEMENT_NOT_FOUND>",
+    )
+    if statement in ("UPDATE", "DELETE"):
+        return "INFO"
+    return "DEFAULT"
 
 
 def alert_context(event):
@@ -98,19 +118,3 @@ def alert_context(event):
         )
         or event.deep_get("protoPayload", "metadata", "resourceName", default="<TABLE_NOT_FOUND>"),
     }
-
-
-def dedup(event):
-    actor = event.deep_get(
-        "protoPayload", "authenticationInfo", "principalEmail", default="<ACTOR_NOT_FOUND>"
-    )
-    table = event.deep_get(
-        "protoPayload",
-        "metadata",
-        "jobChange",
-        "job",
-        "jobConfig",
-        "queryConfig",
-        "destinationTable",
-    ) or event.deep_get("protoPayload", "metadata", "resourceName", default="<TABLE_NOT_FOUND>")
-    return f"{actor}:{table}"

--- a/rules/gcp_audit_rules/gcp_destructive_queries.yml
+++ b/rules/gcp_audit_rules/gcp_destructive_queries.yml
@@ -5,6 +5,8 @@ Enabled: true
 Filename: gcp_destructive_queries.py
 Reference: https://cloud.google.com/bigquery/docs/managing-tables
 Severity: Info
+SummaryAttributes:
+  - p_alert_context.table
 Tests:
   - ExpectedResult: true
     Log:
@@ -119,6 +121,71 @@ Tests:
         severity: NOTICE
         timestamp: "2023-03-28 18:37:06.079"
     Name: TableDeletion
+  - ExpectedResult: true
+    Log:
+      insertid: abcdefghijklmn
+      logname: projects/gcp-project1/logs/cloudaudit.googleapis.com%2Fdata_access
+      operation:
+        id: 1234567890123-gcp-project1:abcdefghijklmnopqrstuvwz
+        last: true
+        producer: bigquery.googleapis.com
+      p_any_emails:
+        - user@company.io
+      p_any_ip_addresses:
+        - 1.2.3.4
+      p_event_time: "2023-03-28 18:37:06.079"
+      p_log_type: GCP.AuditLog
+      p_parse_time: "2023-03-28 18:38:14.478"
+      p_row_id: 06bf03d9d5dfbadba981899e1787bf05
+      p_schema_version: 0
+      p_source_id: 964c7894-9a0d-4ddf-864f-0193438221d6
+      p_source_label: gcp-logsource
+      protopayload:
+        at_sign_type: type.googleapis.com/google.cloud.audit.AuditLog
+        authenticationInfo:
+          principalEmail: user@company.io
+        authorizationInfo:
+          - granted: true
+            permission: bigquery.jobs.create
+            resource: projects/gcp-project1
+        metadata:
+          "@type": type.googleapis.com/google.cloud.audit.BigQueryAuditMetadata
+          jobChange:
+            after: DONE
+            job:
+              jobConfig:
+                queryConfig:
+                  createDisposition: CREATE_IF_NEEDED
+                  destinationTable: projects/gcp-project1/datasets/test1/tables/newtable
+                  priority: QUERY_INTERACTIVE
+                  query: DELETE from test1.newtable WHERE foo = bar
+                  statementType: DELETE
+                  writeDisposition: WRITE_EMPTY
+                type: QUERY
+              jobName: projects/gcp-project1/jobs/abcdefghijklmnopqrstuvwz
+              jobStats:
+                createTime: "2023-03-28T18:37:05.842Z"
+                endTime: "2023-03-28T18:37:06.073Z"
+                queryStats: {}
+                startTime: "2023-03-28T18:37:05.934Z"
+              jobStatus:
+                jobState: DONE
+        methodName: google.cloud.bigquery.v2.JobService.InsertJob
+        requestMetadata:
+          callerIP: 1.2.3.4
+          callerSuppliedUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36,gzip(gfe),gzip(gfe)
+        resourceName: projects/gcp-project1/jobs/abcdefghijklmnopqrstuvwz
+        serviceName: bigquery.googleapis.com
+        status: {}
+      receivetimestamp: "2023-03-28 18:37:06.745"
+      resource:
+        labels:
+          location: US
+          project_id: gcp-project1
+        type: bigquery_project
+      severity: INFO
+      timestamp: "2023-03-28 18:37:06.079"
+    Name: DataDeletion
 DedupPeriodMinutes: 60
 LogTypes:
   - GCP.AuditLog


### PR DESCRIPTION
### Background

Adjust the tuning strategy to prevent alert storms from a few users updating/deleting from many tables. Also adjusts the severities to only surface the more severe table-level deletions as actionable alerts, and relegate the row-level deletions to loggable signals.

### Changes

- remove `dedup`
- add `severity`
- adjust title format based on the type of action taken in the event
  - previously the title displayed incorrectly for tableDeletion and datasetDeletion events; this is fixed now

### Testing

- new unit test
