### PR TITLE
Adjust AWS Potential Backdoor Lambda Function title

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_backdoor_lambda_function.py
+++ b/rules/aws_cloudtrail_rules/aws_backdoor_lambda_function.py
@@ -16,7 +16,7 @@ def rule(event):
 
 def title(event):
     lambda_name = event.deep_get(
-        "responseElements", "functionName", default="LAMBDA_NAME_NOT_FOUND"
+        "requestParameters", "functionName", default="LAMBDA_NAME_NOT_FOUND"
     )
     return (
         f"[AWS.CloudTrail] User [{event.udm('actor_user')}] "


### PR DESCRIPTION
Adjust the title for this detection so it will pull the name instead of returning unknown.