### PR TITLE
ASK-1696: Ignore JWT mismatch in queries

### DIFF
--- a/queries/snowflake_queries/snowflake_brute_force_ip_query.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_ip_query.yml
@@ -19,6 +19,7 @@ Query: |
     DATEDIFF(HOUR, event_timestamp, CURRENT_TIMESTAMP) < 24
     AND event_type = 'LOGIN'
     AND error_code is NOT NULL
+    AND error_code IS NOT 394304 # Ignore JWT Fingerprint Mismatch
   GROUP BY client_ip, reported_client_type
   HAVING counts >= 5;
 Schedule:

--- a/queries/snowflake_queries/snowflake_brute_force_username_query.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_username_query.yml
@@ -19,6 +19,7 @@ Query: |
     DATEDIFF(HOUR, event_timestamp, CURRENT_TIMESTAMP) < 24
     AND event_type = 'LOGIN'
     AND error_code IS NOT NULL
+    AND error_code IS NOT 394304 # Ignore JWT Fingerprint Mismatch
   GROUP BY reported_client_type, user_name
   HAVING counts >=5;
 Schedule:


### PR DESCRIPTION
### Background

We tuned the streaming rules to ignore JWT mismatches as false-positives, but we didn't tune the queries themselves. This PR ignores those error codes.

### Changes

- ignore error code 394304, which corresponds to a JWT finger print mismatch

### Testing

- N/A
