### PR TITLE
THREAT-431 Update AWS rules to use new `get_actor_user` udm

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_console_login_without_mfa.py
+++ b/rules/aws_cloudtrail_rules/aws_console_login_without_mfa.py
@@ -42,7 +42,7 @@ def rule(event):
     new_user_string = (
         event.deep_get("userIdentity", "userName", default="<MISSING_USER_NAME>")
         + "-"
-        + event.deep_get("userIdentity", "principalId", default="<MISSING_ID>")
+        + event.udm("actor_user")
     )
     is_new_user = check_account_age(new_user_string)
     if isinstance(is_new_user, str):

--- a/rules/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
+++ b/rules/aws_cloudtrail_rules/aws_console_login_without_mfa.yml
@@ -58,6 +58,7 @@ Tests:
         "eventID": "1",
         "eventType": "AwsConsoleSignIn",
         "recipientAccountId": "123456789012",
+        "p_log_type": "AWS.CloudTrail",
       }
   - Name: No MFA Login - IAM User Unknown Account
     ExpectedResult: true
@@ -92,6 +93,7 @@ Tests:
         "eventID": "1",
         "eventType": "AwsConsoleSignIn",
         "recipientAccountId": "123456789013",
+        "p_log_type": "AWS.CloudTrail",
       }
   - Name: No MFA Login - Root User
     ExpectedResult: true
@@ -126,6 +128,7 @@ Tests:
         "eventID": "1",
         "eventType": "AwsConsoleSignIn",
         "recipientAccountId": "123456789012",
+        "p_log_type": "AWS.CloudTrail",
       }
   - Name: MFA Login - SAML
     ExpectedResult: false
@@ -161,6 +164,7 @@ Tests:
         "eventID": "1",
         "eventType": "AwsConsoleSignIn",
         "recipientAccountId": "123456789012",
+        "p_log_type": "AWS.CloudTrail",
       }
   - Name: MFA Login
     ExpectedResult: false
@@ -195,6 +199,7 @@ Tests:
         "eventID": "1",
         "eventType": "AwsConsoleSignIn",
         "recipientAccountId": "123456789012",
+        "p_log_type": "AWS.CloudTrail",
       }
   - Name: No MFA - Login Failed
     ExpectedResult: false
@@ -229,6 +234,7 @@ Tests:
         "eventID": "1",
         "eventType": "AwsConsoleSignIn",
         "recipientAccountId": "123456789012",
+        "p_log_type": "AWS.CloudTrail",
       }
   - Name: No MFA - authenticated from session with MFA
     ExpectedResult: false
@@ -264,6 +270,7 @@ Tests:
               },
             "type": "AssumedRole",
           },
+        "p_log_type": "AWS.CloudTrail",
       }
 
   - Name: No MFA Login - New User
@@ -299,6 +306,7 @@ Tests:
         "eventID": "1",
         "eventType": "AwsConsoleSignIn",
         "recipientAccountId": "123456789012",
+        "p_log_type": "AWS.CloudTrail",
       }
   - Name: AWS SSOv2 Login
     ExpectedResult: false
@@ -346,6 +354,7 @@ Tests:
               },
             "type": "AssumedRole",
           },
+        "p_log_type": "AWS.CloudTrail",
       }
 
   - Name: AssumeRole from MFA User Session
@@ -385,6 +394,7 @@ Tests:
               },
             "type": "AssumedRole",
           },
+        "p_log_type": "AWS.CloudTrail",
       }
   - Name: No MFA - IAM Role and External IDP
     ExpectedResult: false

--- a/rules/aws_cloudtrail_rules/aws_ec2_many_passwors_read_attempts.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_many_passwors_read_attempts.py
@@ -17,7 +17,7 @@ def title(event: PantherEvent) -> str:
 
 def dedup(event: PantherEvent) -> str:
     # Dedup events based on the principal ID
-    return event.deep_get("userIdentity", "principalId")
+    return event.udm("actor_user")
 
 
 def severity(event: PantherEvent) -> str:

--- a/rules/aws_cloudtrail_rules/aws_software_discovery.py
+++ b/rules/aws_cloudtrail_rules/aws_software_discovery.py
@@ -29,14 +29,14 @@ def rule(event):
 
 def title(event):
     return (
-        f"User [{event.deep_get('userIdentity', 'principalId')}] "
+        f"User [{event.udm('actor_user')}] "
         f"performed a [{event.get('eventName')}] "
         f"action in AWS account [{event.get('recipientAccountId')}]."
     )
 
 
 def dedup(event):
-    return event.deep_get("userIdentity", "principalId", default="NO_PRINCIPAL_ID_FOUND")
+    return event.udm("actor_user")
 
 
 def alert_context(event):

--- a/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.py
+++ b/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.py
@@ -23,7 +23,7 @@ def rule(event):
 
 
 def dedup(event):
-    return event.deep_get("userIdentity", "principalId", default="<UNKNOWN_PRINCIPAL>")
+    return event.udm("actor_user")
 
 
 def title(event):

--- a/rules/aws_cloudtrail_rules/aws_vpce_access_denied.py
+++ b/rules/aws_cloudtrail_rules/aws_vpce_access_denied.py
@@ -35,6 +35,7 @@ def alert_context(event):
             "api_call": event.get("eventName", "unknown"),
             "error_message": event.get("errorMessage", ""),
             "resources": event.get("resources", []),
+            "actor_user": event.udm("actor_user"),
         }
     )
 

--- a/rules/aws_cloudtrail_rules/aws_vpce_external_principal.py
+++ b/rules/aws_cloudtrail_rules/aws_vpce_external_principal.py
@@ -59,6 +59,7 @@ def alert_context(event):
             "event_source": event.get("eventSource", "unknown"),
             "api_call": event.get("eventName", "unknown"),
             "resources": event.get("resources", []),
+            "actor_user": event.udm("actor_user"),
         }
     )
 

--- a/rules/aws_cloudtrail_rules/aws_waf_disassociation.py
+++ b/rules/aws_cloudtrail_rules/aws_waf_disassociation.py
@@ -15,6 +15,7 @@ def alert_context(event):
         "eventName": event.get("eventName"),
         "recipientAccountId": event.get("recipientAccountId"),
         "requestID": event.get("requestID"),
+        "actor_user": event.udm("actor_user"),
         "requestParameters": event.deep_get("requestParameters", "resourceArn"),
         "userIdentity": event.deep_get("userIdentity", "principalId"),
     }


### PR DESCRIPTION
### Changes

- Updated AWS CloudTrail rules to use `event.udm('actor_user')` instead of `userIdentity.principalId`

### Testing

pat test
