### PR TITLE
Google.Workspace.ManyDocsDownloaded: Convert to Signal

### DIFF
--- a/rules/gsuite_activityevent_rules/google_workspace_many_docs_downloaded.py
+++ b/rules/gsuite_activityevent_rules/google_workspace_many_docs_downloaded.py
@@ -5,11 +5,6 @@ def rule(event: PantherEvent) -> bool:
     return event.get("name") == "download"
 
 
-def title(event: PantherEvent) -> str:
-    actor = event.deep_get("actor", "email", default="<UNKNOWN ACTOR>")
-    return f"{actor} downloaded an excessive number of documents."
-
-
 def alert_context(event: PantherEvent) -> dict:
     return {
         "actor": event.deep_get("actor", "email", default="<UNKNOWN ACTOR>"),

--- a/rules/gsuite_activityevent_rules/google_workspace_many_docs_downloaded.yml
+++ b/rules/gsuite_activityevent_rules/google_workspace_many_docs_downloaded.yml
@@ -6,11 +6,13 @@ Enabled: true
 LogTypes:
   - GSuite.ActivityEvent
 Severity: Info
+CreateAlert: false
 Reports:
   MITRE ATT&CK:
     - TA0010:T1567
 Description: >
-  Checks whether a user has downloaded a large number of documents from Google Drive within a 5-minute period.
+  Checks whether a user has downloaded a large number of documents from Google Drive
+  within a 5-minute period.
 DedupPeriodMinutes: 5
 Threshold: 20
 Reference: >


### PR DESCRIPTION
### Background

Recently we learned that the `download` event is generated every time Google Drives performs a sync to a local device, which means the majority of alerts generated by this rule would be false positives. As far as I can tell, we don't get enough information about the client in the ActivityEvent logs to filter Drive syncs out, so the next best option is to move the rule toa. signal.

[See ASK-1860 for additional context.](https://panther-labs.atlassian.net/browse/ASK-1860)

### Changes

- make `Google.Workspace.ManyDocsDownloaded` a signal

### Testing

- make test
