### PR TITLE
Update aws_unauthorized_api_call.py by adding p_log_type

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.py
+++ b/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.py
@@ -23,7 +23,7 @@ def rule(event):
 
 
 def dedup(event):
-    return event.udm("actor_user")
+    return event.udm("actor_user") or "ACTOR_USER_NOT_FOUND"
 
 
 def title(event):

--- a/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.py
+++ b/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.py
@@ -23,7 +23,7 @@ def rule(event):
 
 
 def dedup(event):
-    return event.udm("actor_user") or "ACTOR_USER_NOT_FOUND"
+    return event.udm("actor_user")
 
 
 def title(event):

--- a/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.yml
+++ b/rules/aws_cloudtrail_rules/aws_unauthorized_api_call.yml
@@ -64,6 +64,7 @@ Tests:
         "eventID": "1",
         "eventType": "AwsApiCall",
         "recipientAccountId": "123456789012",
+        p_log_type: "AWS.CloudTrail",
       }
   - Name: Unauthorized API Call from Within AWS (FQDN)
     ExpectedResult: false
@@ -102,6 +103,7 @@ Tests:
         "eventID": "1",
         "eventType": "AwsApiCall",
         "recipientAccountId": "123456789012",
+        p_log_type: "AWS.CloudTrail",
       }
   - Name: Authorized API Call
     ExpectedResult: false
@@ -138,4 +140,5 @@ Tests:
         "eventID": "1",
         "eventType": "AwsApiCall",
         "recipientAccountId": "123456789012",
+        p_log_type: "AWS.CloudTrail",
       }


### PR DESCRIPTION
### Background

pypanther test failing with `Exception occurred in dedup(): detection [AWS.CloudTrail.UnauthorizedAPICall-prototype] method [dedup] returned [NoneType], expected [str]`

### Changes

- Updated aws_unauthorized_api_call.py by adding dedup default

### Testing

pat test
