### PR TITLE
[THREAT-453] Remove set-output from Github Action

### DIFF
--- a/.github/workflows/check-packs.yml
+++ b/.github/workflows/check-packs.yml
@@ -30,7 +30,9 @@ jobs:
         run: |
           # Get the output for the PR comment body
           panther_analysis_tool check-packs 2> errors.txt || true
-          echo ::set-output name=errors::`cat errors.txt`
+          echo 'errors<<EOF' >> $GITHUB_OUTPUT # Use a delimiter
+          cat errors.txt >> $GITHUB_OUTPUT      # Append the content
+          echo 'EOF' >> $GITHUB_OUTPUT          # Close the delimiter
 
       - name: Check packs (Exit Code)
         run: |


### PR DESCRIPTION
### Background

Removes the `set-output` command since it will be deprecated ([docs](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)).

### Changes

- Replaces `set-output` with `echo` to the `$GITHUB_OUTPUT` file

