### PR TITLE
ASK-1980 Snowflake queries syntax error

### DIFF
--- a/queries/snowflake_queries/snowflake_brute_force_ip_query.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_ip_query.yml
@@ -19,7 +19,7 @@ Query: |
     DATEDIFF(HOUR, event_timestamp, CURRENT_TIMESTAMP) < 24
     AND event_type = 'LOGIN'
     AND error_code is NOT NULL
-    AND error_code != 394304 # Ignore JWT Fingerprint Mismatch
+    AND error_code != 394304 -- Ignore JWT Fingerprint Mismatch
   GROUP BY client_ip, reported_client_type
   HAVING counts >= 5;
 Schedule:

--- a/queries/snowflake_queries/snowflake_brute_force_ip_query.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_ip_query.yml
@@ -19,7 +19,7 @@ Query: |
     DATEDIFF(HOUR, event_timestamp, CURRENT_TIMESTAMP) < 24
     AND event_type = 'LOGIN'
     AND error_code is NOT NULL
-    AND error_code IS NOT 394304 # Ignore JWT Fingerprint Mismatch
+    AND error_code != 394304 # Ignore JWT Fingerprint Mismatch
   GROUP BY client_ip, reported_client_type
   HAVING counts >= 5;
 Schedule:

--- a/queries/snowflake_queries/snowflake_brute_force_username_query.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_username_query.yml
@@ -19,7 +19,7 @@ Query: |
     DATEDIFF(HOUR, event_timestamp, CURRENT_TIMESTAMP) < 24
     AND event_type = 'LOGIN'
     AND error_code IS NOT NULL
-    AND error_code IS NOT 394304 # Ignore JWT Fingerprint Mismatch
+    AND error_code != 394304 # Ignore JWT Fingerprint Mismatch
   GROUP BY reported_client_type, user_name
   HAVING counts >=5;
 Schedule:

--- a/queries/snowflake_queries/snowflake_brute_force_username_query.yml
+++ b/queries/snowflake_queries/snowflake_brute_force_username_query.yml
@@ -19,7 +19,7 @@ Query: |
     DATEDIFF(HOUR, event_timestamp, CURRENT_TIMESTAMP) < 24
     AND event_type = 'LOGIN'
     AND error_code IS NOT NULL
-    AND error_code != 394304 # Ignore JWT Fingerprint Mismatch
+    AND error_code != 394304 -- Ignore JWT Fingerprint Mismatch
   GROUP BY reported_client_type, user_name
   HAVING counts >=5;
 Schedule:


### PR DESCRIPTION
### Background

Customer ran into an error during their CircleCI deployment when using the panther_analysis_tool to upload analysis items after updating to our latest release (v3.77.0). The error appears related to changes made in this recent [PR](https://github.com/panther-labs/panther-analysis/pull/1599/files).

### Changes

- replaced `is not` by `!=`
