### PR TITLE
Changes to some caching rules for time-based caching

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_ec2_multi_instance_connect.py
+++ b/rules/aws_cloudtrail_rules/aws_ec2_multi_instance_connect.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import json
 
 from panther_aws_helpers import aws_cloudtrail_success, aws_rule_context, lookup_aws_account_name
@@ -9,7 +10,8 @@ def rule(event: PantherEvent) -> bool:
     if not (aws_cloudtrail_success(event) and event.get("eventName") == "SendSSHPublicKey"):
         return False
 
-    key = event.deep_get("requestParameters", "sSHPublicKey")
+    offset = dt.datetime.fromisoformat(event["p_event_time"]).timestamp() // 3600 * 3600
+    key = f"{event.deep_get('requestParameters', 'sSHPublicKey')}-{offset}"
     if not key:
         return False
     target_instance_id = event.deep_get("requestParameters", "instanceId")

--- a/rules/aws_cloudtrail_rules/aws_ssm_decrypt_ssm_params.py
+++ b/rules/aws_cloudtrail_rules/aws_ssm_decrypt_ssm_params.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import json
 
 from panther_aws_helpers import aws_cloudtrail_success, aws_rule_context, lookup_aws_account_name
@@ -59,10 +60,11 @@ def alert_context(event: PantherEvent) -> dict:
 def get_cache_key(event) -> str:
     """Use the field values in the event to generate a cache key unique to this actor and
     account ID."""
+    offset = dt.datetime.fromisoformat(event["p_event_time"]).timestamp() // 3600 * 3600
     actor = event.udm("actor_user")
     account = event.get("recipientAccountId")
     rule_id = "AWS.SSM.DecryptSSMParams"
-    return f"{rule_id}-{account}-{actor}"
+    return f"{rule_id}-{account}-{actor}-{offset}"
 
 
 def get_param_names(event) -> set[str]:

--- a/rules/aws_cloudtrail_rules/aws_ssm_decrypt_ssm_params.yml
+++ b/rules/aws_cloudtrail_rules/aws_ssm_decrypt_ssm_params.yml
@@ -33,6 +33,7 @@ Tests:
         returnValue: ''
     Log:
       {
+        "p_event_time": "2025-02-14 19:43:09.000000000",
         "p_log_type": "AWS.CloudTrail",
         "awsRegion": "us-west-2",
         "eventCategory": "Management",
@@ -93,6 +94,7 @@ Tests:
         returnValue: ''
     Log:
       {
+        "p_event_time": "2025-02-14 19:42:57.000000000",
         "p_log_type": "AWS.CloudTrail",
         "awsRegion": "us-west-2",
         "eventCategory": "Management",
@@ -201,6 +203,7 @@ Tests:
         returnValue: ''
     Log:
       {
+        "p_event_time": "2025-02-14 19:42:57.000000000",
         "p_log_type": "AWS.CloudTrail",
         "awsRegion": "us-west-2",
         "eventCategory": "Management",
@@ -303,6 +306,7 @@ Tests:
         returnValue: ''
     Log:
       {
+        "p_event_time": "2025-02-14 19:42:57.000000000",
         "p_log_type": "AWS.CloudTrail",
         "awsRegion": "us-west-2",
         "eventCategory": "Management",

--- a/rules/aws_cloudtrail_rules/aws_ssm_distributed_command.py
+++ b/rules/aws_cloudtrail_rules/aws_ssm_distributed_command.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import json
 
 from panther_aws_helpers import aws_cloudtrail_success, aws_rule_context, lookup_aws_account_name
@@ -56,10 +57,11 @@ def alert_context(event: PantherEvent) -> dict:
 def get_cache_key(event) -> str:
     """Use the field values in the event to generate a cache key unique to this actor and
     account ID."""
+    offset = dt.datetime.fromisoformat(event["p_event_time"]).timestamp() // 3600 * 3600
     actor = event.udm("actor_user")
     account = event.get("recipientAccountId")
     rule_id = "AWS.SSM.DistributedCommand"
-    return f"{rule_id}-{account}-{actor}"
+    return f"{rule_id}-{account}-{actor}-{offset}"
 
 
 def get_cached_instance_ids(key: str) -> set[str]:


### PR DESCRIPTION
### Background

Some of our rules are designed to cache items for a set time after the first entry, but the caching helpers don't support this currently. As a workaround for now, we can cache these according to an arbitrary "time bucket" instead.

### Changes

- update the cache keys to include a timetsamp

### Testing

- all the keys are generated properly
