### PR TITLE
Github Repo Security Change: fix transition order

### DIFF
--- a/correlation_rules/github_advanced_security_change_not_followed_by_repo_archived.yml
+++ b/correlation_rules/github_advanced_security_change_not_followed_by_repo_archived.yml
@@ -14,8 +14,8 @@ Detection:
         Absence: true
     Transitions:
       - ID: GHASChange NOT FOLLOWED BY RepoArchived
-        From: RepoArchived
-        To: GHASChange
+        From: GHASChange
+        To: RepoArchived
         WithinTimeFrameMinutes: 60
         Match:
           - On: p_alert_context.repo


### PR DESCRIPTION
### Background

The order of the transition was incorrect, looking for a repo being archived BEFORE the security setting is changed.

### Changes

- Swap transition order

### Testing

- Test cases run as expected
