### PR TITLE
Restrict internal workflows to upstream repo only

### DIFF
--- a/.github/workflows/airflow-update.yml
+++ b/.github/workflows/airflow-update.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   update-airflow:
     runs-on: ubuntu-latest
+    if: github.repository == 'panther-labs/panther-analysis'
     steps:
       - name: Checkout panther-analysis
         uses: actions/checkout@v4

--- a/.github/workflows/check-packs.yml
+++ b/.github/workflows/check-packs.yml
@@ -12,6 +12,7 @@ jobs:
   check_packs:
     name: check packs
     runs-on: ubuntu-latest
+    if: github.repository == 'panther-labs/panther-analysis'
 
     steps:
       - name: Checkout panther-analysis

--- a/.github/workflows/generate-indexes.yml
+++ b/.github/workflows/generate-indexes.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   generate-indexes:
     runs-on: ubuntu-latest
+    if: github.repository == 'panther-labs/panther-analysis'
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/pre-release-upload.yml
+++ b/.github/workflows/pre-release-upload.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   upload:
-    if: github.head_ref == 'main'
+    if: github.head_ref == 'main' && github.repository == 'panther-labs/panther-analysis'
     name: Pre-Release Upload to GA
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
### Background

Customers often encounter issues using workflows that are intended for our internal use only. I've added some checks to these workflows to prevent them running on downstream clones and forks. This should ideally lead to an improved customer experience.

### Changes

- Added a filter to internal workflows (that aren't workflow-dispatch) which checks if the host repo is panther-labs/panther-analysis and exits if it is not.

### Testing

- We'll see if the actions still run when this PR is created 👀 
