### PR TITLE
Fix peer group anomaly query to use correct time window for lookback

### DIFF
--- a/queries/macros/anomalies.yml
+++ b/queries/macros/anomalies.yml
@@ -128,7 +128,7 @@ Query: |-
         from logs right outer join dimensions
         on (dimensions.t1 < logs.p_event_time and logs.p_event_time <= dimensions.t2)
         and logs.{{ entity_field }} = dimensions.{{ entity_field }}
-        where dimensions.t1 >= (select max(t1) from tbins)
+        where dimensions.t1 >= (select min(p_event_time) from logs)
         group by
             dimensions.t1,
             dimensions.t2,


### PR DESCRIPTION
### Background

A customer raised an issue with the peer group annomali macro not returning any results. After some testing I determined the macro was using the incorrect time window when building a statistical profile for the entities. This caused all entities to effectively have no history, making the analysis fail.

[See ASK-2105 for additional context.](https://panther-labs.atlassian.net/browse/ASK-2105)

### Changes

- fixed the lookback window for the `data_entity` subquery in `statistical_anomaly_peer`

### Testing

- after testing on sample data, the query is able to infer statistical values for each entity and group's historical behaviour
