### PR TITLE
Okta Rate Limit detection enhancements

### DIFF
--- a/rules/okta_rules/okta_rate_limits.py
+++ b/rules/okta_rules/okta_rate_limits.py
@@ -22,14 +22,17 @@ def rule(event):
 
 
 def title(event):
+    actor = event.deep_get("actor", "alternateId")
+    if actor == "unknown":
+        actor = event.deep_get("actor", "displayName", default="<id-not-found>")
     return (
         f"Okta Rate Limit Event: [{event.get('eventtype','')}] "
-        f"by [{event.deep_get('actor', 'alternateId', default='<id-not-found>')}]"
+        f"by [{actor}/{event.deep_get('actor', 'type', default='<type-not-found>')}] "
     )
 
 
 def dedup(event):
-    return event.deep_get("actor", "alternateId", default="<id-not-found>")
+    return event.deep_get("actor", "id")
 
 
 def alert_context(event):

--- a/rules/okta_rules/okta_rate_limits.yml
+++ b/rules/okta_rules/okta_rate_limits.yml
@@ -241,3 +241,57 @@ Tests:
       uuid: aa-11-22-33-44-bb
       version: "0"
     Name: Non event
+  - ExpectedResult: true
+    Log:
+      actor:
+        alternateId: unknown
+        displayName: Homer Simpson
+        id: 00abc456
+        type: User
+      authenticationcontext:
+        authenticationStep: 0
+        externalSessionId: abc12345
+      client:
+        device: Unknown
+        ipAddress: 1.2.3.4
+        userAgent:
+          browser: UNKNOWN
+          os: Unknown
+          rawUserAgent: Chrome
+        zone: "null"
+      debugcontext:
+        debugData:
+          authnRequestId: ABCDFDE
+          dtHash: adfalsjflasfjsdfd
+          operationRateLimitScopeType: User
+          operationRateLimitSecondsToReset: "10"
+          operationRateLimitSubtype: Authenticated user
+          operationRateLimitThreshold: "40"
+          operationRateLimitTimeSpan: "10"
+          operationRateLimitTimeUnit: SECONDS
+          operationRateLimitType: Web request
+          requestId: asfsagadffdaf
+          requestUri: /app/google/
+          url: /app/google/
+      displaymessage: Operation rate limit violation
+      eventtype: system.operation.rate_limit.violation
+      outcome:
+        reason: Too many requests attempted by an individual user
+        result: DENY
+      published: "2022-08-29 16:07:26.592"
+      request:
+        ipChain:
+          - ip: 1.2.3.4
+            version: V4
+      securitycontext: {}
+      severity: WARN
+      target:
+        - id: /app/{app}/{key}/
+          type: URL Pattern
+      transaction:
+        detail: {}
+        id: YABCDE
+        type: WEB
+      uuid: asdfdashh
+      version: "0"
+    Name: system.operation.ratelimit.violation - unknown altid


### PR DESCRIPTION
Adds a check for 'unknown' in the alternateId and replaces with display name if this is the case. Okta uses unknown for a lot of actors making this field less helpful in the title for this detection. Added actor type to title to help with faster triage. Changed dedup to use actor:id which will be unique rather than alternateId which may have the default 'unknown' value