### PR TITLE
Fix GCP Workload Identity Pool rule title

### DIFF
--- a/rules/gcp_audit_rules/gcp_workload_identity_pool_created_or_updated.py
+++ b/rules/gcp_audit_rules/gcp_workload_identity_pool_created_or_updated.py
@@ -19,7 +19,7 @@ def title(event):
     project_id = event.deep_get("resource", "labels", "project_id", default="<PROJECT_NOT_FOUND>")
 
     return (
-        f"GCP: [{actor}] created or updated workforce pool "
+        f"GCP: [{actor}] created or updated workload identity pool "
         f"[{workload_identity_pool}] in project [{project_id}]"
     )
 


### PR DESCRIPTION
### Background

The rule title is incorrect and can be confusing due to an existing [Workforce Identity rule](https://github.com/panther-labs/panther-analysis/blob/develop/rules/gcp_audit_rules/gcp_workforce_pool_created_or_updated.py#L24) that returns the same title.

### Changes

- Updates the rule title to match the correct GCP `WorkloadIdentityPools` method types

### Testing

- pat test
