### PR TITLE
fix(aws): fix alert title and include error message

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_secretsmanager_retrieve_secrets.py
+++ b/rules/aws_cloudtrail_rules/aws_secretsmanager_retrieve_secrets.py
@@ -13,8 +13,11 @@ def rule(event):
 
 def title(event):
     user = event.udm("actor_user")
-    return f"[{user}] attempted to retrieve a large number of secrets from AWS Secrets Manager"
+    return f"[{user}] is not authorized to retrieve secrets from AWS Secrets Manager"
 
 
 def alert_context(event):
-    return aws_rule_context(event)
+    return aws_rule_context(event) | {
+        "errorCode": event.get("errorCode"),
+        "errorMessage": event.get("errorMessage"),
+    }


### PR DESCRIPTION
### Background

The alert title is misleading and does not reflect the detection logic.

### Changes

This change:

- Updates the alert title to accurately reflect the detection logic (i.e. `AccessDenied` error when retrieving secrets)
- Includes the `errorMessage` in the alert context, which is a crucial piece of information for security engineers and incident responders 

### Testing

<!-- - <Testing steps> -->
