### PR TITLE
ASK-2236 Increase in alerts for `GSuite suspicious login` rule

### DIFF
--- a/indexes/alpha-index.md
+++ b/indexes/alpha-index.md
@@ -1305,6 +1305,8 @@
   - A Workspace Admin Has Modified The Trusted Domains List
 - [Suspicious GSuite Login](../rules/gsuite_activityevent_rules/gsuite_suspicious_logins.yml)
   - GSuite reported a suspicious login for this user.
+- [Suspicious is_suspicious tag](../rules/gsuite_activityevent_rules/gsuite_is_suspicious_tag.yml)
+  - GSuite reported a suspicious activity for this user.
 
 
 # M

--- a/indexes/detection-coverage.json
+++ b/indexes/detection-coverage.json
@@ -6309,6 +6309,15 @@
         "YAMLPath": "rules/gsuite_activityevent_rules/gsuite_suspicious_logins.yml"
     },
     {
+        "AnalysisType": "Rule",
+        "Description": "GSuite reported a suspicious activity for this user.",
+        "DisplayName": "Suspicious is_suspicious tag",
+        "LogTypes": [
+            "GSuite.ActivityEvent"
+        ],
+        "YAMLPath": "rules/gsuite_activityevent_rules/gsuite_is_suspicious_tag.yml"
+    },
+    {
         "AnalysisType": "Scheduled Query",
         "Description": "This query can be used for the detection of unusual, non-common applications and client characteristics that had been used to connect to the Snowflake account, using a comparison to the previous usage baseline.",
         "DisplayName": "Suspicious Snowflake Sessions - Unusual Application",

--- a/indexes/gworkspace.md
+++ b/indexes/gworkspace.md
@@ -80,5 +80,7 @@
   - A Workspace Admin Has Modified The Trusted Domains List
 - [Suspicious GSuite Login](../rules/gsuite_activityevent_rules/gsuite_suspicious_logins.yml)
   - GSuite reported a suspicious login for this user.
+- [Suspicious is_suspicious tag](../rules/gsuite_activityevent_rules/gsuite_is_suspicious_tag.yml)
+  - GSuite reported a suspicious activity for this user.
 
 

--- a/indexes/saas.md
+++ b/indexes/saas.md
@@ -130,6 +130,8 @@
   - A Workspace Admin Has Modified The Trusted Domains List
 - [Suspicious GSuite Login](../rules/gsuite_activityevent_rules/gsuite_suspicious_logins.yml)
   - GSuite reported a suspicious login for this user.
+- [Suspicious is_suspicious tag](../rules/gsuite_activityevent_rules/gsuite_is_suspicious_tag.yml)
+  - GSuite reported a suspicious activity for this user.
 
 
 ## Okta

--- a/packs/gsuite_reports.yml
+++ b/packs/gsuite_reports.yml
@@ -20,6 +20,7 @@ PackDefinition:
     - GSuite.DeviceCompromise
     - GSuite.DeviceUnlockFailure
     - GSuite.DeviceSuspiciousActivity
+    - GSuite.IsSuspiciousTag
     - GSuite.Rule
     - GSuite.SuspiciousLogins
     - GSuite.TwoStepVerification

--- a/rules/gsuite_activityevent_rules/gsuite_is_suspicious_tag.py
+++ b/rules/gsuite_activityevent_rules/gsuite_is_suspicious_tag.py
@@ -1,0 +1,7 @@
+def rule(event):
+    return event.deep_get("parameters", "is_suspicious") is True
+
+
+def title(event):
+    user = event.deep_get("actor", "email", default="<UNKNOWN_USER>")
+    return f"A suspicious action was reported for user [{user}]"

--- a/rules/gsuite_activityevent_rules/gsuite_is_suspicious_tag.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_is_suspicious_tag.yml
@@ -1,0 +1,44 @@
+AnalysisType: rule
+Filename: gsuite_is_suspicious_tag.py
+RuleID: "GSuite.IsSuspiciousTag"
+DisplayName: "Suspicious is_suspicious tag"
+Enabled: true
+LogTypes:
+  - GSuite.ActivityEvent
+Tags:
+  - GSuite
+Severity: Medium
+Description: >
+  GSuite reported a suspicious activity for this user.
+Reference: https://support.google.com/a/answer/7102416?hl=en
+Runbook: >
+  Checkout the details of the activity and verify this behavior with the user to ensure the account wasn't compromised.
+SummaryAttributes:
+  - actor:email
+Tests:
+  - Name: Normal Login Event
+    ExpectedResult: false
+    Log:
+      {
+        "id": { "applicationName": "login" },
+        "kind": "admin#reports#activity",
+        "type": "account_warning",
+        "name": "login_success",
+        "parameters": { "affected_email_address": "bobert@ext.runpanther.io" },
+      }
+
+  - Name: Login Success But Flagged Suspicious
+    ExpectedResult: true
+    Log:
+      {
+        "id": { "applicationName": "login" },
+        "actor": {
+          "email": bobert@ext.runpanther.io"},
+        "kind": "admin#reports#activity",
+        "type": "login",
+        "name": "login_success",
+        "parameters": {
+          "affected_email_address": "bobert@ext.runpanther.io",
+          "is_suspicious": true
+        }
+      }

--- a/rules/gsuite_activityevent_rules/gsuite_is_suspicious_tag.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_is_suspicious_tag.yml
@@ -7,7 +7,8 @@ LogTypes:
   - GSuite.ActivityEvent
 Tags:
   - GSuite
-Severity: Medium
+  - Beta
+Severity: Info # Will be Medium in the future
 Description: >
   GSuite reported a suspicious activity for this user.
 Reference: https://support.google.com/a/answer/7102416?hl=en

--- a/rules/gsuite_activityevent_rules/gsuite_suspicious_logins.py
+++ b/rules/gsuite_activityevent_rules/gsuite_suspicious_logins.py
@@ -12,14 +12,9 @@ def rule(event):
     if event.get("name") in SUSPICIOUS_LOGIN_TYPES:
         return True
 
-    if event.deep_get("parameters", "is_suspicious") is True:
-        return True
-
     return False
 
 
 def title(event):
-    user = event.deep_get("actor", "email")
-    if not user:
-        user = "<UNKNOWN_USER>"
+    user = event.deep_get("actor", "email", default="<UNKNOWN_USER>")
     return f"A suspicious login was reported for user [{user}]"

--- a/rules/gsuite_activityevent_rules/gsuite_suspicious_logins.yml
+++ b/rules/gsuite_activityevent_rules/gsuite_suspicious_logins.yml
@@ -46,19 +46,3 @@ Tests:
         "name": "suspicious_login",
         "parameters": { "affected_email_address": "bobert@ext.runpanther.io" },
       }
-
-  - Name: Login Success But Flagged Suspicious
-    ExpectedResult: true
-    Log:
-      {
-        "id": { "applicationName": "login" },
-        "actor": {
-          "email": bobert@ext.runpanther.io"},
-        "kind": "admin#reports#activity",
-        "type": "login",
-        "name": "login_success",
-        "parameters": {
-          "affected_email_address": "bobert@ext.runpanther.io",
-          "is_suspicious": true
-        }
-      }


### PR DESCRIPTION
### Background

After adding the check for `is_suspicious` tag to the `GSuite suspicious login rule` the rule became noisier. At the same time, the are issues that this check catches, so deleting it would be wrong.

### Changes

- Divided the rule into two. That way, customers can decide for themselves whether they want this new check enabled or not.

### Testing

pat test
