### PR TITLE
ASK 2296: Fix M365 external forwarding bug

### DIFF
--- a/rules/microsoft_rules/microsoft_exchange_external_forwarding.py
+++ b/rules/microsoft_rules/microsoft_exchange_external_forwarding.py
@@ -37,10 +37,6 @@ def rule(event):
         param_name = param.get("Name", "")
         param_value = param.get("Value", "")
 
-        # Check for suspicious patterns
-        if param_name in SUSPICIOUS_PATTERNS and param_value == SUSPICIOUS_PATTERNS[param_name]:
-            return True
-
         # Check for external forwarding
         if param_name in FORWARDING_PARAMETERS and param_value:
             if is_external_address(param_value, primary_domain, onmicrosoft_domain):
@@ -77,5 +73,21 @@ def title(event):
     )
 
 
+def severity(event):
+    if not is_suspicious_pattern(event):
+        return "LOW"
+    return "DEFAULT"
+
+
 def alert_context(event):
     return m365_alert_context(event)
+
+
+def is_suspicious_pattern(event):
+    parameters = event.get("parameters", [])
+    for param in parameters:
+        param_name = param.get("Name", "")
+        param_value = param.get("Value", "")
+        if param_name in SUSPICIOUS_PATTERNS and param_value == SUSPICIOUS_PATTERNS[param_name]:
+            return True
+    return False

--- a/rules/microsoft_rules/microsoft_exchange_external_forwarding.yml
+++ b/rules/microsoft_rules/microsoft_exchange_external_forwarding.yml
@@ -289,3 +289,34 @@ Tests:
       userkey: "12345"
       usertype: 2
       workload: Exchange
+  - Name: Internal Forwarding with Suspicious Pattern
+    ExpectedResult: false
+    Log:
+      clientip: "1.2.3.4:10736"
+      creationtime: "2025-07-07 09:11:11.000000000"
+      externalaccess: false
+      id: 111-22-33
+      objectid: "ABC001.prod.outlook.com/Microsoft Exchange Hosted Organizations/simpsons.onmicrosoft.com/444-55-66\\Move GitHub emails"
+      operation: New-InboxRule
+      organizationid: 11-aa-bb
+      organizationname: simpsons.onmicrosoft.com
+      originatingserver: QWERTY (1.2.3.4)
+      parameters:
+        - Name: AlwaysDeleteOutlookRulesBlob
+          Value: "False"
+        - Name: Force
+          Value: "False"
+        - Name: MoveToFolder
+          Value: "MYFolder"
+        - Name: Name
+          Value: "Move emails to another folder"
+        - Name: FromAddressContainsWords
+          Value: "specialsender"
+        - Name: StopProcessingRules
+          Value: "True"
+      recordtype: 1
+      resultstatus: "True"
+      userid: homer.simpson@simpsons.onmicrosoft
+      userkey: homer.simpson@simpsons.onmicrosoft
+      usertype: 2
+      workload: Exchange


### PR DESCRIPTION
### Background

A customer identified that the rule alerts when a customer "forwards" an event internally with what might be considered suspicious methods. This is outside the scope of what the rule is intended to catch, so we've remove these false positives.

### Changes

- only alert if a rule was created to forward to an EXTERNAL destination
- add a severity modifier to downgrade the severity if a rule forwards externally but without any suspicious indicators

### Testing

- added unit test provided by customer's previous false positive
