### PR TITLE
Update MITRE mapping: Amazon.EKS.Audit.SystemNamespaceFromPublicIP

### DIFF
--- a/rules/aws_eks_rules/system_namespace_public_ip.yml
+++ b/rules/aws_eks_rules/system_namespace_public_ip.yml
@@ -7,9 +7,11 @@ LogTypes:
   - Amazon.EKS.Audit
 Tags:
   - EKS
+  - Discovery
+  - Log Enumeration
 Reports:
   MITRE ATT&CK:
-    - "TA0027:T1475" # Tactic ID:Technique ID (https://attack.mitre.org/tactics/enterprise/)
+    - "TA0007:T1654" # Discovery: Log Enumeration
 Reference: https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html
 Severity: Info
 CreateAlert: false

--- a/rules/aws_eks_rules/system_namespace_public_ip.yml
+++ b/rules/aws_eks_rules/system_namespace_public_ip.yml
@@ -7,11 +7,15 @@ LogTypes:
   - Amazon.EKS.Audit
 Tags:
   - EKS
-  - Discovery
-  - Log Enumeration
+  - Initial Access
+  - Lateral Movement
+  - "Exploit Public-Facing Application"
+  - Remote Services
+  - Cloud Services
 Reports:
   MITRE ATT&CK:
-    - "TA0007:T1654" # Discovery: Log Enumeration
+    - "TA0001:T1190" # Initial Access: Exploit Public-Facing Application
+    - "TA0008:T1201.007" # Lateral Movement: Remote Services: Cloud Services
 Reference: https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html
 Severity: Info
 CreateAlert: false


### PR DESCRIPTION
### Background

The MITRE mappings for this rule pointed to "Initial Access: Deliver Malicious App via Authorized App Store", which was wildly inaccurate. This PR adjusts the mapping to "Discovery: Log Enumeration" which seems a more appropriate tactic and technique for what the rule is designed to detect (access to system logs from external IP).

### Changes

- Change MITRE mapping and add corresponding tags

### Testing

- N/A
