### PR TITLE
Add support for GCP Service Manager to GCP.IAM.CorporateEmail

### DIFF
--- a/packs/gcp_audit.yml
+++ b/packs/gcp_audit.yml
@@ -57,5 +57,8 @@ PackDefinition:
     # Globals used in these rules/policies
     - panther_gcp_helpers
     - panther_base_helpers
+    - panther_config
+    - panther_config_defaults
+    - panther_config_overrides
     - panther_event_type_helpers
 DisplayName: "Panther GCP Audit Pack"

--- a/rules/gcp_audit_rules/gcp_iam_corp_email.yml
+++ b/rules/gcp_audit_rules/gcp_iam_corp_email.yml
@@ -382,3 +382,191 @@ Tests:
         "logName": "projects/western-verve-123456/logs/cloudaudit.googleapis.com%2Factivity",
         "receiveTimestamp": "2020-05-15T03:51:35.977314225Z",
       }
+  - Name: Expected GCP service account added by Service Agent Manager
+    ExpectedResult: false
+    Log:
+      {
+        "protoPayload":
+          {
+            "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+            "status": {},
+            "authenticationInfo":
+              {
+                "principalEmail": "service-agent-manager@system.gserviceaccount.com",
+              },
+            "requestMetadata":
+              {
+                "callerIp": "136.24.229.58",
+                "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36,gzip(gfe)",
+                "requestAttributes": {},
+                "destinationAttributes": {},
+              },
+            "serviceName": "cloudresourcemanager.googleapis.com",
+            "methodName": "SetIamPolicy",
+            "authorizationInfo":
+              [
+                {
+                  "resource": "projects/western-verve-123456",
+                  "permission": "resourcemanager.projects.setIamPolicy",
+                  "granted": true,
+                  "resourceAttributes": {},
+                },
+                {
+                  "resource": "projects/western-verve-123456",
+                  "permission": "resourcemanager.projects.setIamPolicy",
+                  "granted": true,
+                  "resourceAttributes": {},
+                },
+              ],
+            "resourceName": "projects/western-verve-123456",
+            "serviceData":
+              {
+                "@type": "type.googleapis.com/google.iam.v1.logging.AuditData",
+                "policyDelta":
+                  {
+                    "bindingDeltas":
+                      [
+                        {
+                          "action": "ADD",
+                          "role": "roles/logging.serviceAgent",
+                          "member": "serviceAccount:service-951849100836@gcp-sa-logging.iam.gserviceaccount.com",
+                        },
+                      ],
+                  },
+              },
+            "request":
+              {
+                "resource": "western-verve-123456",
+                "@type": "type.googleapis.com/google.iam.v1.SetIamPolicyRequest",
+                "policy":
+                  {
+                    "bindings":
+                      [
+                        {
+                          "members": ["user:user-two@gmail.com"],
+                          "role": "roles/appengine.serviceAdmin",
+                        },
+                        {
+                          "members":
+                            [
+                              "serviceAccount:service-951849100836@compute-system.iam.gserviceaccount.com",
+                            ],
+                          "role": "roles/compute.serviceAgent",
+                        },
+                        {
+                          "role": "roles/editor",
+                          "members":
+                            [
+                              "serviceAccount:951849100836-compute@developer.gserviceaccount.com",
+                              "serviceAccount:951849100836@cloudservices.gserviceaccount.com",
+                            ],
+                        },
+                        {
+                          "members": ["user:test@runpanther.com"],
+                          "role": "roles/owner",
+                        },
+                        {
+                          "members": ["user:user-two@gmail.com"],
+                          "role": "roles/pubsub.admin",
+                        },
+                        {
+                          "members":
+                            [
+                              "serviceAccount:pubsub-reader@western-verve-123456.iam.gserviceaccount.com",
+                            ],
+                          "role": "roles/pubsub.subscriber",
+                        },
+                        {
+                          "members":
+                            [
+                              "serviceAccount:pubsub-reader@western-verve-123456.iam.gserviceaccount.com",
+                            ],
+                          "role": "roles/pubsub.viewer",
+                        },
+                        {
+                          "role": "roles/resourcemanager.organizationAdmin",
+                          "members": ["user:test@runpanther.com"],
+                        },
+                        {
+                          "members":
+                            [
+                              "serviceAccount:service-951849100836@gcp-sa-logging.iam.gserviceaccount.com",
+                            ],
+                          "role": "roles/logging.ServiceAgent",
+                        },
+                      ],
+                    "etag": "BwWk8zJlg2o=",
+                  },
+              },
+            "response":
+              {
+                "etag": "BwWlp7rH6tY=",
+                "bindings":
+                  [
+                    {
+                      "members": ["user:user-two@gmail.com"],
+                      "role": "roles/appengine.serviceAdmin",
+                    },
+                    {
+                      "members":
+                        [
+                          "serviceAccount:service-951849100836@compute-system.iam.gserviceaccount.com",
+                        ],
+                      "role": "roles/compute.serviceAgent",
+                    },
+                    {
+                      "members":
+                        [
+                          "serviceAccount:951849100836-compute@developer.gserviceaccount.com",
+                          "serviceAccount:951849100836@cloudservices.gserviceaccount.com",
+                        ],
+                      "role": "roles/editor",
+                    },
+                    {
+                      "members": ["user:test@runpanther.com"],
+                      "role": "roles/owner",
+                    },
+                    {
+                      "role": "roles/pubsub.admin",
+                      "members": ["user:user-two@gmail.com"],
+                    },
+                    {
+                      "role": "roles/pubsub.subscriber",
+                      "members":
+                        [
+                          "serviceAccount:pubsub-reader@western-verve-123456.iam.gserviceaccount.com",
+                        ],
+                    },
+                    {
+                      "members":
+                        [
+                          "serviceAccount:pubsub-reader@western-verve-123456.iam.gserviceaccount.com",
+                        ],
+                      "role": "roles/pubsub.viewer",
+                    },
+                    {
+                      "members": ["user:test@runpanther.com"],
+                      "role": "roles/resourcemanager.organizationAdmin",
+                    },
+                    {
+                      "members":
+                        [
+                          "serviceAccount:service-951849100836@gcp-sa-logging.iam.gserviceaccount.com",
+                        ],
+                      "role": "roles/logging.ServiceAgent",
+                    },
+                  ],
+                "@type": "type.googleapis.com/google.iam.v1.Policy",
+              },
+          },
+        "insertId": "mrbji0dal80",
+        "resource":
+          {
+            "type": "project",
+            "labels": { "project_id": "western-verve-123456" },
+          },
+        "timestamp": "2020-05-15T03:51:35.019Z",
+        "severity": "NOTICE",
+        "logName": "projects/western-verve-123456/logs/cloudaudit.googleapis.com%2Factivity",
+        "receiveTimestamp": "2020-05-15T03:51:35.977314225Z",
+      }


### PR DESCRIPTION
### Background

Fixes the `GCP.IAM.CorporateEmail` rule to not break when GCP services make changes. [See this PR for more info.](https://github.com/panther-labs/panther-analysis/pull/1573)

### Changes

- add additional filtering for new binding members

### Testing

- added a new unit test
