### PR TITLE
Add dbprint placeholder function

### DIFF
--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -3,7 +3,9 @@
 
 # pylint: disable=C0302 (too-many-lines)
 
+import contextlib
 import datetime
+import io
 import os
 import secrets
 import string
@@ -1286,6 +1288,15 @@ class TestGeoInfoFromIP(unittest.TestCase):
             exc.exception.args[0],
             "IPInfo is not configured on the provided match_field: fake_field",
         )
+
+
+class TestDbprint(unittest.TestCase):
+    def test_dbprint(self):
+        """Assert that dbprint doesn't print anything to stdout."""
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            p_b_h.dbprint("test")
+        self.assertEqual(buffer.getvalue(), "")
 
 
 class TestDeepGet(unittest.TestCase):

--- a/global_helpers/panther_base_helpers.py
+++ b/global_helpers/panther_base_helpers.py
@@ -352,3 +352,10 @@ def pantherflow_investigation(event, interval="30m"):
     query += "| sort p_event_time"
 
     return query
+
+
+def dbprint(*values: object, sep: str = " ", end: str = "\n"):  # pylint: disable=unused-argument
+    """This is a placeholder function for printing to stdout when using pat debug. The debugging
+    comamnd will patch this to `print`. We introduce this function so users can print potentially
+    sensitive fields when debugging unit tests, and not worry about it being logged when Panther
+    the rule on production logs."""


### PR DESCRIPTION
### Background

PAT's upcoming `debug` feature allows rule output to be displayed in the console. It's been mentioned that customers may use this to print the values of some fields which may contain sensitive information in production logs, and forget to remove those statements before upload, causing that information to be logged during rule evaluation. To prevent this, I've added a placeholder `dbprint` function. It does nothing by default, but will be patched by PAT during debugging to behave like `print`. In essence, this function will only work during debugging, and will do nothing during real rule evaluation, eliminating the risk that users could inadvertently log sensitive info.

### Changes

- add new `dbprint` function to `panther_base_helpers`
- added unit test

### Testing

- confirmed the function doesn't do anything
