### PR TITLE
Schema fix for managed LUTs

### DIFF
--- a/.vscode/schemas/lookup_table.json
+++ b/.vscode/schemas/lookup_table.json
@@ -43,6 +43,25 @@
         }
       ]
     },
+    "Refresh": {
+      "type": "object",
+      "properties": {
+        "RoleARN": {
+          "type": "string"
+        },
+        "ObjectPath": {
+          "type": "string"
+        },
+        "PeriodMinutes": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "RoleARN",
+        "ObjectPath",
+        "PeriodMinutes"
+      ]
+    },
     "Schema": {
       "type": "string"
     },
@@ -82,7 +101,6 @@
     "AnalysisType",
     "LookupName",
     "Enabled",
-    "Filename",
     "Schema",
     "LogTypeMap"
   ],


### PR DESCRIPTION
### Background

VScode schemas were failing on managed LUTs with Refresh settings.

### Changes

- added Refresh field
- made Filename optional

### Testing

- VScode approves of managed LUT files now
