### PR TITLE
Add PantherEvent type hints

### DIFF
--- a/global_helpers/panther_type_hints.py
+++ b/global_helpers/panther_type_hints.py
@@ -1,0 +1,5 @@
+# Import some types for type hinting
+from panther_core import PantherEvent
+from panther_core.immutable import ImmutableCaseInsensitiveDict, ImmutableList
+
+__all__ = ["PantherEvent", "ImmutableCaseInsensitiveDict", "ImmutableList"]

--- a/global_helpers/panther_type_hints.yml
+++ b/global_helpers/panther_type_hints.yml
@@ -1,0 +1,5 @@
+AnalysisType: global
+Filename: panther_type_hints.py
+GlobalID: "panther_type_hints"
+Description: >
+  Used to define global type hints for Panther events and other Panther-specific data types


### PR DESCRIPTION
### Background

Some people really like type hints (myself included) since IDEs can provide autocompletion for specific functions and helpful tooltips. If you wanted type hints for Panther-specific data types, you had to import them from `panther_core`, which the majority of our users don't know enough about to know where to import the types from. This PR brings those types into a helper module, making them more accessible.

### Changes

- Adding `PantherEvent`, `ImmutableCaseInsensitiveDict`, and `ImmutableList` as importable types for type hinting

### Testing

- I have type hints, it works
