### PR TITLE
add email config to query schema

### DIFF
--- a/.vscode/schemas/query.json
+++ b/.vscode/schemas/query.json
@@ -58,6 +58,24 @@
           "type": "integer"
         }
       }
+    },
+    "EmailConfig": {
+      "properties": {
+        "PreferAttachment": {
+          "type": "boolean"
+        },
+        "Recipients": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "SendEmpty": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     }
   },
   "allOf": [


### PR DESCRIPTION
### Background

new email config property should not show errors in IDEs

<High level overview here>

### Changes

- updated schema file for queries

### Testing

tested before:

<img width="916" height="642" alt="Screenshot 2025-09-12 at 9 47 36 AM" src="https://github.com/user-attachments/assets/c8079292-7a3b-485f-8afb-34cbfa900df4" />

after:

<img width="1040" height="691" alt="Screenshot 2025-09-12 at 9 49 58 AM" src="https://github.com/user-attachments/assets/20204a0f-2b95-4e26-90b6-8e753c8c0626" />

