### PR TITLE
Add 1Password SDK to allowed clients for OnePassword.Unusual.Client

### DIFF
--- a/rules/onepassword_rules/onepassword_unusual_client.py
+++ b/rules/onepassword_rules/onepassword_unusual_client.py
@@ -21,6 +21,7 @@ def rule(event):
         "1Password Browser Extension",
         "1Password for Android",
         "1Password for Linux",
+        "1Password SDK",
     ]
 
     return event.deep_get("client", "app_name") not in client_allowlist


### PR DESCRIPTION
### Background

The `client_allowlist` variable already excludes some client names but since we get lots of "1Password SDK" alerts, I wanted to add this one to the list as well.

### Changes

- Just added a client name: 1Password SDK
