### PR TITLE
Switch Version Tags to Hashes for GHA workflows

### DIFF
--- a/.github/workflows/check-packs.yml
+++ b/.github/workflows/check-packs.yml
@@ -42,7 +42,7 @@ jobs:
           exit $(panther_analysis_tool check-packs)
 
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b #v3.0.1
         if: failure()
         with:
           mode: upsert
@@ -55,7 +55,7 @@ jobs:
           comment-tag: check-packs
 
       - name: Delete comment
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b #v3.0.1
         if: success()
         with:
           mode: delete

--- a/.github/workflows/generate-indexes.yml
+++ b/.github/workflows/generate-indexes.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: pip3 install -r ./.scripts/requirements.txt
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec #v6.3.0
         with:
           gpg_private_key: ${{ secrets.PANTHER_BOT_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PANTHER_BOT_GPG_PRIVATE_KEY_PASSPHRASE }}

--- a/.github/workflows/invisible-characters.yml
+++ b/.github/workflows/invisible-characters.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c #v6.0.0
         with:
           python-version: '3.12'
       - name: Test Invisible Characters
@@ -61,7 +61,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c #v6.0.0
         with:
           python-version: '3.12'
 

--- a/packs/gsuite_reports.yml
+++ b/packs/gsuite_reports.yml
@@ -12,7 +12,6 @@ PackDefinition:
     - GSuite.AdvancedProtection
     - GSuite.CalendarMadePublic
     - GSuite.Drive.Many.Documents.Deleted
-    - Google.Drive.High.Download.Count
     - GSuite.GoogleAccess
     - GSuite.GovernmentBackedAttack
     - GSuite.GroupBannedUser


### PR DESCRIPTION
### Background

5 steps were using tagged versions instead of hashes for action imports (e.g. @v5.0 instead of @hash), given recent supply chain attacks figured it's worth using hashes, especially for third party imports

Also removed a deprecated gsuite rule from a pack definition

### Changes

- `thollander/actions-comment-pull-request@v3` pinned to hash for `v3.0.1`
- `actions/setup-python@v6` pinned to hash for `v6.0.0`
- `crazy-max/ghaction-import-gpg@v6` pinned to hash for `v6.3.0`

Deprecated `Google.Drive.High.Download.Count` removed from gsuite reports pack.

### Testing

Not sure how to test the GHA's. I guess I can run them from this branch w/ `workflow_dispatch`.

- [ ] Manual Test of `.github/workflows/check-packs.yml`
- [ ] Manual Test of `.github/workflows/generate-indexes.yml`
- [ ] Manual Test of `.github/workflows/invisible-characters.yml`
