### PR TITLE
Impossible travel IP logic check

### DIFF
--- a/rules/standard_rules/impossible_travel_login.py
+++ b/rules/standard_rules/impossible_travel_login.py
@@ -169,8 +169,13 @@ def rule(event):
     EVENT_CITY_TRACKING["speed_units"] = "km/h"
     EVENT_CITY_TRACKING["distance"] = int(distance)
     EVENT_CITY_TRACKING["distance_units"] = "km"
-
-    return speed > 900  # Boeing 747 cruising speed
+    old_ip = deep_get(EVENT_CITY_TRACKING, "previous", "source_ip", default="<NO_PREV_IP>")
+    new_ip = deep_get(EVENT_CITY_TRACKING, "current", "source_ip", default="<NO_NEW_IP>")
+    if old_ip == new_ip:
+        # Same IP address, no alert
+        return False
+    else:
+        return speed > 900  # Boeing 747 cruising speed
 
 
 def title(event):
@@ -180,10 +185,12 @@ def title(event):
     new_city = deep_get(EVENT_CITY_TRACKING, "current", "city", default="<NO_PREV_CITY>")
     speed = deep_get(EVENT_CITY_TRACKING, "speed", default="<NO_SPEED>")
     distance = deep_get(EVENT_CITY_TRACKING, "distance", default="<NO_DISTANCE>")
+    old_ip = deep_get(EVENT_CITY_TRACKING, "previous", "source_ip", default="<NO_PREV_IP>")
+    new_ip = deep_get(EVENT_CITY_TRACKING, "current", "source_ip", default="<NO_NEW_IP>")
     return (
         f"Impossible Travel: [{event.udm('actor_user')}] "
         f"in [{log_source}] went [{speed}] km/h for [{distance}] km "
-        f"between [{old_city}] and [{new_city}]"
+        f"between [{old_city}/{old_ip}] and [{new_city}/{new_ip}]"
     )
 
 

--- a/rules/standard_rules/impossible_travel_login.py
+++ b/rules/standard_rules/impossible_travel_login.py
@@ -174,8 +174,7 @@ def rule(event):
     if old_ip == new_ip:
         # Same IP address, no alert
         return False
-    else:
-        return speed > 900  # Boeing 747 cruising speed
+    return speed > 900  # Boeing 747 cruising speed
 
 
 def title(event):

--- a/rules/standard_rules/impossible_travel_login.py
+++ b/rules/standard_rules/impossible_travel_login.py
@@ -169,7 +169,9 @@ def rule(event):
     EVENT_CITY_TRACKING["speed_units"] = "km/h"
     EVENT_CITY_TRACKING["distance"] = int(distance)
     EVENT_CITY_TRACKING["distance_units"] = "km"
-    if deep_get(EVENT_CITY_TRACKING, "previous", "source_ip", default="<NO_PREV_IP>") == deep_get(EVENT_CITY_TRACKING, "current", "source_ip", default="<NO_NEW_IP>"):
+    if deep_get(EVENT_CITY_TRACKING, "previous", "source_ip", default="<NO_PREV_IP>") == deep_get(
+        EVENT_CITY_TRACKING, "current", "source_ip", default="<NO_NEW_IP>"
+    ):
         # Same IP address, no alert
         return False
     return speed > 900  # Boeing 747 cruising speed

--- a/rules/standard_rules/impossible_travel_login.py
+++ b/rules/standard_rules/impossible_travel_login.py
@@ -169,9 +169,7 @@ def rule(event):
     EVENT_CITY_TRACKING["speed_units"] = "km/h"
     EVENT_CITY_TRACKING["distance"] = int(distance)
     EVENT_CITY_TRACKING["distance_units"] = "km"
-    old_ip = deep_get(EVENT_CITY_TRACKING, "previous", "source_ip", default="<NO_PREV_IP>")
-    new_ip = deep_get(EVENT_CITY_TRACKING, "current", "source_ip", default="<NO_NEW_IP>")
-    if old_ip == new_ip:
+    if deep_get(EVENT_CITY_TRACKING, "previous", "source_ip", default="<NO_PREV_IP>") == deep_get(EVENT_CITY_TRACKING, "current", "source_ip", default="<NO_NEW_IP>"):
         # Same IP address, no alert
         return False
     return speed > 900  # Boeing 747 cruising speed

--- a/rules/standard_rules/impossible_travel_login.yml
+++ b/rules/standard_rules/impossible_travel_login.yml
@@ -693,12 +693,12 @@ Tests:
           [
             {
               "p_event_time": "2023-10-03T18:26:01.951000",
-              "source_ip": "192.168.100.100",
+              "source_ip": "192.168.100.101",
               "city": "Minas Tirith",
               "country": "Gondor",
               "lat": "0.00000",
               "lng": "0.00000",
-              "p_match": "192.168.100.100",
+              "p_match": "192.168.100.101",
               "postal_code": "55555",
               "region": "Pellenor",
               "region_code": "PL",


### PR DESCRIPTION
Adds a check for matching IPs in the standard impossible travel detection - failure to check caused false positives when the geolocation information was changed within the caching period. Required updating the Notion test case because the IPs matched. Also added the IPs to the title for response QOL - helps with at-a-glance identification of common IPs within the environment as well as AWS, MS, etc. Used EVENT_CITY_TRACKING in the rule detection for consistency with the title IP lookup.