### PR TITLE
Auth0 rule correction and new rules

### DIFF
--- a/queries/auth0_queries/auth0_brute_force.yml
+++ b/queries/auth0_queries/auth0_brute_force.yml
@@ -1,0 +1,17 @@
+AnalysisType: scheduled_query
+QueryName: Auth0 Brute Force Detection
+Enabled: true
+# run every hour and look for >= 5 incidents in the last hour
+Query: |
+  SELECT
+   data, COUNT(*) OVER () AS total_incidents
+  FROM
+   panther_logs.public.auth0_events
+  WHERE
+   data:type IN ('limit_mu', 'limit_sul', 'limit_wc')
+   AND p_occurs_since('1 hour')
+  QUALIFY COUNT(*) OVER () > 4
+
+Schedule:
+  CronExpression: '0 * * * *'
+  TimeoutMinutes: 1

--- a/rules/auth0_rules/auth0_cic_credential_stuffing.py
+++ b/rules/auth0_rules/auth0_cic_credential_stuffing.py
@@ -3,7 +3,6 @@ from panther_auth0_helpers import auth0_alert_context
 SUSPICIOUS_EVENT_TYPES = (
     "scoa",
     "fcoa",
-    "pwd_leak",
 )
 
 

--- a/rules/auth0_rules/auth0_cic_credential_stuffing.yml
+++ b/rules/auth0_rules/auth0_cic_credential_stuffing.yml
@@ -4,7 +4,7 @@ LogTypes:
 RuleID: "Auth0.CIC.Credential.Stuffing"
 Filename: auth0_cic_credential_stuffing.py
 DisplayName: "Auth0 CIC Credential Stuffing"
-Description: Okta has determined that the cross-origin authentication feature in Customer Identity Cloud (CIC) is prone to being targeted by threat actors orchestrating credential-stuffing attacks.  Okta has observed suspicious activity that started on April 15, 2024.  Review tenant logs for unexpected fcoa, scoa, and pwd_leak events.
+Description: Okta has determined that the cross-origin authentication feature in Customer Identity Cloud (CIC) is prone to being targeted by threat actors orchestrating credential-stuffing attacks.  Okta has observed suspicious activity that started on April 15, 2024.  Review tenant logs for unexpected fcoa and scoa events.
 Enabled: true
 Severity: High
 Runbook: If a user password was compromised in a credential stuffing attack, the user's credentials should be rotated immediately out of an abundance of caution.
@@ -14,216 +14,51 @@ Threshold: 1
 Tests:
   - ExpectedResult: true
     Log:
+      log_id: "90020241029185251974499000000000000001223372087732751235"
       data:
-        client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
-        client_name: ""
-        date: "2023-05-23 20:47:51.149000000"
-        description: Someone behind the IP address ip attempted to login with a leaked password.
+        audience: "https://shared.app-api.clientdomain.com"
+        client_id: "EmEDkk1wKV0bmzZut3rbEC5vxBE6UiZV"
+        client_name: "App Frontend"
+        connection: "Username-Password-Authentication"
+        connection_id: "con_BvGURiLLdngYaT0D"
+        date: "2024-10-29 18:52:51.953000000"
+        description: "Unable to configure verification page."
         details:
-          request:
-            auth:
-              credentials:
-                jti: e6343ec1d24a41e6bd43a6be748cac11
-              strategy: jwt
-              user:
-                email: homer.simpson@yourcompany.com
-                name: Homer Simpson
-                user_id: google-oauth2|105261262156475850461
-            body:
-              integration_id: 64bee519-818f-4473-ab08-7c380f28da77
-            channel: https://manage.auth0.com/
-            ip: 12.12.12.12
-            method: post
-            path: /api/v2/integrations/installed
-            query: {}
-            userAgent: >-
-              Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
-              (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36
-          response:
-            body:
-              integration_id: 64bee519-818f-4473-ab08-7c380f28da77
-            statusCode: 200
-        ip: 12.12.12.12
-        log_id: "90020230523204756343781000000000000001223372037583230452"
-        type: pwd_leak
-        user_agent: >-
-          Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
-          like Gecko) Chrome/113.0.0.0 Safari/537.36
-        user_id: google-oauth2|105261262156475850461
-      log_id: "90020230523204756343781000000000000001223372037583230452"
-    Name: Auth0 Credential Stuffing Event
-  - ExpectedResult: false
-    Log:
-      data:
-        client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
-        client_name: ""
-        date: "2023-05-23 20:47:51.149000000"
-        description: Install an available integration
-        details:
-          request:
-            auth:
-              credentials:
-                jti: 949869e066205b5076e6df203fdd7b9b
-                scopes:
-                  - create:actions
-                  - create:actions_log_sessions
-                  - create:authentication_methods
-                  - create:client_credentials
-                  - create:client_grants
-                  - create:clients
-                  - create:connections
-                  - create:custom_domains
-                  - create:email_provider
-                  - create:email_templates
-                  - create:guardian_enrollment_tickets
-                  - create:integrations
-                  - create:log_streams
-                  - create:organization_connections
-                  - create:organization_invitations
-                  - create:organization_member_roles
-                  - create:organization_members
-                  - create:organizations
-                  - create:requested_scopes
-                  - create:resource_servers
-                  - create:roles
-                  - create:rules
-                  - create:shields
-                  - create:signing_keys
-                  - create:tenant_invitations
-                  - create:test_email_dispatch
-                  - create:users
-                  - delete:actions
-                  - delete:anomaly_blocks
-                  - delete:authentication_methods
-                  - delete:branding
-                  - delete:client_credentials
-                  - delete:client_grants
-                  - delete:clients
-                  - delete:connections
-                  - delete:custom_domains
-                  - delete:device_credentials
-                  - delete:email_provider
-                  - delete:email_templates
-                  - delete:grants
-                  - delete:guardian_enrollments
-                  - delete:integrations
-                  - delete:log_streams
-                  - delete:organization_connections
-                  - delete:organization_invitations
-                  - delete:organization_member_roles
-                  - delete:organization_members
-                  - delete:organizations
-                  - delete:owners
-                  - delete:requested_scopes
-                  - delete:resource_servers
-                  - delete:roles
-                  - delete:rules
-                  - delete:rules_configs
-                  - delete:shields
-                  - delete:tenant_invitations
-                  - delete:tenant_members
-                  - delete:tenants
-                  - delete:users
-                  - read:actions
-                  - read:anomaly_blocks
-                  - read:attack_protection
-                  - read:authentication_methods
-                  - read:branding
-                  - read:checks
-                  - read:client_credentials
-                  - read:client_grants
-                  - read:client_keys
-                  - read:clients
-                  - read:connections
-                  - read:custom_domains
-                  - read:device_credentials
-                  - read:email_provider
-                  - read:email_templates
-                  - read:email_triggers
-                  - read:entity_counts
-                  - read:grants
-                  - read:guardian_factors
-                  - read:insights
-                  - read:integrations
-                  - read:log_streams
-                  - read:logs
-                  - read:mfa_policies
-                  - read:organization_connections
-                  - read:organization_invitations
-                  - read:organization_member_roles
-                  - read:organization_members
-                  - read:organizations
-                  - read:prompts
-                  - read:requested_scopes
-                  - read:resource_servers
-                  - read:roles
-                  - read:rules
-                  - read:rules_configs
-                  - read:shields
-                  - read:signing_keys
-                  - read:stats
-                  - read:tenant_invitations
-                  - read:tenant_members
-                  - read:tenant_settings
-                  - read:triggers
-                  - read:users
-                  - run:checks
-                  - update:actions
-                  - update:attack_protection
-                  - update:authentication_methods
-                  - update:branding
-                  - update:client_credentials
-                  - update:client_grants
-                  - update:client_keys
-                  - update:clients
-                  - update:connections
-                  - update:custom_domains
-                  - update:email_provider
-                  - update:email_templates
-                  - update:email_triggers
-                  - update:guardian_factors
-                  - update:integrations
-                  - update:log_streams
-                  - update:mfa_policies
-                  - update:organization_connections
-                  - update:organizations
-                  - update:prompts
-                  - update:requested_scopes
-                  - update:resource_servers
-                  - update:roles
-                  - update:rules
-                  - update:rules_configs
-                  - update:shields
-                  - update:signing_keys
-                  - update:tenant_members
-                  - update:tenant_settings
-                  - update:triggers
-                  - update:users
-              strategy: jwt
-              user:
-                email: user.name@yourcompany.io
-                name: User Name
-                user_id: google-oauth2|105261262156475850461
-            body:
-              AfterAuthentication: false
-            channel: https://manage.auth0.com/
-            ip: 12.12.12.12
-            method: patch
-            path: /api/v2/risk-assessment/config
-            query: {}
-            userAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36
-          response:
-            body:
-              AfterAuthentication: false
-              BeforeLoginPrompt: false
-              BeforeLoginPromptMonitoring: false
-            statusCode: 200
-        ip: 12.12.12.12
-        log_id: "90020230523204756343781000000000000001223372037583230452"
-        type: sapi
-        user_agent: >-
-          Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
-          like Gecko) Chrome/113.0.0.0 Safari/537.36
-        user_id: google-oauth2|105261262156475850461
-      log_id: "90020230523204756343781000000000000001223372037583230452"
-    Name: Other Event
+          body: {}
+          connection: "Username-Password-Authentication"
+          error:
+            message: "Unable to configure verification page."
+            oauthError: "server_error"
+            type: "oauth-authorization"
+          qs:
+            _csrf: "TUReBWZ8-Fp9mvFrk6S3beuGrvKIkZVFfcKk"
+            _intstate: "deprecated"
+            audience: "https://shared.app-api.clientdomain.com"
+            auth0Client: "eyJuYW1lIjoibG9jay5qcyIsInZlcnNpb24iOiIxMi4nYjOnsiYXV0aDAuanMiOiI5LjI2LjAifX0="
+            client_id: "EmEDkk1wKV0bmzZut3rbE0C5vxBE6UiZV"
+            code_challenge: "oDe_o-4xT4_qdBvbbDiHPlVyoNKglqtNKqYrzcZt72M"
+            code_challenge_method: "S256"
+            connection: "Username-Password-Authentication"
+            login_hint: ""
+            login_ticket: "Uyqi3p1wDRZIWomeW3XxbjmSiBYNHzT8"
+            nonce: "eW9wRjRhTFpMNlYyNHNJT1NvRm1jUUl0sM2ZxYk80azZILjdSVnBMcy14cg=="
+            protocol: "oauth2"
+            realm: "Username-Password-Authentication"
+            redirect_uri: "https://redirect.app.clientdomain.com"
+            response_mode: "query"
+            response_type: "code"
+            scope: "openid profile email offline_access"
+            screen_hint: "login"
+            state: "hKFo2SBPSW1RRnlhcjhxUVJZLUVwNzI0SzVjM3ItT10E4NXdMdKFupWxvZ2luo3RpZNkgdWtpQXVpakxnRlZ5Tm1ER2k4a0szTXZXLXNFSzQ5cFajY2lk2SBFbUVEa2sxd0tWMGJtelp1dDNyYkVDNXZ4QkU2VWlaVg"
+          session_id: "OJ0d2L-gDTvkmwEctP8d3XwtLD8Yu1qh"
+        hostname: "auth.clientdomain.com"
+        ip: "2605:59c8:3075:214:d003:e902:2b01:dc14"
+        log_id: "90020241029185251974499000000000000001223372087732751235"
+        scope:
+          - "openid"
+          - "profile"
+          - "email"
+          - "offline_access"
+        type: "fcoa"
+        user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"
+    Name: FCOA Event

--- a/rules/auth0_rules/auth0_leaked_password_login_attempt.py
+++ b/rules/auth0_rules/auth0_leaked_password_login_attempt.py
@@ -1,0 +1,13 @@
+from panther_core import PantherEvent
+
+
+def rule(event: PantherEvent) -> bool:
+    return event.deep_get("data", "type") == "pwd_leak"
+
+
+def title(event: PantherEvent) -> str:
+    ip_address = event.deep_get("data", "ip", default="NO_IP_FOUND")
+    user_name = event.deep_get("data", "user_name", default="NO_USERNAME")
+    event_title = "Someone behind the IP address {} attempted to login with a leaked password with username {}"
+    
+    return event_title.format(ip_address, user_name)

--- a/rules/auth0_rules/auth0_leaked_password_login_attempt.yml
+++ b/rules/auth0_rules/auth0_leaked_password_login_attempt.yml
@@ -1,0 +1,29 @@
+AnalysisType: rule
+Description: Detect Auth0 Leaked Password Login Attempt
+DisplayName: "Auth0 Leaked Password Login Attempt"
+Enabled: true
+Filename: auth0_leaked_password_login_attempt.py
+Severity: Medium
+DedupPeriodMinutes: 60
+Threshold: 1
+LogTypes:
+  - Auth0.Events
+RuleID: "Auth0.Leaked.Password.Login.Attempt"
+Tests:
+  - ExpectedResult: true
+    Log:
+      log_id: "90020251001053916537654000000000000001223372122475524001"
+      data:
+        date: "2025-10-01 05:39:16.467000000"
+        type: "pwd_leak"
+        description: "Someone behind the IP address: 2601:140:9702:ee80:0000:1f55:93a7:e970 attempted to login with a leaked password. A shield to prevent this action was enabled, further attempts are blocked."
+        connection: "Username-Password-Authentication"
+        connection_id: "con_BvGURiLLdngYaT0D"
+        client_id: "11Qpq1o8fbGgnZuFJnQCyjuC1ll8YFt0"
+        ip: "2601:140:9702:ee80:9049:1f55:0000:e970"
+        hostname: "auth.clientdomain.com"
+        user_id: ""
+        user_name: "geergo.michael@gmail.com"
+        log_id: "90020251001053916537654000000000000001223372122475524001"
+        user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+    Name: FCOA Event

--- a/rules/auth0_rules/auth0_limits.py
+++ b/rules/auth0_rules/auth0_limits.py
@@ -1,0 +1,51 @@
+from panther_core import PantherEvent
+
+SUSPICIOUS_EVENT_TYPES = (
+    "api_limit",
+    "gd_otp_rate_limit_exceed",
+    "gd_recovery_rate_limit_exceed",
+    "limit_delegation",
+    "limit_mu",
+    "limit_sul",
+    "limit_wc",
+)
+
+EVENT_TITLES = (
+    "The maximum number of requests to the Authentication or Management APIs has been reached for {}",
+    "Too many MFA failures occured for {}",
+    "{} has entered a wrong recovery code too many times",
+    "Rate limit exceeded to the delegation token endpoint by {}",
+    "{} IP address is blocked because it attempted too many sign-ups or failed logins: {}",
+    "{} is temporarily blocked from logging in because they reached the maximum logins from {}",
+    "{} IP address is blocked because it reached the maximum failed login attempts into a single account: {}",
+)
+
+
+def rule(event: PantherEvent) -> bool:
+    return event.deep_get("data", "type") in SUSPICIOUS_EVENT_TYPES
+
+
+def title(event: PantherEvent) -> str:
+    limit_mu_index = SUSPICIOUS_EVENT_TYPES.index("limit_mu")
+    limit_sul_index = SUSPICIOUS_EVENT_TYPES.index("limit_sul")
+    limit_wc_index = SUSPICIOUS_EVENT_TYPES.index("limit_wc")
+
+    event_type = event.deep_get("data", "type")
+    event_index = SUSPICIOUS_EVENT_TYPES.index(event_type)
+    event_title = EVENT_TITLES[event_index]
+
+    # limit_mu or limit_wc
+    if event_index in {limit_mu_index, limit_wc_index}:
+        ip_address = event.deep_get("data", "ip", default="NO_IP_FOUND")
+        username = event.deep_get("data", "user_name", default="NO_USER_FOUND")
+        return event_title.format(ip_address, username)
+
+    # limit_sul
+    if event_index == limit_sul_index:
+        ip_address = event.deep_get("data", "ip", default="NO_IP_FOUND")
+        username = event.deep_get("data", "user_name", default="NO_USER_FOUND")
+        return event_title.format(username, ip_address)
+
+    # other cases have only "user_name" field in their titles
+    username = event.deep_get("data", "user_name", default="NO_USER_FOUND")
+    return event_title.format(username)

--- a/rules/auth0_rules/auth0_limits.yml
+++ b/rules/auth0_rules/auth0_limits.yml
@@ -1,0 +1,29 @@
+AnalysisType: rule
+Description: Detect Auth0 Limit Logs
+DisplayName: "Auth0 Limit Detections"
+Enabled: true
+Filename: intrusionops_auth0_limits.py
+Severity: Medium
+DedupPeriodMinutes: 60
+Threshold: 1
+LogTypes:
+  - Auth0.Events
+RuleID: "Auth0.Limits"
+Tests:
+  - ExpectedResult: true
+    Log:
+      log_id: "90020250930212349746493000000000000001223372122436618809"
+      data:
+        date: "2025-09-30 21:23:49.689000000"
+        type: "limit_wc"
+        description: "User (dhruv@ncaatinaction.com) attempted 10 consecutive logins unsuccessfully. Brute force protection is enabled for this connection, further attempts are blocked from this IP address for this user."
+        connection: "Username-Password-Authentication"
+        connection_id: "con_BvGURiLLdngYaT0D"
+        client_id: "11Qpq1o8fbGgnZuFJnQCyjuC1ll8YFt0"
+        ip: "49.23.45.198"
+        hostname: "auth.clientdomain.com"
+        user_id: ""
+        user_name: "dhruv@ncaatinaction.com"
+        log_id: "90020250930212349746493000000000000001223372122436618809"
+        user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+    Name: Limit WC Event

--- a/rules/auth0_rules/auth0_login_brute_force.py
+++ b/rules/auth0_rules/auth0_login_brute_force.py
@@ -1,0 +1,10 @@
+from panther_core import PantherEvent
+
+
+def rule(event: PantherEvent) -> bool:  # noqa: ARG001
+    return True
+
+
+def title(event: PantherEvent) -> str:
+    total_incidents = event.get("total_incidents", 5)
+    return f"Auth0 Brute Force detected: {total_incidents} attempts in the past hour"

--- a/rules/auth0_rules/auth0_login_brute_force.yml
+++ b/rules/auth0_rules/auth0_login_brute_force.yml
@@ -1,0 +1,14 @@
+AnalysisType: scheduled_rule
+Filename: auth0_brute_force.py
+DisplayName: "Auth0 Brute Force"
+Enabled: true
+Severity: Medium
+Description: Scheduled rule for brute force detection for Auth0 login or signup which looks for incidents of more than 10 incidents in one hour
+DedupPeriodMinutes: 60
+Threshold: 1
+Reference: https://auth0.com/docs/deploy-monitor/logs/log-event-type-codes
+InlineFilters:
+    - All: []
+ScheduledQueries:
+    - Auth0 Brute Force Detection
+RuleID: "Auth0.Brute.Force"


### PR DESCRIPTION
### Changes

The `Auth0.CIC.Credential.Stuffing` rule handles `scoa`, `fcoa` and `pwd_leak` incidents. The `pwd_leak` incidents' logs are different than the other two. So I created a new rule to `pwd_leak` separately. 

Also we decided to make our auth0 rules public. I added two rules and one scheduled rule with its query. We are using these rules for a long time and they work fine. I can give you more info if it's needed