### PR TITLE
Auth0 New rules

### DIFF
--- a/indexes/alpha-index.md
+++ b/indexes/alpha-index.md
@@ -768,6 +768,10 @@
 
 ## Auth0
 
+- [Auth0 Attack Protection Monitoring Disabled](../rules/auth0_rules/auth0_attack_protection_disabled.yml)
+  - An attack protection monitoring configuration was changed.
+- [Auth0 Bot Detection Policy Disabled](../rules/auth0_rules/auth0_bot_detection_disabled.yml)
+  - A bot detection policy was disabled.
 - [Auth0 CIC Credential Stuffing](../rules/auth0_rules/auth0_cic_credential_stuffing.yml)
   - Okta has determined that the cross-origin authentication feature in Customer Identity Cloud (CIC) is prone to being targeted by threat actors orchestrating credential-stuffing attacks.  Okta has observed suspicious activity that started on April 15, 2024.  Review tenant logs for unexpected fcoa, scoa, and pwd_leak events.
 - [Auth0 CIC Credential Stuffing Query](../queries/auth0_queries/auth0_cic_credential_stuffing_query.yml)
@@ -788,6 +792,10 @@
   - An Auth0 User enabled the mfa risk assessment setting for your organization's tenant.
 - [Auth0 Post Login Action Flow Updated](../rules/auth0_rules/auth0_post_login_action_flow.yml)
   - An Auth0 User updated a post login action flow for your organization's tenant.
+- [Auth0 Push Notification Fatigue](../rules/auth0_rules/auth0_push_notification_fatigue.yml)
+  - Push notifications threshold exceeded for a user. It may indicate a push notification fatigue attempt.
+- [Auth0 Refresh Token Reused](../rules/auth0_rules/auth0_token_reuse.yml)
+  - A refresh token was reused.
 - [Auth0 User Invitation Created](../rules/auth0_rules/auth0_user_invitation_created.yml)
 - [Auth0 User Joined Tenant](../rules/auth0_rules/auth0_user_joined_tenant.yml)
   - User accepted invitation from Auth0 member to join an Auth0 tenant.
@@ -799,8 +807,8 @@
   - Detects an Axonius API Key Reset
 - [Axonius External User Added](../rules/axonius_rules/axonius_add_external_user.yml)
   - Detects when an external user is added in Axonius
-- [Axonius login from Tor IP](../rules/axonius_rules/axonius_tor_login.yml)
-  - Detects an Axonius login from Tor IP address
+- [Axonius login from Tor IP](../rules/axonius_rules/axonius_too_many_failed_logins.yml)
+  - Detects an Axonius login from a malicious IP address
 - [Axonius Webhook Created](../rules/axonius_rules/axonius_webhook_created.yml)
   - Detects when an Axonius Webhook is Created
 

--- a/indexes/detection-coverage.json
+++ b/indexes/detection-coverage.json
@@ -325,6 +325,24 @@
     },
     {
         "AnalysisType": "Rule",
+        "Description": "An attack protection monitoring configuration was changed.",
+        "DisplayName": "Auth0 Attack Protection Monitoring Disabled",
+        "LogTypes": [
+            "Auth0.Events"
+        ],
+        "YAMLPath": "rules/auth0_rules/auth0_attack_protection_disabled.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "A bot detection policy was disabled.",
+        "DisplayName": "Auth0 Bot Detection Policy Disabled",
+        "LogTypes": [
+            "Auth0.Events"
+        ],
+        "YAMLPath": "rules/auth0_rules/auth0_bot_detection_disabled.yml"
+    },
+    {
+        "AnalysisType": "Rule",
         "Description": "Okta has determined that the cross-origin authentication feature in Customer Identity Cloud (CIC) is prone to being targeted by threat actors orchestrating credential-stuffing attacks.  Okta has observed suspicious activity that started on April 15, 2024.  Review tenant logs for unexpected fcoa, scoa, and pwd_leak events.",
         "DisplayName": "Auth0 CIC Credential Stuffing",
         "LogTypes": [
@@ -412,6 +430,24 @@
             "Auth0.Events"
         ],
         "YAMLPath": "rules/auth0_rules/auth0_post_login_action_flow.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "Push notifications threshold exceeded for a user. It may indicate a push notification fatigue attempt.",
+        "DisplayName": "Auth0 Push Notification Fatigue",
+        "LogTypes": [
+            "Auth0.Events"
+        ],
+        "YAMLPath": "rules/auth0_rules/auth0_push_notification_fatigue.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "A refresh token was reused.",
+        "DisplayName": "Auth0 Refresh Token Reused",
+        "LogTypes": [
+            "Auth0.Events"
+        ],
+        "YAMLPath": "rules/auth0_rules/auth0_token_reuse.yml"
     },
     {
         "AnalysisType": "Rule",
@@ -2280,12 +2316,12 @@
     },
     {
         "AnalysisType": "Rule",
-        "Description": "Detects an Axonius login from Tor IP address",
+        "Description": "Detects an Axonius login from a malicious IP address",
         "DisplayName": "Axonius login from Tor IP",
         "LogTypes": [
             "Axonius.Activity"
         ],
-        "YAMLPath": "rules/axonius_rules/axonius_tor_login.yml"
+        "YAMLPath": "rules/axonius_rules/axonius_too_many_failed_logins.yml"
     },
     {
         "AnalysisType": "Rule",

--- a/rules/auth0_rules/auth0_attack_protection_disabled.py
+++ b/rules/auth0_rules/auth0_attack_protection_disabled.py
@@ -1,0 +1,79 @@
+from panther_auth0_helpers import auth0_alert_context, is_auth0_config_event
+
+
+def rule(event):
+
+    data_type = event.deep_get("data", "type", default="<NO_DATA_TYPE_FOUND>")
+
+    data_description = event.deep_get("data", "description", default="<NO_DATA_DESCRIPTION_FOUND>")
+
+    request_path = event.deep_get(
+        "data", "details", "request", "path", default="<NO_REQUEST_PATH_FOUND>"
+    )
+
+    response_body_enabled = event.deep_get(
+        "data", "details", "response", "body", "enabled", default="<NO_ENABLED_INFO_FOUND>"
+    )
+
+    response_body_shields = event.deep_get(
+        "data", "details", "response", "body", "shields", default="<NO_SHIELD_INFO_FOUND>"
+    )
+
+    response_status_code = event.deep_get(
+        "data", "details", "response", "statusCode", default="<NO_RESPONSE_CODE_FOUND>"
+    )
+
+    return all(
+        [
+            data_type == "sapi",
+            (
+                (
+                    "Suspicious IP Throttling" in data_description
+                    and request_path == "/v2/attack-protection/suspicious-ip-throttling"
+                )
+                or (
+                    "Brute-force" in data_description
+                    and request_path == "/v2/attack-protection/brute-force-protection"
+                )
+                or (
+                    "Breached Password Detection" in data_description
+                    and request_path == "/v2/attack-protection/breached-password-detection"
+                )
+            ),
+            (
+                (response_body_enabled is False or response_body_enabled == "disabled")
+                or (
+                    (response_body_enabled is True or response_body_enabled == "enabled")
+                    and response_body_shields != "block"
+                )
+            ),
+            response_status_code == 200,
+            is_auth0_config_event(event),
+        ]
+    )
+
+
+def title(event):
+    user = event.deep_get(
+        "data", "details", "request", "auth", "user", "email", default="<NO_USER_FOUND>"
+    )
+    data_description = event.deep_get("data", "description", default="<NO_DATA_DESCRIPTION_FOUND>")
+
+    response_body_enabled = event.deep_get(
+        "data", "details", "response", "body", "enabled", default="<NO_ENABLED_INFO_FOUND>"
+    )
+
+    response_body_shields = event.deep_get(
+        "data", "details", "response", "body", "shields", default="<NO_SHIELD_INFO_FOUND>"
+    )
+    p_source_label = event.get("p_source_label", "<NO_P_SOURCE_LABEL_FOUND>")
+    return (
+        f"Auth0 User [{user}] updated shields to [{response_body_shields}]"
+        f"or set attack protection monitoring to [{response_body_enabled}]"
+        f"with message [{data_description}] in"
+        f"your organization's tenant [{p_source_label}]."
+    )
+
+
+def alert_context(event):
+    return auth0_alert_context(event)

--- a/rules/auth0_rules/auth0_attack_protection_disabled.yml
+++ b/rules/auth0_rules/auth0_attack_protection_disabled.yml
@@ -1,0 +1,436 @@
+AnalysisType: rule
+Description: An attack protection monitoring configuration was changed.
+DisplayName: "Auth0 Attack Protection Monitoring Disabled"
+Enabled: true
+Filename: auth0_attack_protection_disabled.py
+Runbook: Assess if this was done by the user for a valid business reason. Be vigilant to re-enable this setting as it's in the best security interest for your organization's security posture.
+Reference: https://github.com/auth0/auth0-customer-detections/tree/main/detections
+Severity: High
+Tests:
+
+# IP Throttling
+
+  - ExpectedResult: true
+    Log:
+      data:
+        client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+        client_name: ""
+        date: "2025-10-03 14:09:32.149000000"
+        description: "Update Suspicious IP Throttling settings"
+        details:
+          request:
+            auth:
+              credentials:
+                jti: 0000000000ecaf1bfbadb06900d22049
+              strategy: jwt
+              user:
+                email: denethor@lotr.com
+                name: Homer Simpson
+                user_id: google-oauth2|105261262156475850461
+            body:
+              enabled: true
+            channel: https://manage.auth0.com/
+            ip: 12.12.12.12
+            method: post
+            path: /v2/attack-protection/suspicious-ip-throttling
+            query: {}
+            userAgent: >-
+              Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+              (KHTML, like Gecko) Chrome/1.2.3.4 Safari/537.36
+          response:
+            body:
+              enabled: false
+            statusCode: 200
+        ip: 12.12.12.12
+        log_id: "90020230523204756343781000000000000001223372037583230452"
+        type: sapi
+        user_agent: >-
+          Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+          like Gecko) Chrome/1.2.3.4 Safari/537.36
+        user_id: google-oauth2|105261262156475850461
+      log_id: "90020230523204756343781000000000000001223372037583230452"
+      p_any_ip_addresses:
+        - 12.12.12.12
+      p_any_usernames:
+        - google-oauth2|105261262156475850461
+      p_event_time: "2023-05-23 20:47:51.149"
+      p_log_type: Auth0.Events
+      p_parse_time: "2023-05-23 20:49:28.671"
+      p_row_id: 00000000004a745ce33b57be383c543e
+      p_schema_version: 0
+      p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+      p_source_label: Org Auth0 Tenant Label
+    Name: Auth0 IP Throttling Disabled
+  - ExpectedResult: false
+    Log:
+      data:
+        client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+        client_name: ""
+        date: "2025-10-03 14:09:32.149000000"
+        description: "Update Suspicious IP Throttling settings"
+        details:
+          request:
+            auth:
+              credentials:
+                jti: 0000000000ecaf1bfbadb06900d22049
+              strategy: jwt
+              user:
+                email: denethor@lotr.com
+                name: Homer Simpson
+                user_id: google-oauth2|105261262156475850461
+            body:
+              enabled: true
+            channel: https://manage.auth0.com/
+            ip: 12.12.12.12
+            method: post
+            path: /v2/attack-protection/suspicious-ip-throttling
+            query: {}
+            userAgent: >-
+              Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+              (KHTML, like Gecko) Chrome/1.2.3.4 Safari/537.36
+          response:
+            body:
+              enabled: true
+            statusCode: 400
+        ip: 12.12.12.12
+        log_id: "90020230523204756343781000000000000001223372037583230452"
+        type: sapi
+        user_agent: >-
+          Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+          like Gecko) Chrome/1.2.3.4 Safari/537.36
+        user_id: google-oauth2|105261262156475850461
+      log_id: "90020230523204756343781000000000000001223372037583230452"
+      p_any_ip_addresses:
+        - 12.12.12.12
+      p_any_usernames:
+        - google-oauth2|105261262156475850461
+      p_event_time: "2023-05-23 20:47:51.149"
+      p_log_type: Auth0.Events
+      p_parse_time: "2023-05-23 20:49:28.671"
+      p_row_id: 00000000004a745ce33b57be383c543e
+      p_schema_version: 0
+      p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+      p_source_label: Org Auth0 Tenant Label
+    Name: Failed IP Throttling Update Event
+
+# Breached Password
+
+  - ExpectedResult: true
+    Log:
+      data:
+        client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+        client_name: ""
+        date: "2025-10-03 14:09:32.149000000"
+        description: "Update Breached Password Detection settings"
+        details:
+          request:
+            auth:
+              credentials:
+                jti: 0000000000ecaf1bfbadb06900d22049
+              strategy: jwt
+              user:
+                email: denethor@lotr.com
+                name: Homer Simpson
+                user_id: google-oauth2|105261262156475850461
+            body:
+              enabled: true
+            channel: https://manage.auth0.com/
+            ip: 12.12.12.12
+            method: post
+            path: /v2/attack-protection/breached-password-detection
+            query: {}
+            userAgent: >-
+              Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+              (KHTML, like Gecko) Chrome/1.2.3.4 Safari/537.36
+          response:
+            body:
+              enabled: false
+            statusCode: 200
+        ip: 12.12.12.12
+        log_id: "90020230523204756343781000000000000001223372037583230452"
+        type: sapi
+        user_agent: >-
+          Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+          like Gecko) Chrome/1.2.3.4 Safari/537.36
+        user_id: google-oauth2|105261262156475850461
+      log_id: "90020230523204756343781000000000000001223372037583230452"
+      p_any_ip_addresses:
+        - 12.12.12.12
+      p_any_usernames:
+        - google-oauth2|105261262156475850461
+      p_event_time: "2023-05-23 20:47:51.149"
+      p_log_type: Auth0.Events
+      p_parse_time: "2023-05-23 20:49:28.671"
+      p_row_id: 00000000004a745ce33b57be383c543e
+      p_schema_version: 0
+      p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+      p_source_label: Org Auth0 Tenant Label
+    Name: Auth0 Breached Password Protection Disabled
+  - ExpectedResult: false
+    Log:
+      data:
+        client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+        client_name: ""
+        date: "2025-10-03 14:09:32.149000000"
+        description: "Update Breached Password Detection settings"
+        details:
+          request:
+            auth:
+              credentials:
+                jti: 0000000000ecaf1bfbadb06900d22049
+              strategy: jwt
+              user:
+                email: denethor@lotr.com
+                name: Homer Simpson
+                user_id: google-oauth2|105261262156475850461
+            body:
+              enabled: true
+            channel: https://manage.auth0.com/
+            ip: 12.12.12.12
+            method: post
+            path: /v2/attack-protection/breached-password-detection
+            query: {}
+            userAgent: >-
+              Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+              (KHTML, like Gecko) Chrome/1.2.3.4 Safari/537.36
+          response:
+            body:
+              enabled: true
+            statusCode: 400
+        ip: 12.12.12.12
+        log_id: "90020230523204756343781000000000000001223372037583230452"
+        type: sapi
+        user_agent: >-
+          Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+          like Gecko) Chrome/1.2.3.4 Safari/537.36
+        user_id: google-oauth2|105261262156475850461
+      log_id: "90020230523204756343781000000000000001223372037583230452"
+      p_any_ip_addresses:
+        - 12.12.12.12
+      p_any_usernames:
+        - google-oauth2|105261262156475850461
+      p_event_time: "2023-05-23 20:47:51.149"
+      p_log_type: Auth0.Events
+      p_parse_time: "2023-05-23 20:49:28.671"
+      p_row_id: 00000000004a745ce33b57be383c543e
+      p_schema_version: 0
+      p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+      p_source_label: Org Auth0 Tenant Label
+    Name: Failed Breached Password Update Event
+
+# Brute-Force
+
+  - ExpectedResult: true
+    Log:
+      data:
+        client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+        client_name: ""
+        date: "2025-10-03 14:09:32.149000000"
+        description: "Update Brute-force settings"
+        details:
+          request:
+            auth:
+              credentials:
+                jti: 0000000000ecaf1bfbadb06900d22049
+              strategy: jwt
+              user:
+                email: denethor@lotr.com
+                name: Homer Simpson
+                user_id: google-oauth2|105261262156475850461
+            body:
+              enabled: true
+            channel: https://manage.auth0.com/
+            ip: 12.12.12.12
+            method: post
+            path: /v2/attack-protection/brute-force-protection
+            query: {}
+            userAgent: >-
+              Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+              (KHTML, like Gecko) Chrome/1.2.3.4 Safari/537.36
+          response:
+            body:
+              enabled: false
+            statusCode: 200
+        ip: 12.12.12.12
+        log_id: "90020230523204756343781000000000000001223372037583230452"
+        type: sapi
+        user_agent: >-
+          Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+          like Gecko) Chrome/1.2.3.4 Safari/537.36
+        user_id: google-oauth2|105261262156475850461
+      log_id: "90020230523204756343781000000000000001223372037583230452"
+      p_any_ip_addresses:
+        - 12.12.12.12
+      p_any_usernames:
+        - google-oauth2|105261262156475850461
+      p_event_time: "2023-05-23 20:47:51.149"
+      p_log_type: Auth0.Events
+      p_parse_time: "2023-05-23 20:49:28.671"
+      p_row_id: 00000000004a745ce33b57be383c543e
+      p_schema_version: 0
+      p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+      p_source_label: Org Auth0 Tenant Label
+    Name: Auth0 Brute-Force Monitoring Disabled
+  - ExpectedResult: false
+    Log:
+      data:
+        client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+        client_name: ""
+        date: "2025-10-03 14:09:32.149000000"
+        description: "Update Brute-force settings"
+        details:
+          request:
+            auth:
+              credentials:
+                jti: 0000000000ecaf1bfbadb06900d22049
+              strategy: jwt
+              user:
+                email: denethor@lotr.com
+                name: Homer Simpson
+                user_id: google-oauth2|105261262156475850461
+            body:
+              enabled: true
+            channel: https://manage.auth0.com/
+            ip: 12.12.12.12
+            method: post
+            path: /v2/attack-protection/brute-force-protection
+            query: {}
+            userAgent: >-
+              Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+              (KHTML, like Gecko) Chrome/1.2.3.4 Safari/537.36
+          response:
+            body:
+              enabled: true
+            statusCode: 400
+        ip: 12.12.12.12
+        log_id: "90020230523204756343781000000000000001223372037583230452"
+        type: sapi
+        user_agent: >-
+          Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+          like Gecko) Chrome/1.2.3.4 Safari/537.36
+        user_id: google-oauth2|105261262156475850461
+      log_id: "90020230523204756343781000000000000001223372037583230452"
+      p_any_ip_addresses:
+        - 12.12.12.12
+      p_any_usernames:
+        - google-oauth2|105261262156475850461
+      p_event_time: "2023-05-23 20:47:51.149"
+      p_log_type: Auth0.Events
+      p_parse_time: "2023-05-23 20:49:28.671"
+      p_row_id: 00000000004a745ce33b57be383c543e
+      p_schema_version: 0
+      p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+      p_source_label: Org Auth0 Tenant Label
+    Name: Failed Brute-Force Monitoring Disabled
+
+# Block shield disabled
+
+  - ExpectedResult: true
+    Log:
+      data:
+        client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+        client_name: ""
+        date: "2025-10-03 14:09:32.149000000"
+        description: "Update Suspicious IP Throttling settings"
+        details:
+          request:
+            auth:
+              credentials:
+                jti: 0000000000ecaf1bfbadb06900d22049
+              strategy: jwt
+              user:
+                email: denethor@lotr.com
+                name: Homer Simpson
+                user_id: google-oauth2|105261262156475850461
+            body:
+              enabled: true
+            channel: https://manage.auth0.com/
+            ip: 12.12.12.12
+            method: post
+            path: /v2/attack-protection/suspicious-ip-throttling
+            query: {}
+            userAgent: >-
+              Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+              (KHTML, like Gecko) Chrome/1.2.3.4 Safari/537.36
+          response:
+            body:
+              enabled: true
+              shields: "user_notification"
+            statusCode: 200
+        ip: 12.12.12.12
+        log_id: "90020230523204756343781000000000000001223372037583230452"
+        type: sapi
+        user_agent: >-
+          Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+          like Gecko) Chrome/1.2.3.4 Safari/537.36
+        user_id: google-oauth2|105261262156475850461
+      log_id: "90020230523204756343781000000000000001223372037583230452"
+      p_any_ip_addresses:
+        - 12.12.12.12
+      p_any_usernames:
+        - google-oauth2|105261262156475850461
+      p_event_time: "2023-05-23 20:47:51.149"
+      p_log_type: Auth0.Events
+      p_parse_time: "2023-05-23 20:49:28.671"
+      p_row_id: 00000000004a745ce33b57be383c543e
+      p_schema_version: 0
+      p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+      p_source_label: Org Auth0 Tenant Label
+    Name: Disable Block Shield
+  - ExpectedResult: false
+    Log:
+      data:
+        client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+        client_name: ""
+        date: "2025-10-03 14:09:32.149000000"
+        description: "Update Suspicious IP Throttling settings"
+        details:
+          request:
+            auth:
+              credentials:
+                jti: 0000000000ecaf1bfbadb06900d22049
+              strategy: jwt
+              user:
+                email: denethor@lotr.com
+                name: Homer Simpson
+                user_id: google-oauth2|105261262156475850461
+            body:
+              enabled: true
+            channel: https://manage.auth0.com/
+            ip: 12.12.12.12
+            method: post
+            path: /v2/attack-protection/suspicious-ip-throttling
+            query: {}
+            userAgent: >-
+              Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+              (KHTML, like Gecko) Chrome/1.2.3.4 Safari/537.36
+          response:
+            body:
+              enabled: true
+              shields: "block"
+            statusCode: 400
+        ip: 12.12.12.12
+        log_id: "90020230523204756343781000000000000001223372037583230452"
+        type: sapi
+        user_agent: >-
+          Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+          like Gecko) Chrome/1.2.3.4 Safari/537.36
+        user_id: google-oauth2|105261262156475850461
+      log_id: "90020230523204756343781000000000000001223372037583230452"
+      p_any_ip_addresses:
+        - 12.12.12.12
+      p_any_usernames:
+        - google-oauth2|105261262156475850461
+      p_event_time: "2023-05-23 20:47:51.149"
+      p_log_type: Auth0.Events
+      p_parse_time: "2023-05-23 20:49:28.671"
+      p_row_id: 00000000004a745ce33b57be383c543e
+      p_schema_version: 0
+      p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+      p_source_label: Org Auth0 Tenant Label
+    Name: Block Event Already Enabled
+DedupPeriodMinutes: 60
+LogTypes:
+  - Auth0.Events
+RuleID: "Auth0.AttackProtection.Disabled"
+Threshold: 1

--- a/rules/auth0_rules/auth0_bot_detection_disabled.py
+++ b/rules/auth0_rules/auth0_bot_detection_disabled.py
@@ -1,0 +1,60 @@
+from panther_auth0_helpers import auth0_alert_context, is_auth0_config_event
+
+
+def rule(event):
+
+    data_type = event.deep_get("data", "type", default="<NO_DATA_TYPE_FOUND>")
+
+    data_description = event.deep_get("data", "description", default="<NO_DATA_DESCRIPTION_FOUND>")
+
+    bot_p_policy = event.deep_get(
+        "data",
+        "details",
+        "response",
+        "body",
+        "passwordless_policy",
+        default="<NO_PASSWORDLESS_POLICY_FOUND>",
+    )
+
+    bot_reset_policy = event.deep_get(
+        "data",
+        "details",
+        "response",
+        "body",
+        "password_reset_policy",
+        default="<NO_PASSWORD_RESET_POLICY_FOUND>",
+    )
+
+    bot_policy = event.deep_get(
+        "data", "details", "response", "body", "policy", default="<NO_BOT_POLICY_FOUND>"
+    )
+
+    response_status_code = event.deep_get(
+        "data", "details", "response", "statusCode", default="<NO_RESPONSE_CODE_FOUND>"
+    )
+    return all(
+        [
+            data_type == "sapi",
+            (
+                data_description == "Create or update the anomaly detection captcha"
+                and (bot_p_policy == "off" or bot_reset_policy == "off" or bot_policy == "off")
+            ),
+            response_status_code == 200,
+            is_auth0_config_event(event),
+        ]
+    )
+
+
+def title(event):
+    user = event.deep_get(
+        "data", "details", "request", "auth", "user", "email", default="<NO_USER_FOUND>"
+    )
+    p_source_label = event.get("p_source_label", "<NO_P_SOURCE_LABEL_FOUND>")
+    return (
+        f"Auth0 User [{user}] disabled bot detection in "
+        f"your organization's tenant [{p_source_label}]."
+    )
+
+
+def alert_context(event):
+    return auth0_alert_context(event)

--- a/rules/auth0_rules/auth0_bot_detection_disabled.yml
+++ b/rules/auth0_rules/auth0_bot_detection_disabled.yml
@@ -1,0 +1,118 @@
+AnalysisType: rule
+Description: A bot detection policy was disabled.
+DisplayName: "Auth0 Bot Detection Policy Disabled"
+Enabled: true
+Filename: auth0_bot_detection_disabled.py
+Runbook: Assess if this was done by the user for a valid business reason. Be vigilant to re-enable this setting as it's in the best security interest for your organization's security posture.
+Reference: https://github.com/auth0/auth0-customer-detections/tree/main/detections
+Severity: High
+Tests:
+  - ExpectedResult: true
+    Log:
+      data:
+        client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+        client_name: ""
+        date: "2025-10-03 14:09:32.149000000"
+        description: "Create or update the anomaly detection captcha"
+        details:
+          request:
+            auth:
+              credentials:
+                jti: 0000000000ecaf1bfbadb06900d22049
+              strategy: jwt
+              user:
+                email: denethor@lotr.com
+                name: Homer Simpson
+                user_id: google-oauth2|105261262156475850461
+            body:
+              enabled: true
+            channel: https://manage.auth0.com/
+            ip: 12.12.12.12
+            method: post
+            path: /v2/attack-protection/bot-detection
+            query: {}
+            userAgent: >-
+              Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+              (KHTML, like Gecko) Chrome/1.2.3.4 Safari/537.36
+          response:
+            body:
+              policy: off
+              password_reset_policy: off
+              passwordless_policy: off
+            statusCode: 200
+        ip: 12.12.12.12
+        log_id: "90020230523204756343781000000000000001223372037583230452"
+        type: sapi
+        user_agent: >-
+          Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+          like Gecko) Chrome/1.2.3.4 Safari/537.36
+        user_id: google-oauth2|105261262156475850461
+      log_id: "90020230523204756343781000000000000001223372037583230452"
+      p_any_ip_addresses:
+        - 12.12.12.12
+      p_any_usernames:
+        - google-oauth2|105261262156475850461
+      p_event_time: "2023-05-23 20:47:51.149"
+      p_log_type: Auth0.Events
+      p_parse_time: "2023-05-23 20:49:28.671"
+      p_row_id: 00000000004a745ce33b57be383c543e
+      p_schema_version: 0
+      p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+      p_source_label: Org Auth0 Tenant Label
+    Name: Auth0 Bot Detection Policy Disabled
+  - ExpectedResult: false
+    Log:
+      data:
+        client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+        client_name: ""
+        date: "2025-10-03 14:09:32.149000000"
+        description: "Create or update the anomaly detection captcha"
+        details:
+          request:
+            auth:
+              credentials:
+                jti: 0000000000ecaf1bfbadb06900d22049
+              strategy: jwt
+              user:
+                email: denethor@lotr.com
+                name: Homer Simpson
+                user_id: google-oauth2|105261262156475850461
+            body:
+              enabled: true
+            channel: https://manage.auth0.com/
+            ip: 12.12.12.12
+            method: post
+            path: /v2/attack-protection/bot-detection
+            query: {}
+            userAgent: >-
+              Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+              (KHTML, like Gecko) Chrome/1.2.3.4 Safari/537.36
+          response:
+            body:
+              policy: on
+            statusCode: 200
+        ip: 12.12.12.12
+        log_id: "90020230523204756343781000000000000001223372037583230452"
+        type: sapi
+        user_agent: >-
+          Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+          like Gecko) Chrome/1.2.3.4 Safari/537.36
+        user_id: google-oauth2|105261262156475850461
+      log_id: "90020230523204756343781000000000000001223372037583230452"
+      p_any_ip_addresses:
+        - 12.12.12.12
+      p_any_usernames:
+        - google-oauth2|105261262156475850461
+      p_event_time: "2023-05-23 20:47:51.149"
+      p_log_type: Auth0.Events
+      p_parse_time: "2023-05-23 20:49:28.671"
+      p_row_id: 00000000004a745ce33b57be383c543e
+      p_schema_version: 0
+      p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+      p_source_label: Org Auth0 Tenant Label
+    Name: Enable Bot Detection Feature
+DedupPeriodMinutes: 60
+LogTypes:
+  - Auth0.Events
+RuleID: "Auth0.BotDetection.Disabled"
+Threshold: 1

--- a/rules/auth0_rules/auth0_push_notification_fatigue.py
+++ b/rules/auth0_rules/auth0_push_notification_fatigue.py
@@ -1,0 +1,47 @@
+import json
+
+from panther_auth0_helpers import auth0_alert_context, is_auth0_config_event
+from panther_detection_helpers.caching import add_to_string_set
+
+# Determine how many push notifications must be sent before triggering an alert.
+PUSH_FATIGUE_THRESHOLD = 5
+
+RULE_ID = "Auth0.PushNotification.Fatigue"
+WITHIN_TIMEFRAME_MINUTES = 1
+
+
+def rule(event):
+
+    data_type = event.deep_get("data", "type", default="<NO_DATA_TYPE_FOUND>")
+    if data_type != "gd_send_pn":
+        return False
+    user = event.deep_get(
+        "data", "details", "request", "auth", "user", "email", default="<NO_USER_FOUND>"
+    )
+    key = f"{RULE_ID}-{user}"
+    unique_alerts = add_to_string_set(key, WITHIN_TIMEFRAME_MINUTES * 60)
+
+    if isinstance(unique_alerts, str):
+        unique_alerts = json.loads(unique_alerts)
+    if len(unique_alerts) >= PUSH_FATIGUE_THRESHOLD:
+        return all(
+            [
+                unique_alerts,
+                is_auth0_config_event(event),
+            ]
+        )
+    return False
+
+
+def title(event):
+    user = event.deep_get(
+        "data", "details", "request", "auth", "user", "email", default="<NO_USER_FOUND>"
+    )
+    return (
+        f"Auth0 User [{user}] has received an excessive number of MFA push notifications,"
+        f"possible MFA fatigue detected"
+    )
+
+
+def alert_context(event):
+    return auth0_alert_context(event)

--- a/rules/auth0_rules/auth0_push_notification_fatigue.yml
+++ b/rules/auth0_rules/auth0_push_notification_fatigue.yml
@@ -1,0 +1,120 @@
+AnalysisType: rule
+Description: Push notifications threshold exceeded for a user. It may indicate a push notification fatigue attempt.
+DisplayName: "Auth0 Push Notificatin Fatigue"
+Enabled: true
+Filename: auth0_push_notification_fatigue.py
+Runbook: Assess if this was done by the user for a valid business reason. Be vigilant to re-enable this setting as it's in the best security interest for your organization's security posture.
+Reference: https://github.com/auth0/auth0-customer-detections/tree/main/detections
+Severity: High
+Tests:
+  - ExpectedResult: true
+    Mocks:
+    - {
+        "objectName": "add_to_string_set",
+        "returnValue": '["homer.simpson@yourcompany.com", "homer.simpson@yourcompany.com", "homer.simpson@yourcompany.com", "homer.simpson@yourcompany.com", "homer.simpson@yourcompany.com"]',
+      }
+    Log:
+      data:
+        client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+        client_name: ""
+        date: "2025-10-03 14:09:32.149000000"
+        description: "Push notification for MFA successfully sent"
+        details:
+          request:
+            auth:
+              credentials:
+                jti: 0000000000ecaf1bfbadb06900d22049
+              strategy: jwt
+              user:
+                email: denethor@lotr.com
+                name: Homer Simpson
+                user_id: google-oauth2|105261262156475850461
+            body:
+              enabled: true
+            channel: https://manage.auth0.com/
+            ip: 12.12.12.12
+            method: post
+            path: /v2/attack-protection/push-notification
+            query: {}
+            userAgent: >-
+              Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+              (KHTML, like Gecko) Chrome/1.2.3.4 Safari/537.36
+          response:
+            body: []
+            statusCode: 200
+        ip: 12.12.12.12
+        log_id: "90020230523204756343781000000000000001223372037583230452"
+        type: "gd_send_pn"
+        user_agent: >-
+          Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+          like Gecko) Chrome/1.2.3.4 Safari/537.36
+        user_id: google-oauth2|105261262156475850461
+      log_id: "90020230523204756343781000000000000001223372037583230452"
+      p_any_ip_addresses:
+        - 12.12.12.12
+      p_any_usernames:
+        - google-oauth2|105261262156475850461
+      p_event_time: "2023-05-23 20:47:51.149"
+      p_log_type: Auth0.Events
+      p_parse_time: "2023-05-23 20:49:28.671"
+      p_row_id: 00000000004a745ce33b57be383c543e
+      p_schema_version: 0
+      p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+      p_source_label: Org Auth0 Tenant Label
+    Name: Push Notification Fatigue
+  - ExpectedResult: false
+    Log:
+      data:
+        client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+        client_name: ""
+        date: "2025-10-03 14:09:32.149000000"
+        description: "Create or update the anomaly detection captcha"
+        details:
+          request:
+            auth:
+              credentials:
+                jti: 0000000000ecaf1bfbadb06900d22049
+              strategy: jwt
+              user:
+                email: denethor@lotr.com
+                name: Homer Simpson
+                user_id: google-oauth2|105261262156475850461
+            body:
+              enabled: true
+            channel: https://manage.auth0.com/
+            ip: 12.12.12.12
+            method: post
+            path: /v2/attack-protection/bot-detection
+            query: {}
+            userAgent: >-
+              Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+              (KHTML, like Gecko) Chrome/1.2.3.4 Safari/537.36
+          response:
+            body:
+              policy: on
+            statusCode: 200
+        ip: 12.12.12.12
+        log_id: "90020230523204756343781000000000000001223372037583230452"
+        type: sapi
+        user_agent: >-
+          Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+          like Gecko) Chrome/1.2.3.4 Safari/537.36
+        user_id: google-oauth2|105261262156475850461
+      log_id: "90020230523204756343781000000000000001223372037583230452"
+      p_any_ip_addresses:
+        - 12.12.12.12
+      p_any_usernames:
+        - google-oauth2|105261262156475850461
+      p_event_time: "2023-05-23 20:47:51.149"
+      p_log_type: Auth0.Events
+      p_parse_time: "2023-05-23 20:49:28.671"
+      p_row_id: 00000000004a745ce33b57be383c543e
+      p_schema_version: 0
+      p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+      p_source_label: Org Auth0 Tenant Label
+    Name: Other Event
+DedupPeriodMinutes: 60
+LogTypes:
+  - Auth0.Events
+RuleID: "Auth0.PushNotification.Fatigue"
+Threshold: 5

--- a/rules/auth0_rules/auth0_push_notification_fatigue.yml
+++ b/rules/auth0_rules/auth0_push_notification_fatigue.yml
@@ -1,6 +1,6 @@
 AnalysisType: rule
 Description: Push notifications threshold exceeded for a user. It may indicate a push notification fatigue attempt.
-DisplayName: "Auth0 Push Notificatin Fatigue"
+DisplayName: "Auth0 Push Notification Fatigue"
 Enabled: true
 Filename: auth0_push_notification_fatigue.py
 Runbook: Assess if this was done by the user for a valid business reason. Be vigilant to re-enable this setting as it's in the best security interest for your organization's security posture.

--- a/rules/auth0_rules/auth0_token_reuse.py
+++ b/rules/auth0_rules/auth0_token_reuse.py
@@ -1,0 +1,31 @@
+from panther_auth0_helpers import auth0_alert_context, is_auth0_config_event
+
+
+def rule(event):
+
+    data_description = event.deep_get("data", "description", default="<NO_DATA_DESCRIPTION_FOUND>")
+    data_type = event.deep_get("data", "type", default="<NO_DATA_TYPE_FOUND>")
+
+    return all(
+        [
+            data_description
+            == "Unsuccessful Refresh Token exchange, reused refresh token detected",
+            data_type == "ferrt",
+            is_auth0_config_event(event),
+        ]
+    )
+
+
+def title(event):
+    user = event.deep_get(
+        "data", "details", "request", "auth", "user", "email", default="<NO_USER_FOUND>"
+    )
+    p_source_label = event.get("p_source_label", "<NO_P_SOURCE_LABEL_FOUND>")
+    return (
+        f"Auth0 User [{user}] attempted to reuse a refresh token for"
+        f"your organization's tenant [{p_source_label}]."
+    )
+
+
+def alert_context(event):
+    return auth0_alert_context(event)

--- a/rules/auth0_rules/auth0_token_reuse.yml
+++ b/rules/auth0_rules/auth0_token_reuse.yml
@@ -1,0 +1,118 @@
+AnalysisType: rule
+Description: A refresh token was reused.
+DisplayName: "Auth0 Refresh Token Reused"
+Enabled: true
+Filename: auth0_token_reuse.py
+Runbook: Assess if this was done by the user for a valid business reason. Be vigilant to re-enable this setting as it's in the best security interest for your organization's security posture.
+Reference: https://github.com/auth0/auth0-customer-detections/tree/main/detections
+Severity: High
+Tests:
+  - ExpectedResult: true
+    Log:
+      data:
+        client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+        client_name: ""
+        date: "2025-10-03 14:09:32.149000000"
+        description: "Unsuccessful Refresh Token exchange, reused refresh token detected"
+        details:
+          request:
+            auth:
+              credentials:
+                jti: 0000000000ecaf1bfbadb06900d22049
+              strategy: jwt
+              user:
+                email: denethor@lotr.com
+                name: Homer Simpson
+                user_id: google-oauth2|105261262156475850461
+            body:
+              enabled: true
+            channel: https://manage.auth0.com/
+            ip: 12.12.12.12
+            method: post
+            path: /v2/attack-protection/token-reuse
+            query: {}
+            userAgent: >-
+              Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+              (KHTML, like Gecko) Chrome/1.2.3.4 Safari/537.36
+          response:
+            body:
+              policy: off
+              password_reset_policy: off
+              passwordless_policy: off
+            statusCode: 200
+        ip: 12.12.12.12
+        log_id: "90020230523204756343781000000000000001223372037583230452"
+        type: "ferrt"
+        user_agent: >-
+          Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+          like Gecko) Chrome/1.2.3.4 Safari/537.36
+        user_id: google-oauth2|105261262156475850461
+      log_id: "90020230523204756343781000000000000001223372037583230452"
+      p_any_ip_addresses:
+        - 12.12.12.12
+      p_any_usernames:
+        - google-oauth2|105261262156475850461
+      p_event_time: "2023-05-23 20:47:51.149"
+      p_log_type: Auth0.Events
+      p_parse_time: "2023-05-23 20:49:28.671"
+      p_row_id: 00000000004a745ce33b57be383c543e
+      p_schema_version: 0
+      p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+      p_source_label: Org Auth0 Tenant Label
+    Name: Auth0 Bot Detection Policy Disabled
+  - ExpectedResult: false
+    Log:
+      data:
+        client_id: 1HXWWGKk1Zj3JF8GvMrnCSirccDs4qvr
+        client_name: ""
+        date: "2025-10-03 14:09:32.149000000"
+        description: "Create or update the anomaly detection captcha"
+        details:
+          request:
+            auth:
+              credentials:
+                jti: 0000000000ecaf1bfbadb06900d22049
+              strategy: jwt
+              user:
+                email: denethor@lotr.com
+                name: Homer Simpson
+                user_id: google-oauth2|105261262156475850461
+            body:
+              enabled: true
+            channel: https://manage.auth0.com/
+            ip: 12.12.12.12
+            method: post
+            path: /v2/attack-protection/bot-detection
+            query: {}
+            userAgent: >-
+              Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+              (KHTML, like Gecko) Chrome/1.2.3.4 Safari/537.36
+          response:
+            body:
+              policy: on
+            statusCode: 200
+        ip: 12.12.12.12
+        log_id: "90020230523204756343781000000000000001223372037583230452"
+        type: sapi
+        user_agent: >-
+          Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+          like Gecko) Chrome/1.2.3.4 Safari/537.36
+        user_id: google-oauth2|105261262156475850461
+      log_id: "90020230523204756343781000000000000001223372037583230452"
+      p_any_ip_addresses:
+        - 12.12.12.12
+      p_any_usernames:
+        - google-oauth2|105261262156475850461
+      p_event_time: "2023-05-23 20:47:51.149"
+      p_log_type: Auth0.Events
+      p_parse_time: "2023-05-23 20:49:28.671"
+      p_row_id: 00000000004a745ce33b57be383c543e
+      p_schema_version: 0
+      p_source_id: b9031579-b2c5-45c2-b15c-632b995a4e36
+      p_source_label: Org Auth0 Tenant Label
+    Name: Other Event
+DedupPeriodMinutes: 60
+LogTypes:
+  - Auth0.Events
+RuleID: "Auth0.RefreshToken.Reuse"
+Threshold: 1


### PR DESCRIPTION
### Background

Introduce new rules for auth0

### Changes

New rules:
- "Auth0 Attack Protection Monitoring Disabled" : alerts when an attack protection monitoring feature (IP throttling, brute-force, breached password) gets disabled entirely or its configuration settings are not set to the "block" action.
Groups together:
1) https://github.com/auth0/auth0-customer-detections/blob/main/detections/attack_protection_features_turned_off.yml
2) https://github.com/auth0/auth0-customer-detections/blob/main/detections/breached_password_detection_settings_manipulated.yml
3) https://github.com/auth0/auth0-customer-detections/blob/main/detections/brute_force_critical_settings_manipulated.yml
4) https://github.com/auth0/auth0-customer-detections/blob/main/detections/suspicious_ip_throttling_critical_settings_manipulated.yml

- "Auth0 Bot Detection Policy Disabled" : alerts when the bot detection protection feature gets disabled.
From: https://github.com/auth0/auth0-customer-detections/blob/main/detections/bot_detection_turned_off.yml

- "Auth0 Push Notification Fatigue": alerts when a single user receives at least 5 push notifications in the span of one minute. The configuration can be changed both for the number of MFA notifications and the time.
From: https://github.com/auth0/auth0-customer-detections/blob/main/detections/risk_for_mfa_push_fatigue.yml

- "Auth0 Refresh Token Reused": alerts when a refresh token gets reused.

### Testing

Tested with panther analysis tool with unit tests for each condition logic.
To test:
`panther_analysis_tool test --path rules/auth0_rules/`
