### PR TITLE
GSuite suspicious login username fix

### DIFF
--- a/rules/gsuite_activityevent_rules/gsuite_suspicious_logins.py
+++ b/rules/gsuite_activityevent_rules/gsuite_suspicious_logins.py
@@ -16,6 +16,7 @@ def rule(event):
 
 
 def title(event):
-    user = event.deep_get("actor", "email") or \
-        event.deep_get("parameters", "affected_email_address", default="<UNKNOWN_USER>")
+    user = event.deep_get("actor", "email") or event.deep_get(
+        "parameters", "affected_email_address", default="<UNKNOWN_USER>"
+    )
     return f"A suspicious login was reported for user [{user}]"


### PR DESCRIPTION
### Background

The rule fails to get username:

<img width="510" height="704" alt="image" src="https://github.com/user-attachments/assets/b338776e-5dd7-45fe-bccd-6ade4b9c4eb2" />

### Changes

I added a backup way of getting the username

### Testing

A sample json that we receive:

```json
{
	"actor": {
		"callerType": "KEY",
		"key": "Google"
	},
	"id": {
		"applicationName": "login",
		"customerId": "C04120000",
		"time": "2025-10-10 03:56:58.000000000",
		"uniqueQualifier": "-7371611914195500000"
	},
	"ipAddress": "2a09:0000:0000:0000:0:0:41a:3a",
	"kind": "admin#reports#activity",
	"name": "suspicious_login",
	"parameters": {
		"affected_email_address": "george.michael@domain.com",
		"login_timestamp": 1760068618000000
	},
	"type": "account_warning"
}
```
