### PR TITLE
GitHub rules: alert on completed workflow runs and opened PRs only

### DIFF
--- a/rules/github_rules/github_malicious_pr_titles.py
+++ b/rules/github_rules/github_malicious_pr_titles.py
@@ -37,7 +37,7 @@ COMPILED_BASH_PATTERNS = [
 
 
 def rule(event):
-    if not is_pull_request_event(event):
+    if not is_pull_request_event(event) or event.deep_get("action") != "opened":
         return False
 
     if pr_title := event.deep_get("pull_request", "title"):

--- a/rules/github_rules/github_pull_request_target_usage.py
+++ b/rules/github_rules/github_pull_request_target_usage.py
@@ -7,7 +7,10 @@ from panther_github_helpers import (
 
 
 def rule(event):
-    return event.deep_get("workflow_run", "event") == "pull_request_target"
+    return (
+        event.deep_get("workflow_run", "event") == "pull_request_target"
+        and event.get("action") == "completed"
+    )
 
 
 def title(event):

--- a/rules/github_rules/github_pull_request_target_usage.yml
+++ b/rules/github_rules/github_pull_request_target_usage.yml
@@ -142,3 +142,34 @@ Tests:
         id: 243627255
         full_name: "example-org/example-repo"
         private: true
+
+  - Name: "Pull request target workflow requested"
+    ExpectedResult: false
+    Log:
+      action: "requested"
+      workflow_run:
+        id: 12345678
+        name: "Security Scan"
+        event: "pull_request_target"
+        status: "completed"
+        conclusion: "success"
+        html_url: "https://github.com/example-org/example-repo/actions/runs/12345678"
+        head_branch: "feature-branch"
+        pull_requests:
+          - number: 123
+            head:
+              ref: "feature-branch"
+              repo:
+                id: 243627255
+                name: "example-repo"
+                full_name: "example-org/example-repo"
+            base:
+              ref: "main"
+              repo:
+                id: 243627255
+                name: "example-repo"
+                full_name: "example-org/example-repo"
+      repository:
+        id: 243627255
+        full_name: "example-org/example-repo"
+        private: true


### PR DESCRIPTION
### Background

If these two rules trigger, they trigger for each action: PR for opened, closed, reopened and workflows for requested, in_progress and completed. It makes more sense to alert only when a malicious PR is opened for the first time, and when a workflow is completed to indicate success, to avoid triplicated alerts.

### Changes

- <Describe changes here>

### Testing

- <Testing steps>
