### PR TITLE
Helper False Positive Reduction: is_base64() rework

### DIFF
--- a/rules/standard_rules/standard_dns_base64.yml
+++ b/rules/standard_rules/standard_dns_base64.yml
@@ -270,3 +270,61 @@ Tests:
         "p_source_label": "Crowdstrike-FDR-Dev",
         "timestamp": "2023-04-23 18:50:05.712",
       }
+  - Name: Crowdstrike DNS Request w/ Bait Domain (Negative)
+    ExpectedResult: false
+    Log:
+      {
+        "ConfigBuild": "1007.3.0016606.11",
+        "ConfigStateHash": "1331552299",
+        "ContextProcessId": "21866918",
+        "ContextThreadId": "43270698197",
+        "ContextTimeStamp": "2023-04-23 18:50:03.172",
+        "Entitlements": "15",
+        "aid": "877761efa8db44d792ddc2redacted",
+        "aip": "1.1.1.1",
+        "cid": "cfe698690964434083fecdredacted",
+        "event":
+          {
+            "ConfigBuild": "1007.3.0016606.11",
+            "ConfigStateHash": "1331552299",
+            "ContextProcessId": "21866918",
+            "ContextThreadId": "43270698197",
+            "ContextTimeStamp": "1682275803.172",
+            "DnsRequestCount": "1",
+            "DomainName": "SystemRoot", # would decode to K+-zdh
+            "DualRequest": "0",
+            "EffectiveTransmissionClass": "3",
+            "Entitlements": "15",
+            "EventOrigin": "1",
+            "InterfaceIndex": "0",
+            "QueryStatus": "9003",
+            "RequestType": "1",
+            "aid": "877761efa8db44d792ddc2redacted",
+            "aip": "1.1.1.1",
+            "cid": "cfe698690964434083fecdredacted",
+            "event_platform": "Win",
+            "event_simpleName": "DnsRequest",
+            "id": "4f006a14-0fdf-474e-bfca-021a00a935ad",
+            "name": "DnsRequestV4",
+            "timestamp": "1682275805712",
+          },
+        "event_platform": "Win",
+        "event_simpleName": "DnsRequest",
+        "fdr_event_type": "DnsRequest",
+        "id": "4f006a14-0fdf-474e-bfca-021a00a935ad",
+        "name": "DnsRequestV4",
+        "p_any_domain_names": ["win8.ipv6.microsoft.com"],
+        "p_any_ip_addresses": ["1.1.1.1"],
+        "p_any_md5_hashes":
+          ["877761efa8db44d792ddc2redacted", "cfe698690964434083fecdredacted"],
+        "p_any_trace_ids":
+          ["877761efa8db44d792ddc2redacted", "cfe698690964434083fecdredacted"],
+        "p_event_time": "2023-04-23 18:50:03.172",
+        "p_log_type": "Crowdstrike.FDREvent",
+        "p_parse_time": "2023-04-23 19:00:53.11",
+        "p_row_id": "f2c89ec8f09cbc8ca2c1cbdf171a",
+        "p_schema_version": 0,
+        "p_source_id": "1f33f64c-124d-413c-a9e3-d51ccedd8e77",
+        "p_source_label": "Crowdstrike-FDR-Dev",
+        "timestamp": "2023-04-23 18:50:05.712",
+      }


### PR DESCRIPTION
### Background

is_base64() was returning true for certain FP cases because of a lax regex

### Changes

- Update to is_base64 global helper
- Update to `Crowdstrike.Base64EncodedArgs` detection to handle new helper
- Add test to `Standard.DNSBase64` to handle sample case

### Testing

- `panther_analysis_tool test --path rules/ --filter RuleID=Standard.DNSBase64`
-  'panther-analysis % panther_analysis_tool test --path rules/ --filter RuleID=Crowdstrike.Base64EncodedArgs`
