### PR TITLE
fix for slack user assigned admin permission username and email

### DIFF
--- a/rules/slack_rules/slack_user_privilege_escalation.py
+++ b/rules/slack_rules/slack_user_privilege_escalation.py
@@ -24,7 +24,7 @@ def title(event):
         return f"{USER_PRIV_ESC_ACTIONS[action]} from {actor_username} ({actor_email})"
 
     if action == "permissions_assigned":
-        return f"{USER_PRIV_ESC_ACTIONS[action]} {entity_username} ({entity_email})"
+        return f"{USER_PRIV_ESC_ACTIONS[action]} {actor_username} ({actor_email})"
 
     if action == "role_change_to_admin":
         return f"{USER_PRIV_ESC_ACTIONS[action]} {entity_username} ({entity_email})"


### PR DESCRIPTION
### Background

when the `Slack.AuditLogs.UserPrivilegeEscalation` rule's `action` is `permissions_assigned` the email and name is unknown

<img width="571" height="430" alt="image" src="https://github.com/user-attachments/assets/18049a32-2ce1-49de-a77c-07f2a39e1ea7" />


### Changes

when the `action` is `permissions_assigned`, the email and name is in the `actor` field

### Testing

```json
"actor": {
		"type": "user",
		"user": {
			"id": "U05U7CZKV0T",
			"name": "George Michael",
			"email": "george.michael@domain.com",
			"team": "E06E4V7VBBK"
		}
	},
```

even in the rule's test data, the email and name is inside the `actor` field: [source](https://github.com/panther-labs/panther-analysis/blob/a834394d8c8ac9526b693ee708199931ba6867e0/rules/slack_rules/slack_user_privilege_escalation.yml#L65)
