### PR TITLE
Finetune a policy to avoid false positive created due to case-sensitivity.

### DIFF
--- a/policies/aws_s3_policies/aws_s3_bucket_policy_confused_deputy.py
+++ b/policies/aws_s3_policies/aws_s3_bucket_policy_confused_deputy.py
@@ -25,6 +25,8 @@ def policy(resource):
                 if isinstance(condition, dict):
                     flat_condition_keys.update(condition.keys())
             # Check if any required condition key is present
-            if not {str.casefold(x) for x in REQUIRED_CONDITIONS} & {str.casefold(x) for x in flat_condition_keys}:
+            if not {str.casefold(x) for x in REQUIRED_CONDITIONS} & {
+                str.casefold(x) for x in flat_condition_keys
+            }:
                 return False
     return True


### PR DESCRIPTION
updated "S3 Bucket Policy Confused Deputy Protection for Service Principals" policy  to convert statement conditions to lower case as they are not case-sensitive. Here is the reference AWS link - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html

### Background

<High level overview here>

### Changes

- <Describe changes here>

### Testing

- <Testing steps>
