### PR TITLE
generate versions action creates pr

### DIFF
--- a/.github/workflows/generate-versions-file.yml
+++ b/.github/workflows/generate-versions-file.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - "main"
-      - "mcr/EPD-4377-versioning-in-pr"
 
 jobs:
   generate-versions:


### PR DESCRIPTION
### Background

The new versioning [PR](https://github.com/panther-labs/panther-analysis/pull/1757) finally merged and we cut a release, but it [failed](https://github.com/panther-labs/panther-analysis/actions/runs/19306666684/job/55215862292)
```
[main b9541aa7] Auto-generated .versions.yml file
 1 file changed, 9113 insertions(+)
 create mode 100644 .versions.yml
warning: not sending a push certificate since the receiving end does not support --signed push
remote: error: GH006: Protected branch update failed for refs/heads/main.        
remote: 
remote: - Changes must be made through a pull request.        
remote: 
remote: - 2 of 2 required status checks are expected.        
To https://github.com/panther-labs/panther-analysis
 ! [remote rejected]   HEAD -> main (protected branch hook declined)
error: failed to push some refs to 'https://github.com/panther-labs/panther-analysis'
```

To fix this, I am keeping everything as is, but having it put the changes in a new PR instead of committing directly to main. 

No PR will be created if no changes to the file were made. This will also prevent an infinite loop of this. 

### Changes

- Updates the github action

### Testing

- Changed the target branch to this current branch and pushed a commit (Auto-generated .versions.yml file: https://github.com/panther-labs/panther-analysis/pull/1795)
- Tested with changes and with no changes
