### PR TITLE
Updating Runbook Markdown Syntax for Azure Failed SignIns Rule

### DIFF
--- a/rules/azure_signin_rules/azure_failed_signins.yml
+++ b/rules/azure_signin_rules/azure_failed_signins.yml
@@ -16,7 +16,7 @@ Reports:
   MITRE ATT&CK:
     - TA0006:T1110
     - TA0001:T1078
-Runbook: >
+Runbook: |
   Querying Sign-In logs for the ServicePrincipalName or UserPrincipalName may indicate
   that the principal is under attack, or that a sign-in credential rolled and some
   user of the credential didn't get updated.


### PR DESCRIPTION
### Background

For multithreaded lines in runbooks, it was switched from > to |. This allows for intended formatiting, readability, and structure.

### Changes

Use | instead of > for Runbooks

### Testing

Use | instead of > for Runbooks