### PR TITLE
Updating Runbook Markdown Syntax for Cisco rules

### DIFF
--- a/rules/cisco_umbrella_dns_rules/fuzzy_matching_domains.yml
+++ b/rules/cisco_umbrella_dns_rules/fuzzy_matching_domains.yml
@@ -12,7 +12,7 @@ Tags:
 Reference: https://umbrella.cisco.com/blog/abcs-of-dns
 Severity: Medium
 Description: Identify lookups to suspicious domains that could indicate a phishing attack.
-Runbook: >
+Runbook: |
   Validate if your organization owns the domain, otherwise investigate the host that made
   the domain resolution.
 


### PR DESCRIPTION
### Background

For multithreaded lines in runbooks, it was switched from > to |. This allows for intended formatiting, readability, and structure.

### Changes

- Use | instead of > for Runbooks

### Testing

- Use | instead of > for Runbooks