### PR TITLE
Updating Runbook Markdown Syntax for Okta Rules

### DIFF
--- a/rules/okta_rules/okta_idp_create_modify.yml
+++ b/rules/okta_rules/okta_idp_create_modify.yml
@@ -17,7 +17,7 @@ Description: >
   to access applications within the compromised Org on behalf of other users. This second Identity Provider,
   also controlled by the attacker, would act as a “source” IdP in an inbound federation relationship
   (sometimes called “Org2Org”) with the target.
-Runbook: >
+Runbook: |
   Delegate access to this feature to a Custom Admin Role with the minimum required permissions.
   Constrain these roles to groups that exclude highly privileged administrators.
 Reference: >


### PR DESCRIPTION
### Background

For multithreaded lines in runbooks, it was switched from > to |. This allows for intended formatiting, readability, and structure.

### Changes

-Use | instead of > for Runbooks

### Testing

-Use | instead of > for Runbooks