### PR TITLE
Updating Runbook Markdown Syntax for Standard Rules

### DIFF
--- a/rules/standard_rules/impossible_travel_login.yml
+++ b/rules/standard_rules/impossible_travel_login.yml
@@ -16,7 +16,7 @@ Reports:
     - TA0001:T1078
 Severity: High
 Description: A user has subsequent logins from two geographic locations that are very far apart
-Runbook: >
+Runbook: |
   Reach out to the user if needed to validate the activity, then lock the account.
 
   If the user responds that the geolocation on the new location is incorrect, you can directly


### PR DESCRIPTION
### Background

For multithreaded lines in runbooks, it was switched from > to |. This allows for intended formatiting, readability, and structure.

### Changes

-Use | instead of > for Runbooks

### Testing

-Use | instead of > for Runbooks