### PR TITLE
Updating Runbook Markdown Syntax for AWS S3 Policies

### DIFF
--- a/policies/aws_s3_policies/aws_s3_bucket_policy_confused_deputy.yml
+++ b/policies/aws_s3_policies/aws_s3_bucket_policy_confused_deputy.yml
@@ -12,7 +12,7 @@ Tags:
 Severity: High
 Description: >
   Ensures that S3 bucket policies with service principals include conditions to prevent the confused deputy problem.
-Runbook: >
+Runbook: |
   Update the bucket policy to include conditions such as aws:SourceArn, aws:SourceAccount,
   aws:SourceOrgID, or aws:SourceOrgPaths when a service principal is specified.
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html


### PR DESCRIPTION
### Background

For multithreaded lines in runbooks, it was switched from > to |. This allows for intended formatiting, readability, and structure.

### Changes

-Use | instead of > for Runbooks

### Testing

-Use | instead of > for Runbooks
