### PR TITLE
Updating Runbook Markdown Syntax for AWS Cloudwatch Policies

### DIFF
--- a/policies/aws_cloudwatch_policies/aws_cloudwatch_loggroup_data_retention.yml
+++ b/policies/aws_cloudwatch_policies/aws_cloudwatch_loggroup_data_retention.yml
@@ -12,7 +12,7 @@ Severity: Low
 Description: >
   By default, logs are kept indefinitely and never expire. You can adjust the retention policy
   for each log group, keeping the indefinite retention, or choosing a specific retention period.
-Runbook: >
+Runbook: |
   Change the CloudWatch log group retention from the CloudWatch Logs web console,
   SDK, CloudFormation, or any other supported method.
 Reference: https://docs.aws.amazon.com/cli/latest/reference/logs/put-retention-policy.html


### PR DESCRIPTION
### Background

For multithreaded lines in runbooks, it was switched from > to |. This allows for intended formatiting, readability, and structure.

### Changes

-Use | instead of > for Runbooks

### Testing

-Use | instead of > for Runbooks
