### PR TITLE
Updating Runbook Markdown Syntax for AWS RDS Policies

### DIFF
--- a/policies/aws_rds_policies/aws_rds_instance_auto_minor_version_upgrade_enabled.yml
+++ b/policies/aws_rds_policies/aws_rds_instance_auto_minor_version_upgrade_enabled.yml
@@ -16,7 +16,7 @@ Severity: Low
 Description: >
   If you want Amazon RDS to upgrade the DB engine version of a database automatically,
   you can enable auto minor version upgrades for the database.
-Runbook: >
+Runbook: |
   For major version upgrades, you must manually modify the DB engine version through the
   AWS Management Console, AWS CLI, or RDS API. For minor version upgrades,
   you can manually modify the engine version, or you can choose to enable auto minor version upgrades.


### PR DESCRIPTION
### Background
For multithreaded lines in runbooks, it was switched from > to |. This allows for intended formatiting, readability, and structure.

### Changes

-Use | instead of > for Runbooks

### Testing

-Use | instead of > for Runbooks
