### PR TITLE
Use alternateId by default instead of displayName

### DIFF
--- a/data_models/okta_data_model.py
+++ b/data_models/okta_data_model.py
@@ -32,7 +32,7 @@ def get_event_type(event):
 
 
 def get_actor_user(event):
-    actor = deep_get(event, "actor", "displayName", default="unknown")
+    actor = deep_get(event, "actor", "alternateId", default="unknown")
     if actor == "unknown":
-        actor = deep_get(event, "actor", "alternateId", default="Unknown User")
+        actor = deep_get(event, "actor", "displayName", default="Unknown User")
     return actor


### PR DESCRIPTION
### Background

Most of data models use email as actor. For Okta, It only use email (`alternateId`) if the `displayName` is not set.

### Changes

Use `alternateId` by default, fallback to `displayName`
