### PR TITLE
Bump PAT dependency for Python 3.13 compatibility

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1248,7 +1248,8 @@
                 "sha256:efa08d63ef03d079dcae1dfe334f6c8847ba8b645d08df286358b1f5293d24ab",
                 "sha256:f01da5790e95815eb5a8a138508c01c758e5f5bc0ce4286c4f7028b8dd7ac3d0",
                 "sha256:f34019dced51047d6f70cb9383b2ae2853b7fc4dce65129a5acd49f4f9256646",
-                "sha256:f6d3d39611ac2e4f62c3128a9eed45f19a6608670c5a2f4f07f24e8de3441d38"
+                "sha256:f6d3d39611ac2e4f62c3128a9eed45f19a6608670c5a2f4f07f24e8de3441d38",
+                "sha256:56ea19c157ed8c74b6be51b5fa1c3aff6e289a041575f0556f66e5fb848bb137"
             ],
             "markers": "python_version >= '3.5'",
             "version": "==0.2.15"


### PR DESCRIPTION
### Background

<High level overview here>

### Changes

- <Describe changes here>

### Testing

- <Testing steps>
