### PR TITLE
Tune AWS.WAF.Managed.IPReputation

### DIFF
--- a/rules/aws_waf_rules/aws_waf_managed_ip_reputation.py
+++ b/rules/aws_waf_rules/aws_waf_managed_ip_reputation.py
@@ -1,8 +1,9 @@
-from panther_aws_helpers import (
-    waf_alert_context,
-    waf_get_matched_rule,
-    waf_rule_group_matches,
-    waf_severity,
+import re
+
+from panther_aws_helpers import waf_alert_context, waf_get_matched_rule, waf_rule_group_matches
+
+STATIC_ASSET_PATTERN = re.compile(
+    r"\.(css|js|png|jpg|jpeg|gif|svg|woff2?|ttf|ico|map)$", re.IGNORECASE
 )
 
 RULE_GROUPS = [
@@ -12,7 +13,16 @@ RULE_GROUPS = [
 
 
 def rule(event):
-    return waf_rule_group_matches(event, RULE_GROUPS)
+    if not waf_rule_group_matches(event, RULE_GROUPS):
+        return False
+
+    # Skip requests to static assets
+    uri = event.deep_get("httpRequest", "uri", default="")
+
+    if STATIC_ASSET_PATTERN.search(uri):
+        return False
+
+    return True
 
 
 def title(event):
@@ -25,7 +35,3 @@ def title(event):
 
 def alert_context(event):
     return waf_alert_context(event, RULE_GROUPS)
-
-
-def severity(event):
-    return waf_severity(event)

--- a/rules/aws_waf_rules/aws_waf_managed_ip_reputation.yml
+++ b/rules/aws_waf_rules/aws_waf_managed_ip_reputation.yml
@@ -17,7 +17,7 @@ Reports:
     - TA0001:T1190
     - TA0043:T1595
     - TA0005:T1090
-Severity: Low
+Severity: Info
 Description: >
   Detects AWS WAF IP Reputation and Anonymous IP List managed rule group matches. Flags requests
   from IPs on Amazon threat intelligence lists including known bots, reconnaissance sources, DDoS


### PR DESCRIPTION
### Background

Excluding requests to static assets, downgrading to Info as AWS WAF IP rules appear broad

### Changes

- <Describe changes here>

### Testing

- <Testing steps>
