### PR TITLE
fix(azure): case-insensitive resource-ID parsing in panther_azureactivity_helpers

### DIFF
--- a/global_helpers/panther_azureactivity_helpers.py
+++ b/global_helpers/panther_azureactivity_helpers.py
@@ -74,10 +74,17 @@ def azure_parse_json_string(json_str):
 
 
 def extract_resource_name_from_id(resource_id, resource_type, default="<UNKNOWN>"):
-    """Extract resource name from Azure resourceId path.
+    """Extract resource name from Azure resourceId path (case-insensitive).
 
     Azure resourceId paths follow the format:
     /subscriptions/{sub}/resourceGroups/{rg}/providers/{provider}/{resourceType}/{name}/...
+
+    Azure Monitor Activity logs frequently deliver resourceId fully uppercased
+    (e.g. ``/SUBSCRIPTIONS/<id>/RESOURCEGROUPS/RG/PROVIDERS/MICROSOFT.STORAGE/
+    STORAGEACCOUNTS/ACCOUNT``), so segment markers must be compared
+    case-insensitively. The returned name preserves the original casing from
+    ``resource_id`` so downstream correlation still matches the authoritative
+    resource name.
 
     Args:
         resource_id: Full Azure resource ID path
@@ -85,20 +92,17 @@ def extract_resource_name_from_id(resource_id, resource_type, default="<UNKNOWN>
         default: Default value if extraction fails (can be None or str)
 
     Returns:
-        Extracted resource name or default value
+        Extracted resource name (original case) or default value
 
     """
     if not resource_id:
         return default
 
     parts = resource_id.split("/")
-    if resource_type in parts:
-        try:
-            idx = parts.index(resource_type)
-            if idx + 1 < len(parts):
-                return parts[idx + 1]
-        except (ValueError, IndexError):
-            pass
+    lower_marker = resource_type.lower()
+    for idx, part in enumerate(parts):
+        if part.lower() == lower_marker and idx + 1 < len(parts):
+            return parts[idx + 1]
 
     return default
 


### PR DESCRIPTION
# Upstream PR: fix(azure): case-insensitive resource-ID parsing in panther_azureactivity_helpers

**Target repo:** `panther-labs/panther-analysis`
**Base branch:** `develop`
**Feature branch:** `fix-azure-helper-case-sensitivity`
**Local commit:** `5cab9323` (in `panther-work/panther-analysis/`)
**File changed:** `global_helpers/panther_azureactivity_helpers.py`
**Lines:** +13 / -9 (1 file)

Operator action to submit:

```bash
cd ~/work/scratch/claude/operations/team-dco/panther-work/panther-analysis
# Fork panther-labs/panther-analysis to your GitHub account, then:
git remote add fork git@github.com:<your-gh-user>/panther-analysis.git
git push -u fork fix-azure-helper-case-sensitivity
# Open PR via GitHub UI or `gh pr create` using the title and body below.
```

---

## PR Title

```
fix(azure): case-insensitive resource-ID parsing in panther_azureactivity_helpers
```

---

## PR Body

### Summary

`extract_resource_name_from_id()` in `global_helpers/panther_azureactivity_helpers.py` uses `parts.index(resource_type)` to locate a named segment in an Azure resourceId path. `list.index()` is case-sensitive, but Azure Monitor Activity logs frequently deliver `resourceId` fully uppercased. For those events the helper silently returns the `default` (`<UNKNOWN>`) for every resource type it looks up — `storageAccounts`, `resourceGroups`, `vaults`, `runbooks`, and any other caller.

This breaks downstream enrichment (alert context, dedup keys, lookup-based suppression) on any detection that uses this helper against real-world uppercased resourceIds.

### Evidence

Observed in production Azure Monitor Activity logs during our 2026-04-20 weekly detection review. Representative resourceId delivered by Azure:

```
/SUBSCRIPTIONS/12345678-1234-1234-1234-123456789abc/RESOURCEGROUPS/PROD-RG/PROVIDERS/MICROSOFT.STORAGE/STORAGEACCOUNTS/MYSTORAGE
```

Current behavior:

```python
>>> extract_resource_name_from_id(uppercased_id, "storageAccounts")
'<UNKNOWN>'  # because "storageAccounts" != "STORAGEACCOUNTS"
>>> extract_resource_name_from_id(uppercased_id, "resourceGroups")
'<UNKNOWN>'  # because "resourceGroups" != "RESOURCEGROUPS"
```

Expected behavior:

```python
>>> extract_resource_name_from_id(uppercased_id, "storageAccounts")
'MYSTORAGE'
>>> extract_resource_name_from_id(uppercased_id, "resourceGroups")
'PROD-RG'
```

### Fix

Compare each path segment's `.lower()` against `resource_type.lower()` instead of relying on `list.index()`. The returned name is still the original (unmodified) value at `parts[idx + 1]`, so downstream correlation against authoritative resource names continues to match the caller's expectations for case.

### Contract compatibility

- Same signature, same default behavior, same return type.
- Mixed-case resourceIds (the common documented case) continue to work unchanged.
- Previously-broken uppercased resourceIds now extract correctly.
- Returned values preserve the source casing from `resource_id` (the fix is in the **marker comparison**, not the return).

### Test plan

- [ ] `pipenv run panther_analysis_tool test --path global_helpers/` — existing global-helper tests still pass.
- [ ] Add unit test with uppercased resourceId → extracts correctly.
- [ ] Add unit test with mixed-case resourceId → still extracts correctly (regression guard).
- [ ] Grep for callers of `extract_resource_name_from_id` — all now benefit without code change.

### Downstream impact (reason we found it)

In our fork, we'd patched this helper locally and several Azure.MonitorActivity detections were consuming the patched version. Upstreaming this means we can eventually drop the fork of the helper itself. We still carry downstream-specific customizations of a few detection rules that will remain in our fork; this PR is just for the helper.

### Related

- Separate follow-up: the NSGModifiedOrDeleted detection has its own inline case-sensitive `split("/resourceGroups/")` (not using this helper). Fixed locally in our repo — may file a separate upstream PR if the detection is upstream-hosted.
