### PR TITLE
Update to MicrosoftGraph.SecurityAlertV2 schema

### DIFF
--- a/global_helpers/panther_msft_helpers.py
+++ b/global_helpers/panther_msft_helpers.py
@@ -5,9 +5,11 @@ def msft_graph_alert_context(event):
     return {
         "category": event.get("category", ""),
         "description": event.get("description", ""),
-        "userStates": event.get("userStates", []),
-        "fileStates": event.get("fileStates", []),
-        "hostStates": event.get("hostStates", []),
+        "evidence": event.get("evidence", []),
+        "serviceSource": event.get("serviceSource", ""),
+        "productName": event.get("productName", ""),
+        "incidentId": event.get("incidentId", ""),
+        "alertWebUrl": event.get("alertWebUrl", ""),
     }
 
 

--- a/indexes/detection-coverage.json
+++ b/indexes/detection-coverage.json
@@ -6907,7 +6907,7 @@
         "Description": "The Microsoft Graph security API federates queries to all onboarded security providers, including Azure AD Identity Protection, Microsoft 365, Microsoft Defender (Cloud, Endpoint, Identity) and Microsoft Sentinel",
         "DisplayName": "Microsoft Graph Passthrough",
         "LogTypes": [
-            "MicrosoftGraph.SecurityAlert"
+            "MicrosoftGraph.SecurityAlertV2"
         ],
         "YAMLPath": "rules/microsoft_rules/microsoft_graph_passthrough.yml"
     },

--- a/rules/microsoft_rules/microsoft_graph_passthrough.py
+++ b/rules/microsoft_rules/microsoft_graph_passthrough.py
@@ -1,10 +1,15 @@
 from panther_msft_helpers import msft_graph_alert_context
 
+SEVERITY_MAP = {
+    "informational": "INFO",
+    "low": "LOW",
+    "medium": "MEDIUM",
+    "high": "HIGH",
+}
+
 
 def rule(event):
-    return (
-        event.get("status") == "newAlert" and event.get("severity", "").lower() != "informational"
-    )
+    return event.get("status") == "new" and event.get("severity", "").lower() != "informational"
 
 
 def title(event):
@@ -16,9 +21,7 @@ def dedup(event):
 
 
 def severity(event):
-    if event.get("severity", "").lower() == "informational":
-        return "INFO"
-    return event.get("severity")
+    return SEVERITY_MAP.get(event.get("severity", "").lower(), "INFO")
 
 
 def alert_context(event):

--- a/rules/microsoft_rules/microsoft_graph_passthrough.yml
+++ b/rules/microsoft_rules/microsoft_graph_passthrough.yml
@@ -1,6 +1,6 @@
 AnalysisType: rule
 Description: The Microsoft Graph security API federates queries to all onboarded security providers, including Azure AD Identity Protection, Microsoft 365, Microsoft Defender (Cloud, Endpoint, Identity) and Microsoft Sentinel
-Reference: https://learn.microsoft.com/en-us/graph/api/resources/security-api-overview
+Reference: https://learn.microsoft.com/en-us/graph/api/resources/security-alert?view=graph-rest-1.0
 DisplayName: "Microsoft Graph Passthrough"
 Enabled: true
 Filename: microsoft_graph_passthrough.py
@@ -8,81 +8,80 @@ Severity: Medium
 Tests:
   - ExpectedResult: true
     Log:
-      azuretenantid: 12345-abcde-a1b2k3
-      category: AnonymousLogin
-      createddatetime: "2022-08-04 14:31:48.438"
-      description: Sign-in from an anonymous IP address (e.g. Tor browser, anonymizer VPNs)
-      eventdatetime: "2022-08-04 14:31:48.438"
+      tenantId: 12345-abcde-a1b2k3
       id: abcd12345efghijk6789
-      lastmodifieddatetime: "2022-08-04 14:34:56.229"
-      severity: medium
-      status: newAlert
       title: Anonymous IP address
-      userstates:
-        - aadUserId: 011d5ede-0faa-4946-a25e-b2cd0c47a52c
-          accountName: homer.simpson
-          domainName: corporation.onmicrosoft.com
-          emailRole: unknown
-          logonDateTime: "2022-08-04 14:31:48.438699700"
-          logonIp: 185.220.103.6
-          logonLocation: Brooklyn, New York, US
-          userPrincipalName: homer.simpson@corporation.onmicrosoft.com
-      vendorinformation:
-        provider: IPC
-        vendor: Microsoft
-    Name: Anonymous Login Event
+      description: Sign-in from an anonymous IP address (e.g. Tor browser, anonymizer VPNs)
+      category: AnonymousLogin
+      createdDateTime: "2026-04-01T14:31:48.438Z"
+      firstActivityDateTime: "2026-04-01T14:31:48.438Z"
+      lastActivityDateTime: "2026-04-01T14:31:48.438Z"
+      lastUpdateDateTime: "2026-04-01T14:34:56.229Z"
+      severity: medium
+      status: new
+      serviceSource: microsoftDefenderForIdentity
+      productName: Microsoft Defender for Identity
+      evidence:
+        - at_sign_odata_type: "#microsoft.graph.security.userEvidence"
+          userAccount:
+            accountName: homer.simpson
+            domainName: corporation.onmicrosoft.com
+            userPrincipalName: homer.simpson@corporation.onmicrosoft.com
+            azureAdUserId: 011d5ede-0faa-4946-a25e-b2cd0c47a52c
+        - at_sign_odata_type: "#microsoft.graph.security.ipEvidence"
+          ipAddress: 185.220.103.6
+          countryLetterCode: US
+    Name: Anonymous Login Event (v2)
   - ExpectedResult: true
     Log:
-      azuretenantid: abcdef-123456-ghijklmn
-      category: PasswordSpray
-      createddatetime: "2022-08-17 09:28:04.767"
-      description: Password spray attack detected
-      eventdatetime: "2022-08-16 14:22:00.698"
+      tenantId: abcdef-123456-ghijklmn
       id: abcdefg-123456-hijklmno
-      lastmodifieddatetime: "2022-08-17 14:30:21.979"
-      severity: high
-      status: newAlert
       title: Password Spray
-      userstates:
-        - aadUserId: abcdefg-123456-lmnop
-          accountName: homer.simpson
-          domainName: corporation.onmicrosoft.com
-          emailRole: unknown
-          logonDateTime: "2022-08-16 14:22:00.698619500"
-          logonIp: 109.70.100.21
-          logonLocation: San Francisco, CA
-          userPrincipalName: homer.simpson@corporation.onmicrosoft.com
-      vendorinformation:
-        provider: IPC
-        vendor: Microsoft
-    Name: Password Spray Event
+      description: Password spray attack detected
+      category: PasswordSpray
+      createdDateTime: "2026-04-02T09:28:04.767Z"
+      firstActivityDateTime: "2026-04-02T14:22:00.698Z"
+      lastUpdateDateTime: "2026-04-02T14:30:21.979Z"
+      severity: high
+      status: new
+      serviceSource: microsoftDefenderForIdentity
+      evidence:
+        - at_sign_odata_type: "#microsoft.graph.security.userEvidence"
+          userAccount:
+            accountName: homer.simpson
+            domainName: corporation.onmicrosoft.com
+            userPrincipalName: homer.simpson@corporation.onmicrosoft.com
+    Name: Password Spray Event (v2)
   - ExpectedResult: false
     Log:
-      azuretenantid: abcdefg-12345
-      category: AnonymousLogin
-      createddatetime: "2022-09-12 19:54:13.725"
-      description: Sign-in from an anonymous IP address (e.g. Tor browser, anonymizer VPNs)
-      eventdatetime: "2022-09-12 19:54:13.725"
+      tenantId: abcdefg-12345
       id: abcdefg12345hijklmnop
-      lastmodifieddatetime: "2022-09-12 19:56:57.833"
+      title: Anonymous IP address
+      description: Sign-in from an anonymous IP address (e.g. Tor browser, anonymizer VPNs)
+      category: AnonymousLogin
+      createdDateTime: "2026-04-03T19:54:13.725Z"
+      firstActivityDateTime: "2026-04-03T19:54:13.725Z"
+      lastUpdateDateTime: "2026-04-03T19:56:57.833Z"
       severity: high
       status: resolved
-      title: Anonymous IP address
-      userstates:
-        - aadUserId: abcdefg1234
-          accountName: homer.simpson
-          domainName: corporation.onmicrosoft.com
-          emailRole: unknown
-          logonDateTime: "2022-09-12 19:54:13.725589800"
-          logonIp: 109.70.100.35
-          logonLocation: San Francisco, CA
-          userPrincipalName: homer.simpson@corporation.onmicrosoft.com
-      vendorinformation:
-        provider: IPC
-        vendor: Microsoft
-    Name: Resolved Event
+      serviceSource: microsoftDefenderForIdentity
+    Name: Resolved Event (v2)
+  - ExpectedResult: false
+    Log:
+      tenantId: abcdefg-12345
+      id: info-event-1
+      title: Informational signal
+      description: Low-noise informational alert
+      category: Informational
+      createdDateTime: "2026-04-04T10:00:00.000Z"
+      firstActivityDateTime: "2026-04-04T10:00:00.000Z"
+      lastUpdateDateTime: "2026-04-04T10:00:00.000Z"
+      severity: informational
+      status: new
+      serviceSource: microsoftDefenderForCloud
+    Name: Informational Severity Event (v2)
 DedupPeriodMinutes: 60
 LogTypes:
-  - MicrosoftGraph.SecurityAlert
+  - MicrosoftGraph.SecurityAlertV2
 RuleID: "Microsoft.Graph.Passthrough"
 Threshold: 1


### PR DESCRIPTION
   rules/microsoft_rules/microsoft_graph_passthrough.yml
 - LogTypes: MicrosoftGraph.SecurityAlert → MicrosoftGraph.SecurityAlertV2
  - Replaced fixtures with v2 shape: tenantId, firstActivityDateTime, lastUpdateDateTime, createdDateTime, serviceSource/productName, polymorphic evidence[] array discriminated by at_sign_odata_type (the schema renames @odata.type)
  - Status newAlert → new, resolved unchanged. Added an informational-severity negative test.

  rules/microsoft_rules/microsoft_graph_passthrough.py
  - Match on status == "new" (v2 lifecycle value) instead of "newAlert"
  - severity() now maps the v2 lowercase enum (informational/low/medium/high) to Panther severities; v1 returned the raw provider string which won't be a valid severity for v2 anyway

  global_helpers/panther_msft_helpers.py
  - msft_graph_alert_context() returns v2 fields: evidence, serviceSource, productName, incidentId, alertWebUrl. Dropped v1-only userStates/fileStates/hostStates.

