### PR TITLE
fix: normalize CrowdStrike SeverityName to Panther severity levels

### DIFF
--- a/global_helpers/panther_crowdstrike_fdr_helpers.py
+++ b/global_helpers/panther_crowdstrike_fdr_helpers.py
@@ -59,3 +59,22 @@ def get_crowdstrike_field(event, field_name, default=None):
         or event.deep_get("unknown_payload", field_name)
         or default
     )
+
+
+_CROWDSTRIKE_SEVERITY_MAP = {
+    "informational": "INFO",
+    "low": "LOW",
+    "medium": "MEDIUM",
+    "high": "HIGH",
+    "critical": "CRITICAL",
+}
+
+
+def crowdstrike_severity(event) -> str:
+    """Maps CrowdStrike SeverityName to a Panther severity level.
+
+    CrowdStrike uses "Informational" where Panther expects "INFO"; this
+    normalizes all variants case-insensitively and falls back to DEFAULT.
+    """
+    severity_name = get_crowdstrike_field(event, "SeverityName", default="")
+    return _CROWDSTRIKE_SEVERITY_MAP.get(severity_name.lower(), "DEFAULT")

--- a/rules/crowdstrike_rules/crowdstrike_detection_passthrough.py
+++ b/rules/crowdstrike_rules/crowdstrike_detection_passthrough.py
@@ -2,6 +2,7 @@ import uuid
 
 from panther_crowdstrike_fdr_helpers import (
     crowdstrike_detection_alert_context,
+    crowdstrike_severity,
     get_crowdstrike_field,
 )
 
@@ -26,7 +27,7 @@ def alert_context(event):
 
 
 def severity(event):
-    return get_crowdstrike_field(event, "SeverityName")
+    return crowdstrike_severity(event)
 
 
 def dedup(event):

--- a/rules/crowdstrike_rules/crowdstrike_detection_passthrough.yml
+++ b/rules/crowdstrike_rules/crowdstrike_detection_passthrough.yml
@@ -159,6 +159,48 @@ Tests:
         "p_schema_version": 0,
         "timestamp": "2021-03-24 18:19:49",
       }
+  - Name: Informational Severity Finding
+    ExpectedResult: true
+    Log:
+      {
+        "cid": "00000000006e49842267fc5837c4e2fc",
+        "Technique": "Informational Activity",
+        "AgentIdString": "00000000000000000000000000000000",
+        "Name": "NGAV",
+        "Hostname": "macbook",
+        "CommandLine": "/Applications/app.app/Contents/MacOS/pup app",
+        "Objective": "Falcon Detection Method",
+        "Nonce": 1,
+        "SHA256String": "00000000009d4244ff0eff80712145e92dfbdc1990483402aca903f70c020e60",
+        "ExternalApiType": "Event_EppDetectionSummaryEvent",
+        "PatternDispositionValue": 0,
+        "CompositeId": "00000000000000000000000000000000:ind:00000000006e49842267fc5837c4e2fc:222222222222222222-33333-444444",
+        "Severity": 1,
+        "PatternDispositionDescription": "Detection, standard detection.",
+        "SeverityName": "Informational",
+        "MD5String": "000000000034829cb7cd82035c444f38",
+        "EventUUID": "000000000034829cb7cd82035c444f38",
+        "UserName": "bobert",
+        "FilePath": "/Applications/app.app/Contents/MacOS/",
+        "timestamp": "2021-09-18 20:38:52Z",
+        "ParentCommandLine": "/usr/libexec/runningboardd",
+        "Description": "Informational sample detection.",
+        "LocalIP": "1.1.1.1",
+        "ProcessEndTime": "1970-01-01 00:00:00Z",
+        "SHA1String": "0000000000000000000000000000000000000000",
+        "OriginSourceIpAddress": "",
+        "GrandParentImageFileName": "/sbin/launchd",
+        "MachineDomain": "",
+        "ParentImageFileName": "/usr/libexec/runningboardd",
+        "FalconHostLink": "https://falcon.us-2.crowdstrike.com/activity/detections/detail/00000000000000000000000000000000/222222222222222222?",
+        "UTCTimestamp": "2021-09-18 20:38:52Z",
+        "FileName": "pup app",
+        "EventType": "Event_ExternalApiEvent",
+        "CustomerIdString": "00000000006e49842267fc5837c4e2fc",
+        "Tactic": "Malware",
+        "SensorId": "00000000000000000000000000000000",
+        "eid": 118,
+      }
   - Name: Non-match (FDREvent)
     ExpectedResult: false
     Log:


### PR DESCRIPTION
## Summary

- Adds `crowdstrike_severity()` to `panther_crowdstrike_fdr_helpers.py` that maps CrowdStrike `SeverityName` values to Panther severity levels case-insensitively (`"Informational"` → `"INFO"`, `"Low"` → `"LOW"`, etc.), falling back to `"DEFAULT"` for unknown values
- Updates `crowdstrike_detection_passthrough.py` to use the new helper instead of returning the raw `SeverityName` field
- Adds an `"Informational"` severity test case to `crowdstrike_detection_passthrough.yml`

Fixes ASK-3764 — CrowdStrike emits `SeverityName: "Informational"` but the passthrough rule's `severity()` function was returning that string directly, which Panther doesn't recognize (it expects `"INFO"`).

## Test plan

- [ ] Existing unit tests for `crowdstrike_detection_passthrough` pass (Low severity, FDREvent format, non-match)
- [ ] New `Informational Severity Finding` test case passes
- [ ] Verify `crowdstrike_severity()` maps all CrowdStrike severity names correctly

https://claude.ai/code/session_01Tt8jRV9Hfix5v9deDoBaUh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt8jRV9Hfix5v9deDoBaUh)_