### PR TITLE
[THREAT-689] Anthropic Compliance API Rules

### DIFF
--- a/global_helpers/panther_anthropic_helpers.py
+++ b/global_helpers/panther_anthropic_helpers.py
@@ -1,0 +1,49 @@
+from panther_base_helpers import pantherflow_investigation
+
+
+def anthropic_actor_id(event):
+    """Returns the best available actor identifier, cascading through email, API key, then IP."""
+    return (
+        event.deep_get("actor", "email_address")
+        or event.deep_get("actor", "api_key_id")
+        or event.deep_get("actor", "ip_address", default="<UNKNOWN_ACTOR>")
+    )
+
+
+def anthropic_alert_context(event):
+    """Returns common context for Anthropic Activity alerts"""
+    context = {
+        "event_type": event.get("type", ""),
+        "actor_type": event.deep_get("actor", "type", default=""),
+        "actor_email": event.deep_get("actor", "email_address", default=""),
+        "actor_user_id": event.deep_get("actor", "user_id", default=""),
+        "ip_address": event.deep_get("actor", "ip_address", default=""),
+        "user_agent": event.deep_get("actor", "user_agent", default=""),
+        "api_key_id": event.deep_get("actor", "api_key_id", default=""),
+        "organization_id": event.get("organization_id", ""),
+        "ips": event.get("p_any_ip_addresses", []),
+        "PantherFlow Investigation": pantherflow_investigation(event),
+    }
+    optional_context = {
+        "target_id": event.get("target_id"),
+        "target_type": event.get("target_type"),
+        "role": event.get("role"),
+        "resource_type": event.get("resource_type"),
+        "resource_id": event.get("resource_id"),
+        "updates": event.get("updates"),
+        "claude_chat_id": event.get("claude_chat_id"),
+        "claude_project_id": event.get("claude_project_id"),
+        "mcp_server_id": event.get("mcp_server_id"),
+        "mcp_server_name": event.get("mcp_server_name"),
+        "integration_type": event.get("integration_type"),
+        "audience": event.get("audience"),
+        "is_enabled": event.get("is_enabled"),
+        "admin_api_key_id": event.get("admin_api_key_id"),
+        "service_key_id": event.get("service_key_id"),
+        "service_name": event.get("service_name"),
+        "connection_id": event.get("connection_id"),
+        "deleted_user_id": event.get("deleted_user_id"),
+        "deleted_user_email": event.get("deleted_user_email"),
+    }
+    context.update({k: v for k, v in optional_context.items() if v is not None})
+    return context

--- a/global_helpers/panther_anthropic_helpers.yml
+++ b/global_helpers/panther_anthropic_helpers.yml
@@ -1,0 +1,5 @@
+AnalysisType: global
+Filename: panther_anthropic_helpers.py
+GlobalID: "panther_anthropic_helpers"
+Description: >
+  Used to define global helpers and variables for Anthropic Activity events.

--- a/indexes/alpha-index.md
+++ b/indexes/alpha-index.md
@@ -41,6 +41,7 @@
 - [AWS VPCFlow](#aws-vpcflow)
 - [AWS WAF](#aws-waf)
 - [AWS WAFWebACL](#aws-wafwebacl)
+- [Anthropic](#anthropic)
 - [AppOmni](#appomni)
 - [Asana](#asana)
 - [Atlassian](#atlassian)
@@ -872,6 +873,44 @@
   - Detects AWS WAF SQL Database managed rule group matches. Covers SQL injection patterns in query arguments, request body, cookies, and URI path, including extended patterns not covered by the Core Rule Set.
 - [AWS WAF ReactJS RCE Attempt via Body](../rules/aws_waf_rules/aws_waf_reactjsrce_body.yml)
   - Detects AWS WAF ReactJSRCE_BODY managed rule matches indicating React2Shell (CVE-2025-55182) ReactJS RCE attempts via HTTP body. Monitors all WAF sources: ALB, CloudFront, API Gateway, AppSync.
+
+
+## Anthropic
+
+- [Anthropic Admin API Key Created](../rules/anthropic_rules/anthropic_admin_api_key_created.yml)
+  - Detects when a new admin API key is created. Admin API keys have elevated privileges and their creation should be verified as authorized. The admin_api_key_id and scopes fields identify the key and its permissions.
+- [Anthropic Admin API Key Deleted](../rules/anthropic_rules/anthropic_admin_api_key_deleted.yml)
+  - Detects when an admin API key is deleted. Unauthorized deletion could indicate an attacker revoking legitimate credentials to disrupt operations or covering tracks after using a compromised key.
+- [Anthropic Artifact Shared Publicly](../rules/anthropic_rules/anthropic_artifact_shared_publicly.yml)
+  - Detects when an artifact's sharing audience is changed to public. Public artifacts are accessible to anyone with the link, which could expose sensitive content outside the organization.
+- [Anthropic Excessive Chat Access Failures](../rules/anthropic_rules/anthropic_excessive_chat_access_failures.yml)
+  - Detects when a single actor generates more than 50 chat access failures within a 10-minute window. Could indicate automated chat enumeration or unauthorized bulk access attempts. The claude_chat_id field identifies which chats were targeted — sequential or patterned IDs suggest scripted enumeration, while scattered IDs suggest shared-link browsing.
+- [Anthropic Integration Connected](../rules/anthropic_rules/anthropic_integration_connected.yml)
+  - Tracks when a user connects an external integration (e.g., GitHub, Google Drive) to their Anthropic account. Logged for compliance visibility into external data pathways. The integration_type field identifies which service was connected.
+- [Anthropic IP Restriction Deleted](../rules/anthropic_rules/anthropic_ip_restriction_deleted.yml)
+  - Detects when an organization IP restriction is deleted. IP restrictions are a critical network-level access control — removing them allows access from any IP address, which could indicate an attacker widening the attack surface after gaining admin access.
+- [Anthropic MCP Server Created](../rules/anthropic_rules/anthropic_mcp_server_created.yml)
+  - Detects when a new MCP (Model Context Protocol) server integration is created. Each MCP server is a new external data pathway that could be used for data exfiltration. Every new integration should be verified as approved, especially when created by external contractors or service accounts.
+- [Anthropic MCP Server Deleted](../rules/anthropic_rules/anthropic_mcp_server_deleted.yml)
+  - Detects when an MCP server integration is deleted from the organization. Removing an approved integration could indicate an attacker covering tracks or unauthorized configuration changes. The mcp_server_name and mcp_server_id fields identify which integration was removed.
+- [Anthropic Organization Settings Updated](../rules/anthropic_rules/anthropic_org_settings_updated.yml)
+  - Detects when organization-wide settings are modified in Anthropic. These changes can affect security posture for all users (e.g., SSO configuration, data retention, access controls). The updates field identifies which settings were changed.
+- [Anthropic Organization User Deleted](../rules/anthropic_rules/anthropic_org_user_deleted.yml)
+  - Tracks when a user is removed from the Anthropic organization. Logged for compliance visibility into user lifecycle changes. The deleted_user_id and deleted_user_email fields identify who was removed.
+- [Anthropic Primary Owner Transferred](../rules/anthropic_rules/anthropic_primary_owner_transferred.yml)
+  - Detects when the primary owner role of the Anthropic organization is transferred to another member. This is an extremely high-privilege action that gives full control of the organization. The previous_owner_id and new_owner_id fields identify who gave up and received ownership.
+- [Anthropic Role Granted](../rules/anthropic_rules/anthropic_role_granted.yml)
+  - Tracks all role grants in the Anthropic organization. Currently used to build visibility into the role taxonomy as the log source matures. Once sufficient data is collected on org-level vs project-level role patterns, this rule can be refined to alert at higher severity for elevated roles.
+- [Anthropic Service Key Created](../rules/anthropic_rules/anthropic_service_key_created.yml)
+  - Detects when a new service key is created. Service keys provide programmatic access and their creation should be verified as authorized. The service_key_id, service_name, key_name, and scopes fields identify the key and its permissions.
+- [Anthropic Service Key Revoked](../rules/anthropic_rules/anthropic_service_key_revoked.yml)
+  - Detects when a service key is revoked. Unauthorized revocation could indicate an attacker disrupting integrations or covering tracks after using a compromised key. The service_key_id and service_name fields identify which key was revoked.
+- [Anthropic Spend Limit Deleted](../rules/anthropic_rules/anthropic_spend_limit_deleted.yml)
+  - Detects when a platform spend limit is deleted. A deleted spend limit without a subsequent recreate could indicate an attacker removing financial guardrails to enable large-scale API usage or data exfiltration. Note that normal admin workflow often involves a delete immediately followed by a create (editing a limit).
+- [Anthropic SSO Disabled](../rules/anthropic_rules/anthropic_sso_disabled.yml)
+  - Detects when SSO is disabled or an SSO connection is deactivated for the organization. Disabling SSO allows users to bypass the identity provider and use weaker authentication methods. This is a critical security posture change that could indicate an attacker attempting to maintain access without IdP visibility.
+- [Anthropic SSO Login Failed](../rules/anthropic_rules/anthropic_sso_login_failed.yml)
+  - Detects failed SSO login attempts to the Anthropic organization. The actor is unauthenticated so no email is available — only the source IP. Every failure is alerted on as SSO failures should be rare in normal operation.
 
 
 ## AppOmni

--- a/indexes/detection-coverage.json
+++ b/indexes/detection-coverage.json
@@ -208,6 +208,159 @@
     },
     {
         "AnalysisType": "Rule",
+        "Description": "Detects when a new admin API key is created. Admin API keys have elevated privileges and their creation should be verified as authorized. The admin_api_key_id and scopes fields identify the key and its permissions.",
+        "DisplayName": "Anthropic Admin API Key Created",
+        "LogTypes": [
+            "Anthropic.Activity"
+        ],
+        "YAMLPath": "rules/anthropic_rules/anthropic_admin_api_key_created.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "Detects when an admin API key is deleted. Unauthorized deletion could indicate an attacker revoking legitimate credentials to disrupt operations or covering tracks after using a compromised key.",
+        "DisplayName": "Anthropic Admin API Key Deleted",
+        "LogTypes": [
+            "Anthropic.Activity"
+        ],
+        "YAMLPath": "rules/anthropic_rules/anthropic_admin_api_key_deleted.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "Detects when an artifact's sharing audience is changed to public. Public artifacts are accessible to anyone with the link, which could expose sensitive content outside the organization.",
+        "DisplayName": "Anthropic Artifact Shared Publicly",
+        "LogTypes": [
+            "Anthropic.Activity"
+        ],
+        "YAMLPath": "rules/anthropic_rules/anthropic_artifact_shared_publicly.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "Detects when a single actor generates more than 50 chat access failures within a 10-minute window. Could indicate automated chat enumeration or unauthorized bulk access attempts. The claude_chat_id field identifies which chats were targeted \u2014 sequential or patterned IDs suggest scripted enumeration, while scattered IDs suggest shared-link browsing.",
+        "DisplayName": "Anthropic Excessive Chat Access Failures",
+        "LogTypes": [
+            "Anthropic.Activity"
+        ],
+        "YAMLPath": "rules/anthropic_rules/anthropic_excessive_chat_access_failures.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "Tracks when a user connects an external integration (e.g., GitHub, Google Drive) to their Anthropic account. Logged for compliance visibility into external data pathways. The integration_type field identifies which service was connected.",
+        "DisplayName": "Anthropic Integration Connected",
+        "LogTypes": [
+            "Anthropic.Activity"
+        ],
+        "YAMLPath": "rules/anthropic_rules/anthropic_integration_connected.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "Detects when an organization IP restriction is deleted. IP restrictions are a critical network-level access control \u2014 removing them allows access from any IP address, which could indicate an attacker widening the attack surface after gaining admin access.",
+        "DisplayName": "Anthropic IP Restriction Deleted",
+        "LogTypes": [
+            "Anthropic.Activity"
+        ],
+        "YAMLPath": "rules/anthropic_rules/anthropic_ip_restriction_deleted.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "Detects when a new MCP (Model Context Protocol) server integration is created. Each MCP server is a new external data pathway that could be used for data exfiltration. Every new integration should be verified as approved, especially when created by external contractors or service accounts.",
+        "DisplayName": "Anthropic MCP Server Created",
+        "LogTypes": [
+            "Anthropic.Activity"
+        ],
+        "YAMLPath": "rules/anthropic_rules/anthropic_mcp_server_created.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "Detects when an MCP server integration is deleted from the organization. Removing an approved integration could indicate an attacker covering tracks or unauthorized configuration changes. The mcp_server_name and mcp_server_id fields identify which integration was removed.",
+        "DisplayName": "Anthropic MCP Server Deleted",
+        "LogTypes": [
+            "Anthropic.Activity"
+        ],
+        "YAMLPath": "rules/anthropic_rules/anthropic_mcp_server_deleted.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "Detects when organization-wide settings are modified in Anthropic. These changes can affect security posture for all users (e.g., SSO configuration, data retention, access controls). The updates field identifies which settings were changed.",
+        "DisplayName": "Anthropic Organization Settings Updated",
+        "LogTypes": [
+            "Anthropic.Activity"
+        ],
+        "YAMLPath": "rules/anthropic_rules/anthropic_org_settings_updated.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "Tracks when a user is removed from the Anthropic organization. Logged for compliance visibility into user lifecycle changes. The deleted_user_id and deleted_user_email fields identify who was removed.",
+        "DisplayName": "Anthropic Organization User Deleted",
+        "LogTypes": [
+            "Anthropic.Activity"
+        ],
+        "YAMLPath": "rules/anthropic_rules/anthropic_org_user_deleted.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "Detects when the primary owner role of the Anthropic organization is transferred to another member. This is an extremely high-privilege action that gives full control of the organization. The previous_owner_id and new_owner_id fields identify who gave up and received ownership.",
+        "DisplayName": "Anthropic Primary Owner Transferred",
+        "LogTypes": [
+            "Anthropic.Activity"
+        ],
+        "YAMLPath": "rules/anthropic_rules/anthropic_primary_owner_transferred.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "Tracks all role grants in the Anthropic organization. Currently used to build visibility into the role taxonomy as the log source matures. Once sufficient data is collected on org-level vs project-level role patterns, this rule can be refined to alert at higher severity for elevated roles.",
+        "DisplayName": "Anthropic Role Granted",
+        "LogTypes": [
+            "Anthropic.Activity"
+        ],
+        "YAMLPath": "rules/anthropic_rules/anthropic_role_granted.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "Detects when a new service key is created. Service keys provide programmatic access and their creation should be verified as authorized. The service_key_id, service_name, key_name, and scopes fields identify the key and its permissions.",
+        "DisplayName": "Anthropic Service Key Created",
+        "LogTypes": [
+            "Anthropic.Activity"
+        ],
+        "YAMLPath": "rules/anthropic_rules/anthropic_service_key_created.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "Detects when a service key is revoked. Unauthorized revocation could indicate an attacker disrupting integrations or covering tracks after using a compromised key. The service_key_id and service_name fields identify which key was revoked.",
+        "DisplayName": "Anthropic Service Key Revoked",
+        "LogTypes": [
+            "Anthropic.Activity"
+        ],
+        "YAMLPath": "rules/anthropic_rules/anthropic_service_key_revoked.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "Detects when a platform spend limit is deleted. A deleted spend limit without a subsequent recreate could indicate an attacker removing financial guardrails to enable large-scale API usage or data exfiltration. Note that normal admin workflow often involves a delete immediately followed by a create (editing a limit).",
+        "DisplayName": "Anthropic Spend Limit Deleted",
+        "LogTypes": [
+            "Anthropic.Activity"
+        ],
+        "YAMLPath": "rules/anthropic_rules/anthropic_spend_limit_deleted.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "Detects when SSO is disabled or an SSO connection is deactivated for the organization. Disabling SSO allows users to bypass the identity provider and use weaker authentication methods. This is a critical security posture change that could indicate an attacker attempting to maintain access without IdP visibility.",
+        "DisplayName": "Anthropic SSO Disabled",
+        "LogTypes": [
+            "Anthropic.Activity"
+        ],
+        "YAMLPath": "rules/anthropic_rules/anthropic_sso_disabled.yml"
+    },
+    {
+        "AnalysisType": "Rule",
+        "Description": "Detects failed SSO login attempts to the Anthropic organization. The actor is unauthenticated so no email is available \u2014 only the source IP. Every failure is alerted on as SSO failures should be rare in normal operation.",
+        "DisplayName": "Anthropic SSO Login Failed",
+        "LogTypes": [
+            "Anthropic.Activity"
+        ],
+        "YAMLPath": "rules/anthropic_rules/anthropic_sso_login_failed.yml"
+    },
+    {
+        "AnalysisType": "Rule",
         "Description": "",
         "DisplayName": "AppOmni Alert Passthrough",
         "LogTypes": [

--- a/rules/anthropic_rules/anthropic_admin_api_key_created.py
+++ b/rules/anthropic_rules/anthropic_admin_api_key_created.py
@@ -1,0 +1,18 @@
+from panther_anthropic_helpers import anthropic_actor_id, anthropic_alert_context
+
+
+def rule(event):
+    return event.get("type") == "admin_api_key_created"
+
+
+def title(event):
+    actor_email = anthropic_actor_id(event)
+    return f"Anthropic: Admin API key created by [{actor_email}]"
+
+
+def dedup(event):
+    return anthropic_actor_id(event)
+
+
+def alert_context(event):
+    return anthropic_alert_context(event)

--- a/rules/anthropic_rules/anthropic_admin_api_key_created.yml
+++ b/rules/anthropic_rules/anthropic_admin_api_key_created.yml
@@ -1,0 +1,55 @@
+AnalysisType: rule
+RuleID: Anthropic.Activity.Admin.API.Key.Created
+DisplayName: "Anthropic Admin API Key Created"
+Enabled: true
+Status: Experimental
+Filename: anthropic_admin_api_key_created.py
+LogTypes:
+  - Anthropic.Activity
+Severity: Medium
+Description: >
+  Detects when a new admin API key is created. Admin API keys have elevated
+  privileges and their creation should be verified as authorized. The
+  admin_api_key_id and scopes fields identify the key and its permissions.
+Runbook: |
+  1. Find all Anthropic.Activity events by actor:email_address in the 6 hours before and after the alert to determine if this is part of routine admin work
+  2. Check if actor:email_address has created admin API keys in the past 90 days to determine if this is a first-time action
+  3. Check if actor:ip_address is associated with known VPN/proxy services or matches previously seen IP addresses for this actor
+Tags:
+  - Anthropic
+  - Credential Access
+Reports:
+  MITRE ATT&CK:
+    - TA0006:T1098.001  # Account Manipulation: Additional Cloud Credentials
+Tests:
+  - Name: Admin API key created
+    ExpectedResult: true
+    Log:
+      {
+        "id": "activity_01ABC123",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "admin_api_key_created",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: Non-matching event type
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01DEF456",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "admin_api_key_updated",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1"
+        }
+      }

--- a/rules/anthropic_rules/anthropic_admin_api_key_deleted.py
+++ b/rules/anthropic_rules/anthropic_admin_api_key_deleted.py
@@ -1,0 +1,18 @@
+from panther_anthropic_helpers import anthropic_actor_id, anthropic_alert_context
+
+
+def rule(event):
+    return event.get("type") == "admin_api_key_deleted"
+
+
+def title(event):
+    actor_email = anthropic_actor_id(event)
+    return f"Anthropic: Admin API key deleted by [{actor_email}]"
+
+
+def dedup(event):
+    return anthropic_actor_id(event)
+
+
+def alert_context(event):
+    return anthropic_alert_context(event)

--- a/rules/anthropic_rules/anthropic_admin_api_key_deleted.yml
+++ b/rules/anthropic_rules/anthropic_admin_api_key_deleted.yml
@@ -1,0 +1,55 @@
+AnalysisType: rule
+RuleID: Anthropic.Activity.Admin.API.Key.Deleted
+DisplayName: "Anthropic Admin API Key Deleted"
+Enabled: true
+Status: Experimental
+Filename: anthropic_admin_api_key_deleted.py
+LogTypes:
+  - Anthropic.Activity
+Severity: Medium
+Description: >
+  Detects when an admin API key is deleted. Unauthorized deletion could
+  indicate an attacker revoking legitimate credentials to disrupt operations
+  or covering tracks after using a compromised key.
+Runbook: |
+  1. Find all Anthropic.Activity events by actor:email_address in the 6 hours before and after the alert to determine if this is part of routine key rotation
+  2. Check if an admin_api_key_created event occurred near this deletion to determine if this is a key rotation or a standalone deletion
+  3. Check if actor:ip_address is associated with known VPN/proxy services or matches previously seen IP addresses for this actor
+Tags:
+  - Anthropic
+  - Credential Access
+Reports:
+  MITRE ATT&CK:
+    - TA0006:T1098.001  # Account Manipulation: Additional Cloud Credentials
+Tests:
+  - Name: Admin API key deleted
+    ExpectedResult: true
+    Log:
+      {
+        "id": "activity_01ABC123",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "admin_api_key_deleted",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: Non-matching event type
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01DEF456",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "admin_api_key_created",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1"
+        }
+      }

--- a/rules/anthropic_rules/anthropic_artifact_shared_publicly.py
+++ b/rules/anthropic_rules/anthropic_artifact_shared_publicly.py
@@ -1,0 +1,30 @@
+from panther_anthropic_helpers import anthropic_actor_id, anthropic_alert_context
+
+
+def rule(event):
+    if event.get("type") != "claude_artifact_sharing_updated":
+        return False
+    audience = event.get("audience")
+    if audience is None:
+        return False
+    # Panther's event wrapper intercepts .get("type") and ["type"] on nested
+    # objects, returning the parent event's type. String matching on the
+    # serialized audience is the only reliable approach in the test framework.
+    # In production, audience entries only have a "type" key, so matching
+    # "'public'" or '"public"' is equivalent to checking entry.type == "public".
+    audience_str = str(audience)
+    return "'public'" in audience_str or '"public"' in audience_str
+
+
+def title(event):
+    actor_email = anthropic_actor_id(event)
+    artifact_id = event.get("claude_artifact_id", "<UNKNOWN_ARTIFACT>")
+    return f"Anthropic: Artifact [{artifact_id}] shared publicly by [{actor_email}]"
+
+
+def dedup(event):
+    return anthropic_actor_id(event)
+
+
+def alert_context(event):
+    return anthropic_alert_context(event)

--- a/rules/anthropic_rules/anthropic_artifact_shared_publicly.yml
+++ b/rules/anthropic_rules/anthropic_artifact_shared_publicly.yml
@@ -1,0 +1,74 @@
+AnalysisType: rule
+RuleID: Anthropic.Activity.Artifact.Shared.Publicly
+DisplayName: "Anthropic Artifact Shared Publicly"
+Enabled: true
+Status: Experimental
+Filename: anthropic_artifact_shared_publicly.py
+LogTypes:
+  - Anthropic.Activity
+Severity: Medium
+Description: >
+  Detects when an artifact's sharing audience is changed to public. Public
+  artifacts are accessible to anyone with the link, which could expose
+  sensitive content outside the organization.
+Runbook: |
+  1. Find all Anthropic.Activity events by actor:email_address in the 1 hour before and after the alert to understand the context of the sharing change
+  2. Check if the claude_artifact_id has been viewed or accessed by external users in the 24 hours after the sharing change
+  3. Check if actor:email_address has shared other artifacts publicly in the past 30 days to determine if this is a pattern
+Tags:
+  - Anthropic
+  - Data Loss Prevention
+Reports:
+  MITRE ATT&CK:
+    - TA0010:T1567  # Exfiltration Over Web Service
+Tests:
+  - Name: Artifact shared publicly
+    ExpectedResult: true
+    Log:
+      {
+        "id": "activity_01ABC123",
+        "created_at": "2026-05-07T09:10:01Z",
+        "organization_id": "org_01XYZ",
+        "type": "claude_artifact_sharing_updated",
+        "claude_artifact_id": "claude_artifact_01ABC",
+        "audience": [{"type": "public"}],
+        "actor": {
+          "type": "user_actor",
+          "email_address": "user@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: Artifact shared with organization only
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01DEF456",
+        "created_at": "2026-05-07T09:10:01Z",
+        "organization_id": "org_01XYZ",
+        "type": "claude_artifact_sharing_updated",
+        "claude_artifact_id": "claude_artifact_01DEF",
+        "audience": [{"type": "organization"}],
+        "actor": {
+          "type": "user_actor",
+          "email_address": "user@example.com",
+          "user_id": "user_01DEF",
+          "ip_address": "10.0.0.2"
+        }
+      }
+  - Name: Non-matching event type
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01GHI789",
+        "created_at": "2026-05-07T09:10:01Z",
+        "organization_id": "org_01XYZ",
+        "type": "claude_chat_created",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "user@example.com",
+          "user_id": "user_01GHI",
+          "ip_address": "10.0.0.3"
+        }
+      }

--- a/rules/anthropic_rules/anthropic_excessive_chat_access_failures.py
+++ b/rules/anthropic_rules/anthropic_excessive_chat_access_failures.py
@@ -1,0 +1,17 @@
+from panther_anthropic_helpers import anthropic_actor_id, anthropic_alert_context
+
+
+def rule(event):
+    return event.get("type") == "claude_chat_access_failed"
+
+
+def title(event):
+    return f"Anthropic: Excessive chat access failures from [{anthropic_actor_id(event)}]"
+
+
+def dedup(event):
+    return anthropic_actor_id(event)
+
+
+def alert_context(event):
+    return anthropic_alert_context(event)

--- a/rules/anthropic_rules/anthropic_excessive_chat_access_failures.yml
+++ b/rules/anthropic_rules/anthropic_excessive_chat_access_failures.yml
@@ -1,0 +1,77 @@
+AnalysisType: rule
+RuleID: Anthropic.Activity.Excessive.Chat.Access.Failures
+DisplayName: "Anthropic Excessive Chat Access Failures"
+Enabled: true
+Status: Experimental
+Filename: anthropic_excessive_chat_access_failures.py
+LogTypes:
+  - Anthropic.Activity
+Severity: Medium
+Threshold: 50
+DedupPeriodMinutes: 10
+Description: >
+  Detects when a single actor generates more than 50 chat access failures
+  within a 10-minute window. Could indicate automated chat enumeration
+  or unauthorized bulk access attempts. The claude_chat_id field identifies
+  which chats were targeted — sequential or patterned IDs suggest scripted
+  enumeration, while scattered IDs suggest shared-link browsing.
+Runbook: |
+  1. Find all Anthropic.Activity events by actor:email_address in the 1 hour before and after the alert to establish whether this is part of normal browsing or an isolated burst
+  2. Compare the actor's claude_chat_access_failed count to their claude_chat_viewed count in the same window — a high failure-to-success ratio suggests enumeration rather than shared-link browsing
+  3. Check if actor:ip_address appears in threat intelligence feeds or is associated with known VPN/proxy services
+Tags:
+  - Anthropic
+  - Access Control
+  - Enumeration
+Reports:
+  MITRE ATT&CK:
+    - TA0007:T1087  # Account Discovery
+Tests:
+  - Name: Chat access failure event
+    ExpectedResult: true
+    Log:
+      {
+        "id": "evt_01ABC123",
+        "created_at": "2026-04-28T08:00:00Z",
+        "organization_id": "org_123",
+        "type": "claude_chat_access_failed",
+        "claude_chat_id": "chat_01ABC",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "user@example.com",
+          "user_id": "user_01XYZ",
+          "ip_address": "192.168.1.1",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: Non-matching event type
+    ExpectedResult: false
+    Log:
+      {
+        "id": "evt_01DEF456",
+        "created_at": "2026-04-28T08:00:00Z",
+        "organization_id": "org_123",
+        "type": "claude_chat_viewed",
+        "claude_chat_id": "chat_01DEF",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "user@example.com",
+          "user_id": "user_01XYZ",
+          "ip_address": "192.168.1.1"
+        }
+      }
+  - Name: API actor access failure
+    ExpectedResult: true
+    Log:
+      {
+        "id": "evt_01GHI789",
+        "created_at": "2026-04-28T08:00:00Z",
+        "organization_id": "org_123",
+        "type": "claude_chat_access_failed",
+        "claude_chat_id": "chat_01GHI",
+        "actor": {
+          "type": "api_actor",
+          "api_key_id": "key_01ABC",
+          "ip_address": "10.0.0.1"
+        }
+      }

--- a/rules/anthropic_rules/anthropic_integration_connected.py
+++ b/rules/anthropic_rules/anthropic_integration_connected.py
@@ -1,0 +1,19 @@
+from panther_anthropic_helpers import anthropic_actor_id, anthropic_alert_context
+
+
+def rule(event):
+    return event.get("type") == "integration_user_connected"
+
+
+def title(event):
+    actor_email = anthropic_actor_id(event)
+    integration_type = event.get("integration_type", "<UNKNOWN_TYPE>")
+    return f"Anthropic: User [{actor_email}] connected [{integration_type}] integration"
+
+
+def dedup(event):
+    return anthropic_actor_id(event)
+
+
+def alert_context(event):
+    return anthropic_alert_context(event)

--- a/rules/anthropic_rules/anthropic_integration_connected.yml
+++ b/rules/anthropic_rules/anthropic_integration_connected.yml
@@ -1,0 +1,57 @@
+AnalysisType: rule
+RuleID: Anthropic.Activity.Integration.Connected
+DisplayName: "Anthropic Integration Connected"
+Enabled: true
+Status: Experimental
+Filename: anthropic_integration_connected.py
+LogTypes:
+  - Anthropic.Activity
+Severity: Info
+Description: >
+  Tracks when a user connects an external integration (e.g., GitHub, Google Drive)
+  to their Anthropic account. Logged for compliance visibility into external data
+  pathways. The integration_type field identifies which service was connected.
+Runbook: |
+  1. Find all Anthropic.Activity events by actor:email_address in the 1 hour before and after the alert to understand the context of the integration connection
+  2. Check if actor:email_address has connected other integrations in the past 30 days to identify unusual patterns
+  3. Check if actor:ip_address matches previously seen IP addresses for this actor
+Tags:
+  - Anthropic
+  - Compliance
+  - Integrations
+Reports:
+  MITRE ATT&CK:
+    - TA0009:T1530  # Data from Cloud Storage
+Tests:
+  - Name: GitHub integration connected
+    ExpectedResult: true
+    Log:
+      {
+        "id": "activity_01ABC123",
+        "created_at": "2026-05-06T17:38:28Z",
+        "organization_id": "org_01XYZ",
+        "type": "integration_user_connected",
+        "integration_type": "github",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "user@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: Non-matching event type
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01DEF456",
+        "created_at": "2026-05-06T17:38:28Z",
+        "organization_id": "org_01XYZ",
+        "type": "claude_chat_created",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "user@example.com",
+          "user_id": "user_01DEF",
+          "ip_address": "10.0.0.2"
+        }
+      }

--- a/rules/anthropic_rules/anthropic_ip_restriction_deleted.py
+++ b/rules/anthropic_rules/anthropic_ip_restriction_deleted.py
@@ -1,0 +1,18 @@
+from panther_anthropic_helpers import anthropic_actor_id, anthropic_alert_context
+
+
+def rule(event):
+    return event.get("type") == "org_ip_restriction_deleted"
+
+
+def title(event):
+    actor_email = anthropic_actor_id(event)
+    return f"Anthropic: IP restriction deleted by [{actor_email}]"
+
+
+def dedup(event):
+    return anthropic_actor_id(event)
+
+
+def alert_context(event):
+    return anthropic_alert_context(event)

--- a/rules/anthropic_rules/anthropic_ip_restriction_deleted.yml
+++ b/rules/anthropic_rules/anthropic_ip_restriction_deleted.yml
@@ -1,0 +1,57 @@
+AnalysisType: rule
+RuleID: Anthropic.Activity.IP.Restriction.Deleted
+DisplayName: "Anthropic IP Restriction Deleted"
+Enabled: true
+Status: Experimental
+Filename: anthropic_ip_restriction_deleted.py
+LogTypes:
+  - Anthropic.Activity
+Severity: High
+Description: >
+  Detects when an organization IP restriction is deleted. IP restrictions
+  are a critical network-level access control — removing them allows access
+  from any IP address, which could indicate an attacker widening the attack
+  surface after gaining admin access.
+Runbook: |
+  1. Find all Anthropic.Activity events by actor:email_address in the 24 hours before the alert to identify any suspicious activity leading up to the IP restriction change
+  2. Check if actor:ip_address matches previously seen IP addresses for this actor in the past 30 days to detect potential account compromise
+  3. Check if other org_ip_restriction events (created, updated) occurred in the 1 hour around the alert to determine if this is a policy replacement or a standalone deletion
+Tags:
+  - Anthropic
+  - Network Security
+  - Defense Evasion
+Reports:
+  MITRE ATT&CK:
+    - TA0005:T1562.001  # Impair Defenses: Disable or Modify Tools
+Tests:
+  - Name: IP restriction deleted
+    ExpectedResult: true
+    Log:
+      {
+        "id": "activity_01ABC123",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "org_ip_restriction_deleted",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: IP restriction created - not a match
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01DEF456",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "org_ip_restriction_created",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1"
+        }
+      }

--- a/rules/anthropic_rules/anthropic_mcp_server_created.py
+++ b/rules/anthropic_rules/anthropic_mcp_server_created.py
@@ -1,0 +1,19 @@
+from panther_anthropic_helpers import anthropic_actor_id, anthropic_alert_context
+
+
+def rule(event):
+    return event.get("type") == "mcp_server_created"
+
+
+def title(event):
+    actor_email = anthropic_actor_id(event)
+    server_name = event.get("mcp_server_name", "<UNKNOWN_SERVER>")
+    return f"Anthropic: MCP server [{server_name}] created by [{actor_email}]"
+
+
+def dedup(event):
+    return anthropic_actor_id(event)
+
+
+def alert_context(event):
+    return anthropic_alert_context(event)

--- a/rules/anthropic_rules/anthropic_mcp_server_created.yml
+++ b/rules/anthropic_rules/anthropic_mcp_server_created.yml
@@ -1,0 +1,59 @@
+AnalysisType: rule
+RuleID: Anthropic.Activity.MCP.Server.Created
+DisplayName: "Anthropic MCP Server Created"
+Enabled: true
+Status: Experimental
+Filename: anthropic_mcp_server_created.py
+LogTypes:
+  - Anthropic.Activity
+Severity: Medium
+Description: >
+  Detects when a new MCP (Model Context Protocol) server integration is created.
+  Each MCP server is a new external data pathway that could be used for data
+  exfiltration. Every new integration should be verified as approved, especially
+  when created by external contractors or service accounts.
+Runbook: |
+  1. Find all Anthropic.Activity events by actor:email_address in the 1 hour before and after the alert to understand the context of the MCP server creation
+  2. Check if actor:email_address is an external contractor (ext. domain) or internal employee, and whether they have created MCP servers in the past 90 days
+  3. Check if actor:ip_address is associated with known VPN/proxy services or matches previously seen IP addresses for this actor
+Tags:
+  - Anthropic
+  - Configuration
+  - Supply Chain
+Reports:
+  MITRE ATT&CK:
+    - TA0010:T1567  # Exfiltration Over Web Service
+Tests:
+  - Name: MCP server created
+    ExpectedResult: true
+    Log:
+      {
+        "id": "activity_01ABC123",
+        "created_at": "2026-04-28T19:26:58Z",
+        "organization_id": "org_01XYZ",
+        "type": "mcp_server_created",
+        "mcp_server_id": "mcpsrv_01ABC",
+        "mcp_server_name": "Snowflake",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "contractor@ext.example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: Non-matching event type
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01DEF456",
+        "created_at": "2026-04-28T19:26:58Z",
+        "organization_id": "org_01XYZ",
+        "type": "claude_chat_created",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "user@example.com",
+          "user_id": "user_01DEF",
+          "ip_address": "10.0.0.2"
+        }
+      }

--- a/rules/anthropic_rules/anthropic_mcp_server_deleted.py
+++ b/rules/anthropic_rules/anthropic_mcp_server_deleted.py
@@ -1,0 +1,19 @@
+from panther_anthropic_helpers import anthropic_actor_id, anthropic_alert_context
+
+
+def rule(event):
+    return event.get("type") == "mcp_server_deleted"
+
+
+def title(event):
+    actor_email = anthropic_actor_id(event)
+    server_name = event.get("mcp_server_name", "<UNKNOWN_SERVER>")
+    return f"Anthropic: MCP server [{server_name}] deleted by [{actor_email}]"
+
+
+def dedup(event):
+    return anthropic_actor_id(event)
+
+
+def alert_context(event):
+    return anthropic_alert_context(event)

--- a/rules/anthropic_rules/anthropic_mcp_server_deleted.yml
+++ b/rules/anthropic_rules/anthropic_mcp_server_deleted.yml
@@ -1,0 +1,60 @@
+AnalysisType: rule
+RuleID: Anthropic.Activity.MCP.Server.Deleted
+DisplayName: "Anthropic MCP Server Deleted"
+Enabled: true
+Status: Experimental
+Filename: anthropic_mcp_server_deleted.py
+LogTypes:
+  - Anthropic.Activity
+Severity: Low
+Description: >
+  Detects when an MCP server integration is deleted from the organization.
+  Removing an approved integration could indicate an attacker covering tracks
+  or unauthorized configuration changes. The mcp_server_name and mcp_server_id
+  fields identify which integration was removed.
+Runbook: |
+  1. Find all Anthropic.Activity events with type mcp_server_created by actor:email_address in the 10 minutes after the alert to determine if this was a delete-then-recreate (config fix) or a standalone deletion
+  2. Check if actor:email_address has performed other administrative actions (claude_organization_settings_updated, mcp_server_created) in the 6 hours around the alert to assess if this is part of routine admin work
+  3. Find all alerts for actor:email_address in the past 7 days to check for signs of account compromise preceding this action
+Tags:
+  - Anthropic
+  - Configuration
+Reports:
+  MITRE ATT&CK:
+    - TA0005:T1562  # Impair Defenses
+Tests:
+  - Name: MCP server deleted
+    ExpectedResult: true
+    Log:
+      {
+        "id": "activity_01ABC123",
+        "created_at": "2026-05-05T21:46:28Z",
+        "organization_id": "org_01XYZ",
+        "type": "mcp_server_deleted",
+        "mcp_server_id": "mcpsrv_01ABC",
+        "mcp_server_name": "Snowflake",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: MCP server created - not a match
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01DEF456",
+        "created_at": "2026-05-05T21:52:51Z",
+        "organization_id": "org_01XYZ",
+        "type": "mcp_server_created",
+        "mcp_server_id": "mcpsrv_01DEF",
+        "mcp_server_name": "Snowflake",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1"
+        }
+      }

--- a/rules/anthropic_rules/anthropic_org_settings_updated.py
+++ b/rules/anthropic_rules/anthropic_org_settings_updated.py
@@ -1,0 +1,51 @@
+import re
+
+from panther_anthropic_helpers import anthropic_actor_id, anthropic_alert_context
+
+PARENT_EVENT_TYPE = "claude_organization_settings_updated"
+
+
+def rule(event):
+    return event.get("type") == PARENT_EVENT_TYPE
+
+
+def _extract_update_type(entry_str):
+    """Extract the first type value from a single serialized update entry."""
+    match = re.search(r"'type':\s*'([^']+)'", entry_str)
+    if not match:
+        match = re.search(r'"type":\s*"([^"]+)"', entry_str)
+    return match.group(1) if match else None
+
+
+def _extract_update_types(updates):
+    """Extract top-level update type values from the updates list.
+
+    Serializes each entry individually to avoid capturing type values
+    from nested objects. Uses string parsing because Panther's event
+    wrapper intercepts .get("type") on nested objects.
+    """
+    result = []
+    for entry in updates:
+        update_type = _extract_update_type(str(entry))
+        if update_type and update_type != PARENT_EVENT_TYPE:
+            result.append(update_type)
+    return result
+
+
+def title(event):
+    actor_email = anthropic_actor_id(event)
+    updates = event.get("updates", [])
+    if updates:
+        update_types = _extract_update_types(updates)
+        if update_types:
+            types_str = ", ".join(update_types)
+            return f"Anthropic: Organization settings updated by" f" [{actor_email}]: {types_str}"
+    return f"Anthropic: Organization settings updated by [{actor_email}]"
+
+
+def dedup(event):
+    return anthropic_actor_id(event)
+
+
+def alert_context(event):
+    return anthropic_alert_context(event)

--- a/rules/anthropic_rules/anthropic_org_settings_updated.yml
+++ b/rules/anthropic_rules/anthropic_org_settings_updated.yml
@@ -1,0 +1,56 @@
+AnalysisType: rule
+RuleID: Anthropic.Activity.Organization.Settings.Updated
+DisplayName: "Anthropic Organization Settings Updated"
+Enabled: true
+Status: Experimental
+Filename: anthropic_org_settings_updated.py
+LogTypes:
+  - Anthropic.Activity
+Severity: Medium
+Description: >
+  Detects when organization-wide settings are modified in Anthropic. These changes
+  can affect security posture for all users (e.g., SSO configuration, data retention,
+  access controls). The updates field identifies which settings were changed.
+Runbook: |
+  1. Find all Anthropic.Activity events by actor:email_address in the 6 hours before and after the alert to understand what other administrative actions they performed
+  2. Check if actor:email_address has performed claude_organization_settings_updated events in the past 90 days to determine if this is routine admin activity or a first-time action
+  3. Check if actor:ip_address is associated with known VPN/proxy services or matches previously seen IP addresses for this actor
+Tags:
+  - Anthropic
+  - Configuration
+Reports:
+  MITRE ATT&CK:
+    - TA0005:T1562  # Impair Defenses
+Tests:
+  - Name: Org settings updated with updates field
+    ExpectedResult: true
+    Log:
+      {
+        "id": "activity_01ABC123",
+        "created_at": "2026-04-29T09:14:15Z",
+        "organization_id": "org_01XYZ",
+        "type": "claude_organization_settings_updated",
+        "updates": [{"type": "vcs_connections", "current_value": [{"org_name": "example-org", "type": "github"}]}],
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: Non-matching event type
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01DEF456",
+        "created_at": "2026-04-29T09:14:15Z",
+        "organization_id": "org_01XYZ",
+        "type": "claude_user_settings_updated",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "user@example.com",
+          "user_id": "user_01DEF",
+          "ip_address": "10.0.0.2"
+        }
+      }

--- a/rules/anthropic_rules/anthropic_org_user_deleted.py
+++ b/rules/anthropic_rules/anthropic_org_user_deleted.py
@@ -1,0 +1,19 @@
+from panther_anthropic_helpers import anthropic_actor_id, anthropic_alert_context
+
+
+def rule(event):
+    return event.get("type") == "org_user_deleted"
+
+
+def title(event):
+    actor_email = anthropic_actor_id(event)
+    deleted_user = event.get("deleted_user_email") or event.get("deleted_user_id", "<UNKNOWN_USER>")
+    return f"Anthropic: User [{deleted_user}] deleted from org by [{actor_email}]"
+
+
+def dedup(event):
+    return anthropic_actor_id(event)
+
+
+def alert_context(event):
+    return anthropic_alert_context(event)

--- a/rules/anthropic_rules/anthropic_org_user_deleted.yml
+++ b/rules/anthropic_rules/anthropic_org_user_deleted.yml
@@ -1,0 +1,58 @@
+AnalysisType: rule
+RuleID: Anthropic.Activity.Org.User.Deleted
+DisplayName: "Anthropic Organization User Deleted"
+Enabled: true
+Status: Experimental
+Filename: anthropic_org_user_deleted.py
+LogTypes:
+  - Anthropic.Activity
+Severity: Info
+Description: >
+  Tracks when a user is removed from the Anthropic organization. Logged
+  for compliance visibility into user lifecycle changes. The deleted_user_id
+  and deleted_user_email fields identify who was removed.
+Runbook: |
+  1. Find all Anthropic.Activity events by actor:email_address in the 6 hours before and after the alert to determine if this is part of routine offboarding or an isolated deletion
+  2. Check if the deleted user had any unusual activity (claude_chat_access_failed, claude_organization_settings_updated) in the 7 days before removal
+  3. Check if actor:email_address has deleted other users in the past 7 days to identify potential bulk unauthorized removals
+Tags:
+  - Anthropic
+  - Compliance
+  - User Lifecycle
+Reports:
+  MITRE ATT&CK:
+    - TA0040:T1531  # Account Access Removal
+Tests:
+  - Name: Org user deleted
+    ExpectedResult: true
+    Log:
+      {
+        "id": "activity_01ABC123",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "org_user_deleted",
+        "deleted_user_id": "user_01DEF",
+        "deleted_user_email": "deleted-user@example.com",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: Non-matching event type
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01DEF456",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "org_user_invite_sent",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1"
+        }
+      }

--- a/rules/anthropic_rules/anthropic_primary_owner_transferred.py
+++ b/rules/anthropic_rules/anthropic_primary_owner_transferred.py
@@ -1,0 +1,18 @@
+from panther_anthropic_helpers import anthropic_actor_id, anthropic_alert_context
+
+
+def rule(event):
+    return event.get("type") == "primary_owner_transferred"
+
+
+def title(event):
+    actor_email = anthropic_actor_id(event)
+    return f"Anthropic: Primary owner transferred by [{actor_email}]"
+
+
+def dedup(event):
+    return anthropic_actor_id(event)
+
+
+def alert_context(event):
+    return anthropic_alert_context(event)

--- a/rules/anthropic_rules/anthropic_primary_owner_transferred.yml
+++ b/rules/anthropic_rules/anthropic_primary_owner_transferred.yml
@@ -1,0 +1,56 @@
+AnalysisType: rule
+RuleID: Anthropic.Activity.Primary.Owner.Transferred
+DisplayName: "Anthropic Primary Owner Transferred"
+Enabled: true
+Status: Experimental
+Filename: anthropic_primary_owner_transferred.py
+LogTypes:
+  - Anthropic.Activity
+Severity: High
+Description: >
+  Detects when the primary owner role of the Anthropic organization is
+  transferred to another member. This is an extremely high-privilege action
+  that gives full control of the organization. The previous_owner_id and
+  new_owner_id fields identify who gave up and received ownership.
+Runbook: |
+  1. Find all Anthropic.Activity events by actor:email_address in the 24 hours before the alert to identify any suspicious activity leading up to the ownership transfer
+  2. Check if actor:ip_address matches previously seen IP addresses for this actor in the past 30 days to detect potential account compromise
+  3. Find all alerts for actor:email_address in the past 7 days to check for signs of account compromise preceding this action
+Tags:
+  - Anthropic
+  - Privilege Escalation
+Reports:
+  MITRE ATT&CK:
+    - TA0003:T1098.003  # Account Manipulation: Additional Cloud Roles
+Tests:
+  - Name: Primary owner transferred
+    ExpectedResult: true
+    Log:
+      {
+        "id": "activity_01ABC123",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "primary_owner_transferred",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "owner@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: Non-matching event type
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01DEF456",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "role_assignment_granted",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01DEF",
+          "ip_address": "10.0.0.2"
+        }
+      }

--- a/rules/anthropic_rules/anthropic_role_granted.py
+++ b/rules/anthropic_rules/anthropic_role_granted.py
@@ -1,0 +1,20 @@
+from panther_anthropic_helpers import anthropic_actor_id, anthropic_alert_context
+
+
+def rule(event):
+    return event.get("type") == "role_assignment_granted"
+
+
+def title(event):
+    actor_email = anthropic_actor_id(event)
+    role = event.get("role", "<UNKNOWN_ROLE>")
+    target_id = event.get("target_id", "<UNKNOWN_TARGET>")
+    return f"Anthropic: Role [{role}] granted to [{target_id}] by [{actor_email}]"
+
+
+def dedup(event):
+    return anthropic_actor_id(event)
+
+
+def alert_context(event):
+    return anthropic_alert_context(event)

--- a/rules/anthropic_rules/anthropic_role_granted.yml
+++ b/rules/anthropic_rules/anthropic_role_granted.yml
@@ -1,0 +1,61 @@
+AnalysisType: rule
+RuleID: Anthropic.Activity.Role.Granted
+DisplayName: "Anthropic Role Granted"
+Enabled: true
+Status: Experimental
+Filename: anthropic_role_granted.py
+LogTypes:
+  - Anthropic.Activity
+Severity: Info
+Description: >
+  Tracks all role grants in the Anthropic organization. Currently used to
+  build visibility into the role taxonomy as the log source matures. Once
+  sufficient data is collected on org-level vs project-level role patterns,
+  this rule can be refined to alert at higher severity for elevated roles.
+Runbook: |
+  1. Find all Anthropic.Activity events by actor:email_address in the 6 hours before and after the alert to determine if this is part of routine project creation or an isolated privilege grant
+  2. Check if target_id has been granted other roles in the past 7 days to identify potential privilege accumulation
+  3. Check if actor:ip_address is associated with known VPN/proxy services or matches previously seen IP addresses for this actor
+Tags:
+  - Anthropic
+  - Access Control
+Reports:
+  MITRE ATT&CK:
+    - TA0004:T1098  # Account Manipulation
+Tests:
+  - Name: Role granted
+    ExpectedResult: true
+    Log:
+      {
+        "id": "activity_01ABC123",
+        "created_at": "2026-05-07T13:02:42Z",
+        "organization_id": "org_01XYZ",
+        "type": "role_assignment_granted",
+        "target_id": "user_01DEF",
+        "target_type": "organization_member",
+        "role": "chat_project:viewer",
+        "resource_type": "chat_project",
+        "resource_id": "claude_proj_01ABC",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: Non-matching event type
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01DEF456",
+        "created_at": "2026-05-07T13:02:42Z",
+        "organization_id": "org_01XYZ",
+        "type": "claude_chat_created",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "user@example.com",
+          "user_id": "user_01DEF",
+          "ip_address": "10.0.0.2"
+        }
+      }

--- a/rules/anthropic_rules/anthropic_service_key_created.py
+++ b/rules/anthropic_rules/anthropic_service_key_created.py
@@ -1,0 +1,18 @@
+from panther_anthropic_helpers import anthropic_actor_id, anthropic_alert_context
+
+
+def rule(event):
+    return event.get("type") == "service_key_created"
+
+
+def title(event):
+    actor_email = anthropic_actor_id(event)
+    return f"Anthropic: Service key created by [{actor_email}]"
+
+
+def dedup(event):
+    return anthropic_actor_id(event)
+
+
+def alert_context(event):
+    return anthropic_alert_context(event)

--- a/rules/anthropic_rules/anthropic_service_key_created.yml
+++ b/rules/anthropic_rules/anthropic_service_key_created.yml
@@ -1,0 +1,56 @@
+AnalysisType: rule
+RuleID: Anthropic.Activity.Service.Key.Created
+DisplayName: "Anthropic Service Key Created"
+Enabled: true
+Status: Experimental
+Filename: anthropic_service_key_created.py
+LogTypes:
+  - Anthropic.Activity
+Severity: Medium
+Description: >
+  Detects when a new service key is created. Service keys provide
+  programmatic access and their creation should be verified as authorized.
+  The service_key_id, service_name, key_name, and scopes fields identify
+  the key and its permissions.
+Runbook: |
+  1. Find all Anthropic.Activity events by actor:email_address in the 6 hours before and after the alert to determine if this is part of routine service account setup
+  2. Check if actor:email_address has created service keys in the past 90 days to determine if this is a first-time action
+  3. Check if actor:ip_address is associated with known VPN/proxy services or matches previously seen IP addresses for this actor
+Tags:
+  - Anthropic
+  - Credential Access
+Reports:
+  MITRE ATT&CK:
+    - TA0006:T1098.001  # Account Manipulation: Additional Cloud Credentials
+Tests:
+  - Name: Service key created
+    ExpectedResult: true
+    Log:
+      {
+        "id": "activity_01ABC123",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "service_key_created",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: Non-matching event type
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01DEF456",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "service_key_revoked",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1"
+        }
+      }

--- a/rules/anthropic_rules/anthropic_service_key_revoked.py
+++ b/rules/anthropic_rules/anthropic_service_key_revoked.py
@@ -1,0 +1,18 @@
+from panther_anthropic_helpers import anthropic_actor_id, anthropic_alert_context
+
+
+def rule(event):
+    return event.get("type") == "service_key_revoked"
+
+
+def title(event):
+    actor_email = anthropic_actor_id(event)
+    return f"Anthropic: Service key revoked by [{actor_email}]"
+
+
+def dedup(event):
+    return anthropic_actor_id(event)
+
+
+def alert_context(event):
+    return anthropic_alert_context(event)

--- a/rules/anthropic_rules/anthropic_service_key_revoked.yml
+++ b/rules/anthropic_rules/anthropic_service_key_revoked.yml
@@ -1,0 +1,56 @@
+AnalysisType: rule
+RuleID: Anthropic.Activity.Service.Key.Revoked
+DisplayName: "Anthropic Service Key Revoked"
+Enabled: true
+Status: Experimental
+Filename: anthropic_service_key_revoked.py
+LogTypes:
+  - Anthropic.Activity
+Severity: Medium
+Description: >
+  Detects when a service key is revoked. Unauthorized revocation could
+  indicate an attacker disrupting integrations or covering tracks after
+  using a compromised key. The service_key_id and service_name fields
+  identify which key was revoked.
+Runbook: |
+  1. Find all Anthropic.Activity events by actor:email_address in the 6 hours before and after the alert to determine if this is part of routine key rotation or incident response
+  2. Check if a service_key_created event occurred near this revocation to determine if this is a key rotation or a standalone revocation
+  3. Check if actor:ip_address is associated with known VPN/proxy services or matches previously seen IP addresses for this actor
+Tags:
+  - Anthropic
+  - Credential Access
+Reports:
+  MITRE ATT&CK:
+    - TA0006:T1098.001  # Account Manipulation: Additional Cloud Credentials
+Tests:
+  - Name: Service key revoked
+    ExpectedResult: true
+    Log:
+      {
+        "id": "activity_01ABC123",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "service_key_revoked",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: Non-matching event type
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01DEF456",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "service_key_created",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1"
+        }
+      }

--- a/rules/anthropic_rules/anthropic_spend_limit_deleted.py
+++ b/rules/anthropic_rules/anthropic_spend_limit_deleted.py
@@ -1,0 +1,18 @@
+from panther_anthropic_helpers import anthropic_actor_id, anthropic_alert_context
+
+
+def rule(event):
+    return event.get("type") == "platform_spend_limit_deleted"
+
+
+def title(event):
+    actor_email = anthropic_actor_id(event)
+    return f"Anthropic: Platform spend limit deleted by [{actor_email}]"
+
+
+def dedup(event):
+    return anthropic_actor_id(event)
+
+
+def alert_context(event):
+    return anthropic_alert_context(event)

--- a/rules/anthropic_rules/anthropic_spend_limit_deleted.yml
+++ b/rules/anthropic_rules/anthropic_spend_limit_deleted.yml
@@ -1,0 +1,56 @@
+AnalysisType: rule
+RuleID: Anthropic.Activity.Spend.Limit.Deleted
+DisplayName: "Anthropic Spend Limit Deleted"
+Enabled: true
+Status: Experimental
+Filename: anthropic_spend_limit_deleted.py
+LogTypes:
+  - Anthropic.Activity
+Severity: Medium
+Description: >
+  Detects when a platform spend limit is deleted. A deleted spend limit without
+  a subsequent recreate could indicate an attacker removing financial guardrails
+  to enable large-scale API usage or data exfiltration. Note that normal admin
+  workflow often involves a delete immediately followed by a create (editing a limit).
+Runbook: |
+  1. Find all Anthropic.Activity events with type platform_spend_limit_created by actor:email_address in the 10 minutes after the alert to determine if this was a delete-then-recreate (normal edit) or a standalone deletion
+  2. Check if actor:email_address has performed other administrative actions (claude_organization_settings_updated, role_assignment_granted) in the 6 hours around the alert to assess if this is part of routine admin work
+  3. Find all alerts for actor:email_address in the past 7 days to check for signs of account compromise preceding this action
+Tags:
+  - Anthropic
+  - Financial Controls
+Reports:
+  MITRE ATT&CK:
+    - TA0040:T1496  # Resource Hijacking
+Tests:
+  - Name: Spend limit deleted
+    ExpectedResult: true
+    Log:
+      {
+        "id": "activity_01ABC123",
+        "created_at": "2026-04-30T09:46:26Z",
+        "organization_id": "org_01XYZ",
+        "type": "platform_spend_limit_deleted",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: Spend limit created - not a match
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01DEF456",
+        "created_at": "2026-04-30T09:46:27Z",
+        "organization_id": "org_01XYZ",
+        "type": "platform_spend_limit_created",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1"
+        }
+      }

--- a/rules/anthropic_rules/anthropic_sso_disabled.py
+++ b/rules/anthropic_rules/anthropic_sso_disabled.py
@@ -1,0 +1,26 @@
+from panther_anthropic_helpers import anthropic_actor_id, anthropic_alert_context
+
+
+def rule(event):
+    event_type = event.get("type")
+    if event_type == "org_sso_toggled":
+        return event.get("is_enabled") in (False, "false")
+    if event_type == "org_sso_connection_deactivated":
+        return True
+    return False
+
+
+def title(event):
+    actor_email = anthropic_actor_id(event)
+    event_type = event.get("type")
+    if event_type == "org_sso_toggled":
+        return f"Anthropic: SSO disabled by [{actor_email}]"
+    return f"Anthropic: SSO connection deactivated by [{actor_email}]"
+
+
+def dedup(event):
+    return anthropic_actor_id(event)
+
+
+def alert_context(event):
+    return anthropic_alert_context(event)

--- a/rules/anthropic_rules/anthropic_sso_disabled.yml
+++ b/rules/anthropic_rules/anthropic_sso_disabled.yml
@@ -1,0 +1,91 @@
+AnalysisType: rule
+RuleID: Anthropic.Activity.SSO.Disabled
+DisplayName: "Anthropic SSO Disabled"
+Enabled: true
+Status: Experimental
+Filename: anthropic_sso_disabled.py
+LogTypes:
+  - Anthropic.Activity
+Severity: High
+Description: >
+  Detects when SSO is disabled or an SSO connection is deactivated for the
+  organization. Disabling SSO allows users to bypass the identity provider
+  and use weaker authentication methods. This is a critical security posture
+  change that could indicate an attacker attempting to maintain access
+  without IdP visibility.
+Runbook: |
+  1. Find all Anthropic.Activity events by actor:email_address in the 24 hours before the alert to identify any suspicious activity leading up to the SSO change
+  2. Check if actor:ip_address matches previously seen IP addresses for this actor in the past 30 days to detect potential account compromise
+  3. Find all SSO-related events (sso_login_failed, sso_login_initiated, sso_login_succeeded) in the 1 hour before and after the alert to understand the authentication context
+Tags:
+  - Anthropic
+  - Authentication
+  - Defense Evasion
+Reports:
+  MITRE ATT&CK:
+    - TA0005:T1562.001  # Impair Defenses: Disable or Modify Tools
+Tests:
+  - Name: SSO toggled off
+    ExpectedResult: true
+    Log:
+      {
+        "id": "activity_01ABC123",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "org_sso_toggled",
+        "is_enabled": false,
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: SSO toggled on - not a match
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01DEF456",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "org_sso_toggled",
+        "is_enabled": true,
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "10.0.0.1"
+        }
+      }
+  - Name: SSO connection deactivated
+    ExpectedResult: true
+    Log:
+      {
+        "id": "activity_01GHI789",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "org_sso_connection_deactivated",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "admin@example.com",
+          "user_id": "user_01GHI",
+          "ip_address": "10.0.0.3",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: Non-matching event type
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01JKL012",
+        "created_at": "2026-05-07T10:00:00Z",
+        "organization_id": "org_01XYZ",
+        "type": "sso_login_succeeded",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "user@example.com",
+          "user_id": "user_01JKL",
+          "ip_address": "10.0.0.4"
+        }
+      }

--- a/rules/anthropic_rules/anthropic_sso_login_failed.py
+++ b/rules/anthropic_rules/anthropic_sso_login_failed.py
@@ -1,0 +1,18 @@
+from panther_anthropic_helpers import anthropic_actor_id, anthropic_alert_context
+
+
+def rule(event):
+    return event.get("type") == "sso_login_failed"
+
+
+def title(event):
+    actor = anthropic_actor_id(event)
+    return f"Anthropic: SSO login failed from [{actor}]"
+
+
+def dedup(event):
+    return anthropic_actor_id(event)
+
+
+def alert_context(event):
+    return anthropic_alert_context(event)

--- a/rules/anthropic_rules/anthropic_sso_login_failed.yml
+++ b/rules/anthropic_rules/anthropic_sso_login_failed.yml
@@ -1,0 +1,53 @@
+AnalysisType: rule
+RuleID: Anthropic.Activity.SSO.Login.Failed
+DisplayName: "Anthropic SSO Login Failed"
+Enabled: true
+Status: Experimental
+Filename: anthropic_sso_login_failed.py
+LogTypes:
+  - Anthropic.Activity
+Severity: Medium
+Description: >
+  Detects failed SSO login attempts to the Anthropic organization. The actor
+  is unauthenticated so no email is available — only the source IP. Every
+  failure is alerted on as SSO failures should be rare in normal operation.
+Runbook: |
+  1. Find all Anthropic.Activity SSO events (sso_login_initiated, sso_login_succeeded, sso_login_failed) from actor:ip_address in the 1 hour before and after the alert to determine if this was a one-off or part of a burst
+  2. Check if actor:ip_address appears in threat intelligence feeds or is associated with known VPN/proxy services
+  3. Check if actor:ip_address has been seen in successful sso_login_succeeded events in the past 30 days to determine if this is a known user IP
+Tags:
+  - Anthropic
+  - Authentication
+Reports:
+  MITRE ATT&CK:
+    - TA0006:T1110  # Brute Force
+Tests:
+  - Name: SSO login failed
+    ExpectedResult: true
+    Log:
+      {
+        "id": "activity_01ABC123",
+        "created_at": "2026-05-05T21:33:29Z",
+        "organization_id": "org_01XYZ",
+        "type": "sso_login_failed",
+        "actor": {
+          "type": "unauthenticated_user_actor",
+          "ip_address": "192.168.1.1",
+          "user_agent": "Mozilla/5.0"
+        }
+      }
+  - Name: SSO login succeeded - not a match
+    ExpectedResult: false
+    Log:
+      {
+        "id": "activity_01DEF456",
+        "created_at": "2026-05-05T21:33:29Z",
+        "organization_id": "org_01XYZ",
+        "type": "sso_login_succeeded",
+        "actor": {
+          "type": "user_actor",
+          "email_address": "user@example.com",
+          "user_id": "user_01ABC",
+          "ip_address": "192.168.1.1"
+        }
+      }


### PR DESCRIPTION
## Background
   
Adds Anthropic Activity log OOTB detection coverage in Experimental status, with a global helper and 17 rules across authentication, access control, configuration, credential management, and compliance.                                                                                                      

## Changes

### Global Helper                                                                                                                               

- `panther_anthropic_helpers` — shared `anthropic_alert_context()` with actor details, IPs, PantherFlow investigation link, and optional fields
                                                                                                                                                
### Rules by Severity                                                                                                                             
  
#### High (3)                                                                                                                                      
  - SSO Disabled — SSO toggled off or SSO connection deactivated                                                                              
  - Primary Owner Transferred — org ownership change                                                                                            
  - IP Restriction Deleted — network access control removed
                                                                                                                                                
#### Medium (8)                                                                                                                                    
  - Excessive Chat Access Failures — >50 failures in 10min per actor (threshold rule)
  - SSO Login Failed — every failed SSO attempt                                                                                                 
  - Organization Settings Updated — org-wide config changes, title includes update type                                                       
  - MCP Server Created — new external integration, title includes server name                                                                   
  - Admin API Key Created — admin key lifecycle                                                                                                 
  - Admin API Key Deleted — admin key lifecycle                                                                                                 
  - Service Key Created — service account key lifecycle                                                                                         
  - Service Key Revoked — service account key lifecycle                                                                                         
  - Spend Limit Deleted — financial control removal                                                                                             
  - Artifact Shared Publicly — artifact audience changed to public                                                                              
  
 #### Low (1)                                                                                                                                       
  - MCP Server Deleted — integration removal                                                                                                  
                                                                                                                                                
 #### Info (3)                                                                                                                                    
  - Role Granted — all role grants for visibility (building baseline of role taxonomy)                                                          
  - Integration Connected — user connected external integration (compliance)                                                                    
  - Org User Deleted — user removal (compliance)    
### Testing

- `make fmt lint`
- `pipenv run panther_analysis_tool test --path rules/anthropic_rules/`