### PR TITLE
Fix FDR Passthrough Severity Function

### DIFF
--- a/policies/aws_iam_policies/aws_iam_role_external_permission.py
+++ b/policies/aws_iam_policies/aws_iam_role_external_permission.py
@@ -22,8 +22,7 @@ accounts = [
 PERMISSION = "lambda:AddPermission"
 
 # CONFIGURATION_REQUIRED: modify policy to contain specified permission, above
-mock_policy_has_permission = json.loads(
-    """
+mock_policy_has_permission = json.loads("""
 {
     "PolicyDocument": {
         "Version": "2012-10-17",
@@ -39,11 +38,9 @@ mock_policy_has_permission = json.loads(
         ]
     }
 }
-"""
-)
+""")
 
-mock_policy_no_permission = json.loads(
-    """
+mock_policy_no_permission = json.loads("""
 {
     "PolicyDocument": {
         "Version": "2012-10-17",
@@ -56,8 +53,7 @@ mock_policy_no_permission = json.loads(
         ]
     }
 }
-"""
-)
+""")
 
 
 # check to see if the account that is granted permission is third party

--- a/policies/aws_iam_policies/aws_iam_role_external_permission.py
+++ b/policies/aws_iam_policies/aws_iam_role_external_permission.py
@@ -22,7 +22,8 @@ accounts = [
 PERMISSION = "lambda:AddPermission"
 
 # CONFIGURATION_REQUIRED: modify policy to contain specified permission, above
-mock_policy_has_permission = json.loads("""
+mock_policy_has_permission = json.loads(
+    """
 {
     "PolicyDocument": {
         "Version": "2012-10-17",
@@ -38,9 +39,11 @@ mock_policy_has_permission = json.loads("""
         ]
     }
 }
-""")
+"""
+)
 
-mock_policy_no_permission = json.loads("""
+mock_policy_no_permission = json.loads(
+    """
 {
     "PolicyDocument": {
         "Version": "2012-10-17",
@@ -53,7 +56,8 @@ mock_policy_no_permission = json.loads("""
         ]
     }
 }
-""")
+"""
+)
 
 
 # check to see if the account that is granted permission is third party

--- a/rules/crowdstrike_rules/crowdstrike_detection_passthrough.py
+++ b/rules/crowdstrike_rules/crowdstrike_detection_passthrough.py
@@ -26,7 +26,19 @@ def alert_context(event):
 
 
 def severity(event):
-    return get_crowdstrike_field(event, "SeverityName")
+    # First, try returning the severity based on the SeverityName
+    sevname = get_crowdstrike_field(event, "SeverityName").upper()
+    allowed_values = ("INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL")
+    if sevname == "INFORMATIONAL":
+        sevname = "INFO"
+    if sevname in allowed_values:
+        return sevname
+
+    # Else, fallback on the numerical value, falling back on MEDIUM if we still don't have a value
+    sevval = get_crowdstrike_field(event, "Severity")
+    return {1: "INFO", 2: "LOW", 3: "MEDIUM", 4: "HIGH", 5: "CRITICAL", 6: "CRITICAL"}.get(
+        sevval, "DEFAULT"
+    )
 
 
 def dedup(event):

--- a/rules/crowdstrike_rules/event_stream_rules/crowdstrike_detection_summary.py
+++ b/rules/crowdstrike_rules/event_stream_rules/crowdstrike_detection_summary.py
@@ -21,7 +21,7 @@ def dedup(event: PantherEvent):
 
 def severity(event: PantherEvent):
     # First, try returning the severity based on the SeverityName
-    sevname = event.deep_get("event", "SeverityName").upper()
+    sevname = str(event.deep_get("event", "SeverityName")).upper()
     allowed_values = ("INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL")
     if sevname == "INFORMATIONAL":
         sevname = "INFO"


### PR DESCRIPTION
### Background

Customer reported that the rule doesn't return the right severity when the `SeverityName` is `Informational`. The event stream version of this rule already had logic for this, so I copied it over and adjusted the `Severity` numerical values to match the ones in FDR.

### Changes

- Add more logic to the `severity` function

### Testing

- All unit tests pass
- I checked for a `Medium` FDR detection summary log in TSE instance and confirmed the Severity number scale for FDR is 1-6 instead of 0-5
