### PR TITLE
Fix release tag target and add version bump option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,15 @@ on:
         description: "Branch to release from"
         required: true
         default: "main"
+      bump:
+        description: "Version bump type"
+        required: true
+        default: "minor"
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
 
 permissions:
   contents: read
@@ -41,11 +50,18 @@ jobs:
           export AWS_REGION=${{ secrets.AWS_REGION }}
           export AWS_DEFAULT_REGION=${{ secrets.AWS_REGION }}
           export OLD_VERSION=$(gh release list | grep Latest | awk '{print $1}')
-          export NEW_VERSION=$(echo $OLD_VERSION | awk -F. '{printf "%s.%d.0", $1, $2+1}')
+          export NEW_VERSION=$(echo $OLD_VERSION | awk -F. -v bump="${{ github.event.inputs.bump }}" '{
+            major=substr($1,2)+0; minor=$2+0; patch=$3+0;
+            if (bump=="major") { major++; minor=0; patch=0 }
+            else if (bump=="patch") { patch++ }
+            else { minor++; patch=0 }
+            printf "v%d.%d.%d", major, minor, patch
+          }')
+          export RELEASE_SHA=$(git rev-parse HEAD)
           pip3 install --user pipenv
           rm -rf $(pipenv --venv)
           make install
           pipenv run panther_analysis_tool release --kms-key ${{ secrets.KMS_KEY_ARN }}
           openssl dgst -binary -sha512 panther-analysis-all.zip > ${{ secrets.DIGEST_FILE }}
           aws kms verify --key-id ${{ secrets.KMS_KEY_ARN }} --signing-algorithm ${{ secrets.SIGNING_ALGORITHM }} --message fileb://${{ secrets.DIGEST_FILE }} --message-type DIGEST --output json --signature $(cat panther-analysis-all.sig) | jq '.SignatureValid'
-          gh release create $NEW_VERSION panther-analysis-all.* --title $NEW_VERSION --latest --generate-notes
+          gh release create $NEW_VERSION panther-analysis-all.* --title $NEW_VERSION --target $RELEASE_SHA --latest --generate-notes


### PR DESCRIPTION
## Summary

- `gh release create` had no `--target`, so every release tag landed on the repo's default branch (`develop`) instead of the build SHA. The pat-built `panther-analysis-all.zip` artifact was always correct, but GitHub's auto-generated source archive (e.g. `panther-analysis-3.108.0.zip`) shipped with develop's stale `.versions.yml`. v3.108.0 made it visible because the Anthropic rules PR landed shortly before release. Pinning `--target` to the checked-out SHA fixes the source archive and the git tag in one line.
- Adds a `bump` workflow input (`major`/`minor`/`patch`, defaults to `minor`) so we can cut patch releases like `v3.108.1` without manual version computation.

## Why base=main

Release-infra change that needs to apply to main before the next release runs. Will need a follow-up develop sync so the change isn't lost on the next develop→main merge.

## Test plan

- [ ] Dispatch release.yml with `branch=main`, `bump=patch` → produces `v3.108.1` tagged at main HEAD
- [ ] Confirm `gh release view v3.108.1 --json targetCommitish` returns the main HEAD SHA, not `develop`
- [ ] Confirm the source archive `panther-analysis-3.108.1.zip` includes anthropic entries in `.versions.yml`
- [ ] Confirm the pat artifact `panther-analysis-all.zip` is unchanged in structure (no `.versions.yml`, only AnalysisType files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)