### PR TITLE
Fix Wiz Defend Passthrough severity function

### DIFF
--- a/rules/wiz_rules/wiz_defend_passthrough.py
+++ b/rules/wiz_rules/wiz_defend_passthrough.py
@@ -7,7 +7,12 @@ def title(event):
 
 
 def severity(event):
-    return event.get("severity")
+    sev = event.get("severity", "").upper()
+    if sev == "INFORMATIONAL":
+        return "INFO"
+    if sev in ("INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL"):
+        return sev
+    return "DEFAULT"
 
 
 def dedup(event):

--- a/rules/wiz_rules/wiz_defend_passthrough.py
+++ b/rules/wiz_rules/wiz_defend_passthrough.py
@@ -7,7 +7,7 @@ def title(event):
 
 
 def severity(event):
-    sev = event.get("severity", "").upper()
+    sev = (event.get("severity", "") or "").upper()
     if sev == "INFORMATIONAL":
         return "INFO"
     if sev in ("INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL"):
@@ -17,7 +17,7 @@ def severity(event):
 
 def dedup(event):
     # For lower-severity events, dedup based on specific source rule to reduce overall alert volume
-    if event.get("severity") in ("INFO", "LOW"):
+    if event.get("severity") in ("INFO", "INFORMATIONAL", "LOW"):
         dedup_str = str(event.get("tdrId"))
         if dedup_str:
             return dedup_str


### PR DESCRIPTION
## Summary
- Fixes #2057. The `severity()` function in `Wiz.Defend.Alert.Passthrough` was returning `INFORMATIONAL`, which is not in Panther's allowed set (`INFO`, `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`).
- Maps `INFORMATIONAL` → `INFO`, passes through allowed values, and falls back to `DEFAULT` otherwise — mirroring the recent FDR Passthrough fix in #2056.

## Test plan
- [x] `pipenv run panther_analysis_tool test --filter RuleID=Wiz.Defend.Alert.Passthrough` passes (High/Low/Informational test cases)
- [x] `make fmt && make lint` pass via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)