### PR TITLE
Add Crowdstrike AID device info lookup table

### DIFF
--- a/lookup_tables/crowdstrike/crowdstrike_aid_device_info.yml
+++ b/lookup_tables/crowdstrike/crowdstrike_aid_device_info.yml
@@ -15,60 +15,12 @@ Query: |
       ARRAY_UNIQUE_AGG(aip) AS aips,
       MAX_BY(event, p_event_time) AS details
   FROM panther_logs.public.crowdstrike_fdrevent
-  WHERE p_occurs_since(10d)
+  WHERE p_occurs_since('10d')
       AND fdr_event_type = 'aid_master'
   GROUP BY aid
 LogTypeMap:
   PrimaryKey: aid
   AssociatedLogTypes:
-    - LogType: Crowdstrike.AIDMaster
-      Selectors:
-        - "aid"
-    - LogType: Crowdstrike.ActivityAudit
-      Selectors:
-        - "aid"
-    - LogType: Crowdstrike.CriticalFile
-      Selectors:
-        - "aid"
-    - LogType: Crowdstrike.DetectionSummary
-      Selectors:
-        - "SensorId"
-    - LogType: Crowdstrike.DNSRequest
-      Selectors:
-        - "aid"
     - LogType: Crowdstrike.FDREvent
-      Selectors:
-        - "aid"
-    - LogType: Crowdstrike.GroupIdentity
-      Selectors:
-        - "aid"
-    - LogType: Crowdstrike.ManagedAssets
-      Selectors:
-        - "aid"
-    - LogType: Crowdstrike.NetworkConnect
-      Selectors:
-        - "aid"
-    - LogType: Crowdstrike.NetworkListen
-      Selectors:
-        - "aid"
-    - LogType: Crowdstrike.NotManagedAssets
-      Selectors:
-        - "aid"
-    - LogType: Crowdstrike.ProcessRollup2
-      Selectors:
-        - "aid"
-    - LogType: Crowdstrike.ProcessRollup2Stats
-      Selectors:
-        - "aid"
-    - LogType: Crowdstrike.SyntheticProcessRollup2
-      Selectors:
-        - "aid"
-    - LogType: Crowdstrike.Unknown
-      Selectors:
-        - "aid"
-    - LogType: Crowdstrike.UserIdentity
-      Selectors:
-        - "aid"
-    - LogType: Crowdstrike.UserLogonLogoff
       Selectors:
         - "aid"

--- a/lookup_tables/crowdstrike/crowdstrike_aid_device_info.yml
+++ b/lookup_tables/crowdstrike/crowdstrike_aid_device_info.yml
@@ -1,0 +1,74 @@
+AnalysisType: lookup_table
+LookupName: crowdstrike_aid_device_info
+Enabled: false
+Refresh:
+  PeriodMinutes: 1440
+Description: |
+  Maps Crowdstrike AIDs (Agent IDs) to actual devices, listing the known IPs,
+  hardware, and software specs of the device as most recently recorded by
+  Crowdstrike (within the last 90 days).
+Reference: https://falcon.crowdstrike.com/documentation
+Query: |
+  SELECT
+      aid,
+      MAX_BY(ComputerName, p_event_time) AS ComputerName,
+      ARRAY_UNIQUE_AGG(aip) AS aips,
+      MAX_BY(event, p_event_time) AS details
+  FROM panther_logs.public.crowdstrike_fdrevent
+  WHERE p_occurs_since(10d)
+      AND fdr_event_type = 'aid_master'
+  GROUP BY aid
+LogTypeMap:
+  PrimaryKey: aid
+  AssociatedLogTypes:
+    - LogType: Crowdstrike.AIDMaster
+      Selectors:
+        - "aid"
+    - LogType: Crowdstrike.ActivityAudit
+      Selectors:
+        - "aid"
+    - LogType: Crowdstrike.CriticalFile
+      Selectors:
+        - "aid"
+    - LogType: Crowdstrike.DetectionSummary
+      Selectors:
+        - "SensorId"
+    - LogType: Crowdstrike.DNSRequest
+      Selectors:
+        - "aid"
+    - LogType: Crowdstrike.FDREvent
+      Selectors:
+        - "aid"
+    - LogType: Crowdstrike.GroupIdentity
+      Selectors:
+        - "aid"
+    - LogType: Crowdstrike.ManagedAssets
+      Selectors:
+        - "aid"
+    - LogType: Crowdstrike.NetworkConnect
+      Selectors:
+        - "aid"
+    - LogType: Crowdstrike.NetworkListen
+      Selectors:
+        - "aid"
+    - LogType: Crowdstrike.NotManagedAssets
+      Selectors:
+        - "aid"
+    - LogType: Crowdstrike.ProcessRollup2
+      Selectors:
+        - "aid"
+    - LogType: Crowdstrike.ProcessRollup2Stats
+      Selectors:
+        - "aid"
+    - LogType: Crowdstrike.SyntheticProcessRollup2
+      Selectors:
+        - "aid"
+    - LogType: Crowdstrike.Unknown
+      Selectors:
+        - "aid"
+    - LogType: Crowdstrike.UserIdentity
+      Selectors:
+        - "aid"
+    - LogType: Crowdstrike.UserLogonLogoff
+      Selectors:
+        - "aid"

--- a/packs/crowdstrike.yml
+++ b/packs/crowdstrike.yml
@@ -25,4 +25,6 @@ PackDefinition:
     - Standard.AWS.VPCDns
     - Standard.CiscoUmbrella.DNS
     - Standard.Crowdstrike.FDR
+    # Lookup tables
+    - crowdstrike_aid_device_info
 DisplayName: "Panther Crowdstrike Pack"


### PR DESCRIPTION
## Summary
- Adds `lookup_tables/crowdstrike/crowdstrike_aid_device_info.yml`
- Maps Crowdstrike AIDs to devices with most-recent ComputerName, known IPs (`aip` aggregate), and the full latest `aid_master` event details (10-day window)
- Enriches Crowdstrike log types keyed by `aid` (plus `SensorId` for DetectionSummary)
- Disabled by default; daily refresh (1440 min)
