### PR TITLE
Filter out common Panther queries for correlation rules and SQL enric…

### DIFF
--- a/queries/snowflake_queries/snowflake_0108977_configuration_drift_query.yml
+++ b/queries/snowflake_queries/snowflake_0108977_configuration_drift_query.yml
@@ -18,7 +18,14 @@ Query: |
       end_time
   FROM snowflake.account_usage.query_history
     WHERE ((execution_status = 'SUCCESS'
-      AND query_type NOT in ('SELECT')
+      AND query_type NOT in ('SELECT', 'EXPLAIN')
+      AND (
+        user_name NOT in ('PANTHER_ADMIN', 'PANTHERACCOUNTADMIN')
+        AND NOT (
+          role_name LIKE 'PANTHER_READONLY%'
+          AND query_text LIKE 'COPY INTO @panther_lookups.public.panther_lut_export_stage%'
+        )
+      )
       AND user_name NOT in ('PANTHER_ADMIN', 'PANTHERACCOUNTADMIN')
       AND (query_text ILIKE '%create role%'
           OR query_text ILIKE '%manage grants%'


### PR DESCRIPTION
### Background

Customer reported a number of false positives which looked like they were being triggered by legitimate Panther activity. I ran the query in a test instance and noticed some queries from SQL enrichments (being written to stages) and Correlation rules (running `EXPLAIN`) that were being picked up.

### Changes

- Exclude COPYs performed in `panher_lookups` by `PANTHR_READONLY` users (with fuzzy match for RBAC users)
- Exclude `EXPLAIN` operations since those are just readonly

### Testing

- Ran the query with my mods and got no hits back
