### PR TITLE
Graduate `Anthropic.Activity` rules & `Standard.OTX.MaliciousIndicator` out of experimental + create Anthropic pack

### DIFF
--- a/packs/anthropic.yml
+++ b/packs/anthropic.yml
@@ -22,5 +22,6 @@ PackDefinition:
     - Anthropic.Activity.SSO.Login.Failed
     # Globals used in these detections
     - panther_anthropic_helpers
+    - panther_base_helpers
 
 DisplayName: "Panther Anthropic Pack"

--- a/packs/anthropic.yml
+++ b/packs/anthropic.yml
@@ -1,0 +1,26 @@
+AnalysisType: pack
+PackID: PantherManaged.Anthropic
+Description: Group of all Anthropic detections
+PackDefinition:
+  IDs:
+    - Anthropic.Activity.Admin.API.Key.Created
+    - Anthropic.Activity.Admin.API.Key.Deleted
+    - Anthropic.Activity.Artifact.Shared.Publicly
+    - Anthropic.Activity.Excessive.Chat.Access.Failures
+    - Anthropic.Activity.Integration.Connected
+    - Anthropic.Activity.IP.Restriction.Deleted
+    - Anthropic.Activity.MCP.Server.Created
+    - Anthropic.Activity.MCP.Server.Deleted
+    - Anthropic.Activity.Org.User.Deleted
+    - Anthropic.Activity.Organization.Settings.Updated
+    - Anthropic.Activity.Primary.Owner.Transferred
+    - Anthropic.Activity.Role.Granted
+    - Anthropic.Activity.Service.Key.Created
+    - Anthropic.Activity.Service.Key.Revoked
+    - Anthropic.Activity.Spend.Limit.Deleted
+    - Anthropic.Activity.SSO.Disabled
+    - Anthropic.Activity.SSO.Login.Failed
+    # Globals used in these detections
+    - panther_anthropic_helpers
+
+DisplayName: "Panther Anthropic Pack"

--- a/packs/standard_ruleset.yml
+++ b/packs/standard_ruleset.yml
@@ -37,6 +37,7 @@ PackDefinition:
     - Standard.MFADisabled
     - Standard.NewAWSAccountCreated
     - Standard.NewUserAccountCreated
+    - Standard.OTX.MaliciousIndicator
     # Global Helpers
     - panther_aws_helpers
     - panther_base_helpers

--- a/packs/standard_ruleset.yml
+++ b/packs/standard_ruleset.yml
@@ -45,3 +45,4 @@ PackDefinition:
     - panther_greynoise_helpers
     - panther_ipinfo_helpers
     - panther_lookuptable_helpers
+    - panther_otx_helpers

--- a/rules/anthropic_rules/anthropic_admin_api_key_created.yml
+++ b/rules/anthropic_rules/anthropic_admin_api_key_created.yml
@@ -2,7 +2,6 @@ AnalysisType: rule
 RuleID: Anthropic.Activity.Admin.API.Key.Created
 DisplayName: "Anthropic Admin API Key Created"
 Enabled: true
-Status: Experimental
 Filename: anthropic_admin_api_key_created.py
 LogTypes:
   - Anthropic.Activity

--- a/rules/anthropic_rules/anthropic_admin_api_key_deleted.yml
+++ b/rules/anthropic_rules/anthropic_admin_api_key_deleted.yml
@@ -2,7 +2,6 @@ AnalysisType: rule
 RuleID: Anthropic.Activity.Admin.API.Key.Deleted
 DisplayName: "Anthropic Admin API Key Deleted"
 Enabled: true
-Status: Experimental
 Filename: anthropic_admin_api_key_deleted.py
 LogTypes:
   - Anthropic.Activity

--- a/rules/anthropic_rules/anthropic_artifact_shared_publicly.yml
+++ b/rules/anthropic_rules/anthropic_artifact_shared_publicly.yml
@@ -2,7 +2,6 @@ AnalysisType: rule
 RuleID: Anthropic.Activity.Artifact.Shared.Publicly
 DisplayName: "Anthropic Artifact Shared Publicly"
 Enabled: true
-Status: Experimental
 Filename: anthropic_artifact_shared_publicly.py
 LogTypes:
   - Anthropic.Activity

--- a/rules/anthropic_rules/anthropic_excessive_chat_access_failures.yml
+++ b/rules/anthropic_rules/anthropic_excessive_chat_access_failures.yml
@@ -2,7 +2,6 @@ AnalysisType: rule
 RuleID: Anthropic.Activity.Excessive.Chat.Access.Failures
 DisplayName: "Anthropic Excessive Chat Access Failures"
 Enabled: true
-Status: Experimental
 Filename: anthropic_excessive_chat_access_failures.py
 LogTypes:
   - Anthropic.Activity

--- a/rules/anthropic_rules/anthropic_integration_connected.yml
+++ b/rules/anthropic_rules/anthropic_integration_connected.yml
@@ -2,7 +2,6 @@ AnalysisType: rule
 RuleID: Anthropic.Activity.Integration.Connected
 DisplayName: "Anthropic Integration Connected"
 Enabled: true
-Status: Experimental
 Filename: anthropic_integration_connected.py
 LogTypes:
   - Anthropic.Activity

--- a/rules/anthropic_rules/anthropic_ip_restriction_deleted.yml
+++ b/rules/anthropic_rules/anthropic_ip_restriction_deleted.yml
@@ -2,7 +2,6 @@ AnalysisType: rule
 RuleID: Anthropic.Activity.IP.Restriction.Deleted
 DisplayName: "Anthropic IP Restriction Deleted"
 Enabled: true
-Status: Experimental
 Filename: anthropic_ip_restriction_deleted.py
 LogTypes:
   - Anthropic.Activity

--- a/rules/anthropic_rules/anthropic_mcp_server_created.yml
+++ b/rules/anthropic_rules/anthropic_mcp_server_created.yml
@@ -2,7 +2,6 @@ AnalysisType: rule
 RuleID: Anthropic.Activity.MCP.Server.Created
 DisplayName: "Anthropic MCP Server Created"
 Enabled: true
-Status: Experimental
 Filename: anthropic_mcp_server_created.py
 LogTypes:
   - Anthropic.Activity

--- a/rules/anthropic_rules/anthropic_mcp_server_deleted.yml
+++ b/rules/anthropic_rules/anthropic_mcp_server_deleted.yml
@@ -2,7 +2,6 @@ AnalysisType: rule
 RuleID: Anthropic.Activity.MCP.Server.Deleted
 DisplayName: "Anthropic MCP Server Deleted"
 Enabled: true
-Status: Experimental
 Filename: anthropic_mcp_server_deleted.py
 LogTypes:
   - Anthropic.Activity

--- a/rules/anthropic_rules/anthropic_org_settings_updated.yml
+++ b/rules/anthropic_rules/anthropic_org_settings_updated.yml
@@ -2,7 +2,6 @@ AnalysisType: rule
 RuleID: Anthropic.Activity.Organization.Settings.Updated
 DisplayName: "Anthropic Organization Settings Updated"
 Enabled: true
-Status: Experimental
 Filename: anthropic_org_settings_updated.py
 LogTypes:
   - Anthropic.Activity

--- a/rules/anthropic_rules/anthropic_org_user_deleted.yml
+++ b/rules/anthropic_rules/anthropic_org_user_deleted.yml
@@ -2,7 +2,6 @@ AnalysisType: rule
 RuleID: Anthropic.Activity.Org.User.Deleted
 DisplayName: "Anthropic Organization User Deleted"
 Enabled: true
-Status: Experimental
 Filename: anthropic_org_user_deleted.py
 LogTypes:
   - Anthropic.Activity

--- a/rules/anthropic_rules/anthropic_primary_owner_transferred.yml
+++ b/rules/anthropic_rules/anthropic_primary_owner_transferred.yml
@@ -2,7 +2,6 @@ AnalysisType: rule
 RuleID: Anthropic.Activity.Primary.Owner.Transferred
 DisplayName: "Anthropic Primary Owner Transferred"
 Enabled: true
-Status: Experimental
 Filename: anthropic_primary_owner_transferred.py
 LogTypes:
   - Anthropic.Activity

--- a/rules/anthropic_rules/anthropic_role_granted.yml
+++ b/rules/anthropic_rules/anthropic_role_granted.yml
@@ -2,7 +2,6 @@ AnalysisType: rule
 RuleID: Anthropic.Activity.Role.Granted
 DisplayName: "Anthropic Role Granted"
 Enabled: true
-Status: Experimental
 Filename: anthropic_role_granted.py
 LogTypes:
   - Anthropic.Activity

--- a/rules/anthropic_rules/anthropic_service_key_created.yml
+++ b/rules/anthropic_rules/anthropic_service_key_created.yml
@@ -2,7 +2,6 @@ AnalysisType: rule
 RuleID: Anthropic.Activity.Service.Key.Created
 DisplayName: "Anthropic Service Key Created"
 Enabled: true
-Status: Experimental
 Filename: anthropic_service_key_created.py
 LogTypes:
   - Anthropic.Activity

--- a/rules/anthropic_rules/anthropic_service_key_revoked.yml
+++ b/rules/anthropic_rules/anthropic_service_key_revoked.yml
@@ -2,7 +2,6 @@ AnalysisType: rule
 RuleID: Anthropic.Activity.Service.Key.Revoked
 DisplayName: "Anthropic Service Key Revoked"
 Enabled: true
-Status: Experimental
 Filename: anthropic_service_key_revoked.py
 LogTypes:
   - Anthropic.Activity

--- a/rules/anthropic_rules/anthropic_spend_limit_deleted.yml
+++ b/rules/anthropic_rules/anthropic_spend_limit_deleted.yml
@@ -2,7 +2,6 @@ AnalysisType: rule
 RuleID: Anthropic.Activity.Spend.Limit.Deleted
 DisplayName: "Anthropic Spend Limit Deleted"
 Enabled: true
-Status: Experimental
 Filename: anthropic_spend_limit_deleted.py
 LogTypes:
   - Anthropic.Activity

--- a/rules/anthropic_rules/anthropic_sso_disabled.yml
+++ b/rules/anthropic_rules/anthropic_sso_disabled.yml
@@ -2,7 +2,6 @@ AnalysisType: rule
 RuleID: Anthropic.Activity.SSO.Disabled
 DisplayName: "Anthropic SSO Disabled"
 Enabled: true
-Status: Experimental
 Filename: anthropic_sso_disabled.py
 LogTypes:
   - Anthropic.Activity

--- a/rules/anthropic_rules/anthropic_sso_login_failed.yml
+++ b/rules/anthropic_rules/anthropic_sso_login_failed.yml
@@ -2,7 +2,6 @@ AnalysisType: rule
 RuleID: Anthropic.Activity.SSO.Login.Failed
 DisplayName: "Anthropic SSO Login Failed"
 Enabled: true
-Status: Experimental
 Filename: anthropic_sso_login_failed.py
 LogTypes:
   - Anthropic.Activity

--- a/rules/standard_rules/otx_malicious_indicator.yml
+++ b/rules/standard_rules/otx_malicious_indicator.yml
@@ -3,7 +3,6 @@ Filename: otx_malicious_indicator.py
 RuleID: "Standard.OTX.MaliciousIndicator"
 DisplayName: "OTX Threat Intelligence Indicator Match"
 Enabled: true
-Status: Experimental
 Severity: High
 Description: >-
   Detects when an IP address in any log event matches a known threat indicator


### PR DESCRIPTION
## Summary
- Graduate all 17 `Anthropic.Activity.*` rules out of `Status: Experimental` based on last week's noise/match review
- Create `packs/anthropic.yml` (`PantherManaged.Anthropic`) bundling all 17 rules plus the `panther_anthropic_helpers` global.
- Graduate `Standard.OTX.MaliciousIndicator` out of experimental and add it to `PantherManaged.UniversalDetections` in `packs/standard_ruleset.yml`.

## Test plan
- [x] `pipenv run panther_analysis_tool test --path rules/anthropic_rules/` — 17/17 pass
- [x] `pipenv run panther_analysis_tool test --filter RuleID=Standard.OTX.MaliciousIndicator` — pass
- [x] `pipenv run panther_analysis_tool zip --path packs/anthropic.yml` — pack references resolve cleanly
- [x] `make lint` — clean (10.00/10)
