### PR TITLE
Added Wiz.IssuesWebhook to the Wiz.Alert.Passthrough rule's log sources

### DIFF
--- a/rules/wiz_rules/wiz_alert_passthrough.yml
+++ b/rules/wiz_rules/wiz_alert_passthrough.yml
@@ -9,6 +9,7 @@ Filename: wiz_alert_passthrough.py
 Severity: Medium
 LogTypes:
   - Wiz.Issues
+  - Wiz.IssuesWebhook
 DedupPeriodMinutes: 720
 Threshold: 1
 Tests:


### PR DESCRIPTION
### Changes

If you add the Wiz via S3 the Wiz.Issues is correct but if you add it via webhook the log source should be Wiz.IssuesWebhook

