### PR TITLE
[THREAT-698] PantherAI Skills

### DIFF
--- a/skills/panther_ai_aws_blast_radius_skill.yml
+++ b/skills/panther_ai_aws_blast_radius_skill.yml
@@ -188,6 +188,11 @@ Prompt: |
   LIMIT 200
   ```
 
+  As in Step 4, the `WHERE` filter must match the anchor type from Step 1 — swap the
+  `p_any_aws_arns` predicate for the principal's actual filter (`p_any_actor_ids`,
+  `p_any_aws_account_ids`, `p_any_aws_instance_ids`, `p_any_ip_addresses`, or the direct
+  `userIdentity:accessKeyId::VARCHAR` match for access keys).
+
   Cap entity pivots at 2 hops — entities pivoted to once may be worth re-scoping; entities
   two hops out usually aren't.
 

--- a/skills/panther_ai_aws_blast_radius_skill.yml
+++ b/skills/panther_ai_aws_blast_radius_skill.yml
@@ -1,0 +1,321 @@
+AnalysisType: "skill"
+SkillName: "aws_blast_radius"
+DisplayName: "AWS Blast Radius"
+Description: "Scoping workflow for a compromised AWS principal — IAM user, role ARN, assumed-role session, access key ID, account ID, or EC2 instance. Leads with the alerts and deployed detections Panther already has, then walks the assumed-role chain across accounts and classifies actions by impact — reusing deployed detection logic, with ad-hoc CloudTrail SQL only for the gaps — to produce an IR-style blast-radius timeline. Use whenever an AWS incident anchor is confirmed and the question is \"what else did they touch\"."
+Prompt: |
+  # AWS Blast Radius — Principal Scoping Workflow
+
+  Given a confirmed-compromised AWS principal, enumerate every API call that principal
+  made, every resource they touched, every role they assumed, every account they
+  reached, and every other entity that appeared alongside them. Produce an IR-style
+  timeline and a containment-advisory report.
+
+  **Not for**: confirming whether an indicator is malicious, scoping non-AWS
+  principals such as SaaS users or Okta sessions (different log shape — separate
+  skill), drafting new detections, or
+  executing containment actions. This skill is read-only and advisory.
+
+  **Reuse before you query.** Don't scope this principal in a vacuum with ad-hoc SQL. Lead with
+  what Panther already knows — alerts that fired on the principal, and deployed AWS detections /
+  scheduled queries that already encode these techniques. Hand-write CloudTrail SQL only to fill
+  the gaps deployed content doesn't already answer. The MITRE tactic / technique IDs in
+  `aws_security_knowledge` are the join key for finding that coverage.
+
+  ---
+
+  ## Step 1 — Normalize the principal and pick an anchor time
+
+  Identify what was given and map it to the canonical CloudTrail field path. Use the
+  matching `p_any_*` field for the fast initial sweep, then pull the CloudTrail field
+  directly when analyzing identity details.
+
+  | Principal type | Example | Fast filter (`p_any_*`) | CloudTrail field path |
+  |---|---|---|---|
+  | IAM user ARN | `arn:aws:iam::123:user/Alice` | `p_any_aws_arns` | `userIdentity:arn::VARCHAR` |
+  | IAM role ARN | `arn:aws:iam::123:role/Deploy` | `p_any_aws_arns` | `userIdentity:sessionContext:sessionIssuer:arn::VARCHAR` |
+  | Assumed-role session | `arn:aws:sts::123:assumed-role/Deploy/i-abc` | `p_any_aws_arns` | `userIdentity:arn::VARCHAR` |
+  | Access key ID | `AKIA...` / `ASIA...` | n/a — use CloudTrail field | `userIdentity:accessKeyId::VARCHAR` |
+  | Principal ID | `AIDA...` / `AROA...:session` | `p_any_actor_ids` | `userIdentity:principalId::VARCHAR` |
+  | Account ID | `123456789012` | `p_any_aws_account_ids` | `recipientAccountId::VARCHAR` or `userIdentity:accountId::VARCHAR` |
+  | EC2 instance ID | `i-0abc...` | `p_any_aws_instance_ids` | extract from assumed-role session name, or `resources` array |
+  | Source IP | `203.0.113.10` | `p_any_ip_addresses` | `sourceIPAddress::VARCHAR` |
+
+  **Anchor time (T0)**: ask the analyst — when is the suspected compromise / first
+  malicious action? If unknown, anchor on the earliest alert involving the principal.
+
+  **CloudTrail `userIdentity.type` matters**: `Root` (full account), `IAMUser` (long-lived
+  creds), `AssumedRole` (STS session — has a parent role), `FederatedUser` (SAML/web ID),
+  `AWSService` (service-linked — usually benign). Record the type — it shapes how broad
+  the blast radius can be.
+
+  ---
+
+  ## Step 2 — Anchor on what Panther already knows
+
+  Before writing any SQL, pull existing signal — it's free, fast, and shapes the whole scope:
+
+  - **Alerts already fired on this principal.** Call `panther_ai_alerts_list` filtered by the
+    principal's identifiers (ARN, access key, account, source IP) across the window. Each alert
+    is a confirmed-suspicious event with its rule, severity, and triage state — and often a
+    better anchor time (T0) than the analyst's estimate. Single-event rules, correlation rules,
+    and scheduled queries all surface here.
+  - **Deployed detections relevant to this investigation.** Call `panther_ai_detections_list`
+    (filter by AWS / CloudTrail log type, or by the MITRE tactics in `aws_security_knowledge`)
+    to learn what is *already covered*, and `panther_ai_datalake_list_saved_queries` to find
+    deployed/scheduled query logic you can reuse. Their SQL is audited, parameterised logic for
+    the steps below (timeline, role-chain, exfil) — prefer executing a matching saved query with
+    `panther_ai_datalake_execute_saved_query` (passing the principal / window as template params)
+    over inventing new SQL.
+
+  Carry forward two lists: (a) confirmed events from fired alerts — your scope seeds; and
+  (b) deployed detection logic you can reuse instead of hand-writing SQL.
+
+  ---
+
+  ## Step 3 — Discover available AWS log sources
+
+  Call `panther_ai_log_sources_list` and `panther_ai_log_types_list` to confirm which
+  AWS log types are ingested and healthy. The high-value sources, in priority order: CloudTrail, GuardDuty, VPC Flow, Config, S3 Server Access, ALB/ELB/CloudFront, Access Analyzer.
+
+  Any healthy source with non-zero events in the window but no query coverage is a
+  visibility gap, call it out in the final report.
+
+  ---
+
+  ## Step 4 — Build the activity timeline (tiered windows)
+
+  If a deployed saved/scheduled query (from Step 2) already returns principal-scoped CloudTrail
+  activity, execute it with `panther_ai_datalake_execute_saved_query` (passing the principal and
+  window as template params) first. Only when none fits, fall back to
+  `panther_ai_datalake_execute_sql` with this template — it is the gap-filler, not the default.
+
+  **W1 — Tight (T0 ± 3 days)** — first pass, lowest false-positive risk:
+
+  ```sql
+  SELECT p_event_time,
+         awsRegion,
+         eventSource,
+         eventName,
+         userIdentity:type::VARCHAR        AS identity_type,
+         userIdentity:arn::VARCHAR         AS principal_arn,
+         userIdentity:accessKeyId::VARCHAR AS access_key,
+         sourceIPAddress,
+         userAgent,
+         errorCode,
+         readOnly,
+         ARRAY_TO_STRING(p_any_aws_arns, ',') AS arns_in_event
+  FROM panther_logs.public.aws_cloudtrail
+  WHERE ARRAY_CONTAINS('{principal_arn}'::VARIANT, p_any_aws_arns)
+    AND p_event_time BETWEEN DATEADD('day', -3, '{T0}') AND DATEADD('day', 3, '{T0}')
+  ORDER BY p_event_time ASC
+  LIMIT 1000
+  ```
+
+  Replace the `p_any_*` filter with whichever fast filter from Step 1 matches the
+  principal type. For an access-key investigation, use
+  `userIdentity:accessKeyId::VARCHAR = '{AKIA...}'` directly (no `p_any_*` index).
+
+  **W2 — Campaign window** — once W1 confirms relevant activity, expand from first-seen
+  to last-seen of confirmed-malicious calls.
+
+  **W3 — Full lookback (up to 90 days)** — only when hunting for dormant precursor
+  activity (e.g. when the credential was first staged or first used). Expect noise.
+
+  For each event, capture: `eventName`, `eventSource`, `awsRegion`, `errorCode`,
+  `readOnly`, `sourceIPAddress`, `userAgent`, and the `resources` array. Failed actions
+  (`errorCode` IS NOT NULL) are signal — they reveal what the attacker *tried*, not
+  just what succeeded.
+
+  ---
+
+  ## Step 5 — Walk the assumed-role chain
+
+  Compromised AWS principals frequently chain identities: long-lived IAM user → AssumeRole
+  into a role → AssumeRole into a cross-account role → activity in target account.
+  Reconstruct the chain.
+
+  For every `sts:AssumeRole`, `sts:AssumeRoleWithWebIdentity`, or `sts:AssumeRoleWithSAML`
+  call made by the principal in the window, extract the target role from
+  `requestParameters:roleArn::VARCHAR` and the resulting session ARN from
+  `responseElements:assumedRoleUser:arn::VARCHAR`.
+
+  ```sql
+  SELECT p_event_time,
+         awsRegion,
+         userIdentity:arn::VARCHAR                          AS source_principal,
+         requestParameters:roleArn::VARCHAR                 AS target_role,
+         responseElements:assumedRoleUser:arn::VARCHAR      AS new_session_arn,
+         requestParameters:roleSessionName::VARCHAR         AS session_name,
+         recipientAccountId
+  FROM panther_logs.public.aws_cloudtrail
+  WHERE eventName IN ('AssumeRole', 'AssumeRoleWithWebIdentity', 'AssumeRoleWithSAML')
+    AND (
+      ARRAY_CONTAINS('{principal_arn}'::VARIANT, p_any_aws_arns)
+      OR userIdentity:accessKeyId::VARCHAR = '{access_key}'
+    )
+    AND p_event_time BETWEEN '{W_start}' AND '{W_end}'
+  ORDER BY p_event_time ASC
+  LIMIT 500
+  ```
+
+  For each `new_session_arn`, re-run Step 4 with that ARN as the principal — this is
+  how you cross account boundaries. **Cap chain depth at 3 hops** (source → role A →
+  role B → role C) — beyond that you are almost certainly chasing legitimate service
+  role chains.
+
+  Cross-account hops (where `recipientAccountId` differs from the source account) are
+  high-signal — record them prominently in the report.
+
+  ---
+
+  ## Step 6 — Co-occurring entities (lateral movement candidates)
+
+  For each event found in Steps 4 and 5, pull the *other* `p_any_*` fields. These are
+  resources and identities the principal interacted with in the same call.
+
+  ```sql
+  SELECT DISTINCT
+         ARRAY_TO_STRING(p_any_aws_arns, ',')          AS other_arns,
+         ARRAY_TO_STRING(p_any_aws_instance_ids, ',')  AS other_instances,
+         ARRAY_TO_STRING(p_any_ip_addresses, ',')      AS other_ips,
+         ARRAY_TO_STRING(p_any_aws_account_ids, ',')   AS other_accounts,
+         COUNT(*) AS event_count
+  FROM panther_logs.public.aws_cloudtrail
+  WHERE ARRAY_CONTAINS('{principal_arn}'::VARIANT, p_any_aws_arns)
+    AND p_event_time BETWEEN '{W_start}' AND '{W_end}'
+  GROUP BY 1,2,3,4
+  ORDER BY event_count DESC
+  LIMIT 200
+  ```
+
+  Cap entity pivots at 2 hops — entities pivoted to once may be worth re-scoping; entities
+  two hops out usually aren't.
+
+  ---
+
+  ## Step 7 — Classify actions by impact and map to deployed detections
+
+  Group the windowed event set by `eventName` and bucket each call into an attacker-impact
+  category — identity & access, credential access, persistence, data access / exfil, defense
+  evasion, reconnaissance, lateral movement, impact / destruction. The `aws_security_knowledge`
+  reference holds the canonical high-signal `eventName` lists (with MITRE tactic mappings) for
+  each bucket; use it to classify, and do not redefine the lists here.
+
+  For each high-impact eventName observed, list: which call, when, target resource
+  (from `resources` array), whether it succeeded (`errorCode` NULL), and source IP.
+  `AssumeRole` was already enumerated in Step 5 — cross-reference rather than re-listing.
+
+  Then close the loop against deployed coverage — reuse what Step 2 surfaced, don't re-derive:
+  - For each classified action / chain, resolve its MITRE tactic-technique ID to a deployed
+    detection via the `aws_security_knowledge` "Mapping techniques to deployed detections"
+    guidance (single-event → rule, multi-step chain → correlation rule, volumetric → scheduled
+    query). If an alert already fired (Step 2), mark the action **covered & alerted**.
+  - A high-impact action with **no** deployed detection is a coverage-gap finding for the
+    post-mortem — record it and route to `coverage_gap_analysis`.
+
+  ---
+
+  ## Step 8 — Output: Blast Radius Report
+
+  ```markdown
+  # AWS Blast Radius — <principal ARN or identifier>
+
+  ## Principal Profile
+  - Identity type (`userIdentity.type`): <IAMUser / AssumedRole / Root / FederatedUser>
+  - Canonical ARN: <full ARN>
+  - Access key(s) used: <list of AKIA/ASIA values, if applicable>
+  - Source IPs observed: <list>
+  - User agents observed: <list — flag CLI / SDK / unusual UAs>
+  - Anchor time (T0): <ISO timestamp>
+  - Windows examined: W1 <range>, W2 <range>, W3 <range if used>
+  - Log sources queried: <list, with unhealthy sources or visibility gaps called out>
+
+  ## Activity Timeline (W1)
+  | Time | Region | Source | Event | Resource | Result | Notes |
+  |---|---|---|---|---|---|---|
+
+  ## Assumed-Role Chain
+  | Hop | Source Principal | Target Role | New Session ARN | Account | Cross-account? |
+  |---|---|---|---|---|---|
+
+  ## Resources Touched
+  | Resource ARN | Type | First Action | Last Action | Action Count | Impact |
+  |---|---|---|---|---|---|
+
+  ## High-Impact Actions Observed
+  ### Identity & Access Changes
+  - <eventName @ time, target, success?>
+
+  ### Persistence
+  - <...>
+
+  ### Data Access / Exfil
+  - <...>
+
+  ### Defense Evasion
+  - <...>
+
+  ### Reconnaissance
+  - <...>
+
+  ### Lateral Movement
+  - <...>
+
+  ## Co-occurring Entities
+  | Entity | Type | Co-occurrence Count | Recommended Follow-up |
+  |---|---|---|---|
+
+  ## Existing Detection Coverage
+  - Alerts fired on this principal in window: <list>
+  - High-impact actions with no matching detection: <list — detection-gap findings>
+
+  ## Containment Recommendations (advisory only)
+  - Disable access key(s): <which>
+  - Revoke active sessions: `aws iam list-attached-user-policies` → review; for roles, set `MaxSessionDuration` to minimum and / or attach an explicit deny policy
+  - Rotate credentials: <which IAM users>
+  - Review derived resources (created by the principal): <list>
+  - Review newly attached policies / role trust changes: <list>
+
+  ## Caveats
+  - Co-occurring entities are correlation, not causation — confirm before declaring lateral movement.
+  - `errorCode` NULL means the API call succeeded; failed calls reveal intent but not impact.
+  - Unhealthy / missing AWS log sources during the window: <list> — these are visibility gaps.
+  - If W3 (full lookback) was not run, dormant precursor activity may exist outside the window.
+  - Assumed-role chain capped at 3 hops; deeper chains may exist.
+  ```
+
+  ---
+
+  ## Constraints
+
+  - Read-only. Never disable a principal, revoke a key, attach a deny policy, or modify
+    a rule from this skill. Recommendations only.
+  - Cap entity-pivot recursion at 2 hops; cap assumed-role chain depth at 3 hops.
+  - Every query must have a `LIMIT` and a `p_event_time` bound (no unbounded scans).
+  - Prefer reusing deployed detections and saved queries (`panther_ai_datalake_execute_saved_query`)
+    over ad-hoc SQL; `panther_ai_datalake_execute_sql` is the gap-filler, not the default.
+  - Failed actions (`errorCode` IS NOT NULL) are signal — include them; do not filter out.
+  - If the principal identifier doesn't match any field after Step 1, ask the analyst to
+    clarify rather than guessing.
+  - Surface visibility gaps (unhealthy sources, missing log types) in the report — IR
+    scoping with blind spots is more dangerous than incomplete scoping that names them.
+ToolMessage: "Scoping AWS blast radius for the compromised principal…"
+DependsOn:
+  - aws_security_knowledge
+EagerLoading: false
+RequiredTools:
+  - panther_ai_alerts_list
+  - panther_ai_detections_list
+  - panther_ai_log_sources_list
+  - panther_ai_log_types_list
+  - panther_ai_datalake_list_saved_queries
+  - panther_ai_datalake_execute_saved_query
+  - panther_ai_datalake_execute_sql
+  - panther_ai_datalake_get_query_results
+Enabled: true
+Tags:
+  - aws
+  - cloudtrail
+  - incident-response
+  - blast-radius
+  - scoping

--- a/skills/panther_ai_aws_security_knowledge_skill.yml
+++ b/skills/panther_ai_aws_security_knowledge_skill.yml
@@ -1,0 +1,233 @@
+AnalysisType: "skill"
+SkillName: "aws_security_knowledge"
+DisplayName: "AWS Security Knowledge"
+Description: "Reference mapping of AWS CloudTrail `eventName` values to attacker-impact categories — identity & access, credential access, persistence, data access / exfil, defense evasion, reconnaissance, lateral movement, impact / destruction, and known multi-step attack chains. Use whenever AWS API activity needs to be classified by adversary impact: incident scoping, threat hunts, detection coverage analysis, or post-mortem triage. Also covers reading AWS identifier prefixes (AKIA / ASIA / AROA …) in CloudTrail and mapping techniques to the deployed Panther detections (rules, correlation rules, scheduled queries) that cover them. Knowledge reference — does not run queries itself."
+Prompt: |
+  # AWS Security Knowledge — CloudTrail Action Impact Reference
+
+  Maps high-signal AWS CloudTrail `eventName` values to the attacker-impact category they
+  belong to. Use it to bucket observed API activity by what it lets an adversary *do* —
+  not just what service it touched. The lists are the canonical high-signal calls per
+  category; they are not exhaustive, and a call's significance always depends on context
+  (who made it, whether it succeeded, and whether it is normal for that principal).
+
+  Group an observed event set by `eventName` and classify each into the buckets below.
+
+  ## Reading AWS identifiers in CloudTrail
+
+  Two `userIdentity` fields tell you *what kind of credential* acted before you even look at
+  the eventName. The 4-char prefix on a 21-char unique ID is the type:
+
+  - `userIdentity.accessKeyId` — **`AKIA…`** = long-term IAM user key (no expiry; the prime
+    vehicle for initial access and persistence). **`ASIA…`** = temporary STS credentials
+    (short-lived session token; an attacker must use them before they expire). **`ABIA…`** =
+    STS bearer token.
+  - `userIdentity.principalId` — **`AIDA…`** = IAM user, **`AROA…`** = role, **`AIPA…`** = EC2
+    instance profile, **`AGPA…`** = group, **`ANPA…`** = managed policy.
+
+  Triage cues: an `AKIA…` key acting from a new IP, or an `AROA…` / instance-profile session
+  used far from its workload, is worth a closer look. `AKIA…` exposure is urgent (no expiry);
+  `ASIA…` exposure is time-boxed.
+
+  ## Identity & access changes (IAM) — TA0003 Persistence / TA0004 Privilege Escalation
+  - `CreateUser`, `CreateAccessKey`, `UpdateAccessKey`, `AttachUserPolicy`,
+    `PutUserPolicy`, `AddUserToGroup`, `CreateLoginProfile`, `UpdateLoginProfile`,
+    `DeactivateMFADevice`, `DeleteVirtualMFADevice`, `PassRole`, `UpdateAssumeRolePolicy`,
+    `CreateRole`, `AttachRolePolicy`, `PutRolePolicy`, `CreateServiceSpecificCredential`
+  - `CreatePolicyVersion`, `SetDefaultPolicyVersion` (sneak admin into a customer-managed
+    policy without changing its attachment), `CreatePolicy`
+  - `UpdateDevEndpoint` (Glue — inject an SSH key / code into a privileged dev endpoint)
+  - **`PassRole` is the hinge of most privesc.** Watch it paired with a compute-create call
+    (`RunInstances`, `CreateFunction` / `UpdateFunctionCode`, `CreateDevEndpoint`) that runs
+    attacker-controlled code under a more privileged role.
+
+  ## Credential access — TA0006
+  Calls that hand back usable credentials or tokens — treat a success as "the actor now
+  holds new creds":
+  - `CreateAccessKey`, `CreateLoginProfile` (IAM — long-lived key / console password)
+  - `AssumeRole`, `AssumeRoleWithWebIdentity`, `AssumeRoleWithSAML`, `GetFederationToken`,
+    `GetSessionToken` (STS — temporary credentials). **IR note:** `ASIA…` sessions minted via
+    `GetFederationToken` / `AssumeRole` keep working until they expire even after the source
+    `AKIA…` key is deleted — deactivating the key does *not* revoke already-issued sessions, so
+    eviction must also deny the live session (e.g. an `aws:TokenIssueTime` policy condition).
+  - `GetAuthorizationToken` (ECR), `GetClusterCredentials` (Redshift),
+    `GetCredentialsForIdentity` (Cognito), `rds-db:connect` (RDS IAM auth)
+  - `GetSecretValue` (Secrets Manager), `GetParameter` / `GetParameters` (SSM Parameter Store)
+  - `DescribeInstanceAttribute` (attribute `userData`), `ModifyInstanceAttribute` (EC2 user
+    data often holds bootstrap secrets and credentials)
+  - **IMDS SSRF (T1552.001):** EC2 / Fargate role credentials stolen via the metadata service
+    (`169.254.169.254`, `169.254.170.2`) produce no CloudTrail event of their own — detect the
+    *use* instead: instance-role session credentials appearing from an IP or account that is
+    not the instance. GuardDuty raises
+    `UnauthorizedAccess:IAMUser/InstanceCredentialExfiltration.OutsideAWS` (used from outside
+    AWS) or `.InsideAWS` (used from a different AWS account). Credentials replayed through a
+    VPC endpoint historically evaded the `OutsideAWS` variant; since late 2024 GuardDuty
+    detects many such bypasses via CloudTrail network-activity events (~26 services by
+    mid-2025), so test current behavior. IMDSv2 (token-required PUT) closes the SSRF path; IMDSv1-enabled
+    instances stay exposed.
+
+  ## Persistence — TA0003
+  - `CreateFunction`, `UpdateFunctionCode`, `CreateEventSourceMapping` (Lambda)
+  - `RunInstances`, `CreateLaunchTemplate`, `CreateLaunchConfiguration` (EC2)
+  - `SendSSHPublicKey` (EC2 Instance Connect — push an SSH key without a key pair),
+    `ImportKeyPair` (register an attacker public key)
+  - `PutRule`, `PutTargets` (EventBridge)
+  - `CreateStack`, `UpdateStack` (CloudFormation)
+  - `CreateOpenIDConnectProvider` + a role trusting it via `AssumeRoleWithWebIdentity` (rogue
+    OIDC IdP — a federated backdoor that blends in with legitimate web-identity federation)
+  - `rolesanywhere:CreateTrustAnchor` + `rolesanywhere:CreateProfile` (IAM Roles Anywhere —
+    cert-based access from outside AWS that survives IAM key rotation)
+  - `CreateProject` + `CreateWebhook` + `ImportSourceCredentials` (CodeBuild — GitHub-runner
+    persistence; pairs with `UpdateAssumeRolePolicy`)
+  - `CreateAccessKey`, `CreateLoginProfile` (also identity changes above — dual-purpose)
+
+  ## Data access / exfil — TA0009 Collection / TA0010 Exfiltration
+  - `GetObject`, `ListObjects`, `GetObjectAcl`, `PutObjectAcl` (S3)
+  - `Decrypt`, `GenerateDataKey` (KMS — at unusual volume)
+  - `GetSecretValue` (Secrets Manager), `GetParameter` (SSM Parameter Store)
+  - `CopyDBSnapshot`, `CreateDBSnapshot`, `RestoreDBClusterFromSnapshot` (RDS)
+  - `CreateSnapshot`, `CopySnapshot`, `CreateVolume`, `AttachVolume`, `ModifySnapshotAttribute`,
+    `CreateImage`, `ModifyImageAttribute` (EC2 EBS/AMI — the snapshot-share exfil chain:
+    snapshot a victim volume, share/copy it to an attacker account, mount and read it; T1537).
+    Distinguish **shared to a specific account** (`createVolumePermission` / `launchPermission`
+    adds a `userId`) from **made fully public** (`groups: all`): public EBS snapshots and AMIs
+    are listable by anyone (`describe-snapshots --restorable-by-user-ids all`) and are actively
+    looted. The public-exposure signal is `ModifySnapshotAttribute` / `ModifyImageAttribute`
+    with `add … groups=all` — not the attacker's cross-account read, which never hits your logs.
+  - `GetFunction` (Lambda — pull `Code.Location` for hardcoded secrets and env vars)
+  - `Subscribe`, `AddPermission`, `SetTopicAttributes` (SNS) / `SetQueueAttributes` (SQS) —
+    subscribe to or re-permission a topic/queue to intercept its message data
+  - `PutBucketReplication` (S3 — silently replicate all current and future objects to an
+    attacker bucket, including cross-account; pairs with `CreateRole` / `UpdateAssumeRolePolicy`
+    for the replication role and `s3:InitiateReplication` batch ops; T1537)
+
+  ## Defense evasion — TA0005
+  - `StopLogging`, `DeleteTrail`, `UpdateTrail`, `PutEventSelectors` (CloudTrail)
+  - `DeleteDetector`, `UpdateDetector`, `StopMonitoringMembers` (GuardDuty — disable/suspend),
+    `CreateFilter` (auto-archive findings), `CreateIPSet` / `UpdateIPSet` (add an attacker IP to
+    the *trusted* list → no findings raised on its traffic — tamper, not deletion)
+  - `DeleteFlowLogs` (VPC Flow)
+  - `PutBucketLogging`, `PutBucketPolicy` (S3 logging tamper)
+  - `DeleteConfigurationRecorder`, `StopConfigurationRecorder` (Config)
+  - `AuthorizeSecurityGroupIngress`, `RevokeSecurityGroupIngress` (SG opening)
+  - **User-Agent masquerading (T1036):** offensive frameworks (e.g. Pacu) rewrite the boto3
+    `userAgent` to hide "kali" / "parrot" / "pentoo" — generic or spoofed `userAgent` values
+    on sensitive calls are a weak-but-useful corroborating signal.
+  - **Low-visibility credential validation:** `sqs:ListQueues` (and other data-plane calls)
+    can confirm stolen credentials while staying out of CloudTrail *management* events — the
+    absence of a `GetCallerIdentity` does not mean the credentials were never tested.
+  - **Obfuscated admin policy (T1027):** privesc that dodges string-match detection — `"*:*"`,
+    `"*:Create*"` / `"*:Put*"`, `?` wildcards, or `iam:Put*` instead of a bare `"*"` /
+    `AdministratorAccess`, often placed as an *inline* policy. Evaluate effective permissions
+    (or use Access Analyzer `ValidatePolicy`) on `CreatePolicy` / `CreatePolicyVersion` /
+    `PutUserPolicy` / `PutRolePolicy` / `PutGroupPolicy` — don't match only on the literal `"*"`.
+
+  ## Reconnaissance — TA0007 Discovery
+  - `GetCallerIdentity` — the classic "who am I" first move of a stolen-credential holder;
+    it requires no permissions and cannot be denied by policy, so it always succeeds and
+    always logs. `SimulatePrincipalPolicy`, `GetAccountAuthorizationDetails` (full IAM dump —
+    strong enumeration signal)
+  - `ListUsers`, `ListRoles`, `ListPolicies`
+  - `DescribeInstances`, `DescribeSecurityGroups`, `DescribeVpcs`
+  - `ListBuckets`, `GetBucketPolicy`, `GetBucketAcl`
+  - `ListFunctions` (Lambda), `ListSecrets` (Secrets Manager), `ListTables` / `Scan` (DynamoDB),
+    `DescribeInstanceInformation` (SSM — find managed targets before `SendCommand`)
+  - High-volume `Describe*` / `List*` calls from a single principal = enumeration
+  - **Permission brute-forcing (seen in the wild):** a burst of `Get*` / `List*` / `Describe*`
+    across many *unrelated* services from one principal in a short window — often with a spray
+    of `errorCode = AccessDenied` — is automated IAM permission enumeration (e.g. enumerate-iam,
+    Pacu). Any single call looks benign; the breadth + volume + AccessDenied ratio is the signal.
+
+  ## Lateral movement — TA0008
+  - `AssumeRole`, `AssumeRoleWithWebIdentity`, `AssumeRoleWithSAML` (STS — identity chaining)
+  - `AssumeRole` into `OrganizationAccountAccessRole` — the default `AdministratorAccess` role
+    created in every Organizations *member* account, trusted by the management account root;
+    assuming it is the canonical management-account → member-account org pivot
+  - `SendCommand` (SSM — remote execution on EC2), `StartSession` (SSM Session Manager — shell)
+  - `SendSSHPublicKey` (EC2 Instance Connect — transient SSH key push for direct access)
+  - `CreateRoute`, `CreateVpcPeeringConnection`, `AcceptVpcPeeringConnection` (open a network
+    path between VPCs / accounts for lateral movement)
+  - `CreateHostedZone`, `ChangeResourceRecordSets` (Route 53 — DNS manipulation for traffic
+    redirection / subdomain takeover; privesc when records front trusted services)
+  - **Role-chain juggling:** repeated / cyclical `AssumeRole` (role A → B → A …) that keeps
+    re-minting `ASIA…` sessions from one principal to outlive the max session duration
+  - `GetPasswordData` (Windows EC2 instance password retrieval)
+
+  ## Impact / destruction — TA0040
+  Mass deletion or teardown — ransom, anti-forensics, or sabotage (tools like Cloud-Nuke
+  automate this). A burst of these from one principal in a short window is the signal:
+  - `TerminateInstances`, `DeleteVolume`, `DeleteSnapshot` (EC2)
+  - `DeleteBucket`, `DeleteObject`, `PutBucketLifecycle` (S3 — delete or force-expire data)
+  - `DeleteDBInstance`, `DeleteDBCluster` (RDS), `DeleteTable` (DynamoDB)
+  - `ScheduleKeyDeletion`, `DisableKey` (KMS — destroy keys to make encrypted data
+    unrecoverable; a cloud ransomware primitive)
+  - `DeleteSecret`, `DeleteStack`, `DeleteFunction`
+  - (T1485 Data Destruction / T1486 Data Encrypted for Impact / T1490 Inhibit System Recovery)
+
+  ## High-signal technique combinations
+
+  The strongest signal is rarely one call — it's a sequence from a single principal. Known
+  AWS attack chains to recognize:
+
+  - **Pass-role privilege escalation:** `PassRole` + (`RunInstances` | `CreateFunction` |
+    `UpdateFunctionCode` | `CreateDevEndpoint`) — run code under a higher-privileged role.
+    (T1548 / T1098)
+  - **Policy-version privesc:** `CreatePolicyVersion` + `SetDefaultPolicyVersion` — quietly
+    grant admin on an already-attached policy. (T1098)
+  - **Trust-policy takeover:** `UpdateAssumeRolePolicy` + `AssumeRole` — rewrite a role's
+    trust to include the attacker, then assume it. (T1098)
+  - **Stolen instance credentials:** IMDS SSRF → instance-role session used off-instance
+    (`sourceIPAddress` ≠ the instance, or a different account). (T1552.001)
+  - **Snapshot / AMI exfil to attacker account:** `CreateSnapshot` / `CreateImage` +
+    `ModifySnapshotAttribute` / `ModifyImageAttribute` (share externally) + `CopySnapshot` /
+    `CreateVolume` / `AttachVolume` in the attacker account. (T1537)
+  - **SSM remote execution:** `DescribeInstanceInformation` + `SendCommand`
+    (`AWS-RunShellScript`) or `StartSession` — RCE / shell on managed instances. (T1651)
+  - **Golden SAML:** forged SAML assertion → `AssumeRoleWithSAML` from an unusual IdP or
+    source, bypassing MFA. (T1556)
+  - **Organization pivot:** management-account principal → `AssumeRole` into a member account's
+    `OrganizationAccountAccessRole`, or new IAM Identity Center permission sets / delegated-admin
+    grants — one path to admin across every member account. (T1098 / T1199)
+
+  ## Mapping techniques to deployed detections
+
+  Most techniques here already correspond to Panther detections — don't reason about them in
+  isolation. Resolve an observed technique to deployed coverage using the **MITRE tactic /
+  technique IDs above as the join key**: query `panther_ai_detections_list` by
+  `mitre_attack_tags`, or hand the technique list to `coverage_gap_analysis`.
+
+  Match the signal shape to the detection paradigm:
+  - **A single high-signal `eventName`** (e.g. `StopLogging`, `CreateAccessKey`,
+    `ModifySnapshotAttribute` with `groups=all`, `UpdateIPSet`) → a single-event **rule**.
+  - **A multi-step chain** (the technique combinations above — create-admin, backdoor-role,
+    privesc-via-compromise, S3 exfil-then-delete) → a **correlation rule** spanning events.
+  - **A volumetric / threshold pattern** (permission brute-forcing = burst of `AccessDenied`,
+    enumeration sweeps, abnormal data-access volume) → a **scheduled query**.
+
+  A high-impact technique with **no** matching deployed detection is itself a coverage-gap
+  finding — surface it, and route to `coverage_gap_analysis`.
+
+  ## Recording an observed action
+
+  For each high-impact `eventName` seen, capture: which call, when, the target resource
+  (from the `resources` array), whether it succeeded (`errorCode` IS NULL), and the source
+  IP. Failed calls (`errorCode` IS NOT NULL) are still signal — they reveal what the actor
+  *tried*, not just what landed.
+
+  ## Caveats
+  - These lists are high-signal starting points, not allow/deny lists. Many appear in
+    legitimate automation (CI/CD, IaC, backup jobs) — classify by impact, then judge by
+    context, not by presence alone.
+  - A single bucket hit is a lead, not a verdict. Adversary activity usually spans several
+    buckets (recon → identity change → persistence → exfil); cross-bucket sequences from
+    one principal are the stronger signal.
+DependsOn: []
+EagerLoading: false
+RequiredTools:
+  - panther_ai_detections_list
+Enabled: true
+Tags:
+  - aws
+  - cloudtrail
+  - guardduty
+  - knowledge-primitive

--- a/skills/panther_ai_azure_blast_radius_skill.yml
+++ b/skills/panther_ai_azure_blast_radius_skill.yml
@@ -86,9 +86,15 @@ Prompt: |
   LIMIT 1000
   ```
 
-  Run the analogous query over `panther_logs.public.azure_audit` filtering on
-  `properties:userPrincipalName` / `targetResources` for the Entra plane. **W1** tight (T0 ± 3d) →
-  **W2** campaign → **W3** full lookback. Failed operations are signal — keep them.
+  Run the analogous query over `panther_logs.public.azure_audit` for the Entra plane, with the
+  filter matched to the anchor type from Step 1: `properties:userPrincipalName::VARCHAR` for a
+  user, `properties:servicePrincipalId::VARCHAR` (or the appId in `targetResources`) for a
+  service principal / managed identity, `properties:ipAddress::VARCHAR` /
+  `p_any_ip_addresses` for a source IP — and check `targetResources` in all cases, since the
+  principal may be the *target* of credential-add or role-grant operations, not just the actor.
+  On the ARM side, `caller` holds the UPN for users but the objectId for SPs / managed
+  identities — match accordingly. **W1** tight (T0 ± 3d) → **W2** campaign → **W3** full
+  lookback. Failed operations are signal — keep them.
 
   ---
 

--- a/skills/panther_ai_azure_blast_radius_skill.yml
+++ b/skills/panther_ai_azure_blast_radius_skill.yml
@@ -1,0 +1,244 @@
+AnalysisType: "skill"
+SkillName: "azure_blast_radius"
+DisplayName: "Azure Blast Radius"
+Description: "Scoping workflow for a compromised Azure principal — Entra user, service principal, managed identity, or subscription — across BOTH planes (Entra ID identity and ARM resources). Leads with the alerts and deployed detections Panther already has, then walks the cross-plane chain (credential-add → auth-as-SP → RBAC, elevateAccess, managed-identity hops) and classifies actions by impact (reusing deployed detection logic, with ad-hoc activity-log SQL only for gaps) to produce an IR-style blast-radius timeline. Use whenever an Azure incident anchor is confirmed and the question is \"what else did they touch\"."
+Prompt: |
+  # Azure Blast Radius — Principal Scoping Workflow
+
+  Given a confirmed-compromised Azure principal, enumerate every operation it performed, every
+  resource it touched, every identity it added credentials to or impersonated, every subscription
+  it reached, and every other principal alongside it. Produce an IR-style timeline and a
+  containment-advisory report.
+
+  **Azure has two planes — track both:**
+  - **Entra ID (identity)** — `Azure.Audit`: directory/sign-in ops (`operationName`,
+    `properties.userPrincipalName`, `properties.targetResources`, `properties.ipAddress`).
+  - **ARM (resources)** — `Azure.MonitorActivity`: `operationName` =
+    `Microsoft.<Provider>/<resource>/<verb>`, `caller`, `resourceId`.
+  An attack routinely crosses planes (compromise an Entra app → use its ARM RBAC), so scope both.
+
+  **Not for**: confirming whether an indicator is malicious, scoping non-Azure principals,
+  Microsoft 365 workload audit (separate source), drafting detections, or executing containment.
+  Read-only and advisory.
+
+  **Reuse before you query.** Lead with what Panther already knows — alerts that fired on the
+  principal, and deployed Azure detections / scheduled queries that already encode these
+  techniques. Hand-write activity-log SQL only for the gaps. The MITRE / ATRM IDs in
+  `azure_security_knowledge` are the join key for that coverage.
+
+  ---
+
+  ## Step 1 — Normalize the principal and pick an anchor time
+
+  | Principal type | Example | Plane | Field |
+  |---|---|---|---|
+  | Entra user (UPN) | `alice@org.com` | both | `caller` / `properties:userPrincipalName::VARCHAR` |
+  | Service principal | appId / objectId (GUID) | both | `caller` / `properties:servicePrincipalId::VARCHAR` |
+  | Managed identity | resource-bound identity | ARM | `caller` |
+  | Subscription | GUID | ARM | `resourceId` (scope) |
+  | Source IP | `203.0.113.10` | both | `properties:ipAddress::VARCHAR` / `p_any_ip_addresses` |
+
+  **Anchor time (T0)**: ask the analyst; if unknown, anchor on the earliest alert. Record the
+  **identity type** via `azure_security_knowledge` "Reading Azure identifiers" — a service
+  principal or managed identity widens the blast radius differently than a human user.
+
+  ---
+
+  ## Step 2 — Anchor on what Panther already knows
+
+  Before any SQL, pull existing signal:
+  - **Alerts already fired on this principal** — `panther_ai_alerts_list` filtered by UPN /
+    appId / caller / IP. Both `azure_signin_rules` (Entra) and `azure_activity_rules` (ARM)
+    surface here with rule, severity, and often a better T0.
+  - **Deployed detections + reusable query logic** — `panther_ai_detections_list` (filter by the
+    Azure log types or the MITRE tactics in `azure_security_knowledge`) and
+    `panther_ai_datalake_list_saved_queries`. Prefer `panther_ai_datalake_execute_saved_query`
+    over inventing SQL.
+
+  ---
+
+  ## Step 3 — Discover available Azure log sources
+
+  Call `panther_ai_log_sources_list` / `panther_ai_log_types_list` to confirm both feeds are
+  ingested and healthy: `Azure.Audit` (Entra sign-in + directory audit) and
+  `Azure.MonitorActivity` (ARM activity log). Missing **either** plane is a major visibility gap —
+  an identity-plane compromise is invisible without `Azure.Audit`, and vice-versa. Call it out.
+
+  ---
+
+  ## Step 4 — Build the activity timeline (tiered windows) — both planes
+
+  If a deployed saved/scheduled query (from Step 2) already returns principal-scoped activity,
+  execute it with `panther_ai_datalake_execute_saved_query` first. Otherwise fall back to
+  `panther_ai_datalake_execute_sql` — run **both** plane queries. ARM example:
+
+  ```sql
+  SELECT p_event_time,
+         operationName:value::VARCHAR  AS operation,
+         caller::VARCHAR               AS caller,
+         resourceId::VARCHAR           AS resource,
+         properties:statusCode::VARCHAR AS status,
+         p_any_ip_addresses
+  FROM panther_logs.public.azure_monitoractivity
+  WHERE (caller = '{principal}' OR ARRAY_CONTAINS('{principal}'::VARIANT, p_any_ip_addresses))
+    AND p_event_time BETWEEN DATEADD('day', -3, '{T0}') AND DATEADD('day', 3, '{T0}')
+  ORDER BY p_event_time ASC
+  LIMIT 1000
+  ```
+
+  Run the analogous query over `panther_logs.public.azure_audit` filtering on
+  `properties:userPrincipalName` / `targetResources` for the Entra plane. **W1** tight (T0 ± 3d) →
+  **W2** campaign → **W3** full lookback. Failed operations are signal — keep them.
+
+  ---
+
+  ## Step 5 — Walk the cross-plane chain
+
+  Azure escalation routinely hops planes and identities. Reconstruct:
+  - **App / SP credential addition → auth as SP:** `Update application – Certificates and secrets
+    management` / `Add service principal credentials` (Entra) → the app/SP then acts (Entra + ARM).
+    Re-scope to that SP's appId.
+  - **Role grants:** `Microsoft.Authorization/roleAssignments/write` (ARM RBAC) and `Add member to
+    role` (Entra directory role) — follow the granted principal.
+  - **Elevate access:** `Microsoft.Authorization/elevateAccess/action` — a Global Admin gains RBAC
+    over *every* subscription; after this, expand scope to all subscriptions.
+  - **Managed-identity hops:** a resource's MI used to reach Key Vault / Storage / other resources
+    — follow the MI's role assignments.
+
+  **Cap chain depth at 3 hops.** Cross-subscription and cross-tenant (guest/B2B) reach is
+  high-signal.
+
+  ---
+
+  ## Step 6 — Co-occurring entities (lateral candidates)
+
+  For events in Steps 4–5, pull the other identifiers (`caller`, `targetResources`,
+  `p_any_ip_addresses`) to find co-occurring principals, apps, and resources. Cap entity pivots at
+  2 hops.
+
+  ---
+
+  ## Step 7 — Classify actions by impact and map to deployed detections
+
+  Bucket the windowed operations using `azure_security_knowledge` (recon, initial /
+  credential access, privesc, execution/lateral, persistence, defense evasion, data access /
+  exfil, impact) — and tag which **plane** each came from. Do not redefine the lists. For each
+  high-signal operation record: plane, operationName, caller (+ type), resource/targetResources,
+  source IP, risk state, success/failure.
+
+  Then close the loop against deployed coverage (reuse what Step 2 found):
+  - Resolve each classified operation / chain to a deployed detection via the
+    `azure_security_knowledge` "Mapping techniques to deployed detections" guidance
+    (single op → rule, multi-step chain → correlation rule, volumetric/risk → scheduled query). If
+    an alert already fired (Step 2), mark it **covered & alerted**.
+  - A high-impact action with **no** deployed detection is a coverage-gap finding — record it and
+    route to `coverage_gap_analysis`.
+
+  ---
+
+  ## Step 8 — Output: Blast Radius Report
+
+  ```markdown
+  # Azure Blast Radius — <principal>
+
+  ## Principal Profile
+  - Identity type: <user / service principal / managed identity>
+  - UPN / appId / objectId: <…>
+  - Tenant: <tenant ID> | Subscription(s): <list>
+  - Source IPs observed: <list>
+  - Risk state (`riskState` / `riskLevelAggregated`): <…>
+  - Anchor time (T0): <ISO timestamp>
+  - Windows examined: W1 <range>, W2 <range>, W3 <range if used>
+  - Planes covered: <Entra / ARM> — call out any plane with no log feed as a visibility gap
+
+  ## Activity Timeline (W1)
+  | Time | Plane | Operation | Caller | Resource / Target | Source IP | Result |
+  |---|---|---|---|---|---|---|
+
+  ## Cross-Plane Chain
+  | Hop | Source Principal | Action (cred-add / role-grant / elevate / MI-hop) | Target Identity or Scope | Plane | Cross-subscription? |
+  |---|---|---|---|---|---|
+
+  ## Resources Touched
+  | Resource / Target | Type | First Action | Last Action | Action Count | Impact |
+  |---|---|---|---|---|---|
+
+  ## High-Impact Actions Observed (tag each Entra vs ARM)
+  ### Credential Access
+  - <operation @ time, plane, target, success?>
+
+  ### Privilege Escalation
+  - <...>
+
+  ### Execution / Lateral Movement
+  - <...>
+
+  ### Persistence
+  - <...>
+
+  ### Defense Evasion
+  - <...>
+
+  ### Data Access / Exfil
+  - <...>
+
+  ### Impact / Destruction
+  - <...>
+
+  ## Co-occurring Entities
+  | Entity | Type | Co-occurrence Count | Recommended Follow-up |
+  |---|---|---|---|
+
+  ## Existing Detection Coverage
+  - Alerts fired on this principal in window: <list>
+  - High-impact actions with no matching detection: <list — detection-gap findings>
+
+  ## Containment Recommendations (advisory only)
+  - Revoke app / service-principal credentials added or used: <which>
+  - Remove role assignments granted (ARM RBAC and Entra directory roles): <which>
+  - Reverse `elevateAccess` if observed; review root-scope assignments
+  - Disable the compromised user / SP; revoke refresh tokens and active sessions
+  - Rotate Key Vault secrets the principal could read: <which vaults>
+  - Review resources, policies, webhooks, and guest invites created by the principal: <list>
+
+  ## Caveats
+  - Co-occurring entities are correlation, not causation — confirm before declaring lateral movement.
+  - Failed operations reveal intent, not impact.
+  - Planes with no log feed during the window: <list> — these are visibility gaps.
+  - If W3 (full lookback) was not run, dormant precursor activity may exist outside the window.
+  - Cross-plane chain capped at 3 hops; deeper chains may exist.
+  - Microsoft 365 workload activity (Exchange / SharePoint / Teams audit) is a separate source
+    and is not covered here.
+  ```
+
+  ---
+
+  ## Constraints
+  - Read-only. Never disable a principal, revoke a credential, remove a role, or modify a rule
+    from this skill — recommendations only.
+  - Prefer reusing deployed detections and saved queries (`panther_ai_datalake_execute_saved_query`)
+    over ad-hoc SQL; `panther_ai_datalake_execute_sql` is the gap-filler.
+  - Always scope **both planes** — an Entra-only or ARM-only scope misses half the attack.
+  - Every query needs a `LIMIT` and a `p_event_time` bound. Keep failed operations.
+  - Cap chain depth at 3 hops, entity pivots at 2 hops; surface visibility gaps. If the principal
+    doesn't match any field after Step 1, ask the analyst rather than guessing.
+ToolMessage: "Scoping Azure blast radius for the compromised principal…"
+DependsOn:
+  - azure_security_knowledge
+EagerLoading: false
+RequiredTools:
+  - panther_ai_alerts_list
+  - panther_ai_detections_list
+  - panther_ai_log_sources_list
+  - panther_ai_log_types_list
+  - panther_ai_datalake_list_saved_queries
+  - panther_ai_datalake_execute_saved_query
+  - panther_ai_datalake_execute_sql
+  - panther_ai_datalake_get_query_results
+Enabled: true
+Tags:
+  - azure
+  - entra-id
+  - incident-response
+  - blast-radius
+  - scoping

--- a/skills/panther_ai_azure_security_knowledge_skill.yml
+++ b/skills/panther_ai_azure_security_knowledge_skill.yml
@@ -1,0 +1,197 @@
+AnalysisType: "skill"
+SkillName: "azure_security_knowledge"
+DisplayName: "Azure Security Knowledge"
+Description: "Reference mapping of Azure activity to attacker-impact categories across BOTH planes — Entra ID identity (`Azure.Audit` operations) and ARM resource management (`Azure.MonitorActivity` `operationName`). Covers initial access, credential access, privilege escalation, persistence, defense evasion, lateral movement, data access / exfil, impact, and known multi-step attack chains. Use whenever Azure activity needs to be classified by adversary impact: incident scoping, threat hunts, detection coverage analysis, or post-mortem triage. Also covers reading `caller` identity types and mapping techniques to deployed Panther detections. Technique coverage is validated against Microsoft's Azure Threat Research Matrix (ATRM). Knowledge reference — does not run queries itself."
+Prompt: |
+  # Azure Security Knowledge — Activity Impact Reference
+
+  Maps high-signal Azure activity to the attacker-impact category it belongs to. **Azure has two
+  distinct planes — always identify which you're looking at:**
+
+  - **Entra ID (identity plane)** — directory audit / sign-in (`Azure.Audit`). Operations on
+    users, groups, roles, applications, service principals, and federation. Fields:
+    `operationName`, `properties.userPrincipalName`, `properties.appDisplayName`,
+    `properties.targetResources`, `properties.ipAddress`, `properties.riskState`.
+  - **Azure Resource Manager (control plane)** — subscription/resource ops
+    (`Azure.MonitorActivity`). `operationName` is `Microsoft.<Provider>/<resource>/<verb>`
+    (e.g. `Microsoft.Compute/virtualMachines/runCommand/action`). Fields: `operationName`,
+    `caller`, `resourceId`, `properties`.
+
+  Bucket by what the action lets an adversary *do*, not just which resource. Lists are canonical
+  high-signal operations, not exhaustive; significance depends on who, success/failure, and
+  whether it's normal for that principal. Technique IDs below are cross-referenced with
+  Microsoft's Azure Threat Research Matrix (ATRM, `AZT…`) alongside MITRE ATT&CK. (ATRM has no
+  Defense-Evasion / Lateral-Movement / Exfiltration tactic — those buckets here use MITRE
+  Enterprise framing and fold ATRM techniques in where they fit.)
+
+  ## Reading Azure identifiers
+
+  `caller` (ARM) / `userPrincipalName` / `targetResources` (Entra) tell you the principal type:
+
+  - `user@domain` (UPN) — a **human** Entra user.
+  - a **service principal** — an app identity (GUID `appId` / object ID, `appDisplayName`). SP
+    activity from a new IP, or an SP suddenly doing ARM control-plane work, is high-signal.
+  - a **managed identity** — bound to a resource (system- or user-assigned); its token is fetched
+    from IMDS (`169.254.169.254/metadata/identity/oauth2/token`, header `Metadata: true`). A
+    managed identity acting beyond its resource's role is the token-abuse signal.
+  - **Global Administrator / Privileged Role Administrator** — Entra tenant admins; their use of
+    role/credential operations is the highest-signal identity activity.
+
+  Cues: `properties.riskState` / `riskLevelAggregated` (risky sign-in), `properties.status.errorCode`
+  (auth failure), `ipAddress` / `callerIp` outside expected ranges.
+
+  ## Reconnaissance — TA0043 (ATRM Reconnaissance, AZT101–108)
+  Mostly Entra ID / Graph enumeration, often by an already-valid but low-priv principal:
+  - Gather user / group info (AZT104), application & service-principal info (AZT105), directory
+    **role** assignments (AZT106) — find who is Global Admin and which apps are privileged.
+  - Gather resource & subscription data (AZT107/AZT108) —
+    `Microsoft.Resources/subscriptions/…/read`, tenant-wide resource listing.
+  - Public-accessible-resource discovery (AZT103); IP & port mapping (AZT101/AZT102). Much of
+    this runs attacker-side and may not all reach your tenant logs.
+
+  ## Initial access — TA0001 (ATRM InitialAccess, AZT201–203)
+  - **Valid credentials (AZT201, T1078.004)** — sign-in with stolen user / SP / MI creds. Watch
+    `properties.riskState` and impossible-travel sign-ins.
+  - **Password spraying (AZT202, T1110.003)** — many failed Entra sign-ins across *different*
+    users from one source, then a success. A burst of sign-in failures followed by a clean login
+    is the signal.
+  - **Malicious application consent (AZT203, T1528)** — `Consent to application` /
+    `Add OAuth2PermissionGrant` (Entra): trick a user into consenting an attacker app, granting
+    Graph access to mail/files.
+
+  ## Credential access — TA0006 (ATRM CredentialAccess, AZT601–605)
+  - **Add credentials to an app / service principal (AZT602/AZT603, T1098.001)** — `Update
+    application – Certificates and secrets management`, `Add service principal credentials`
+    (Entra): plant a secret/cert on an existing (often privileged) app to authenticate as it — a
+    stealthy backdoor + token theft.
+  - **Steal managed-identity token / IMDS (AZT601, T1552.005):** stolen via the resource's
+    metadata endpoint; detect the *use* — the MI acting from an unexpected resource/IP.
+  - **Key Vault dumping (AZT604)** — `Microsoft.KeyVault/vaults/secrets/read` +
+    `…/accessPolicies/write` (read or grant access to secrets).
+  - **Resource secret reveal (AZT605)** — `…/storageAccounts/listKeys/action`, connection
+    strings, automation/VM credentials.
+
+  ## Privilege escalation — TA0004 (ATRM PrivilegeEscalation, AZT401–405)
+  - **Elevated access toggle (AZT402)** — `Microsoft.Authorization/elevateAccess/action`: a
+    Global Admin grants themselves **User Access Administrator at root**, gaining RBAC over
+    *every* subscription. Rare and very high-signal.
+  - **Azure RBAC assignment** — `Microsoft.Authorization/roleAssignments/write`: assign an Azure
+    role (e.g. Owner) to a principal.
+  - **PIM role activation / assignment (AZT401)** — activating or assigning an eligible
+    Privileged Identity Management role (e.g. Global Administrator); watch role-activation audit
+    events outside change windows.
+  - **Add member to a privileged directory role** — `Add member to role` (Entra) granting Global
+    Administrator / Privileged Role Administrator.
+  - **Principal impersonation (AZT404)** / **Azure AD application abuse (AZT405)** — act as a
+    more-privileged app/SP, or add API permissions / credentials to an app that already holds
+    privileged Graph roles.
+  - **Local resource hijack (AZT403)** — take over a resource's own identity (e.g. a VM's
+    managed identity or local admin) to act with its assigned roles.
+
+  ## Execution & lateral movement — TA0002 / TA0008 (ATRM Execution AZT301–303; T1059 / T1021)
+  - **VM scripting (AZT301)** — `Microsoft.Compute/virtualMachines/runCommand/action`: run
+    scripts on a VM as `SYSTEM` (Windows) / `root` (Linux); RCE without SSH/RDP.
+  - `Microsoft.Compute/virtualMachines/extensions/write` — install a Custom Script Extension
+    (RCE + persistence).
+  - **Managed device scripting (AZT303)** — push scripts via Intune / endpoint management to
+    enrolled devices; **unmanaged scripting (AZT302)** — run commands on a VM with compromised
+    local creds, outside Azure's control plane.
+  - `Microsoft.Automation/automationAccounts/runbooks/draft/write` + `…/publish/action` +
+    `…/webhooks/action` — run code via Automation runbooks (often with a privileged Run-As / MI).
+  - Bastion / serial-console / managed-identity hops between resources.
+
+  ## Persistence — TA0003 (ATRM Persistence, AZT501–509)
+  - **Account manipulation / creation (AZT501/AZT502)** — `Create user`, `Add member to role`,
+    app/SP credential addition (above) — survives password resets.
+  - **Federation backdoor (T1556)** — `Set domain authentication` / `Set federation settings on
+    domain` (Entra): convert a domain to a federated IdP the attacker controls → forge tokens for
+    any user (Golden SAML class).
+  - **External entity access (AZT507)** — invite an attacker-controlled **guest / B2B** account
+    (`Invite external user`) into the tenant for durable access.
+  - **Azure Policy abuse (AZT508)** — a `deployIfNotExists` / `modify` policy assignment that
+    auto-deploys attacker resources or config on every matching resource (self-healing backdoor).
+  - **HTTP trigger / scheduled jobs / watcher tasks (AZT503/AZT505/AZT504)** — Automation
+    runbooks + schedules + webhooks, Function / Logic App triggers, custom script extensions.
+  - **Azure Bastion (AZT509)** — a standing remote-access path into the VNet.
+
+  ## Defense evasion — TA0005 (T1562 / T1578)
+  - `Microsoft.Authorization/locks/delete` (remove resource locks before tampering),
+    `Microsoft.Insights/diagnosticSettings/delete`, `Microsoft.Insights/logProfiles/delete`
+    (kill activity-log export), disabling Microsoft Defender for Cloud / policy assignments.
+  - Deleting / modifying network security groups (AZT506); disabling NSG flow logs.
+
+  ## Data access / exfil — TA0009 / TA0010 (ATRM Impact AZT701–704; T1530 / T1537)
+  - **Anonymous blob access** — a Storage container set to *Blob* or *Container* public access is
+    readable with no credentials (`…/blobServices/containers/write` setting public access, or
+    account `allowBlobPublicAccess`).
+  - **Soft-deleted blob/resource recovery (AZT704)** — deleted blobs/containers remain
+    recoverable during the retention window; an attacker with access can undelete and read them.
+  - **SAS URI generation (AZT701)** — `Microsoft.Storage/storageAccounts/listAccountSas` /
+    `listServiceSas`, or disk `Microsoft.Compute/disks/beginGetAccess/action` (+ `snapshots/write`)
+    to mint a time-boxed download URL (analog of EBS snapshot exfil — data leaves via a URL, not
+    an RBAC grant, so it can evade IAM-focused detection).
+  - **File share mounting (AZT702)** — `…/storageAccounts/listKeys/action` then mount the Azure
+    Files share with the account key.
+  - **Replication (AZT703)** — object replication / copy to an attacker-controlled account.
+
+  ## Impact / destruction — TA0040 (ATRM Impact AZT705; T1485 / T1486 / T1490 / T1496)
+  - `Microsoft.Compute/virtualMachines/delete`, `Microsoft.Compute/disks/delete`,
+    `Microsoft.Compute/snapshots/delete`, `Microsoft.Authorization/locks/delete` then bulk
+    resource deletes (sabotage / ransom).
+  - **Azure Backup delete (AZT705, T1490)** — `Microsoft.RecoveryServices/vaults/…/delete` or
+    stop-protection-with-data-deletion: destroy backups so data can't be restored.
+  - `Microsoft.KeyVault/vaults/delete` or key destroy (make encrypted data unrecoverable);
+    cryptomining VMs / VMSS scale-out (resource hijacking).
+
+  ## High-signal technique combinations
+  - **Consent → mail theft:** `Consent to application` → app reads mailboxes via Graph. (T1528)
+  - **SP backdoor → escalation:** `Add service principal credentials` on a privileged app →
+    authenticate as it → `roleAssignments/write` or `elevateAccess`. (T1098 → T1548)
+  - **Elevate-to-root:** Global Admin → `Microsoft.Authorization/elevateAccess/action` → RBAC
+    over all subscriptions → `runCommand` on any VM. (T1548 → T1059)
+  - **Federation backdoor:** `Set domain authentication` → forge SAML tokens for any user.
+    (T1556)
+  - **Lock removal → destruction:** `locks/delete` → bulk `delete` of VMs/disks. (T1485)
+
+  ## Mapping techniques to deployed detections
+
+  These techniques are covered by Panther's Azure ruleset (`rules/azure_activity_rules/` for ARM
+  `Azure.MonitorActivity`, `rules/azure_signin_rules/` for `Azure.Audit` identity). Don't reason
+  in isolation:
+  - Resolve an observed technique to deployed coverage via its MITRE tactic-technique ID — query
+    `panther_ai_detections_list` by `mitre_attack_tags`, or hand the list to
+    `coverage_gap_analysis`.
+  - Match signal shape to paradigm: a single high-signal `operationName` (`elevateAccess/action`,
+    `runCommand/action`, `roleAssignments/write`, `Consent to application`) → a **rule**; a
+    multi-step chain → a **correlation rule**; a volumetric / risk pattern (failed-sign-in bursts,
+    risky sign-ins) → a **scheduled query**.
+  - A high-impact technique with **no** matching deployed detection is a coverage-gap finding —
+    surface it and route to `coverage_gap_analysis`.
+
+  ## Recording an observed action
+
+  For each high-signal action capture: which **plane** (Entra vs ARM), the `operationName`, the
+  `caller` / `userPrincipalName` (and identity type), `resourceId` / `targetResources`, source IP,
+  risk state, and success/failure. Failed attempts are still signal.
+
+  ## Caveats
+  - High-signal starting points, not allow/deny lists. IaC (ARM/Bicep/Terraform), CI/CD service
+    principals, and platform automation legitimately do many of these — classify by impact, then
+    judge by principal + plane + context.
+  - Service principals and managed identities act programmatically by design; the signal is one
+    acting outside its normal scope, role, or source.
+  - Don't conflate the planes — an Entra `Add member to role` (directory role) is different from
+    an ARM `roleAssignments/write` (Azure RBAC). Both matter; they're separate authorization
+    systems.
+  - A single bucket hit is a lead; cross-bucket / cross-plane sequences from one principal are
+    the verdict.
+DependsOn: []
+EagerLoading: false
+RequiredTools:
+  - panther_ai_detections_list
+Enabled: true
+Tags:
+  - azure
+  - entra-id
+  - mitre
+  - knowledge-primitive

--- a/skills/panther_ai_coverage_gap_analysis_skill.yml
+++ b/skills/panther_ai_coverage_gap_analysis_skill.yml
@@ -1,0 +1,138 @@
+AnalysisType: "skill"
+SkillName: "coverage_gap_analysis"
+DisplayName: "MITRE ATT&CK Coverage Gap Analysis"
+Description: "Use this skill when the analyst wants to know whether the environment can detect specific MITRE ATT&CK techniques, or whether a threat advisory's techniques are covered by current detections and log sources. Trigger on questions like: \"Do we cover T1003, T1078, T1059?\", \"Which credential-access techniques have no coverage?\", or \"Read this advisory URL and tell me which techniques are covered.\" Do NOT use for active threat hunts or tuning existing detections."
+Prompt: |
+  # Coverage Gap Analysis Skill
+
+  Cross-reference MITRE ATT&CK techniques against the environment's active log sources and deployed detections. Produce a coverage table — fully covered, partially covered, no coverage — with specific gaps named and ranked by remediation effort.
+
+  ## When to invoke
+
+  - "For techniques T1003, T1078, T1059 — do we have coverage?"
+  - "Read this advisory: <URL>. Identify the techniques referenced and tell me which are covered."
+  - "Which credential-access techniques have no rule coverage in our environment?"
+
+  **Not for:** tuning existing detections, writing new rules, live threat hunting.
+
+  ---
+
+  ## Step 1 — Determine the technique list
+
+  Use one of these three paths depending on what the analyst provided:
+
+  **A. Named techniques** — Use the list as-is (e.g., T1003, T1078.003).
+
+  **B. Advisory URL** — Fetch the page with `panther_ai_utilities_fetch_web`. Extract every ATT&CK technique ID (pattern: `T\d{4}(?:\.\d{3})?`) referenced in the advisory. Build the list from those IDs.
+
+  **C. Tactic name only (e.g., "credential access")** — Map the tactic to its MITRE tactic ID (TA00xx), then call `panther_ai_detections_list` with `mitre_attack_tags: ["<TacticID>"]` to discover which techniques exist in the detection library for that tactic. Also reference https://attack.mitre.org/tactics/ to enumerate all known techniques in the tactic that may *not* have rules, so gaps are visible.
+
+  ---
+
+  ## Step 2 — Inventory available log sources
+
+  Call `panther_ai_log_sources_list`.
+
+  Note each source's `integrationLabel`, `integrationType`, and `health.isHealthy`. Only **healthy, enabled** sources count as "data source present." Capture the log types each source produces (field: `logTypes`).
+
+  Also call `panther_ai_log_types_list` to enumerate every log type schema currently loaded. This is your ground-truth list of what data is ingested.
+
+  ---
+
+  ## Step 3 — For each technique, check deployed detection coverage
+
+  Call `panther_ai_detections_list` with `mitre_attack_tags: ["<TacticID>:<TechniqueID>"]` for each technique. Use both the tactic+technique form (e.g., `TA0006:T1003`) and the technique-only form where necessary.
+
+  For each result note:
+  - Detection name, severity, enabled status (`enabled: true/false`)
+  - Log types the detection covers
+  - Whether the detection is `RULE`, `SCHEDULED_RULE`, `CORRELATION_RULE`, or `POLICY`
+
+  Only **enabled** detections count as "deployed rule present."
+
+  ---
+
+  ## Step 4 — Score coverage per technique
+
+  Apply this scoring logic:
+
+  | Condition | Coverage | Remediation effort |
+  |---|---|---|
+  | Data source present AND enabled rule(s) match | **Full** | — |
+  | Data source present AND matching rule exists but is **disabled** | **Partial** (disabled-rule gap) | Trivial — toggle the rule on |
+  | Data source present, no rule of any kind | **Partial** (rule gap) | Easy — search library or author new rule |
+  | Rule present but required log type missing from sources | **Partial** (data gap) | Harder — add and onboard a new log source |
+  | No data source AND no rule | **None** | Hardest — both data and rule work required |
+
+  For "required data source," use MITRE ATT&CK's published data source requirements at https://attack.mitre.org/techniques/<TechniqueID>/ (fetch if needed via `panther_ai_utilities_fetch_web`) and cross-reference against the log types found in Step 2.
+
+  ---
+
+  ## Step 5 — Output the coverage report
+
+  ```markdown
+  # Coverage Analysis — <input description>
+
+  ## Technique Coverage
+
+  | Technique | Tactic | Required Data Source | Data Source Present? | Deployed Rule? | Coverage |
+  |---|---|---|---|---|---|
+  | T1003.001 | Credential Access | Process creation, OS API execution | Yes (<log type>) | No | Partial |
+  | ...
+
+  ## Top Gaps to Close (ranked by remediation effort)
+
+  ### Easy — Rule gap (data source exists, rule needs enabling/creation)
+  1. **<Technique ID> <Technique Name>**
+     - Missing: enabled detection rule
+     - Available log types that could support a rule: <list>
+     - Recommended action: search Panther detection library or create a new rule
+
+  ### Harder — Data source gap (log type not ingested)
+  1. **<Technique ID> <Technique Name>**
+     - Missing log type: <log type>
+     - Impact: rules may exist but cannot fire
+     - Recommended action: add a new log source via Panther log source configuration
+
+  ## Well Covered Techniques
+  <List techniques with Full coverage — useful for audit conversations>
+
+  ## Disabled Rules (require attention)
+  <List any rules found for a technique that are disabled — these are quick wins>
+
+  ## Caveats
+  - "Deployed rule present" means the rule is enabled; it does not mean it fires correctly or that alert volume is manageable.
+  - Coverage is structural, not operational — validate with a detection engineer before reporting to stakeholders.
+  - If a required data source could not be determined from MITRE, this is noted per technique.
+  ```
+
+  ---
+
+  ## Constraints
+
+  - Read-only across all sources. Do not create, enable, or modify rules from this skill.
+  - If you cannot determine whether a rule is enabled, say so explicitly — do not infer.
+  - Be explicit about uncertainty in data source mapping (MITRE data source taxonomy can be ambiguous).
+  - Recommend rule creation or log source addition, then defer to the analyst for action.
+
+  ---
+
+  ## MITRE Reference
+
+  - Technique catalog: https://attack.mitre.org/techniques/enterprise/
+  - Data sources: https://attack.mitre.org/datasources/
+  - Tactics: https://attack.mitre.org/tactics/enterprise/
+ToolMessage: "Analyzing MITRE ATT&CK coverage gaps against your detections and log sources…"
+DependsOn: []
+EagerLoading: false
+RequiredTools:
+  - panther_ai_detections_list
+  - panther_ai_log_sources_list
+  - panther_ai_log_types_list
+  - panther_ai_utilities_fetch_web
+Enabled: true
+Tags:
+  - mitre
+  - coverage
+  - detection-engineering
+  - gap-analysis

--- a/skills/panther_ai_gcp_blast_radius_skill.yml
+++ b/skills/panther_ai_gcp_blast_radius_skill.yml
@@ -88,6 +88,13 @@ Prompt: |
   LIMIT 1000
   ```
 
+  The `p_any_emails` predicate is the user / service-account case — swap it for the anchor's
+  field from the Step 1 table when scoping a different principal type:
+  `protoPayload:authenticationInfo:serviceAccountKeyName::VARCHAR = '{key}'` (SA key),
+  `resource:labels:project_id::VARCHAR = '{project}'` (project),
+  `resource:labels:instance_id::VARCHAR = '{instance}'` (GCE instance), or
+  `ARRAY_CONTAINS('{ip}'::VARIANT, p_any_ip_addresses)` (caller IP).
+
   **W1** tight (T0 ± 3d) → **W2** campaign window (first-to-last confirmed-malicious) → **W3**
   full lookback (up to 90d, dormant precursors only; expect noise). Denied calls
   (`granted = false`) are signal — keep them.

--- a/skills/panther_ai_gcp_blast_radius_skill.yml
+++ b/skills/panther_ai_gcp_blast_radius_skill.yml
@@ -1,0 +1,242 @@
+AnalysisType: "skill"
+SkillName: "gcp_blast_radius"
+DisplayName: "GCP Blast Radius"
+Description: "Scoping workflow for a compromised GCP principal — user, service account, SA key, project, or GCE instance. Leads with the alerts and deployed detections Panther already has, then walks the service-account impersonation chain across projects and classifies actions by impact (reusing deployed detection logic, with ad-hoc Cloud Audit Log SQL only for the gaps) to produce an IR-style blast-radius timeline. Use whenever a GCP incident anchor is confirmed and the question is \"what else did they touch\"."
+Prompt: |
+  # GCP Blast Radius — Principal Scoping Workflow
+
+  Given a confirmed-compromised GCP principal, enumerate every API method that principal called,
+  every resource they touched, every service account they impersonated, every project they
+  reached, and every other entity that appeared alongside them. Produce an IR-style timeline and
+  a containment-advisory report.
+
+  **Not for**: confirming whether an indicator is malicious, scoping non-GCP principals, Google
+  Workspace activity (separate log source — admin/login/token/drive audit), drafting new
+  detections, or executing containment. Read-only and advisory.
+
+  **Reuse before you query.** Don't scope this principal in a vacuum with ad-hoc SQL. Lead with
+  what Panther already knows — alerts that fired on the principal, and deployed GCP detections /
+  scheduled queries that already encode these techniques. Hand-write Cloud Audit Log SQL only to
+  fill the gaps. The MITRE tactic / technique IDs in `gcp_security_knowledge` are the join
+  key for finding that coverage.
+
+  ---
+
+  ## Step 1 — Normalize the principal and pick an anchor time
+
+  Map what was given to the canonical `GCP.AuditLog` field. Use the fast `p_any_*` filter for the
+  initial sweep, then the audit field for detail.
+
+  | Principal type | Example | Fast filter | Audit field path |
+  |---|---|---|---|
+  | User | `alice@org.com` | `p_any_emails` | `protoPayload:authenticationInfo:principalEmail::VARCHAR` |
+  | Service account | `sa@proj.iam.gserviceaccount.com` | `p_any_emails` | `protoPayload:authenticationInfo:principalEmail::VARCHAR` |
+  | SA key | key name / id | n/a | `protoPayload:authenticationInfo:serviceAccountKeyName::VARCHAR` |
+  | Project | `proj-id` | n/a | `resource:labels:project_id::VARCHAR` |
+  | GCE instance | instance id | n/a | `resource:labels:instance_id::VARCHAR` |
+  | Caller IP | `203.0.113.10` | `p_any_ip_addresses` | `protoPayload:requestMetadata:callerIp::VARCHAR` |
+
+  **Anchor time (T0)**: ask the analyst; if unknown, anchor on the earliest alert involving the
+  principal. Note the principal's **identity type** (human vs service account vs default SA) using
+  `gcp_security_knowledge` "Reading GCP identifiers" — default SAs (`appspot`, `developer`)
+  are over-privileged and widen the blast radius.
+
+  ---
+
+  ## Step 2 — Anchor on what Panther already knows
+
+  Before any SQL, pull existing signal — free, fast, and scope-shaping:
+  - **Alerts already fired on this principal** — `panther_ai_alerts_list` filtered by the
+    principal's identifiers (email, project, caller IP). Each alert is a confirmed-suspicious
+    method call with rule, severity, triage state — and often a better T0.
+  - **Deployed detections + reusable query logic** — `panther_ai_detections_list` (filter by GCP
+    log type or the MITRE tactics in `gcp_security_knowledge`) and
+    `panther_ai_datalake_list_saved_queries`. Prefer executing a matching saved query with
+    `panther_ai_datalake_execute_saved_query` over inventing SQL.
+
+  ---
+
+  ## Step 3 — Discover available GCP log sources
+
+  Call `panther_ai_log_sources_list` / `panther_ai_log_types_list` to confirm which GCP log types
+  are ingested and healthy (`GCP.AuditLog` Admin Activity / Data Access / System Event, plus VPC
+  Flow, HTTP LB). A healthy source with events in the window but no query coverage is a visibility
+  gap — call it out.
+
+  ---
+
+  ## Step 4 — Build the activity timeline (tiered windows)
+
+  If a deployed saved/scheduled query (from Step 2) already returns principal-scoped audit
+  activity, execute it with `panther_ai_datalake_execute_saved_query` first. Only when none fits,
+  fall back to `panther_ai_datalake_execute_sql` with this template — the gap-filler, not the
+  default.
+
+  ```sql
+  SELECT p_event_time,
+         protoPayload:methodName::VARCHAR                        AS method,
+         protoPayload:serviceName::VARCHAR                       AS service,
+         protoPayload:authenticationInfo:principalEmail::VARCHAR AS principal,
+         protoPayload:resourceName::VARCHAR                      AS resource,
+         protoPayload:requestMetadata:callerIp::VARCHAR          AS caller_ip,
+         resource:labels:project_id::VARCHAR                     AS project,
+         protoPayload:authorizationInfo[0]:granted::BOOLEAN      AS granted
+  FROM panther_logs.public.gcp_auditlog
+  WHERE ARRAY_CONTAINS('{principal_email}'::VARIANT, p_any_emails)
+    AND p_event_time BETWEEN DATEADD('day', -3, '{T0}') AND DATEADD('day', 3, '{T0}')
+  ORDER BY p_event_time ASC
+  LIMIT 1000
+  ```
+
+  **W1** tight (T0 ± 3d) → **W2** campaign window (first-to-last confirmed-malicious) → **W3**
+  full lookback (up to 90d, dormant precursors only; expect noise). Denied calls
+  (`granted = false`) are signal — keep them.
+
+  ---
+
+  ## Step 5 — Walk the service-account impersonation chain
+
+  GCP's identity-chaining analog is **SA impersonation**: a principal mints a token for a more
+  privileged service account, then acts as it — possibly across projects. Reconstruct the chain.
+
+  For every `GenerateAccessToken`, `GenerateIdToken`, `SignJwt`, or `SignBlob` (and
+  `iam.serviceAccounts.implicitDelegation`) by the principal, extract the target SA from
+  `protoPayload:resourceName` / `request`. Then re-run Step 4 with that SA as the principal. **Cap
+  chain depth at 3 hops.** Cross-project hops (different `project_id`) are high-signal — record
+  them prominently. `actAs` paired with a compute-create (`compute.instances.create`,
+  `cloudfunctions.functions.create`, `run.services.create`, `cloudbuild.builds.create`) is the
+  other escalation path — follow the SA the new resource runs as.
+
+  ---
+
+  ## Step 6 — Co-occurring entities (lateral candidates)
+
+  For events in Steps 4–5, pull the other `p_any_*` fields (`p_any_emails`, `p_any_ip_addresses`,
+  `p_any_domain_names`) to find SAs, users, and resources touched in the same calls. Cap entity
+  pivots at 2 hops.
+
+  ---
+
+  ## Step 7 — Classify actions by impact and map to deployed detections
+
+  Bucket the windowed methods using `gcp_security_knowledge` (discovery, credential access,
+  privilege escalation, persistence, defense evasion, lateral movement, data access / exfil,
+  impact); do not redefine the lists here. For each high-impact method record: method, when,
+  resource, `caller_ip`, and whether it was authorized.
+
+  Then close the loop against deployed coverage (reuse what Step 2 found):
+  - Resolve each classified method / chain to a deployed detection via the
+    `gcp_security_knowledge` "Mapping techniques to deployed detections" guidance
+    (single-method → rule, multi-step chain → correlation rule, volumetric → scheduled query). If
+    an alert already fired (Step 2), mark the action **covered & alerted**.
+  - A high-impact action with **no** deployed detection is a coverage-gap finding — record it and
+    route to `coverage_gap_analysis`.
+
+  ---
+
+  ## Step 8 — Output: Blast Radius Report
+
+  ```markdown
+  # GCP Blast Radius — <principal>
+
+  ## Principal Profile
+  - Identity type: <human / user-created SA / default SA>
+  - principalEmail: <…>
+  - SA key(s) used: <serviceAccountKeyName values, if applicable>
+  - Caller IPs observed: <list>
+  - User agents observed: <list — flag gcloud / SDK / unusual UAs>
+  - Anchor time (T0): <ISO timestamp>
+  - Windows examined: W1 <range>, W2 <range>, W3 <range if used>
+  - Log sources queried: <list, with unhealthy sources or visibility gaps called out>
+
+  ## Activity Timeline (W1)
+  | Time | Method | Service | Resource | Project | Caller IP | Result |
+  |---|---|---|---|---|---|---|
+
+  ## Impersonation Chain
+  | Hop | Source Principal | Target SA | Method | Project | Cross-project? |
+  |---|---|---|---|---|---|
+
+  ## Resources Touched
+  | Resource | Type | First Action | Last Action | Action Count | Impact |
+  |---|---|---|---|---|---|
+
+  ## High-Impact Actions Observed
+  ### Credential Access
+  - <method @ time, target, authorized?>
+
+  ### Privilege Escalation
+  - <...>
+
+  ### Persistence
+  - <...>
+
+  ### Defense Evasion
+  - <...>
+
+  ### Lateral Movement
+  - <...>
+
+  ### Data Access / Exfil
+  - <...>
+
+  ### Impact / Destruction
+  - <...>
+
+  ## Co-occurring Entities
+  | Entity | Type | Co-occurrence Count | Recommended Follow-up |
+  |---|---|---|---|
+
+  ## Existing Detection Coverage
+  - Alerts fired on this principal in window: <list>
+  - High-impact actions with no matching detection: <list — detection-gap findings>
+
+  ## Containment Recommendations (advisory only)
+  - Disable / delete SA key(s): <which>
+  - Revoke short-lived tokens — note already-minted tokens live until expiry, so also remove
+    the IAM bindings (`serviceAccountTokenCreator`, `serviceAccountUser`) that allow re-minting
+  - Remove IAM bindings added by or for the principal: <which>
+  - Review resources created by the principal (instances, functions, scheduler jobs): <list>
+  - Review role definitions changed (`UpdateRole`) and federation providers added: <list>
+
+  ## Caveats
+  - Co-occurring entities are correlation, not causation — confirm before declaring lateral movement.
+  - Denied calls (`granted = false`) reveal intent, not impact.
+  - Unhealthy / missing GCP log sources during the window: <list> — these are visibility gaps.
+  - If W3 (full lookback) was not run, dormant precursor activity may exist outside the window.
+  - Impersonation chain capped at 3 hops; deeper chains may exist.
+  - Google Workspace activity (admin / login / token / drive audit) is a separate log source
+    and is not covered here.
+  ```
+
+  ---
+
+  ## Constraints
+  - Read-only. Never disable a principal, revoke a key, or modify a binding from this skill —
+    recommendations only.
+  - Prefer reusing deployed detections and saved queries (`panther_ai_datalake_execute_saved_query`)
+    over ad-hoc SQL; `panther_ai_datalake_execute_sql` is the gap-filler.
+  - Every query needs a `LIMIT` and a `p_event_time` bound. Keep denied (`granted = false`) calls.
+  - Cap impersonation chain at 3 hops, entity pivots at 2 hops.
+  - Surface visibility gaps; if the principal doesn't match any field after Step 1, ask the
+    analyst rather than guessing.
+ToolMessage: "Scoping GCP blast radius for the compromised principal…"
+DependsOn:
+  - gcp_security_knowledge
+EagerLoading: false
+RequiredTools:
+  - panther_ai_alerts_list
+  - panther_ai_detections_list
+  - panther_ai_log_sources_list
+  - panther_ai_log_types_list
+  - panther_ai_datalake_list_saved_queries
+  - panther_ai_datalake_execute_saved_query
+  - panther_ai_datalake_execute_sql
+  - panther_ai_datalake_get_query_results
+Enabled: true
+Tags:
+  - gcp
+  - audit
+  - incident-response
+  - blast-radius
+  - scoping

--- a/skills/panther_ai_gcp_security_knowledge_skill.yml
+++ b/skills/panther_ai_gcp_security_knowledge_skill.yml
@@ -1,0 +1,188 @@
+AnalysisType: "skill"
+SkillName: "gcp_security_knowledge"
+DisplayName: "GCP Security Knowledge"
+Description: "Reference mapping of GCP Cloud Audit Log `protoPayload.methodName` values to attacker-impact categories — discovery, credential access, privilege escalation, persistence, defense evasion, lateral movement, data access / exfil, impact, and known multi-step attack chains. Use whenever GCP API activity needs to be classified by adversary impact: incident scoping, threat hunts, detection coverage analysis, or post-mortem triage. Also covers reading `principalEmail` service account formats and mapping techniques to deployed Panther detections. Technique coverage is cross-referenced with the GCP & Workspace Attack Matrix. Knowledge reference — does not run queries itself."
+Prompt: |
+  # GCP Security Knowledge — Cloud Audit Log Action Impact Reference
+
+  Maps high-signal GCP `protoPayload.methodName` values to the attacker-impact category they
+  belong to. A GCP audit event is mostly a `methodName` (e.g. `SetIamPolicy`,
+  `google.iam.admin.v1.CreateServiceAccountKey`) by a `principalEmail` against a `resourceName`
+  — bucket by what it lets an adversary *do*, not just which service it touched. Lists are
+  canonical high-signal calls, not exhaustive; significance always depends on context (who,
+  whether `authorizationInfo.granted` was false, and whether it is normal for that principal).
+
+  Reason in these fields: `protoPayload.methodName`, `serviceName`, `resourceName`,
+  `authenticationInfo.principalEmail`, `requestMetadata.callerIp` / `callerSuppliedUserAgent`,
+  `authorizationInfo[].granted`, `resource.labels.project_id`.
+
+  ## Reading GCP identifiers
+
+  The `principalEmail` tells you *what kind of identity* acted:
+
+  - `user@domain` — a **human** (Workspace / Cloud Identity / federated).
+  - `NAME@PROJECT.iam.gserviceaccount.com` — a **user-created service account** (workload).
+  - `PROJECT_ID@appspot.gserviceaccount.com` — the **App Engine default SA**, and
+    `PROJECT_NUMBER-compute@developer.gserviceaccount.com` — the **Compute Engine default SA**.
+    Both get the broad **Editor** role by default — over-privileged and the prime escalation
+    target; a default SA minting keys or calling IAM is high-signal.
+  - `service-PROJECT_NUMBER@…gserviceaccount.com` / `@cloudservices.gserviceaccount.com` —
+    **Google-managed service agents** (usually benign).
+
+  Other cues: `authorizationInfo[].granted = false` (permission denied — the enumeration signal,
+  GCP's analog of `AccessDenied`); `callerIp` outside expected ranges; a service account acting
+  far from its workload or normal services.
+
+  ## Discovery — TA0007 (T1580 / T1087 / T1526)
+  - `projects.testIamPermissions`, `*.getIamPolicy` (probe what the caller can do / who can do what)
+  - `*.list` / `*.get` across compute, storage, iam, resourcemanager
+  - A burst of `authorizationInfo.granted = false` across methods = permission enumeration.
+  - Enumerate SA bindings, org hierarchy, Cloud Asset Inventory, Security Command Center.
+
+  ## Initial access — TA0001 (T1078.004 / T1199 / T1195)
+  - **Leaked / committed SA key** — a `…iam.gserviceaccount.com` principal authenticating from a
+    new IP (keys get committed to git or baked into images). Pairs with key creation below.
+  - **OAuth / consent-grant phishing** — a user consents a malicious third-party OAuth app
+    (Workspace `Authorize access` audit event) granting offline Drive / Gmail / API access.
+  - **SSRF → metadata** — an exposed web app reaching `metadata.google.internal` to steal the
+    instance SA token (see Credential access below).
+  - **Dependency confusion (CloudImposer)** — a malicious package pulled into Cloud Build /
+    App Engine / Composer build pipelines.
+
+  ## Execution — TA0002 (T1059 / T1610 / T1648)
+  The same compute / serverless surfaces that drive privesc are also raw code-execution vectors;
+  watch creates / deploys that run attacker code:
+  - `compute.instances.insert` with a `startup-script`, `compute.instances.setMetadata`
+    (startup-script swap), serial-console / OS Login command execution.
+  - `cloudfunctions.functions.create` / `update`, `run.services.create` (Cloud Run),
+    `cloudbuild.builds.create`, `dataflow.jobs.create`, `dataproc.jobs.create`, Cloud Composer
+    DAG deploy, Cloud Workflows, BigQuery jobs with UDFs.
+  - GKE / Cloud Run container deploy (T1610) — run an attacker image.
+
+  ## Credential access — TA0006 (T1552 / T1528)
+  - `google.iam.admin.v1.CreateServiceAccountKey` (`iam.serviceAccountKeys.create`) — mints a
+    **long-lived SA key** (no expiry; GCP's closest analog to a static access key — durable
+    persistence + initial access).
+  - `GenerateAccessToken` / `iam.serviceAccounts.getAccessToken`, `SignBlob` / `SignJwt`,
+    `iam.serviceAccounts.implicitDelegation` — borrow a service account's identity (short-lived
+    token) without its key.
+  - **Metadata SSRF (T1552.005):** GCE/Cloud Run SA tokens stolen from the metadata server
+    (`metadata.google.internal` / `169.254.169.254`,
+    `/computeMetadata/v1/instance/service-accounts/default/token`, requires `Metadata-Flavor:
+    Google`) leave no audit event of their own — detect the *use*: the instance SA acting from an
+    IP that isn't the instance.
+  - `*.secrets.versions.access` (Secret Manager), `cloudkms` decrypt at volume.
+  - Secrets harvested from **Cloud Build logs**, **Cloud Source Repositories**, and instance /
+    function env vars and metadata; **OAuth refresh-token abuse** (long-lived Workspace / 3P
+    app tokens).
+
+  ## Privilege escalation — TA0004 (T1548)
+  - `SetIamPolicy` — the hinge of GCP privesc: bind a principal to a more privileged role
+    (`roles/owner`, `roles/iam.serviceAccountTokenCreator`, `roles/iam.serviceAccountUser`).
+  - `google.iam.admin.v1.UpdateRole` (`iam.roles.update`) — add permissions to a custom role the
+    attacker already holds.
+  - **actAs + resource-create** (GCP's `PassRole` equivalent): attaching a more-privileged SA to
+    a new compute resource to run code as it — `compute.instances.create`,
+    `cloudfunctions.functions.create` / `update`, `run.services.create`,
+    `cloudbuild.builds.create`, `deploymentmanager.deployments.create`,
+    `dataflow.jobs.create`, `dataproc.clusters.create`, `cloudscheduler.jobs.create`.
+  - **Cloud Build privesc** — `cloudbuild.builds.create` runs as the highly privileged Cloud
+    Build SA (`@cloudbuild.gserviceaccount.com`, often Editor); a classic GCP escalation.
+  - **Domain-wide delegation abuse** — a service account granted Workspace DWD can impersonate
+    *any* Workspace user (read all Gmail / Drive); granting or using DWD bridges GCP → Workspace.
+  - **GKE container escape to node**, **cross-project role assumption** via
+    `iam.serviceAccountTokenCreator`, and **Workload Identity Federation abuse**.
+
+  ## Persistence — TA0003 (T1098 / T1136)
+  - `CreateServiceAccountKey` (durable key), `CreateServiceAccount` + `SetIamPolicy` (new
+    backdoor identity), adding an **external** principal in `SetIamPolicy`.
+  - `google.iam.v1.WorkloadIdentityPools.CreateWorkloadIdentityPoolProvider` /
+    `google.iam.admin.v1.WorkforcePools.CreateWorkforcePool` — **federation backdoor**: trust an
+    attacker-controlled IdP to impersonate GCP identities (analog of a rogue OIDC provider).
+  - `cloudfunctions.functions.create`, `run.services.create`, `cloudscheduler.jobs.create`
+    (scheduled re-exec), compute instance with a malicious `startup-script` metadata key.
+  - **API keys** (`google.api.apikeys.v2.CreateKey`), **project-wide SSH keys** via
+    `compute.projects.setCommonInstanceMetadata`, **OAuth app with offline access** (durable
+    refresh token), **backdoor container images** in GCR / Artifact Registry, and modifying
+    **organization policies** to relax constraints.
+
+  ## Defense evasion — TA0005 (T1562 / T1578)
+  - Logging sink / settings modified, `compute.subnetworks` flow-logs disabled (VPC Flow
+    Logs off), bucket/log retention reduced.
+  - `compute.firewalls.insert` / `update` / `delete` (open or remove network controls).
+  - `google.iam.admin.v1.DeleteRole`, removing IAM bindings, deleting audit log entries / sinks.
+  - Disable **Security Command Center**, **VPC Service Controls** perimeter bypass / dry-run
+    abuse, deploying in low-monitoring regions, living-off-the-land with `gcloud`.
+
+  ## Lateral movement — TA0008 (T1021 / T1199)
+  - `GenerateAccessToken` / `actAs` chaining across service accounts (token-creator hops).
+  - `compute.instances.setMetadata` injecting SSH keys, OS Login abuse, `compute.instances.osLogin`.
+  - IAP / cross-project `SetIamPolicy` granting access into another project.
+
+  ## Data access / exfil — TA0009 / TA0010 (T1530 / T1537)
+  - `storage.objects.get` / `list` at volume, `storage.buckets.setIamPolicy` granting
+    `allUsers` / `allAuthenticatedUsers` (**make a bucket public** — the GCS exposure signal).
+  - BigQuery large scans / **extract jobs** to an external GCS bucket (`bigquery.tables.export`),
+    Cloud SQL / Spanner / Bigtable reads, and **Storage Transfer Service** abuse to copy buckets out.
+  - `compute.snapshots.insert` + `compute.snapshots.setIamPolicy` /
+    `compute.images.setIamPolicy` — share a disk image/snapshot to an attacker project (analog
+    of the EBS snapshot-share exfil chain).
+
+  ## Impact / destruction — TA0040 (T1485 / T1486 / T1496 / T1490)
+  - `storage.buckets.delete` / `storage.objects.delete` at volume, destructive BigQuery queries,
+    a GCS "ransom note" object upload.
+  - `compute.instances.delete`, `cloudkms` key version `destroy` (make encrypted data
+    unrecoverable), deleting projects.
+  - Spinning up compute for cryptomining — resource hijacking (watch mining-pool egress).
+
+  ## High-signal technique combinations
+  - **Stolen SA token → escalation:** metadata SSRF / leaked key → `testIamPermissions` probing
+    → `SetIamPolicy` granting owner. (T1552.005 → T1548)
+  - **actAs privesc:** `compute.instances.create` (or function/cloud-run) attaching the
+    over-privileged default Compute SA → run code as Editor. (T1548)
+  - **Federation backdoor:** `CreateWorkloadIdentityPoolProvider` trusting an attacker IdP →
+    impersonate GCP SAs from outside. (T1098)
+  - **Snapshot exfil:** `compute.snapshots.insert` → `setIamPolicy` sharing to an external
+    project → read it there. (T1537)
+
+  ## Mapping techniques to deployed detections
+
+  These techniques are covered by Panther's GCP ruleset (`rules/gcp_audit_rules/`,
+  `rules/gcp_k8s_rules/`, `rules/gcp_http_lb_rules/`) keyed on `GCP.AuditLog`. Don't reason in
+  isolation:
+  - Resolve an observed technique to deployed coverage via its MITRE tactic-technique ID — query
+    `panther_ai_detections_list` by `mitre_attack_tags`, or hand the list to
+    `coverage_gap_analysis`.
+  - Match signal shape to paradigm: a single high-signal `methodName` (`CreateServiceAccountKey`,
+    `SetIamPolicy`, firewall delete) → a **rule**; a multi-step chain → a **correlation rule**; a
+    volumetric pattern (denied-permission bursts, BigQuery large scans) → a **scheduled query**.
+  - A high-impact technique with **no** matching deployed detection is a coverage-gap finding —
+    surface it and route to `coverage_gap_analysis`.
+
+  ## Recording an observed action
+
+  For each high-signal action capture: `methodName`, `serviceName`, `principalEmail` (and its
+  identity type), `resourceName`, `callerIp`, and whether it was authorized
+  (`authorizationInfo[].granted`). A denied call is still signal — it shows intent.
+
+  ## Caveats
+  - High-signal starting points, not allow/deny lists. Terraform / Deployment Manager, CI/CD,
+    and Google service agents legitimately do many of these — classify by impact, then judge by
+    principal + project + context.
+  - Default service accounts (`appspot`, `developer`) act broadly by design; the signal is *who*
+    is driving them and from *where*.
+  - A single bucket hit is a lead; cross-bucket sequences from one principal are the verdict.
+  - **Google Workspace is a separate log source** (admin / login / token / drive audit), not GCP
+    Cloud Audit Logs. Workspace techniques (admin-console compromise, OAuth grants, Drive access)
+    and the GCP↔Workspace bridge (domain-wide delegation) need the Workspace audit feed — out of
+    scope for this GCP-audit reference; cover them with a Workspace-specific detection set.
+DependsOn: []
+EagerLoading: false
+RequiredTools:
+  - panther_ai_detections_list
+Enabled: true
+Tags:
+  - gcp
+  - audit
+  - mitre
+  - knowledge-primitive

--- a/skills/panther_ai_ioc_enrichment_check_skill.yml
+++ b/skills/panther_ai_ioc_enrichment_check_skill.yml
@@ -1,0 +1,138 @@
+AnalysisType: "skill"
+SkillName: "ioc_enrichment_check"
+DisplayName: "IoC Enrichment Check"
+Description: "Investigate one or more IoCs (IP, domain, URL, file hash, or email) using ONLY Panther's built-in enrichment sources — GreyNoise, VirusTotal, and OTX — plus observed activity in the data lake and alert history. Produces a per-indicator threat-intel report. Use when you want a fast reputation-and-activity check grounded entirely in Panther data. Not for external OSINT / web pivoting, multi-feed campaign sweeps, or hypothesis-driven hunts."
+Prompt: |
+  # IoC Enrichment Check — Panther Enrichment Sources Only
+
+  Given one or more IoCs, produce a threat-intel report built from Panther's
+  built-in enrichment sources (GreyNoise, VirusTotal, OTX), observed activity in the data
+  lake, and alert history. Do NOT web-search, scrape, or call third-party APIs directly —
+  this skill is scoped to what Panther already enriches and ingests.
+
+  **Core principle — silence is a finding.** "No enrichment hit and no observed activity in
+  the queried window" is the honest conclusion when nothing returns. Never escalate that to
+  "the indicator is clean" or "we are not affected."
+
+  ---
+
+  ## Step 1 — Parse and classify the input
+
+  Accept a single indicator or a pasted block. For each item:
+
+  1. **Re-fang defanged notation** before anything else: `hxxps://` → `https://`,
+     `[.]` → `.`, `[@]` → `@`, `[:]` → `:`. Never query the defanged form.
+  2. **Classify** the type: IPv4/IPv6, domain, URL, file hash (SHA-256 / SHA-1 / MD5), or
+     email. For a URL, also extract the host domain so it can be enriched and searched
+     separately.
+  3. **Deduplicate** the set, and **flag anything unparseable** — ask the analyst rather
+     than guessing.
+
+  ---
+
+  ## Step 2 — Enrichment lookup
+
+  Use `panther_ai_enrichments_lookup` to query all available enrichment sources for each
+  indicator. Expect results from the
+  integrated feeds:
+  - **GreyNoise** — internet-scanner classification, noise / RIOT status, actor, tags
+  - **VirusTotal** — AV-engine detections, community score, file / URL / domain / IP context
+  - **OTX (AlienVault Open Threat Exchange)** — pulse associations, threat-actor attribution,
+    malware families, related CVEs
+
+  Query each available source for the indicator. If multiple IoC types were provided, query
+  each one. If a source returns no data or is unavailable, record that explicitly — an
+  unavailable source is itself a reporting caveat, not a silent skip.
+
+  ---
+
+  ## Step 3 — Activity in Panther logs
+
+  Use `panther_ai_datalake_activity_histogram` to check for observed activity in the data
+  lake. The histogram sweeps the `p_any_*` fields
+  across all log types — route the indicator to the matching field:
+  - IPs → `p_any_ip_addresses`
+  - Domains (and URL hosts) → `p_any_domain_names`
+  - File hashes → `p_any_sha256_hashes` / `p_any_sha1_hashes` / `p_any_md5_hashes`
+  - Emails → `p_any_emails`
+
+  Use a lookback window of at least 30 days unless the analyst specifies otherwise. Record
+  which log sources the indicator appeared in, and the first-seen / last-seen timestamps.
+
+  ---
+
+  ## Step 4 — Alert / signal history
+
+  Use `panther_ai_alerts_list` to search for alerts associated with the indicator to learn whether Panther's detections have
+  already fired on it. Filter by relevant name keywords, the matched entity, or time range.
+  Note the rule, severity, and triage state of any matching alert.
+
+  ---
+
+  ## Step 5 — Synthesize and report
+
+  Combine enrichment reputation (Step 2) with observed activity (Step 3) and alert history
+  (Step 4). Classify each indicator:
+
+  - **✅ Detected** — observed in logs AND a Panther alert has fired
+  - **⚠️ Visible but undetected** — observed in logs, no alert (potential detection gap)
+  - **🔎 Flagged by enrichment only** — known-bad per GreyNoise / VT / OTX, no log activity
+  - **❌ No matches** — nothing in enrichments, logs, or alerts within the queried window
+    (this is silence, NOT "clean")
+
+  ```markdown
+  # IoC Enrichment Check — <single indicator or "bulk">
+
+  ## Summary
+  - Indicators processed: <N> (unique after dedup: <M>)
+  - Enrichment hits: <K> | Observed in logs: <K> | Alerts fired: <K>
+  - Enrichment sources unavailable: <list, explicit>
+
+  ## Per-Indicator Findings
+  ### <indicator> (<type>)
+  - Status: <✅ / ⚠️ / 🔎 / ❌>
+  - GreyNoise: <classification / RIOT / actor / tags, or "no data">
+  - VirusTotal: <detection ratio / community score, or "no data">
+  - OTX: <pulses / families / actors, or "no data">
+  - Observed activity: <log sources + first/last seen, or "none in window">
+  - Alerts: <rule, severity, state, or "none">
+
+  ## Could not classify
+  <unparseable items — ask the analyst to clarify>
+
+  ## Caveats
+  - Enrichment sources unavailable during this run: <list>
+  - "No matches" means silence in the queried sources and window — not a clean verdict.
+  - Scope is Panther enrichments + data lake only; external OSINT was not consulted.
+  ```
+
+  ---
+
+  ## Constraints
+
+  - **Enrichment-only.** No external web search, scraping, or direct third-party API calls.
+    If a question genuinely needs OSINT beyond Panther's enrichments, say so and stop —
+    don't improvise an external lookup.
+  - Read-only. Never create a blocklist entry, alert, or rule from this skill — report and
+    recommend, don't act.
+  - Re-fang defanged indicators before querying; never query the defanged form.
+  - Distinguish exact hash matches (sha256 / sha1 / md5) from fuzzy ones — exact is high
+    confidence, fuzzy is corroborating only.
+  - If a query or enrichment source times out or is unavailable, report it explicitly — do
+    not silently retry or omit it.
+  - Silence is a finding. State the sources queried and the window.
+ToolMessage: "Investigating the IoC across Panther enrichments, activity, and alerts…"
+DependsOn: []
+EagerLoading: false
+RequiredTools:
+  - panther_ai_enrichments_lookup
+  - panther_ai_datalake_activity_histogram
+  - panther_ai_alerts_list
+Enabled: true
+Tags:
+  - ioc
+  - enrichment
+  - threat-intelligence
+  - greynoise
+  - virustotal
+  - otx

--- a/skills/panther_ai_kubernetes_blast_radius_skill.yml
+++ b/skills/panther_ai_kubernetes_blast_radius_skill.yml
@@ -1,0 +1,189 @@
+AnalysisType: "skill"
+SkillName: "kubernetes_blast_radius"
+DisplayName: "Kubernetes Blast Radius"
+Description: "Scoping workflow for a compromised Kubernetes principal — a user, service account (`system:serviceaccount:ns:name`), or node — across EKS / GKE / AKS. Leads with the alerts and deployed detections Panther already has, then walks the RBAC / token expansion and pod-exec lateral chain and classifies actions by impact (reusing deployed detection logic, with ad-hoc audit-log SQL only for gaps) to produce an IR-style blast-radius timeline. Provider-agnostic: works against the normalized UDM the unified K8s ruleset uses. Use whenever a K8s incident anchor is confirmed and the question is \"what else did they touch\"."
+Prompt: |
+  # Kubernetes Blast Radius — Principal Scoping Workflow
+
+  Given a confirmed-compromised Kubernetes principal, enumerate every API action it took, every
+  resource it touched, every identity it created or bound, every pod it exec'd into, and every
+  other principal that appeared alongside it. Produce an IR-style timeline and a
+  containment-advisory report.
+
+  **Not for**: confirming whether an indicator is malicious, host/node OS forensics (audit logs
+  only), drafting new detections, or executing containment. Read-only and advisory.
+
+  **Provider-agnostic.** Reason in the normalized UDM fields the unified ruleset uses — `verb`,
+  `resource`, `subresource`, `username`, `namespace`, `responseStatus`, `sourceIPs` — which EKS
+  (`Amazon.EKS.Audit`), GKE (`GCP.AuditLog`), and AKS (`Azure.MonitorActivity`) map into. SQL
+  targets the cluster's specific audit table; the field *meanings* are constant.
+
+  **Reuse before you query.** Lead with what Panther already knows — alerts that fired on the
+  principal, and deployed K8s detections / scheduled queries that already encode these techniques.
+  Hand-write audit SQL only for the gaps. The MITRE IDs in `kubernetes_security_knowledge`
+  are the join key for that coverage.
+
+  ---
+
+  ## Step 1 — Normalize the principal and pick an anchor time
+
+  Identify the principal and its type (drives how broad the blast radius can be — see
+  `kubernetes_security_knowledge` "Reading Kubernetes audit identifiers"):
+
+  | Principal type | UDM `username` form | Fast filter |
+  |---|---|---|
+  | Human / federated user | `alice@org.com` (or OIDC subject) | `p_any_usernames` / `p_any_emails` |
+  | Service account | `system:serviceaccount:<ns>:<name>` | `p_any_usernames` |
+  | Node / kubelet | `system:node:<node>` | `p_any_usernames` |
+  | Anonymous | `system:anonymous` | `p_any_usernames` |
+  | Source IP | `203.0.113.10` | `p_any_ip_addresses` (`sourceIPs`) |
+
+  **Anchor time (T0)**: ask the analyst; if unknown, anchor on the earliest alert. Record the
+  **cluster** — blast radius is per-cluster (and per-account/project the cluster runs in).
+
+  ---
+
+  ## Step 2 — Anchor on what Panther already knows
+
+  Before any SQL, pull existing signal:
+  - **Alerts already fired on this principal** — `panther_ai_alerts_list` filtered by username /
+    sourceIP / cluster. The unified K8s rules (privileged pod, exec, secret dump, RBAC binding,
+    anonymous access) surface here with rule, severity, and a better T0.
+  - **Deployed detections + reusable query logic** — `panther_ai_detections_list` (filter by the
+    K8s log types or the MITRE tactics in `kubernetes_security_knowledge`) and
+    `panther_ai_datalake_list_saved_queries`. Prefer `panther_ai_datalake_execute_saved_query`
+    over inventing SQL.
+
+  ---
+
+  ## Step 3 — Discover available K8s audit sources
+
+  Call `panther_ai_log_sources_list` / `panther_ai_log_types_list` to confirm which cluster audit
+  feeds are ingested and healthy (`Amazon.EKS.Audit`, `GCP.AuditLog` for GKE,
+  `Azure.MonitorActivity` for AKS). A cluster with no audit feed is a blind spot — the most
+  important gap to call out, since this whole workflow depends on the audit log.
+
+  ---
+
+  ## Step 4 — Build the activity timeline (tiered windows)
+
+  If a deployed saved/scheduled query (from Step 2) already returns principal-scoped audit
+  activity, execute it with `panther_ai_datalake_execute_saved_query` first. Otherwise fall back
+  to `panther_ai_datalake_execute_sql` against the cluster's audit table — the gap-filler. Example
+  for an EKS cluster (adapt the table for GKE/AKS; UDM field meanings are the same):
+
+  ```sql
+  SELECT p_event_time,
+         verb,
+         objectRef:resource::VARCHAR     AS resource,
+         objectRef:subresource::VARCHAR  AS subresource,
+         objectRef:namespace::VARCHAR    AS namespace,
+         user:username::VARCHAR          AS username,
+         ARRAY_TO_STRING(sourceIPs, ',') AS source_ips,
+         responseStatus:code::NUMBER     AS status_code
+  FROM panther_logs.public.amazon_eks_audit
+  WHERE ARRAY_CONTAINS('{username}'::VARIANT, p_any_usernames)
+    AND p_event_time BETWEEN DATEADD('day', -3, '{T0}') AND DATEADD('day', 3, '{T0}')
+  ORDER BY p_event_time ASC
+  LIMIT 1000
+  ```
+
+  **W1** tight (T0 ± 3d) → **W2** campaign window → **W3** full lookback. `403 Forbidden`
+  responses are signal (RBAC denial / enumeration) — keep them.
+
+  ---
+
+  ## Step 5 — Walk the RBAC / token / exec chain
+
+  K8s identity-chaining isn't role assumption — it's **RBAC expansion, token minting, and pod
+  exec**. Reconstruct what the principal *became* and *reached*:
+  - **Identity expansion:** `create`/`patch` on `clusterrolebindings` / `rolebindings` (new
+    privileges), `create serviceaccounts/token` (minted tokens), `impersonate` (acted as another
+    subject). For each new binding/SA/impersonated identity, re-scope Step 4 to that identity.
+  - **Lateral via exec:** `create pods/exec`, `pods/attach`, `pods/portforward` — each target pod
+    is a new foothold; pull the pod's service account and re-scope to it.
+  - **Workload deploy:** `create pods` / `deployments` / `daemonsets` / `cronjobs` — record what
+    was deployed and the SA it runs as.
+
+  **Cap chain depth at 3 hops.** Cross-namespace and `kube-system` reach are high-signal.
+
+  ---
+
+  ## Step 6 — Co-occurring entities (lateral candidates)
+
+  For events in Steps 4–5, pull the other `p_any_*` fields (`p_any_usernames`,
+  `p_any_ip_addresses`) and the namespaces/pods touched to find co-occurring principals and
+  targets. Cap entity pivots at 2 hops.
+
+  ---
+
+  ## Step 7 — Classify actions by impact and map to deployed detections
+
+  Bucket the windowed actions using `kubernetes_security_knowledge` (discovery, credential
+  access, RBAC privesc, execution, container escape, persistence, defense evasion, lateral
+  movement, impact); do not redefine the lists. For each high-signal action record: verb,
+  resource/subresource, username (+ type), namespace, sourceIPs, and the responseStatus code.
+
+  Then close the loop against deployed coverage (reuse what Step 2 found):
+  - Resolve each classified action / chain to a deployed detection via the
+    `kubernetes_security_knowledge` "Mapping techniques to deployed detections" guidance
+    (single action → rule, multi-step chain → correlation rule, volumetric/403-burst → scheduled
+    query). If an alert already fired (Step 2), mark it **covered & alerted**.
+  - A high-impact action with **no** deployed detection is a coverage-gap finding — record it and
+    route to `coverage_gap_analysis`.
+
+  ---
+
+  ## Step 8 — Output: Blast Radius Report
+
+  ```markdown
+  # Kubernetes Blast Radius — <principal> in <cluster>
+
+  ## Principal Profile
+  - Principal type (user / serviceaccount / node / anonymous), username, cluster, source IP(s)
+  - Anchor time (T0), windows examined, audit sources queried (with blind spots called out)
+
+  ## Activity Timeline (W1) — | Time | Verb | Resource/Sub | Namespace | Result |
+  ## Identity / Exec Chain — | Hop | From | Action (bind/token/impersonate/exec) | New identity / pod |
+  ## Resources Touched — | Resource | Namespace | First/Last | Count | Impact |
+  ## High-Impact Actions — by category (RBAC privesc / container escape / credential access / …)
+  ## Co-occurring Entities — | Entity | Type | Count | Follow-up |
+  ## Existing Detection Coverage — alerts fired; high-impact actions with no detection (gaps)
+  ## Containment Recommendations (advisory) — revoke/rotate the SA token, delete attacker
+    bindings/SAs, cordon affected nodes, delete attacker pods/workloads, review admission webhooks
+  ## Caveats — correlation ≠ causation; 403s show intent not impact; audit-feed blind spots;
+    chain capped at 3 hops; pod-internal (host) activity not visible in audit logs
+  ```
+
+  ---
+
+  ## Constraints
+  - Read-only. Never delete a binding, revoke a token, cordon a node, or modify a rule from this
+    skill — recommendations only.
+  - Prefer reusing deployed detections and saved queries (`panther_ai_datalake_execute_saved_query`)
+    over ad-hoc SQL; `panther_ai_datalake_execute_sql` is the gap-filler.
+  - Every query needs a `LIMIT` and a `p_event_time` bound. Keep `Forbidden` responses.
+  - Cap chain depth at 3 hops, entity pivots at 2 hops.
+  - The audit log shows API-server activity only — in-pod process/file/network actions are not
+    here; note that boundary. If no audit feed exists for the cluster, say so — it's the gap that
+    invalidates the rest.
+ToolMessage: "Scoping Kubernetes blast radius for the compromised principal…"
+DependsOn:
+  - kubernetes_security_knowledge
+EagerLoading: false
+RequiredTools:
+  - panther_ai_alerts_list
+  - panther_ai_detections_list
+  - panther_ai_log_sources_list
+  - panther_ai_log_types_list
+  - panther_ai_datalake_list_saved_queries
+  - panther_ai_datalake_execute_saved_query
+  - panther_ai_datalake_execute_sql
+  - panther_ai_datalake_get_query_results
+Enabled: true
+Tags:
+  - kubernetes
+  - k8s
+  - audit
+  - incident-response
+  - blast-radius

--- a/skills/panther_ai_kubernetes_blast_radius_skill.yml
+++ b/skills/panther_ai_kubernetes_blast_radius_skill.yml
@@ -88,6 +88,10 @@ Prompt: |
   LIMIT 1000
   ```
 
+  The `p_any_usernames` predicate covers user / service-account / node anchors. For a source-IP
+  anchor, swap it for `ARRAY_CONTAINS('{ip}'::VARIANT, p_any_ip_addresses)` (the `sourceIPs`
+  field) per the Step 1 table.
+
   **W1** tight (T0 ± 3d) → **W2** campaign window → **W3** full lookback. `403 Forbidden`
   responses are signal (RBAC denial / enumeration) — keep them.
 

--- a/skills/panther_ai_kubernetes_security_knowledge_skill.yml
+++ b/skills/panther_ai_kubernetes_security_knowledge_skill.yml
@@ -1,0 +1,169 @@
+AnalysisType: "skill"
+SkillName: "kubernetes_security_knowledge"
+DisplayName: "Kubernetes Security Knowledge"
+Description: "Reference mapping of Kubernetes audit-log activity (`verb` + `resource` + `subresource`) to attacker-impact categories — discovery, credential access, RBAC privilege escalation, execution, persistence, container escape, defense evasion, lateral movement, impact, and known multi-step attack chains. Provider-agnostic: written against the normalized UDM fields that EKS / GKE / AKS audit logs map into, so it applies to the unified cross-provider K8s ruleset. Use whenever K8s API activity needs to be classified by adversary impact: incident scoping, threat hunts, detection coverage analysis, or post-mortem triage. Also covers reading audit-log principals (`system:serviceaccount:…`, `system:anonymous`, `system:node:…`) and mapping techniques to deployed Panther detections. Knowledge reference — does not run queries."
+Prompt: |
+  # Kubernetes Security Knowledge — Audit Log Action Impact Reference
+
+  Maps high-signal Kubernetes audit-log actions to the attacker-impact category they belong to.
+  A K8s audit event is mostly `verb` + `resource` (+ optional `subresource`) by a `username` in
+  a `namespace` — bucket by what the action lets an adversary *do*, not just which resource it
+  touched. Lists are canonical high-signal actions, not exhaustive; significance always depends
+  on context (who, whether it was `Forbidden`, and whether it is normal for that principal).
+
+  **Provider-agnostic.** This is written against the normalized UDM fields the unified ruleset
+  uses — `verb`, `resource`, `subresource`, `username`, `namespace`, `responseStatus`,
+  `sourceIPs`, `requestObject.spec.*` — which EKS (`Amazon.EKS.Audit`), GKE (`GCP.AuditLog`),
+  and AKS (`Azure.MonitorActivity`) all map into. Reason in UDM terms, not provider-specific
+  JSON paths.
+
+  ## Reading Kubernetes audit identifiers
+
+  Before the verb, the `username` tells you *what kind of principal* acted:
+
+  - `system:anonymous` (group `system:unauthenticated`) — **unauthenticated** request. Any
+    non-trivial verb from this principal is a finding; the API server should not allow it.
+  - `system:serviceaccount:<namespace>:<name>` — a **workload** identity (pod-mounted token). A
+    service account acting outside its normal namespace / verbs, or from an external IP, is the
+    core token-abuse signal.
+  - `system:node:<node>` — a **kubelet**. Should only touch its own node's objects
+    (NodeRestriction); broad activity = a stolen node credential.
+  - `system:kube-*` / `system:masters` — **control-plane / cluster-admin**. `system:masters` is
+    the built-in break-glass group (bypasses RBAC) — human use of it is high-signal.
+  - Anything else — a **human / federated** user (OIDC, client cert, cloud IAM).
+
+  Other key fields: `namespace` (`kube-system`, `kube-public`, `kube-node-lease` are *system*
+  namespaces — workload changes there by non-system principals are suspicious); `responseStatus`
+  code `403 Forbidden` (RBAC denial — the permission-enumeration signal) / `401`; `sourceIPs`
+  (a public IP hitting the API server is high-signal); `subresource` (`exec`, `attach`,
+  `portforward`, `proxy`, `log` change what a verb means).
+
+  ## Discovery — TA0007 (T1613 Container & Resource Discovery)
+  - `list` / `get` / `watch` on `pods`, `nodes`, `namespaces`, `services`, `deployments`
+  - `list secrets` / `get secrets` (also credential access — see below)
+  - `get` on `selfsubjectaccessreviews` / `selfsubjectrulesreviews` (probe own permissions)
+  - **403 bursts:** many `Forbidden` responses across resources from one principal = RBAC
+    permission enumeration. Anonymous (`system:anonymous`) discovery is its own strong signal.
+
+  ## Credential access — TA0006 (T1552.007)
+  - `get` / `list` `secrets` (single, namespace-wide, or — worst — across *all* namespaces)
+  - `create serviceaccounts/token` (`TokenRequest`) — mint a token for any service account
+  - `create certificatesigningrequests` + `approve` (subresource) — issue a client cert (a
+    durable, hard-to-revoke credential)
+  - Pod service-account token theft — a workload reading
+    `/var/run/secrets/kubernetes.io/serviceaccount/token` shows up as that SA acting from an
+    unexpected context, not as an audit verb itself
+  - `get configmaps` (often hold credentials/config)
+
+  ## RBAC privilege escalation — TA0004 (T1098 Account Manipulation)
+  - `create` / `patch` `clusterrolebindings` / `rolebindings` (bind a subject to cluster-admin)
+  - `escalate` verb on `roles` / `clusterroles` (grant yourself perms you don't hold)
+  - `bind` verb (attach an existing role to a new subject)
+  - `impersonate` (`users` / `groups` / `serviceaccounts`) — act as another identity, bypassing
+    your own RBAC
+  - `create` / `patch` `roles` / `clusterroles` with wildcard `*` verbs/resources, or write
+    verbs (`create`/`update`/`patch`/`delete`), or `pods/exec`, or `nodes/proxy`
+
+  ## Execution — TA0002 (T1609 Container Admin Command / T1610 Deploy Container)
+  - `create pods/exec` or `get pods/exec` (the `exec` subresource — shell in a running pod),
+    `pods/attach`, ephemeral containers (`patch pods/ephemeralcontainers`)
+  - `create pods/portforward` (tunnel to a pod)
+  - `kubectl cp` (implemented as `pods/exec` of `tar` — copy files in/out of a pod)
+  - `create pods` / `deployments` / `jobs` to run an attacker image (T1610)
+
+  ## Container escape / host privesc — TA0004 (T1611 Escape to Host)
+  Pod-spec security settings in `requestObject.spec` on `create pods` (or workload controllers)
+  that grant host access — the classic escape primitives:
+  - `securityContext.privileged: true` (full kernel access, all capabilities)
+  - `hostPID: true`, `hostIPC: true`, `hostNetwork: true` (share host namespaces; `hostNetwork`
+    also *bypasses NetworkPolicies*)
+  - `hostPath` volumes (mount the host filesystem — e.g. `/`, `/etc`, `/var/run/docker.sock`)
+  - dangerous `capabilities.add` — `SYS_ADMIN`, `NET_ADMIN`, `SYS_MODULE`, `SYS_PTRACE`
+  - `allowPrivilegeEscalation: true` / `runAsNonRoot: false` / running as UID 0
+  - a privileged or host-namespace pod created in a **system namespace** is especially high-signal
+
+  ## Persistence — TA0003
+  - `create mutatingwebhookconfigurations` / `validatingwebhookconfigurations` (admission
+    controller — intercept/modify every future API request; a powerful, stealthy backdoor)
+  - `create cronjobs` / `jobs` (scheduled re-execution), `create daemonsets` (a pod on every
+    node, incl. new ones), `create deployments` (self-healing pods)
+  - `create clusterrolebindings` (durable elevated access), `create serviceaccounts/token`
+  - `create certificatesigningrequests` (durable client cert that survives token rotation)
+
+  ## Defense evasion — TA0005 (T1562 Impair Defenses)
+  - `delete` / `patch` on `events`, audit/webhook config, or logging DaemonSets/agents
+  - `patch` / `delete` system `clusterroles` / `clusterrolebindings` (weaken RBAC), modify a
+    `system:*` role
+  - `delete pods` / `deployments` to remove evidence of a workload after use
+  - re-enabling `system:anonymous` access or binding it to a role
+
+  ## Lateral movement — TA0008
+  - `create pods/exec` / `pods/attach` into other workloads, `pods/portforward`
+  - `nodes/proxy` (reach the kubelet API directly — bypasses the API server's RBAC on the node)
+  - `create services` of type `NodePort` / `LoadBalancer` (expose an internal workload
+    externally), `create ingress`
+  - host-network pods to reach the node network and pivot (NetworkPolicies don't apply)
+
+  ## Impact / destruction — TA0040
+  - `delete` `namespaces` / `deployments` / `pods` / `persistentvolumeclaims` at volume
+    (sabotage / ransom; T1485)
+  - `create pods` running cryptominers — resource hijacking (T1496); watch for high-CPU images
+    / mining-pool egress
+  - `delete` or `scale` critical workloads to cause denial of service
+
+  ## High-signal technique combinations
+
+  The strongest signal is a sequence from one principal, not a single call:
+  - **Token theft → escalation:** stolen SA token → `selfsubjectaccessreviews` probing →
+    `create clusterrolebindings` to cluster-admin. (T1552.007 → T1098)
+  - **Exec-to-escape:** `create pods` with `privileged`/`hostPath` → `create pods/exec` →
+    read host filesystem / `/var/run/docker.sock`. (T1610 → T1609 → T1611)
+  - **Admission-controller backdoor:** `create mutatingwebhookconfigurations` pointing at an
+    attacker service → silently mutate every future pod. (T1610 persistence)
+  - **Anonymous foothold:** `system:anonymous` request succeeds (not `Forbidden`) → enumerate →
+    act. Any successful anonymous non-read verb is critical.
+  - **Secret sweep → exfil:** `list secrets` across all namespaces → external egress from the
+    pod. (T1552.007 → T1041)
+
+  ## Mapping techniques to deployed detections
+
+  These techniques are covered by Panther's **unified cross-provider K8s ruleset**
+  (`rules/kubernetes_rules/`) — it normalizes `Amazon.EKS.Audit`,
+  `GCP.AuditLog` (GKE), and `Azure.MonitorActivity` (AKS) into the UDM used above, so one rule
+  covers all three clouds. Don't reason about a technique in isolation:
+  - Resolve an observed technique to deployed coverage via its MITRE tactic-technique ID —
+    query `panther_ai_detections_list` by `mitre_attack_tags`, or hand the list to
+    `coverage_gap_analysis`.
+  - Match signal shape to paradigm: a single high-signal action (`create pods` privileged,
+    `exec`, `create clusterrolebindings`, `list secrets`) → a **rule**; a multi-step chain → a
+    **correlation rule**; a volumetric pattern (403 bursts, bulk secret access) → a **scheduled
+    query**.
+  - A high-impact technique with **no** matching deployed detection is a coverage-gap finding —
+    surface it and route to `coverage_gap_analysis`.
+
+  ## Recording an observed action
+
+  For each high-signal action capture: `verb`, `resource`/`subresource`, `username` (and its
+  principal type), `namespace`, `sourceIPs`, the `responseStatus` code (did it succeed or
+  `Forbidden`?), and — for pods — the relevant `requestObject.spec.*` security settings. A
+  `Forbidden` is still signal: it shows what the principal *tried*.
+
+  ## Caveats
+  - These are high-signal starting points, not allow/deny lists. CI/CD, operators, GitOps
+    controllers, and autoscalers legitimately do many of these — classify by impact, then judge
+    by principal + namespace + context, not presence alone.
+  - System principals (`system:serviceaccount:kube-system:*`, `system:node:*`) do privileged
+    things by design; the signal is a *non-system* or *external* principal doing them, or a
+    system principal acting from an unexpected source.
+  - A single bucket hit is a lead, not a verdict — cross-bucket sequences from one principal
+    (discovery → escalation → execution → exfil) are the stronger signal.
+DependsOn: []
+EagerLoading: false
+RequiredTools:
+  - panther_ai_detections_list
+Enabled: true
+Tags:
+  - kubernetes
+  - k8s
+  - mitre
+  - knowledge-primitive

--- a/skills/panther_ai_threat_intel_feed_catalog_skill.yml
+++ b/skills/panther_ai_threat_intel_feed_catalog_skill.yml
@@ -1,0 +1,143 @@
+AnalysisType: "skill"
+SkillName: "threat_intel_feed_catalog"
+DisplayName: "Threat Intel Feed Catalog"
+Description: "Catalog of external threat-intelligence feeds and enrichment sources — supply-chain / npm, general APT & malware reporting, machine-readable IoC feeds, and pivot/enrichment services — each with a fetch URL, expected format, and the indicator types you'll typically extract. Use for multi-feed sweeps and campaign research (pulling fresh IoCs from public reporting). For a single indicator checked against Panther's *own* enrichments (GreyNoise / VirusTotal / OTX), use `ioc_enrichment_check` instead — this catalog is the external layer."
+Prompt: |
+  # Threat Intel Feed Catalog
+
+  A catalog of external sources for IoC sweeps, campaign research, and pivot-time enrichment.
+  Each entry lists the fetch URL, the format to expect, and the indicator types you'll typically
+  extract. Note that these domains may need to be allowlisted for fetching within your environment.
+
+  ## When to use / not for
+
+  - **Use** for: multi-feed sweeps, campaign / actor research, harvesting fresh IoCs from public
+    reporting, and enriching an indicator during a pivot.
+  - **Not for**: a single-indicator reputation check against Panther's own integrated
+    enrichments — use `ioc_enrichment_check` (GreyNoise / VirusTotal / OTX in-platform).
+    This catalog is the *external* layer that complements it.
+
+  ## Fetching guidance
+
+  - Many security blogs are JavaScript SPAs that return an empty shell when fetched directly —
+    **prefer the RSS / Atom feed URL** over the HTML page wherever one exists.
+  - If a feed is unreachable, **note it in the report header and continue** with the rest; never
+    fail silently.
+  - Respect rate limits and source terms of service; cache results within an investigation rather
+    than re-fetching.
+
+  ## Supply chain / npm-focused feeds
+
+  Primary sources for package-level IoCs. Check these when investigating a supply-chain attack or
+  running an npm sweep.
+
+  | Source | Fetch URL | Format | Typical indicators |
+  |--------|-----------|--------|--------------------|
+  | Panther | `https://panther.com/blog/` | HTML (parse) | package names, campaign analysis, C2 infrastructure, detection guidance |
+  | OpenSourceMalware | `https://opensourcemalware.com/rss.xml` | RSS | package names, versions, malware families |
+  | Socket.dev | `https://socket.dev/api/blog/feed.atom` | Atom | package names, npm accounts, C2 domains, campaign names |
+  | Aikido | `https://www.aikido.dev/blog/rss.xml` | RSS | package names, attack chains, C2 infrastructure |
+  | 0dayfans | `https://0dayfans.com/feed.rss` | RSS | package names, vulnerability disclosures |
+  | SafeDep | `https://safedep.io/blog/` | HTML (parse) | package names, dependency analysis |
+  | DPRK Research (KMSec) | `https://dprk-research.kmsec.uk/` | HTML (parse) | DPRK actor campaigns, npm accounts, infrastructure |
+  | StepSecurity | `https://www.stepsecurity.io/blog/rss.xml` | RSS | supply-chain attack analysis, package-level IoCs |
+  | GitGuardian | `https://blog.gitguardian.com/rss/` | RSS | campaign analysis, detection guidance, vulnerability disclosures |
+  | GitHub Security Blog | `https://github.blog/security/feed/` | RSS | vulnerability disclosures, attack chains, package-level IoCs |
+  | JFrog | `https://jfrog.com/blog/tag/security-research/feed/` | RSS | package names, vulnerability disclosures, attack chains |
+
+  ## General threat-intelligence feeds
+
+  Check these for actor attribution, broader campaigns, or non-supply-chain indicators.
+
+  | Source | Fetch URL | Format | Typical indicators |
+  |--------|-----------|--------|--------------------|
+  | Talos Intelligence | `https://blog.talosintelligence.com/rss/` | RSS | IPs, domains, hashes, campaign analysis |
+  | SentinelOne Labs | `https://www.sentinelone.com/labs/feed/` | RSS | APT campaigns, malware analysis, hashes |
+  | Unit 42 (Palo Alto) | `https://unit42.paloaltonetworks.com/feed/` | RSS | campaign reports, actor profiles, IoC lists |
+  | Microsoft Security | `https://www.microsoft.com/en-us/security/blog/feed/` | RSS | actor tracking (Storm-*, Midnight Blizzard, …) |
+  | Securelist (Kaspersky) | `https://securelist.com/feed/` | RSS | APT reports, malware families, IoC appendices |
+  | Check Point Research | `https://research.checkpoint.com/feed/` | RSS | campaign analysis, malware teardowns |
+  | CrowdStrike | `https://www.crowdstrike.com/blog/feed/` | RSS | actor tracking, campaign reports |
+  | Wiz | `https://www.wiz.io/feed/rss.xml` | RSS | cloud-attack campaigns, IPs, domains, malware families |
+  | Google TAG / Mandiant | `https://blog.google/threat-analysis-group/rss/` | RSS | nation-state campaigns, 0-day actors |
+  | CISA Advisories | `https://www.cisa.gov/cybersecurity-advisories/all.xml` | RSS | exploited CVEs, actor TTPs, IoC appendices |
+  | Elastic Security Labs | `https://www.elastic.co/security-labs/rss/feed.xml` | RSS | campaign analysis, detection guidance, IoCs |
+  | Apple Security Research | `https://security.apple.com/blog/feed.rss` | RSS | Apple-focused vulnerabilities, attack chains, IoCs |
+  | Trail of Bits | `https://blog.trailofbits.com/feed/` | RSS | vulnerability research, exploit chains |
+
+  ## Machine-readable IoC feeds
+
+  Structured feeds you can ingest directly (no article parsing) — best for bulk pivots and
+  blocklist cross-referencing.
+
+  | Source | Fetch URL | Format | Typical indicators |
+  |--------|-----------|--------|--------------------|
+  | abuse.ch URLhaus | `https://urlhaus.abuse.ch/downloads/csv_recent/` | CSV | malware-distribution URLs, payload hashes |
+  | abuse.ch ThreatFox | `https://threatfox.abuse.ch/export/json/recent/` | JSON | IPs, domains, URLs, hashes tagged by malware family |
+  | abuse.ch Feodo Tracker | `https://feodotracker.abuse.ch/downloads/ipblocklist.json` | JSON | botnet C2 IPs (Emotet, Dridex, etc.) |
+  | MalwareBazaar | `https://bazaar.abuse.ch/export/` | API / CSV | malware sample hashes by family / tag |
+  | CISA KEV | `https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json` | JSON | known-exploited CVEs |
+
+  ## Specialized / enrichment sources
+
+  Not feeds to sweep — query these per indicator during a pivot. VirusTotal, GreyNoise, and OTX
+  are also available as **Panther lookup tables** (see `ioc_enrichment_check` for the
+  in-platform path); the URLs below are for deep dives the lookup tables don't cover.
+
+  | Source | Usage | Access method |
+  |--------|-------|---------------|
+  | VirusTotal | hash / domain / IP / URL reputation | Panther lookup table; web UI for relations & pivots |
+  | GreyNoise | IP noise / scanner classification | Panther lookup table; web UI for RIOT/context |
+  | OTX (AlienVault) | IoC pulse membership, CVE context | Panther lookup table; web UI for pulses |
+  | Shodan / Censys | IP / port / service exposure | web search or API (if available) |
+  | Validin | passive DNS, domain history | web UI — domain → IP resolution history |
+  | SilentPush | domain / IP threat scoring | web UI — infrastructure pivoting |
+  | urlscan.io | URL analysis, screenshot, DOM | web search `site:urlscan.io {domain}` |
+  | whatsmyname.app | username cross-platform search | web UI — paste username, check coding platforms |
+  | npm registry | package metadata, maintainer info | `https://registry.npmjs.org/{package}` / `https://www.npmjs.com/~{username}` |
+  | Socket.dev package | package-level risk assessment | `https://socket.dev/npm/package/{package}` |
+
+  ## Feed parsing strategy
+
+  **RSS / Atom** — for each entry extract:
+  - **Title** — often the package name or campaign label
+  - **Description / summary** — scan for IoCs (IPs, domains, hashes, package names)
+  - **Published date** — filter to your target window
+  - **Link** — fetch the full article for detailed IoC extraction when the summary is thin
+
+  **HTML blog pages** (no feed) — look for: dated article listings (filter to recent), individual
+  article pages (fetch the most relevant), IoC tables / code blocks / "Indicators of Compromise"
+  sections, and campaign / actor names in headers.
+
+  ## IoC extraction patterns
+
+  - **IPs**: `\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b` — drop non-IoC IPs (127.0.0.1, 0.0.0.0,
+    255.255.255.255, RFC1918 ranges)
+  - **Domains**: re-fang defanged notation (`hxxps://`, `[.]com`) before use
+  - **Hashes**: SHA-256 (64 hex), SHA-1 (40 hex), MD5 (32 hex)
+  - **npm packages**: usually in code blocks, inline code, or IoC tables
+  - **Emails**: standard pattern, often in maintainer fields
+  - **CVEs**: `CVE-\d{4}-\d{4,7}`
+  - **MITRE ATT&CK**: `T\d{4}(\.\d{3})?`
+
+  ## Caveats
+
+  - **Feeds drift.** URLs, RSS paths, and formats change without notice — if a fetch 404s or
+    returns HTML where RSS is expected, try the site root for the current feed link and note the
+    change; don't treat this list as guaranteed-current.
+  - **De-fang on output.** Always present extracted indicators defanged (`.` → `[.]`,
+    `https` → `hxxps`) to prevent accidental clicks.
+  - **Reputation ≠ verdict.** A feed hit is a lead; corroborate against internal telemetry
+    (hand matched indicators to `ioc_enrichment_check`) before acting.
+ToolMessage: "Sweeping external threat-intel feeds for fresh indicators…"
+DependsOn: []
+EagerLoading: false
+RequiredTools:
+  - panther_ai_utilities_fetch_web
+Enabled: true
+Tags:
+  - iocs
+  - threat-intelligence
+  - feeds
+  - enrichment
+  - osint


### PR DESCRIPTION
### Background

**Blast-radius workflow skills** — IR-style scoping for a confirmed-compromised principal ("what else did they touch?"):

| Skill | Scope |
|---|---|
| `aws_blast_radius` | IAM users/roles, assumed-role sessions, access keys, EC2 instances — walks the AssumeRole chain across accounts |
| `azure_blast_radius` | Entra users, service principals, managed identities — scopes **both planes** (Entra ID + ARM) and walks cross-plane chains (cred-add → auth-as-SP → RBAC → `elevateAccess`) |
| `gcp_blast_radius` | Users, service accounts, SA keys — walks the SA impersonation chain (`GenerateAccessToken`/`SignJwt`/`actAs`) across projects |
| `kubernetes_blast_radius` | Users, service accounts, nodes — provider-agnostic (EKS/GKE/AKS via the unified UDM), walks RBAC expansion, token minting, and pod-exec chains |

All four share the same 8-step skeleton: normalize the principal → anchor on existing alerts/detections → confirm log sources → tiered timeline (W1 ±3d / W2 campaign / W3 lookback) → walk the identity chain (capped at 3 hops) → co-occurring entities (capped at 2 hops) → classify by impact and map to deployed detections → structured blast-radius report. Key principles baked in: **reuse deployed detections and saved queries before writing ad-hoc SQL**, failed/denied calls are signal, every query bounded by `LIMIT` + `p_event_time`, strictly read-only and advisory.

**Security knowledge primitives** — reference skills mapping raw audit activity to attacker-impact categories, consumed by the blast-radius skills via `DependsOn`:

- `aws_security_knowledge` — CloudTrail `eventName` → impact buckets, AKIA/ASIA/AROA identifier decoding, known attack chains (PassRole privesc, snapshot exfil, golden SAML)
- `azure_security_knowledge` — dual-plane (Entra `operationName` + ARM provider ops), cross-referenced with Microsoft's Azure Threat Research Matrix (ATRM)
- `gcp_security_knowledge` — `methodName` → impact buckets, `principalEmail` identity decoding, metadata-SSRF and actAs escalation patterns
- `kubernetes_security_knowledge` — `verb`+`resource`+`subresource` → impact buckets, principal decoding (`system:anonymous`, `system:serviceaccount:*`, `system:masters`), container-escape primitives

Each maps techniques to deployed Panther rulesets by MITRE tactic/technique ID, and routes uncovered techniques to `coverage_gap_analysis`.

**Standalone skills:**

- `coverage_gap_analysis` — cross-references MITRE ATT&CK techniques (named, from an advisory URL, or by tactic) against active log sources and deployed detections; outputs a coverage table ranked by remediation effort
- `ioc_enrichment_check` — per-indicator reputation + activity check scoped to Panther's built-in enrichments (GreyNoise/VT/OTX), data lake, and alert history; "silence is a finding, not a clean verdict"
- `threat_intel_feed_catalog` — external feed catalog (supply-chain/npm, APT reporting, machine-readable IoC feeds) with fetch URLs, formats, and extraction patterns; complements `ioc_enrichment_check` as the external layer

### Conventions

- Format follows the existing Okta skills: quoted top-level scalars, single-line quoted `Description`, `SkillName` without `_skill` suffix, explicit `DependsOn: []`/`RequiredTools: []`, 2-space indentation
- Knowledge primitives are tagged `knowledge-primitive` and carry no `ToolMessage`; workflow skills declare their full toolset in `RequiredTools`
- All skills are read-only — containment and rule changes are recommendations only
- All sample identifiers are placeholders (RFC 5737 IPs, example ARNs/UPNs)
### Changes

- <Describe changes here>

### Testing

- <Testing steps>
