### PR TITLE
Fix field path bugs in Okta.Support.Reset and Slack app rules

### DIFF
--- a/rules/okta_rules/okta_support_reset.py
+++ b/rules/okta_rules/okta_support_reset.py
@@ -14,13 +14,16 @@ def rule(event):
     return (
         event.deep_get("actor", "alternateId") == "system@okta.com"
         and event.deep_get("transaction", "id") == "unknown"
-        and event.deep_get("userAgent", "rawUserAgent") is None
+        and event.deep_get("client", "userAgent", "rawUserAgent") is None
         and event.deep_get("client", "geographicalContext", "country") is None
     )
 
 
 def title(event):
-    return f"Okta Support Reset Password or MFA for user {event.udm('actor_user')}"
+    targets = event.get("target") or []
+    impacted = next((t for t in targets if t.get("type") == "User"), None) or {}
+    user = impacted.get("alternateId") or impacted.get("displayName") or "<unknown-user>"
+    return f"Okta Support Reset Password or MFA for user {user}"
 
 
 def alert_context(event):

--- a/rules/slack_rules/slack_app_access_expanded.py
+++ b/rules/slack_rules/slack_app_access_expanded.py
@@ -56,7 +56,7 @@ def severity(event):
         return "High"
 
     # Fallback method in case the admin scope is not directly mentioned in entity for whatever
-    if "admin" in event.deep_get("details", "new_scope", default=[]):
+    if "admin" in event.deep_get("details", "new_scopes", default=[]):
         return "High"
 
     if "admin" in event.deep_get("details", "bot_scopes", default=[]):

--- a/rules/slack_rules/slack_app_added.py
+++ b/rules/slack_rules/slack_app_added.py
@@ -20,7 +20,7 @@ def title(event):
 
 def alert_context(event):
     context = slack_alert_context(event)
-    context["scopes"] = event.deep_get("entity", "scopes")
+    context["scopes"] = event.deep_get("entity", "app", "scopes")
 
     return context
 
@@ -32,7 +32,7 @@ def severity(event):
         return "High"
 
     # Fallback method in case the admin scope is not directly mentioned in entity for whatever
-    if "admin" in event.deep_get("details", "new_scope", default=[]):
+    if "admin" in event.deep_get("details", "new_scopes", default=[]):
         return "High"
 
     if "admin" in event.deep_get("details", "bot_scopes", default=[]):


### PR DESCRIPTION
## Summary

- **#2090** `Okta.Support.Reset`: fix `userAgent` path — `event.deep_get("userAgent", "rawUserAgent")` → `event.deep_get("client", "userAgent", "rawUserAgent")` (top-level field doesn't exist; it's nested under `client`)
- **#2089** `Okta.Support.Reset`: fix `title()` to show the impacted user from `target[]` instead of `actor_user` (which always resolves to `system@okta.com`)
- **#2088** `Slack.AuditLogs.AppAdded`: fix `alert_context()` scopes path — `entity.scopes` → `entity.app.scopes` (was always returning `None`)
- **#2087** `Slack.AuditLogs.AppAdded` + `Slack.AuditLogs.AppAccessExpanded`: fix severity fallback — `details.new_scope` → `details.new_scopes` (singular field never exists; escalation could never fire)

## Test plan

- [x] `pat test --filter RuleID=Okta.Support.Reset` — all tests pass
- [x] `pat test --filter RuleID=Slack.AuditLogs.AppAdded` — all tests pass
- [x] `pat test --filter RuleID=Slack.AuditLogs.AppAccessExpanded` — all tests pass
- [x] Pre-commit hooks (fmt + lint) passed

Closes #2087, #2088, #2089, #2090

🤖 Generated with [Claude Code](https://claude.com/claude-code)