### PR TITLE
AWS Root Activity Rule Dedup Tuning

### DIFF
--- a/indexes/alpha-index.md
+++ b/indexes/alpha-index.md
@@ -374,7 +374,7 @@
 - [Root Account Access Key Created](../rules/aws_cloudtrail_rules/aws_root_access_key_created.yml)
   - Detects creation of programmatic access keys for the AWS root account, which violates critical security best practices. Root account credentials provide unrestricted access to all AWS resources and cannot be scoped with granular permissions. If compromised, these keys grant attackers complete control over the AWS environment including billing and account closure capabilities.
 - [Root Account Activity](../rules/aws_cloudtrail_rules/aws_root_activity.yml)
-  - Root account activity was detected.
+  - Root account activity that modifies AWS resources or configuration was detected. Read-only root events (enumeration, console reads) are excluded — only impactful root actions trigger this rule.
 - [Root Console Login](../rules/aws_cloudtrail_rules/aws_console_root_login.yml)
   - The root account has been logged into.
 - [Root Password Changed](../rules/aws_cloudtrail_rules/aws_root_password_changed.yml)

--- a/indexes/aws.md
+++ b/indexes/aws.md
@@ -322,7 +322,7 @@
 - [Root Account Access Key Created](../rules/aws_cloudtrail_rules/aws_root_access_key_created.yml)
   - Detects creation of programmatic access keys for the AWS root account, which violates critical security best practices. Root account credentials provide unrestricted access to all AWS resources and cannot be scoped with granular permissions. If compromised, these keys grant attackers complete control over the AWS environment including billing and account closure capabilities.
 - [Root Account Activity](../rules/aws_cloudtrail_rules/aws_root_activity.yml)
-  - Root account activity was detected.
+  - Root account activity that modifies AWS resources or configuration was detected. Read-only root events (enumeration, console reads) are excluded — only impactful root actions trigger this rule.
 - [Root Console Login](../rules/aws_cloudtrail_rules/aws_console_root_login.yml)
   - The root account has been logged into.
 - [Root Password Changed](../rules/aws_cloudtrail_rules/aws_root_password_changed.yml)

--- a/indexes/detection-coverage.json
+++ b/indexes/detection-coverage.json
@@ -8322,7 +8322,7 @@
     },
     {
         "AnalysisType": "Rule",
-        "Description": "Root account activity was detected.",
+        "Description": "Root account activity that modifies AWS resources or configuration was detected. Read-only root events (enumeration, console reads) are excluded \u2014 only impactful root actions trigger this rule.",
         "DisplayName": "Root Account Activity",
         "LogTypes": [
             "AWS.CloudTrail"

--- a/rules/aws_cloudtrail_rules/aws_root_activity.py
+++ b/rules/aws_cloudtrail_rules/aws_root_activity.py
@@ -10,6 +10,7 @@ def rule(event):
         and event.deep_get("userIdentity", "invokedBy") is None
         and event.get("eventType") != "AwsServiceEvent"
         and event.get("eventName") not in EVENT_ALLOW_LIST
+        and not event.get("readOnly")
     )
 
 
@@ -17,9 +18,7 @@ def dedup(event):
     return (
         event.get("sourceIPAddress", "<UNKNOWN_IP>")
         + ":"
-        + event.get("recipientAccountId")
-        + ":"
-        + str(event.get("readOnly"))
+        + event.get("recipientAccountId", "<UNKNOWN_ACCOUNT>")
     )
 
 
@@ -40,9 +39,3 @@ def alert_context(event):
         "eventTime": event.get("eventTime"),
         "mfaUsed": event.deep_get("additionalEventData", "MFAUsed"),
     }
-
-
-def severity(event):
-    if event.get("readOnly"):
-        return "LOW"
-    return "HIGH"

--- a/rules/aws_cloudtrail_rules/aws_root_activity.py
+++ b/rules/aws_cloudtrail_rules/aws_root_activity.py
@@ -15,11 +15,7 @@ def rule(event):
 
 
 def dedup(event):
-    return (
-        event.get("sourceIPAddress", "<UNKNOWN_IP>")
-        + ":"
-        + event.get("recipientAccountId", "<UNKNOWN_ACCOUNT>")
-    )
+    return event.get("sourceIPAddress", "<UNKNOWN_IP>")
 
 
 def title(event):

--- a/rules/aws_cloudtrail_rules/aws_root_activity.yml
+++ b/rules/aws_cloudtrail_rules/aws_root_activity.yml
@@ -18,7 +18,7 @@ Reports:
     - TA0004:T1078
 Severity: High
 Description: >
-  Root account activity was detected.
+  Root account activity that modifies AWS resources or configuration was detected. Read-only root events (enumeration, console reads) are excluded — only impactful root actions trigger this rule.
 Runbook: >
   Investigate the usage of the root account. If this root activity was not authorized, immediately change the root credentials and investigate what actions the root account took.
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html
@@ -254,5 +254,31 @@ Tests:
           },
         "eventID": "1",
         "eventType": "AwsConsoleSignIn",
+        "recipientAccountId": "123456789012",
+      }
+  - Name: Root Read-Only Enumeration
+    ExpectedResult: false
+    Log:
+      {
+        "eventVersion": "1.08",
+        "userIdentity":
+          {
+            "type": "Root",
+            "principalId": "123456789012",
+            "arn": "arn:aws:iam::123456789012:root",
+            "accountId": "123456789012",
+            "accessKeyId": "1",
+          },
+        "eventTime": "2019-01-01T00:00:00Z",
+        "eventSource": "iam.amazonaws.com",
+        "eventName": "ListAccessKeys",
+        "awsRegion": "us-east-1",
+        "sourceIPAddress": "111.111.111.111",
+        "userAgent": "Mozilla",
+        "readOnly": true,
+        "requestParameters": null,
+        "responseElements": null,
+        "eventID": "1",
+        "eventType": "AwsApiCall",
         "recipientAccountId": "123456789012",
       }


### PR DESCRIPTION
### Background
THREAT-732

<High level overview here>

### Changes

- Simplify dedup() to source IP only. With read-only events filtered
  at rule(), the previous IP:account:readOnly key was effectively
  IP:account, which still fans out one alert per touched account.
  Bulk root operations from a single IP (e.g., org-wide credential
  cleanup, but also a single-IP attacker touching N accounts) now
  collapse to one alert. Tradeoff: analysts must inspect the alert's
  event list to see full account scope.
### Testing

- <Testing steps>
