### PR TITLE
dependency cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "pip" # covers Pipfile and Pipfile.lock (incl. transitive deps)
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
### Background

adding a cooldown to both ecosystems both to avoid constant PRs and to try to mitigate supply-chain attacks. See https://docs.zizmor.sh/audits/#dependabot-cooldown https://github.com/panther-labs/panther-analysis/pull/2104#pullrequestreview-4549532633