### PR TITLE
disable correlation rules by default

### DIFF
--- a/correlation_rules/auth0_account_takeover.yml
+++ b/correlation_rules/auth0_account_takeover.yml
@@ -24,9 +24,9 @@ Detection:
           - GroupID: DeleteUser
             Match: p_alert_context.actor.email
       Schedule:
-        RateMinutes: 10
+        RateMinutes: 1440
         TimeoutMinutes: 5
-      LookbackWindowMinutes: 15
+      LookbackWindowMinutes: 1800
 Tests:
     - Name: New Admin Invited FOLLOWED BY Tenant Member Account Deletion
       ExpectedResult: true

--- a/correlation_rules/auth0_account_takeover.yml
+++ b/correlation_rules/auth0_account_takeover.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "Auth0.AdminInvited.WITH.TenantMemberDeletion"
 DisplayName: "Auth0 New Admin Invited WITH Tenant Member Account Deletion"
-Enabled: true
+Enabled: false
 Tags:
     - Auth0
 Severity: High

--- a/correlation_rules/aws_cloudtrail_stopinstance_followed_by_modifyinstanceattributes.yml
+++ b/correlation_rules/aws_cloudtrail_stopinstance_followed_by_modifyinstanceattributes.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "AWS.EC2.StopInstance.WITH.ModifyInstanceAttributes"
 DisplayName: "StopInstance WITH ModifyInstanceAttributes"
-Enabled: true
+Enabled: false
 Severity: High
 Description: Identifies when StopInstance and ModifyInstanceAttributes CloudTrail events occur in a short period of time. Since EC2 startup scripts cannot be modified without first stopping the instance, StopInstances should be a signal.
 Reference: https://unit42.paloaltonetworks.com/malicious-operations-of-exposed-iam-keys-cryptojacking/

--- a/correlation_rules/aws_cloudtrail_stopinstance_followed_by_modifyinstanceattributes.yml
+++ b/correlation_rules/aws_cloudtrail_stopinstance_followed_by_modifyinstanceattributes.yml
@@ -20,9 +20,9 @@ Detection:
             Match: p_alert_context.instance_ids
           - GroupID: StartupScriptChange
             Match: p_alert_context.instance_ids
-      LookbackWindowMinutes: 90
+      LookbackWindowMinutes: 1800
       Schedule:
-        RateMinutes: 60
+        RateMinutes: 1440
         TimeoutMinutes: 5
 Tests:
     - Name: Instance Stopped, Followed By Script Change

--- a/correlation_rules/aws_console_sign-in_without_okta.yml
+++ b/correlation_rules/aws_console_sign-in_without_okta.yml
@@ -23,9 +23,9 @@ Detection:
           - GroupID: AWS Console Sign-In
             Match: userIdentity.userName
       Schedule:
-        RateMinutes: 10
+        RateMinutes: 1440
         TimeoutMinutes: 5
-      LookbackWindowMinutes: 15
+      LookbackWindowMinutes: 1800
 Tests:
   - Name: AWS Console Sign-In PRECEDED BY Okta Redirect
     ExpectedResult: false

--- a/correlation_rules/aws_create_admin_iam_user.yml
+++ b/correlation_rules/aws_create_admin_iam_user.yml
@@ -22,9 +22,9 @@ Detection:
             Match: p_alert_context.request_username
           - GroupID: AttachAdminUserPolicy
             Match: p_alert_context.request_username
-      LookbackWindowMinutes: 60
+      LookbackWindowMinutes: 1800
       Schedule:
-        RateMinutes: 40
+        RateMinutes: 1440
         TimeoutMinutes: 5
 Tests:
     - Name: User Created, Followed By Admin Policy Attachment

--- a/correlation_rules/aws_create_admin_iam_user.yml
+++ b/correlation_rules/aws_create_admin_iam_user.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "AWS.Administrative.IAM.User.Created.Group"
 DisplayName: "AWS Administrative IAM User Created"
-Enabled: true
+Enabled: false
 Severity: Info
 Tags:
   - Beta

--- a/correlation_rules/aws_create_backdoor_admin_iam_role.yml
+++ b/correlation_rules/aws_create_backdoor_admin_iam_role.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "AWS.Backdoor.Administrative.IAM.Role.Created.Group"
 DisplayName: "AWS Backdoor Administrative IAM Role Created"
-Enabled: true
+Enabled: false
 Severity: High
 Description: Identifies when CreateRole and AttachAdminRolePolicy CloudTrail events occur in a short period of time. This sequence could indicate a potential security breach.
 Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html

--- a/correlation_rules/aws_create_backdoor_admin_iam_role.yml
+++ b/correlation_rules/aws_create_backdoor_admin_iam_role.yml
@@ -20,9 +20,9 @@ Detection:
             Match: p_alert_context.request_rolename
           - GroupID: AttachAdminRolePolicy
             Match: p_alert_context.request_rolename
-      LookbackWindowMinutes: 90
+      LookbackWindowMinutes: 1800
       Schedule:
-        RateMinutes: 30
+        RateMinutes: 1440
         TimeoutMinutes: 5
 Tests:
     - Name: Role Created, Followed By Policy Attachment

--- a/correlation_rules/aws_privilege_escalation_via_user_compromise.yml
+++ b/correlation_rules/aws_privilege_escalation_via_user_compromise.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "AWS.Privilege.Escalation.Via.User.Compromise.Group"
 DisplayName: "AWS Privilege Escalation Via User Compromise"
-Enabled: true
+Enabled: false
 Severity: Medium
 Reports:
   MITRE ATT&CK:

--- a/correlation_rules/aws_privilege_escalation_via_user_compromise.yml
+++ b/correlation_rules/aws_privilege_escalation_via_user_compromise.yml
@@ -19,9 +19,9 @@ Detection:
           - GroupID: User Accessed
             Match: p_alert_context.ip_accessKeyId
       Schedule:
-        RateMinutes: 40
+        RateMinutes: 1440
         TimeoutMinutes: 10
-      LookbackWindowMinutes: 60
+      LookbackWindowMinutes: 1800
 Tests:
     - Name: Access Key Created and Used from Same IP
       ExpectedResult: true

--- a/correlation_rules/aws_s3_disable_security_controls.yml
+++ b/correlation_rules/aws_s3_disable_security_controls.yml
@@ -38,9 +38,9 @@ Detection:
           Match: p_alert_context.bucketName
         - GroupID: MFA Delete Disabled
           Match: p_alert_context.bucketName
-    LookbackWindowMinutes: 90
+    LookbackWindowMinutes: 1800
     Schedule:
-      RateMinutes: 60
+      RateMinutes: 1440
       TimeoutMinutes: 10
 Tests:
   - Name: Suspicious Security Control Disabling

--- a/correlation_rules/aws_s3_exfiltration_and_deletion.yml
+++ b/correlation_rules/aws_s3_exfiltration_and_deletion.yml
@@ -36,9 +36,9 @@ Detection:
           - GroupID: Bulk Deletion
             Match: p_alert_context.bucketName
       Schedule:
-        RateMinutes: 15
+        RateMinutes: 1440
         TimeoutMinutes: 10
-      LookbackWindowMinutes: 30
+      LookbackWindowMinutes: 1800
 Tests:
   - Name: Ransomware Attack Sequence
     ExpectedResult: true

--- a/correlation_rules/aws_s3_exfiltration_and_deletion.yml
+++ b/correlation_rules/aws_s3_exfiltration_and_deletion.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "AWS.S3.ObjectExfiltration.WITH.ObjectDeletion"
 DisplayName: "AWS S3 Object Exfiltration WITH Object Deletion"
-Enabled: true
+Enabled: false
 Severity: High
 Description: >
   Detects a ransomware attack pattern where an attacker with compromised AWS credentials exfiltrates data from an S3 bucket

--- a/correlation_rules/aws_sso_access_token_retrieved_by_unauthenticated_ip.yml
+++ b/correlation_rules/aws_sso_access_token_retrieved_by_unauthenticated_ip.yml
@@ -22,9 +22,9 @@ Detection:
           - GroupID: SSO Access Token Retrieved
             Match: sourceIPAddress
       Schedule:
-        RateMinutes: 80
+        RateMinutes: 1440
         TimeoutMinutes: 5
-      LookbackWindowMinutes: 120
+      LookbackWindowMinutes: 1800
 Tests:
   - Name: AWS SSO Access Token Retrieved by Authenticated IP
     ExpectedResult: false

--- a/correlation_rules/aws_sso_access_token_retrieved_by_unauthenticated_ip.yml
+++ b/correlation_rules/aws_sso_access_token_retrieved_by_unauthenticated_ip.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "AWS.SSO.Access.Token.Retrieved.by.Unauthenticated.IP.Group"
 DisplayName: "AWS SSO Access Token Retrieved by Unauthenticated IP"
-Enabled: true
+Enabled: false
 Severity: Medium
 Description: |-
     When using AWS in an enterprise environment, best practices dictate to use a single sign-on service for identity and access management. AWS SSO is a popular solution, integrating with third-party providers such as Okta and allowing to centrally manage roles and permissions in multiple AWS accounts.

--- a/correlation_rules/aws_user_takeover_via_password_reset.yml
+++ b/correlation_rules/aws_user_takeover_via_password_reset.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "AWS.User.Takeover.Via.Password.Reset.Group"
 DisplayName: "AWS User Takeover Via Password Reset"
-Enabled: true
+Enabled: false
 Severity: High
 Reports:
   MITRE ATT&CK:

--- a/correlation_rules/aws_user_takeover_via_password_reset.yml
+++ b/correlation_rules/aws_user_takeover_via_password_reset.yml
@@ -19,9 +19,9 @@ Detection:
           - GroupID: Login
             Match: p_alert_context.ip_and_username
       Schedule:
-        RateMinutes: 30
+        RateMinutes: 1440
         TimeoutMinutes: 10
-      LookbackWindowMinutes: 90
+      LookbackWindowMinutes: 1800
 Tests:
     - Name: Password Reset, Then Login From Same IP
       ExpectedResult: true

--- a/correlation_rules/azure_storage_cpk_ransomware.yml
+++ b/correlation_rules/azure_storage_cpk_ransomware.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "Azure.Storage.BlobUpload.WITH.CPKEncryptionError"
 DisplayName: "Azure Storage Blob Upload WITH CPK Encryption Error"
-Enabled: true
+Enabled: false
 Severity: High
 Description: >
   Detects potential CPK-based ransomware attacks on Azure Storage by correlating blob

--- a/correlation_rules/azure_storage_cpk_ransomware.yml
+++ b/correlation_rules/azure_storage_cpk_ransomware.yml
@@ -32,9 +32,9 @@ Detection:
           - GroupID: CPK Access Denied
             Match: p_alert_context.blob_path
       Schedule:
-        RateMinutes: 40
+        RateMinutes: 1440
         TimeoutMinutes: 5
-      LookbackWindowMinutes: 60
+      LookbackWindowMinutes: 1800
 Tests:
   - Name: CPK Ransomware Pattern
     ExpectedResult: true

--- a/correlation_rules/gaia_credential_theft_attack_chain.yml
+++ b/correlation_rules/gaia_credential_theft_attack_chain.yml
@@ -39,9 +39,9 @@ Detection:
         - GroupID: Google Login Anomaly
           Match: p_alert_context.username_normalized
     Schedule:
-      RateMinutes: 240
+      RateMinutes: 1440
       TimeoutMinutes: 10
-    LookbackWindowMinutes: 360
+    LookbackWindowMinutes: 1800
 Tests:
   - Name: Credential dump followed by login anomaly for same user
     ExpectedResult: true

--- a/correlation_rules/gcp_cloud_run_service_create_followed_by_set_iam_policy.yml
+++ b/correlation_rules/gcp_cloud_run_service_create_followed_by_set_iam_policy.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "GCP.Cloud.Run.Service.Created.WITH.Set.IAM.Policy"
 DisplayName: "GCP Cloud Run Service Created WITH Set IAM Policy"
-Enabled: true
+Enabled: false
 Severity: High
 Description: Detects run.services.create method for privilege escalation in GCP. The exploit creates a new Cloud Run 
   Service that, when invoked, returns the Service Account's access token by accessing the metadata API of the server 

--- a/correlation_rules/gcp_cloud_run_service_create_followed_by_set_iam_policy.yml
+++ b/correlation_rules/gcp_cloud_run_service_create_followed_by_set_iam_policy.yml
@@ -23,9 +23,9 @@ Detection:
             Match: p_alert_context.caller_ip
           - GroupID: SetIAMPolicy
             Match: p_alert_context.caller_ip
-      LookbackWindowMinutes: 90
+      LookbackWindowMinutes: 1800
       Schedule:
-        RateMinutes: 60
+        RateMinutes: 1440
         TimeoutMinutes: 5
 Tests:
     - Name: GCP Service Run, Followed By IAM Policy Change From Same IP

--- a/correlation_rules/gcp_tag_escalation.yml
+++ b/correlation_rules/gcp_tag_escalation.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "GCP.Privilege.Escalation.Via.TagBinding.Group"
 DisplayName: "GCP Privilege Escalation via TagBinding"
-Enabled: true
+Enabled: false
 Severity: Info
 Description: >
   Detects a sequence of events that could indicate a privilege escalation attempt

--- a/correlation_rules/gcp_tag_escalation.yml
+++ b/correlation_rules/gcp_tag_escalation.yml
@@ -33,9 +33,9 @@ Detection:
           - GroupID: PrivilegedOperation
             Match: p_alert_context.principal
       Schedule:
-        RateMinutes: 20
+        RateMinutes: 1440
         TimeoutMinutes: 10
-      LookbackWindowMinutes: 30
+      LookbackWindowMinutes: 1800
 Tags:
     - attack.privilege_escalation
     - attack.t1548

--- a/correlation_rules/github_advanced_security_change_not_followed_by_repo_archived.yml
+++ b/correlation_rules/github_advanced_security_change_not_followed_by_repo_archived.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "GitHub.Advanced.Security.Change.NOT.FOLLOWED.BY.Repo.Archived"
 DisplayName: "GitHub Advanced Security Change WITHOUT Repo Archived"
-Enabled: true
+Enabled: false
 Severity: Critical
 Tags:
   - GitHub

--- a/correlation_rules/github_advanced_security_change_not_followed_by_repo_archived.yml
+++ b/correlation_rules/github_advanced_security_change_not_followed_by_repo_archived.yml
@@ -32,9 +32,9 @@ Detection:
       - GroupID: RepoArchived
         Match: p_alert_context.repo
     EventEvaluationOrder: Chronological
-    LookbackWindowMinutes: 90
+    LookbackWindowMinutes: 1800
     Schedule:
-      RateMinutes: 60
+      RateMinutes: 1440
       TimeoutMinutes: 10
 Tests:
     - Name: Security Change on Repo, Followed By Same Repo Archived

--- a/correlation_rules/github_artifact_download_from_forked_repo.yml
+++ b/correlation_rules/github_artifact_download_from_forked_repo.yml
@@ -38,9 +38,9 @@ Detection:
         - GroupID: ArtifactDownload
           Match: workflow_job.run_id
     EventEvaluationOrder: Chronological
-    LookbackWindowMinutes: 90
+    LookbackWindowMinutes: 1800
     Schedule:
-      RateMinutes: 60
+      RateMinutes: 1440
       TimeoutMinutes: 10
 Tests:
   - Name: cross-fork workflow with artifact download

--- a/correlation_rules/github_artifact_download_from_forked_repo.yml
+++ b/correlation_rules/github_artifact_download_from_forked_repo.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "GitHub.ArtifactDownload.FROM.CrossFork.Workflow"
 DisplayName: "GitHub Artifact Download from Cross-Fork Workflow"
-Enabled: true
+Enabled: false
 Severity: Medium
 Tags:
   - CI/CD

--- a/correlation_rules/github_pull_request_target_with_checkout_in_workflow.yml
+++ b/correlation_rules/github_pull_request_target_with_checkout_in_workflow.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "GitHub.PullRequestTarget.WITH.Checkout.In.Workflow"
 DisplayName: "GitHub pull_request_target Workflow with Checkout Action"
-Enabled: true
+Enabled: false
 Severity: Medium
 Tags:
   - CI/CD

--- a/correlation_rules/github_pull_request_target_with_checkout_in_workflow.yml
+++ b/correlation_rules/github_pull_request_target_with_checkout_in_workflow.yml
@@ -60,9 +60,9 @@ Detection:
         - GroupID: WorkflowCheckout
           Match: workflow_job.run_id
     EventEvaluationOrder: Chronological
-    LookbackWindowMinutes: 90
+    LookbackWindowMinutes: 1800
     Schedule:
-      RateMinutes: 60
+      RateMinutes: 1440
       TimeoutMinutes: 10
 Tests:
   - Name: pull_request_target with checkout in same workflow

--- a/correlation_rules/github_pull_request_target_with_self_hosted_runner.yml
+++ b/correlation_rules/github_pull_request_target_with_self_hosted_runner.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "GitHub.PullRequestTarget.WITH.SelfHostedRunner"
 DisplayName: "GitHub pull_request_target Workflow on Self-Hosted Runner"
-Enabled: true
+Enabled: false
 Severity: High
 Tags:
   - CI/CD

--- a/correlation_rules/github_pull_request_target_with_self_hosted_runner.yml
+++ b/correlation_rules/github_pull_request_target_with_self_hosted_runner.yml
@@ -70,9 +70,9 @@ Detection:
         - GroupID: SelfHostedRunner
           Match: workflow_job.run_id
     EventEvaluationOrder: Chronological
-    LookbackWindowMinutes: 90
+    LookbackWindowMinutes: 1800
     Schedule:
-      RateMinutes: 60
+      RateMinutes: 1440
       TimeoutMinutes: 10
 Tests:
   - Name: pull_request_target with self-hosted runner

--- a/correlation_rules/notion_login_followed_by_account_change.yml
+++ b/correlation_rules/notion_login_followed_by_account_change.yml
@@ -21,9 +21,9 @@ Detection:
             Match: p_alert_context.actor_id
           - GroupID: AccountChange
             Match: p_alert_context.actor_id
-      LookbackWindowMinutes: 15
+      LookbackWindowMinutes: 1800
       Schedule:
-        RateMinutes: 10
+        RateMinutes: 1440
         TimeoutMinutes: 5
 Tests:
     - Name: Login, Followed By AccountChange within short time

--- a/correlation_rules/notion_login_followed_by_account_change.yml
+++ b/correlation_rules/notion_login_followed_by_account_change.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "Notion.Login.WITH.AccountChange"
 DisplayName: "Notion Login WITH AccountChange"
-Enabled: true
+Enabled: false
 Severity: Medium
 Description: A Notion User logged in then changed their account details.
 Reference: https://www.notion.so/help/account-settings

--- a/correlation_rules/okta_login_without_push.yml
+++ b/correlation_rules/okta_login_without_push.yml
@@ -35,9 +35,9 @@ Detection:
         - GroupID: Okta
           Match: actor.alternateId
     Schedule:
-      RateMinutes: 40
+      RateMinutes: 1440
       TimeoutMinutes: 10
-    LookbackWindowMinutes: 60
+    LookbackWindowMinutes: 1800
 Tests:
   - Name: Okta Login WITH Push Authorized Login In Window
     ExpectedResult: false

--- a/correlation_rules/onelogin_successful_login_after_high_risk_failed_login.yml
+++ b/correlation_rules/onelogin_successful_login_after_high_risk_failed_login.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "OneLogin.HighRiskFailedLogin.WITH.SuccessfulLogin"
 DisplayName: "OneLogin High Risk Failed Login WITH Successful Login"
-Enabled: true
+Enabled: false
 Severity: Medium
 Description: A OneLogin user successfully logged in after a failed high-risk login attempt.
 Reference: https://resources.onelogin.com/OneLogin_RiskBasedAuthentication-WP-v5.pdf

--- a/correlation_rules/onelogin_successful_login_after_high_risk_failed_login.yml
+++ b/correlation_rules/onelogin_successful_login_after_high_risk_failed_login.yml
@@ -21,9 +21,9 @@ Detection:
             Match: user_name
           - GroupID: SuccessfulLogin
             Match: user_name
-      LookbackWindowMinutes: 15
+      LookbackWindowMinutes: 1800
       Schedule:
-        RateMinutes: 10
+        RateMinutes: 1440
         TimeoutMinutes: 5
 Tests:
     - Name: High Risk Failed Login FOLLOWED BY Successful Login within short time

--- a/correlation_rules/openai_brute_force_login_success.yml
+++ b/correlation_rules/openai_brute_force_login_success.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "OpenAI.BruteForce.Login.Success.Group"
 DisplayName: "OpenAI Brute Force Login Success"
-Enabled: true
+Enabled: false
 Severity: High
 Description: |
   Detects successful credential stuffing or brute force attacks against OpenAI accounts.

--- a/correlation_rules/openai_brute_force_login_success.yml
+++ b/correlation_rules/openai_brute_force_login_success.yml
@@ -38,9 +38,9 @@ Detection:
         - GroupID: Successful Login
           Match: p_any_emails
     Schedule:
-      RateMinutes: 20
+      RateMinutes: 1440
       TimeoutMinutes: 5
-    LookbackWindowMinutes: 30
+    LookbackWindowMinutes: 1800
 Tests:
   - Name: "5 Failed Logins FOLLOWED BY Successful Login"
     ExpectedResult: true

--- a/correlation_rules/potential_compromised_okta_credentials.yml
+++ b/correlation_rules/potential_compromised_okta_credentials.yml
@@ -35,9 +35,9 @@ Detection:
         - GroupID: Push Phishing
           Match: new.employee.email
     Schedule:
-      RateMinutes: 40
+      RateMinutes: 1440
       TimeoutMinutes: 10
-    LookbackWindowMinutes: 60
+    LookbackWindowMinutes: 1800
 Tests:
   - Name: Login Without Marker, Followed By Phishing Detection
     ExpectedResult: true

--- a/correlation_rules/secret_exposed_and_not_quarantined.yml
+++ b/correlation_rules/secret_exposed_and_not_quarantined.yml
@@ -19,9 +19,9 @@ Detection:
         - ID: SecretFound
           RuleID: GitHub.Secret.Scanning.Alert.Created
       Schedule:
-        RateMinutes: 40
+        RateMinutes: 1440
         TimeoutMinutes: 10
-      LookbackWindowMinutes: 60
+      LookbackWindowMinutes: 1800
 Tests:
     - Name: Secret Found and Quarantined
       ExpectedResult: false

--- a/correlation_rules/snowflake_data_exfiltration.yml
+++ b/correlation_rules/snowflake_data_exfiltration.yml
@@ -39,7 +39,7 @@ Detection:
     Schedule:
       RateMinutes: 1440
       TimeoutMinutes: 15
-    LookbackWindowMinutes: 2160
+    LookbackWindowMinutes: 1800
 Tests:
     - Name: Data Exfiltration
       ExpectedResult: true

--- a/correlation_rules/snowflake_data_exfiltration.yml
+++ b/correlation_rules/snowflake_data_exfiltration.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "Snowflake.Data.Exfiltration.Group"
 DisplayName: "Snowflake Data Exfiltration"
-Enabled: true
+Enabled: false
 Tags:
   - Snowflake
   - Data Exfiltration

--- a/correlation_rules/snowflake_data_exfiltration_streaming.yml
+++ b/correlation_rules/snowflake_data_exfiltration_streaming.yml
@@ -39,7 +39,7 @@ Detection:
     Schedule:
       RateMinutes: 1440
       TimeoutMinutes: 15
-    LookbackWindowMinutes: 2160
+    LookbackWindowMinutes: 1800
 Tests:
     - Name: Data Exfiltration
       ExpectedResult: true

--- a/correlation_rules/snowflake_data_exfiltration_streaming.yml
+++ b/correlation_rules/snowflake_data_exfiltration_streaming.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "Snowflake.Stream.DataExfiltration.Group"
 DisplayName: "Snowflake Data Exfiltration"
-Enabled: true
+Enabled: false
 Tags:
   - Snowflake
   - Data Exfiltration

--- a/correlation_rules/snowflake_potential_brute_force_success.yml
+++ b/correlation_rules/snowflake_potential_brute_force_success.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "Snowflake.PotentialBruteForceSuccess.Group"
 DisplayName: "Snowflake Brute Force Login Success"
-Enabled: true
+Enabled: false
 Severity: High
 Description: Detecting brute force activity and reporting when a user has incorrectly logged in multiple times and then had a successful login.
 Detection:

--- a/correlation_rules/snowflake_potential_brute_force_success.yml
+++ b/correlation_rules/snowflake_potential_brute_force_success.yml
@@ -18,9 +18,9 @@ Detection:
         - GroupID: Successful Login
           Match: CLIENT_IP
     Schedule:
-      RateMinutes: 20
+      RateMinutes: 1440
       TimeoutMinutes: 15
-    LookbackWindowMinutes: 30
+    LookbackWindowMinutes: 1800
 Tests:
     - Name: Successful Bulk Login
       ExpectedResult: true

--- a/correlation_rules/wiz_issue_followed_by_ssh.yml
+++ b/correlation_rules/wiz_issue_followed_by_ssh.yml
@@ -1,7 +1,7 @@
 AnalysisType: correlation_rule
 RuleID: "Wiz.Issue.WITH.SSH"
 DisplayName: "Wiz Issue WITH SSH to EC2 Instance"
-Enabled: true
+Enabled: false
 Severity: High
 Tags:
     - Configuration Required

--- a/correlation_rules/wiz_issue_followed_by_ssh.yml
+++ b/correlation_rules/wiz_issue_followed_by_ssh.yml
@@ -22,9 +22,9 @@ Detection:
             Match: entitySnapshot.externalId
           - GroupID: SSH Access
             Match: instanceId
-      LookbackWindowMinutes: 60
+      LookbackWindowMinutes: 1800
       Schedule:
-        RateMinutes: 40
+        RateMinutes: 1440
         TimeoutMinutes: 5
 Tests:
     - Name: Wiz Issue Followed By SSH

--- a/indexes/alpha-index.md
+++ b/indexes/alpha-index.md
@@ -194,7 +194,6 @@
   - Identifies when a permission is added to a Lambda function, which could indicate a potential security risk.
 - [AWS Potentially Stolen Service Role](../queries/aws_queries/aws_potentially_compromised_service_role_query.yml)
   - A role was assumed by an AWS service, followed by a user within 24 hours.  This could indicate a stolen or compromised AWS service role.
-- [AWS Privilege Escalation Via User Compromise](../correlation_rules/aws_privilege_escalation_via_user_compromise.yml)
 - [AWS Public RDS Restore](../rules/aws_cloudtrail_rules/aws_rds_publicrestore.yml)
   - Detects the recovery of a new public database instance from a snapshot. It may be part of data exfiltration.
 - [AWS RDS Activity Stream Stopped](../rules/aws_cloudtrail_rules/aws_rds_activity_stream_stopped.yml)
@@ -283,7 +282,6 @@
   - Detects AWS API key creation for a user by another user. Backdoored users can be used to obtain persistence in the AWS environment.
 - [AWS User Login Profile Created or Modified](../rules/aws_cloudtrail_rules/aws_cloudtrail_loginprofilecreatedormodified.yml)
   - An attacker with iam:UpdateLoginProfile permission on other users can change the password used to login to the AWS console. May be legitimate account administration.
-- [AWS User Takeover Via Password Reset](../correlation_rules/aws_user_takeover_via_password_reset.yml)
 - [AWS VPC Flow Logs Removed](../rules/aws_cloudtrail_rules/aws_vpc_flow_logs_deleted.yml)
   - Detects when logs for a VPC have been removed.
 - [AWS WAF Disassociation](../rules/aws_cloudtrail_rules/aws_waf_disassociation.yml)

--- a/indexes/aws.md
+++ b/indexes/aws.md
@@ -142,7 +142,6 @@
   - Identifies when a permission is added to a Lambda function, which could indicate a potential security risk.
 - [AWS Potentially Stolen Service Role](../queries/aws_queries/aws_potentially_compromised_service_role_query.yml)
   - A role was assumed by an AWS service, followed by a user within 24 hours.  This could indicate a stolen or compromised AWS service role.
-- [AWS Privilege Escalation Via User Compromise](../correlation_rules/aws_privilege_escalation_via_user_compromise.yml)
 - [AWS Public RDS Restore](../rules/aws_cloudtrail_rules/aws_rds_publicrestore.yml)
   - Detects the recovery of a new public database instance from a snapshot. It may be part of data exfiltration.
 - [AWS RDS Activity Stream Stopped](../rules/aws_cloudtrail_rules/aws_rds_activity_stream_stopped.yml)
@@ -231,7 +230,6 @@
   - Detects AWS API key creation for a user by another user. Backdoored users can be used to obtain persistence in the AWS environment.
 - [AWS User Login Profile Created or Modified](../rules/aws_cloudtrail_rules/aws_cloudtrail_loginprofilecreatedormodified.yml)
   - An attacker with iam:UpdateLoginProfile permission on other users can change the password used to login to the AWS console. May be legitimate account administration.
-- [AWS User Takeover Via Password Reset](../correlation_rules/aws_user_takeover_via_password_reset.yml)
 - [AWS VPC Flow Logs Removed](../rules/aws_cloudtrail_rules/aws_vpc_flow_logs_deleted.yml)
   - Detects when logs for a VPC have been removed.
 - [AWS WAF Disassociation](../rules/aws_cloudtrail_rules/aws_waf_disassociation.yml)

--- a/indexes/detection-coverage.json
+++ b/indexes/detection-coverage.json
@@ -1791,15 +1791,6 @@
         "YAMLPath": "queries/aws_queries/aws_potentially_compromised_service_role_query.yml"
     },
     {
-        "AnalysisType": "Correlation Rule",
-        "Description": "",
-        "DisplayName": "AWS Privilege Escalation Via User Compromise",
-        "LogTypes": [
-            "AWS.CloudTrail"
-        ],
-        "YAMLPath": "correlation_rules/aws_privilege_escalation_via_user_compromise.yml"
-    },
-    {
         "AnalysisType": "Rule",
         "Description": "Detects the recovery of a new public database instance from a snapshot. It may be part of data exfiltration.",
         "DisplayName": "AWS Public RDS Restore",
@@ -2623,15 +2614,6 @@
             "AWS.CloudTrail"
         ],
         "YAMLPath": "rules/aws_cloudtrail_rules/aws_cloudtrail_loginprofilecreatedormodified.yml"
-    },
-    {
-        "AnalysisType": "Correlation Rule",
-        "Description": "",
-        "DisplayName": "AWS User Takeover Via Password Reset",
-        "LogTypes": [
-            "AWS.CloudTrail"
-        ],
-        "YAMLPath": "correlation_rules/aws_user_takeover_via_password_reset.yml"
     },
     {
         "AnalysisType": "Policy",


### PR DESCRIPTION
Correlation rules should only be enabled if the underlying data sources are available.
