### PR TITLE
Tune AWS.CloudTrail.IMDSCredentialExfiltration

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_imds_credential_exfiltration.py
+++ b/rules/aws_cloudtrail_rules/aws_imds_credential_exfiltration.py
@@ -2,6 +2,7 @@ import ipaddress
 import re
 
 from panther_aws_helpers import aws_rule_context
+from panther_ipinfo_helpers import get_ipinfo_asn
 
 # IMDS credentials appear as assumed-role sessions where the session name
 # is an EC2 instance ID (i-xxxxxxxxxxxxxxxxx)
@@ -32,6 +33,14 @@ def _is_private_ip(ip_str):
         return False
 
 
+def _is_amazon_domain(event):
+    """Check if the source IP's ipinfo ASN enrichment resolves to an amazon.com domain."""
+    ipinfo_asn = get_ipinfo_asn(event)
+    if not ipinfo_asn:
+        return False
+    return ipinfo_asn.domain("sourceIPAddress") == "amazon.com"
+
+
 def rule(event):
     arn = event.deep_get("userIdentity", "arn", default="")
     if not INSTANCE_SESSION_PATTERN.search(arn):
@@ -50,6 +59,14 @@ def rule(event):
     if source_ip in INTERNAL_IPS or source_ip.endswith(".amazonaws.com"):
         return False
     return _is_valid_ip(source_ip) and not _is_private_ip(source_ip)
+
+
+def severity(event):
+    # Source IPs that resolve to an amazon.com ASN domain are lower risk
+    # (e.g. AWS-managed infrastructure making calls on the instance's behalf)
+    if _is_amazon_domain(event):
+        return "INFO"
+    return "DEFAULT"
 
 
 def title(event):

--- a/rules/aws_cloudtrail_rules/aws_imds_credential_exfiltration.yml
+++ b/rules/aws_cloudtrail_rules/aws_imds_credential_exfiltration.yml
@@ -193,3 +193,44 @@ Tests:
           "type": "AssumedRole"
         }
       }
+  - Name: IMDS Credentials Used From Amazon.com ASN Source IP
+    ExpectedResult: true
+    Log:
+      {
+        "awsRegion": "us-east-1",
+        "eventName": "DescribeInstances",
+        "eventSource": "ec2.amazonaws.com",
+        "eventTime": "2024-01-15T10:30:00Z",
+        "eventType": "AwsApiCall",
+        "recipientAccountId": "123456789012",
+        "sourceIPAddress": "52.42.146.205",
+        "userAgent": "aws-cli/2.15.0",
+        "userIdentity": {
+          "accessKeyId": "ASIAIOSFODNN7EXAMPLE",
+          "accountId": "123456789012",
+          "arn": "arn:aws:sts::123456789012:assumed-role/MyAppRole/i-0abcdef1234567890",
+          "principalId": "AROAEXAMPLE:i-0abcdef1234567890",
+          "type": "AssumedRole",
+          "sessionContext": {
+            "sessionIssuer": {
+              "type": "Role",
+              "arn": "arn:aws:iam::123456789012:role/MyAppRole"
+            }
+          }
+        },
+        "p_enrichment":
+          {
+            "ipinfo_asn":
+              {
+                "sourceIPAddress":
+                  {
+                    "asn": "AS16509",
+                    "domain": "amazon.com",
+                    "name": "Amazon.com, Inc.",
+                    "p_match": "52.42.146.205",
+                    "route": "52.40.0.0/14",
+                    "type": "hosting",
+                  },
+              },
+          },
+      }


### PR DESCRIPTION
 ### Background

AWS.CloudTrail.IMDSCredentialExfiltration was triggering on automation routing through VPC NAT gateways.

### Changes

- Tuned AWS.CloudTrail.IMDSCredentialExfiltration to use panther_ipinfo_helpers.get_ipinfo_asn — added a severity() function that downgrades the alert to INFO when sourceIPAddress resolves to an amazon.com ASN domain (e.g. NAT gateway egress), instead of hardcoding the specific IP or role.

### Testing

- Added a matching test case with p_enrichment.ipinfo_asn.sourceIPAddress data and [severity] INFO assertion; all 10 tests pass.
