### PR TITLE
Add GTI/VirusTotal enrichment helpers

### DIFF
--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -495,6 +495,28 @@ class TestGreyNoiseV3ScannerIntelligence(
         self.assertEqual(scanner.cve_list("nonexistent"), [])
         self.assertEqual(scanner.tag_names("nonexistent"), [])
 
+    def test_find_lut_name_handles_list_shaped_match(self):
+        event = PantherEvent(
+            {
+                "p_enrichment": {
+                    "my_custom_greynoise_noise": {
+                        "MultiMatch": [
+                            {
+                                "ip": "142.93.204.250",
+                                "internet_scanner_intelligence": {
+                                    "classification": "malicious",
+                                    "found": True,
+                                },
+                            }
+                        ]
+                    }
+                }
+            }
+        )
+        scanner = p_greynoise_h.GetGreyNoiseV3Object(event)
+        self.assertIsNotNone(scanner)
+        self.assertEqual(scanner.classification("MultiMatch"), ["malicious"])
+
 
 class TestGreyNoiseV3BusinessService(unittest.TestCase):
     def setUp(self):
@@ -735,6 +757,26 @@ class TestOTXPulseIntelligence(unittest.TestCase):
     def test_no_match_field(self):
         otx = p_otx_h.get_otx_object(self.event)
         self.assertIsNone(otx.indicator("NonExistentField"))
+
+    def test_find_lut_name_handles_list_shaped_match(self):
+        event = PantherEvent(
+            {
+                "p_enrichment": {
+                    "pulses_otx": {
+                        "MultiMatch": [
+                            {
+                                "id": "6141bd9b4e9aaa4bdd26b2a8",
+                                "indicator": "198.51.100.23",
+                                "indicator_type": "IPv4",
+                            }
+                        ]
+                    }
+                }
+            }
+        )
+        otx = p_otx_h.get_otx_object(event)
+        self.assertIsNotNone(otx)
+        self.assertEqual(otx.indicator_type("MultiMatch"), ["IPv4"])
 
     def test_severity_adversary_and_malware(self):
         sev = p_otx_h.otx_severity_from_pulse("APT28", ["X-Agent"])
@@ -1012,6 +1054,59 @@ class TestGTIIntelligence(unittest.TestCase):
         self.assertEqual(ctx["ThreatNames"], ["remcos", "rescoms"])
         self.assertIsNotNone(ctx["FirstSubmissionDate"])
         self.assertIsNotNone(ctx["LastAnalysisDate"])
+
+    def test_is_malicious_true_from_detections(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertTrue(gti.is_malicious("FileHash"))
+
+    def test_is_malicious_false_when_benign(self):
+        event = PantherEvent(
+            {
+                "p_enrichment": {
+                    "vt_iocstream": {
+                        "BenignIP": {
+                            "id": "198.51.100.42",
+                            "type": "ip_address",
+                            "gti_url": "https://www.virustotal.com/gui/ip-address/198.51.100.42",
+                            "last_analysis_stats": {
+                                "malicious": 0,
+                                "suspicious": 0,
+                                "harmless": 80,
+                                "undetected": 4,
+                            },
+                        }
+                    }
+                }
+            }
+        )
+        gti = p_gti_h.get_gti_object(event)
+        self.assertFalse(gti.is_malicious("BenignIP"))
+
+    def test_find_gti_lut_name_handles_list_shaped_match(self):
+        event = PantherEvent(
+            {
+                "p_enrichment": {
+                    "vt_iocstream": {
+                        "MultiMatch": [
+                            {
+                                "id": FAKE_SHA256,
+                                "type": "file",
+                                "gti_url": FAKE_GTI_URL,
+                                "last_analysis_stats": {
+                                    "malicious": 42,
+                                    "suspicious": 1,
+                                    "harmless": 0,
+                                    "undetected": 15,
+                                },
+                            }
+                        ]
+                    }
+                }
+            }
+        )
+        gti = p_gti_h.get_gti_object(event)
+        self.assertIsNotNone(gti)
+        self.assertEqual(gti.malicious_count("MultiMatch"), [42])
 
 
 class TestIpInfoHelpersLocation(unittest.TestCase):

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -30,6 +30,7 @@ import panther_cloudflare_helpers as p_cf_h  # pylint: disable=C0413
 import panther_crowdstrike_fdr_helpers as p_cf_fdr_h  # pylint: disable=C0413
 import panther_gcp_helpers as p_gcp_h  # pylint: disable=C0413
 import panther_greynoise_helpers as p_greynoise_h  # pylint: disable=C0413
+import panther_gti_helpers as p_gti_h  # pylint: disable=C0413
 import panther_ipinfo_helpers as p_i_h  # pylint: disable=C0413
 import panther_lookuptable_helpers as p_l_h  # pylint: disable=C0413
 import panther_notion_helpers as p_notion_h  # pylint: disable=C0413
@@ -767,6 +768,250 @@ class TestOTXPulseIntelligence(unittest.TestCase):
         self.assertEqual(ctx["Description"], "Known C2 infrastructure used by APT28.")
         self.assertIsNotNone(ctx["PulseCreated"])
         self.assertIsNotNone(ctx["IndicatorCreated"])
+
+
+FAKE_SHA256 = "0" * 64
+FAKE_MD5 = "0" * 32
+FAKE_SHA1 = "0" * 40
+FAKE_GTI_URL = f"https://www.virustotal.com/gui/file/{FAKE_SHA256}"
+
+
+class TestGTIIntelligence(unittest.TestCase):
+    def setUp(self):
+        self.event = PantherEvent(
+            {
+                "p_enrichment": {
+                    "vt_iocstream": {
+                        "FileHash": {
+                            "id": FAKE_SHA256,
+                            "type": "file",
+                            "type_description": "Win32 EXE",
+                            "meaningful_name": "example-malware.exe",
+                            "names": ["example-malware.exe", "svchost32.exe"],
+                            "md5": FAKE_MD5,
+                            "sha1": FAKE_SHA1,
+                            "sha256": FAKE_SHA256,
+                            "reputation": -12,
+                            "gti_confidence_score": None,
+                            "gti_url": FAKE_GTI_URL,
+                            "last_analysis_stats": {
+                                "malicious": 57,
+                                "suspicious": 0,
+                                "harmless": 0,
+                                "undetected": 13,
+                            },
+                            "threat_severity": {
+                                "threat_severity_level": "SEVERITY_HIGH",
+                                "level_description": (
+                                    "Severity HIGH because it was considered trojan."
+                                ),
+                            },
+                            "popular_threat_classification": {
+                                "suggested_threat_label": "trojan.remcos/rescoms",
+                                "popular_threat_category": [
+                                    {"count": 32, "value": "trojan"},
+                                    {"count": 1, "value": "dropper"},
+                                ],
+                                "popular_threat_name": [
+                                    {"count": 18, "value": "remcos"},
+                                    {"count": 10, "value": "rescoms"},
+                                ],
+                            },
+                            "tags": ["peexe", "payload", "malware"],
+                            "capabilities_tags": ["persistence"],
+                            "creation_date": "2026-05-08T09:00:21",
+                            "first_submission_date": "2026-06-25T18:44:28",
+                            "last_analysis_date": "2026-06-25T20:11:57",
+                        }
+                    }
+                }
+            }
+        )
+
+    def test_gti_object_exists(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertIsNotNone(gti)
+
+    def test_gti_object_none(self):
+        event = PantherEvent({"p_enrichment": {}})
+        gti = p_gti_h.get_gti_object(event)
+        self.assertIsNone(gti)
+
+    def test_indicator_id(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.indicator_id("FileHash"), FAKE_SHA256)
+
+    def test_indicator_type(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.indicator_type("FileHash"), "file")
+
+    def test_type_description(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.type_description("FileHash"), "Win32 EXE")
+
+    def test_meaningful_name(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.meaningful_name("FileHash"), "example-malware.exe")
+
+    def test_names(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.names("FileHash"), ["example-malware.exe", "svchost32.exe"])
+
+    def test_md5(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.md5("FileHash"), FAKE_MD5)
+
+    def test_sha256(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.sha256("FileHash"), FAKE_SHA256)
+
+    def test_reputation(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.reputation("FileHash"), -12)
+
+    def test_last_analysis_stats(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.last_analysis_stats("FileHash")["malicious"], 57)
+
+    def test_malicious_count(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.malicious_count("FileHash"), 57)
+
+    def test_suspicious_count(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.suspicious_count("FileHash"), 0)
+
+    def test_harmless_count(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.harmless_count("FileHash"), 0)
+
+    def test_undetected_count(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.undetected_count("FileHash"), 13)
+
+    def test_threat_severity_level(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.threat_severity_level("FileHash"), "SEVERITY_HIGH")
+
+    def test_threat_severity_description(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(
+            gti.threat_severity_description("FileHash"),
+            "Severity HIGH because it was considered trojan.",
+        )
+
+    def test_suggested_threat_label(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.suggested_threat_label("FileHash"), "trojan.remcos/rescoms")
+
+    def test_threat_categories(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.threat_categories("FileHash"), ["trojan", "dropper"])
+
+    def test_threat_names(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.threat_names("FileHash"), ["remcos", "rescoms"])
+
+    def test_tags(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.tags("FileHash"), ["peexe", "payload", "malware"])
+
+    def test_tags_string(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.tags_string("FileHash"), "peexe, payload, malware")
+
+    def test_capabilities_tags(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.capabilities_tags("FileHash"), ["persistence"])
+
+    def test_gti_link_from_gti_url(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertEqual(gti.gti_link("FileHash"), FAKE_GTI_URL)
+
+    def test_gti_link_built_when_missing(self):
+        event = PantherEvent(
+            {
+                "p_enrichment": {
+                    "vt_iocstream": {
+                        "ClientIP": {
+                            "id": "203.0.113.5",
+                            "type": "ip_address",
+                            "last_analysis_stats": {"malicious": 5},
+                        }
+                    }
+                }
+            }
+        )
+        gti = p_gti_h.get_gti_object(event)
+        self.assertEqual(
+            gti.gti_link("ClientIP"),
+            "https://www.virustotal.com/gui/ip-address/203.0.113.5",
+        )
+
+    def test_creation_date(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        result = gti.creation_date("FileHash")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.year, 2026)
+        self.assertEqual(result.month, 5)
+
+    def test_first_submission_date(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        result = gti.first_submission_date("FileHash")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.year, 2026)
+        self.assertEqual(result.month, 6)
+
+    def test_context(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        context = gti.context("FileHash")
+        self.assertEqual(context["Indicator"], FAKE_SHA256)
+        self.assertEqual(context["IndicatorType"], "file")
+        self.assertEqual(context["MaliciousCount"], 57)
+        self.assertEqual(context["ThreatSeverity"], "SEVERITY_HIGH")
+        self.assertEqual(context["SuggestedThreatLabel"], "trojan.remcos/rescoms")
+        self.assertIn("virustotal.com", context["GTI_URL"])
+
+    def test_no_match_field(self):
+        gti = p_gti_h.get_gti_object(self.event)
+        self.assertIsNone(gti.indicator_id("NonExistentField"))
+
+    def test_severity_high_level(self):
+        sev = p_gti_h.gti_severity_from_verdict("SEVERITY_HIGH", 57)
+        self.assertEqual(sev, "CRITICAL")
+
+    def test_severity_medium_level(self):
+        sev = p_gti_h.gti_severity_from_verdict("SEVERITY_MEDIUM", 3)
+        self.assertEqual(sev, "HIGH")
+
+    def test_severity_low_level(self):
+        sev = p_gti_h.gti_severity_from_verdict("SEVERITY_LOW", 1)
+        self.assertEqual(sev, "MEDIUM")
+
+    def test_severity_no_level_high_detections(self):
+        sev = p_gti_h.gti_severity_from_verdict("", 15)
+        self.assertEqual(sev, "HIGH")
+
+    def test_severity_no_level_no_detections(self):
+        sev = p_gti_h.gti_severity_from_verdict("", 0)
+        self.assertEqual(sev, "MEDIUM")
+
+    def test_gti_severity_from_event(self):
+        sev = p_gti_h.gti_severity(self.event, "FileHash")
+        self.assertEqual(sev, "CRITICAL")
+
+    def test_gti_severity_no_enrichment(self):
+        event = PantherEvent({"p_enrichment": {}})
+        sev = p_gti_h.gti_severity(event, "FileHash")
+        self.assertEqual(sev, "MEDIUM")
+
+    def test_gti_alert_context(self):
+        ctx = p_gti_h.gti_alert_context(self.event, "FileHash")
+        self.assertEqual(ctx["Indicator"], FAKE_SHA256)
+        self.assertEqual(ctx["ThreatCategories"], ["trojan", "dropper"])
+        self.assertEqual(ctx["ThreatNames"], ["remcos", "rescoms"])
+        self.assertIsNotNone(ctx["FirstSubmissionDate"])
+        self.assertIsNotNone(ctx["LastAnalysisDate"])
 
 
 class TestIpInfoHelpersLocation(unittest.TestCase):

--- a/global_helpers/global_helpers_test.py
+++ b/global_helpers/global_helpers_test.py
@@ -517,6 +517,61 @@ class TestGreyNoiseV3ScannerIntelligence(
         self.assertIsNotNone(scanner)
         self.assertEqual(scanner.classification("MultiMatch"), ["malicious"])
 
+    def test_list_shaped_found_is_not_falsely_true(self):
+        event = PantherEvent(
+            {
+                "p_enrichment": {
+                    "my_custom_greynoise_noise": {
+                        "MultiMatch": [
+                            {
+                                "ip": "142.93.204.250",
+                                "internet_scanner_intelligence": {
+                                    "classification": "unknown",
+                                    "found": False,
+                                    "bot": False,
+                                    "spoofable": False,
+                                    "tor": False,
+                                    "vpn": False,
+                                },
+                            }
+                        ]
+                    }
+                }
+            }
+        )
+        scanner = p_greynoise_h.GetGreyNoiseV3Object(event)
+        self.assertFalse(scanner.found("MultiMatch"))
+        self.assertFalse(scanner.is_bot("MultiMatch"))
+        self.assertFalse(scanner.is_spoofable("MultiMatch"))
+        self.assertFalse(scanner.is_tor("MultiMatch"))
+        self.assertFalse(scanner.is_vpn("MultiMatch"))
+
+    def test_list_shaped_found_true_when_any_entry_true(self):
+        event = PantherEvent(
+            {
+                "p_enrichment": {
+                    "my_custom_greynoise_noise": {
+                        "MultiMatch": [
+                            {
+                                "ip": "142.93.204.250",
+                                "internet_scanner_intelligence": {
+                                    "found": False,
+                                },
+                            },
+                            {
+                                "ip": "203.0.113.9",
+                                "internet_scanner_intelligence": {
+                                    "found": True,
+                                },
+                            },
+                        ]
+                    }
+                }
+            }
+        )
+        scanner = p_greynoise_h.GetGreyNoiseV3Object(event)
+        self.assertTrue(scanner.found("MultiMatch"))
+
 
 class TestGreyNoiseV3BusinessService(unittest.TestCase):
     def setUp(self):
@@ -604,6 +659,25 @@ class TestGreyNoiseV3BusinessService(unittest.TestCase):
         """Known business service should return INFO severity"""
         sev = p_greynoise_h.GreyNoiseV3Severity(self.event, "ClientIP")
         self.assertEqual(sev, "INFO")
+
+    def test_list_shaped_found_is_not_falsely_true(self):
+        event = PantherEvent(
+            {
+                "p_enrichment": {
+                    "my_custom_greynoise_noise": {
+                        "MultiMatch": [
+                            {
+                                "ip": "142.93.204.250",
+                                "internet_scanner_intelligence": {"found": False},
+                                "business_service_intelligence": {"found": False},
+                            }
+                        ]
+                    }
+                }
+            }
+        )
+        bsi = p_greynoise_h.GetGreyNoiseV3BusinessServiceObject(event)
+        self.assertFalse(bsi.found("MultiMatch"))
 
 
 class TestOTXPulseIntelligence(unittest.TestCase):

--- a/global_helpers/panther_greynoise_helpers.py
+++ b/global_helpers/panther_greynoise_helpers.py
@@ -47,6 +47,17 @@ def _find_greynoise_v3_lut_name(event) -> str:
     return None
 
 
+def _any_true(value) -> bool:
+    """Coerce a possibly list-shaped lookup value (multiple LUT hits) to a single bool.
+
+    A plain `bool()` on a non-empty list is always True regardless of its contents,
+    so list-shaped values must be reduced with `any()` instead.
+    """
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return any(bool(entry) for entry in value)
+    return bool(value)
+
+
 class _GreyNoiseV3Base(LookupTableMatches):
     """Shared base for GreyNoise V3 helpers with common IP/URL methods."""
 
@@ -79,7 +90,7 @@ class GreyNoiseV3ScannerIntelligence(_GreyNoiseV3Base):
         return self._scanner_lookup(match_field, "actor")
 
     def is_bot(self, match_field: str) -> bool:
-        return bool(self._scanner_lookup(match_field, "bot"))
+        return _any_true(self._scanner_lookup(match_field, "bot"))
 
     def classification(self, match_field: str) -> Union[list[str], str]:
         return self._scanner_lookup(match_field, "classification")
@@ -109,7 +120,7 @@ class GreyNoiseV3ScannerIntelligence(_GreyNoiseV3Base):
             return None
 
     def found(self, match_field: str) -> bool:
-        return bool(self._scanner_lookup(match_field, "found"))
+        return _any_true(self._scanner_lookup(match_field, "found"))
 
     def last_seen(self, match_field: str) -> datetime.date:
         time = self._scanner_lookup(match_field, "last_seen_timestamp")
@@ -147,7 +158,7 @@ class GreyNoiseV3ScannerIntelligence(_GreyNoiseV3Base):
         return self._scanner_lookup(match_field, "metadata", "longitude")
 
     def is_mobile(self, match_field: str) -> bool:
-        return bool(self._scanner_lookup(match_field, "metadata", "mobile"))
+        return _any_true(self._scanner_lookup(match_field, "metadata", "mobile"))
 
     def organization(self, match_field: str) -> Union[list[str], str]:
         return self._scanner_lookup(match_field, "metadata", "organization")
@@ -187,7 +198,7 @@ class GreyNoiseV3ScannerIntelligence(_GreyNoiseV3Base):
 
     # Top-level scanner fields
     def is_spoofable(self, match_field: str) -> bool:
-        return bool(self._scanner_lookup(match_field, "spoofable"))
+        return _any_true(self._scanner_lookup(match_field, "spoofable"))
 
     def tags(self, match_field: str) -> list:
         tags = self._scanner_lookup(match_field, "tags")
@@ -210,10 +221,10 @@ class GreyNoiseV3ScannerIntelligence(_GreyNoiseV3Base):
         return names
 
     def is_tor(self, match_field: str) -> bool:
-        return bool(self._scanner_lookup(match_field, "tor"))
+        return _any_true(self._scanner_lookup(match_field, "tor"))
 
     def is_vpn(self, match_field: str) -> bool:
-        return bool(self._scanner_lookup(match_field, "vpn"))
+        return _any_true(self._scanner_lookup(match_field, "vpn"))
 
     def vpn_service(self, match_field: str) -> Union[list[str], str]:
         return self._scanner_lookup(match_field, "vpn_service")
@@ -240,7 +251,7 @@ class GreyNoiseV3BusinessService(_GreyNoiseV3Base):
         return self._lookup(match_field, "business_service_intelligence", *keys)
 
     def found(self, match_field: str) -> bool:
-        return bool(self._bsi_lookup(match_field, "found"))
+        return _any_true(self._bsi_lookup(match_field, "found"))
 
     def category(self, match_field: str) -> Union[list[str], str]:
         return self._bsi_lookup(match_field, "category")

--- a/global_helpers/panther_greynoise_helpers.py
+++ b/global_helpers/panther_greynoise_helpers.py
@@ -29,12 +29,20 @@ def _find_greynoise_v3_lut_name(event) -> str:
     The LUT name is user-customizable in Panther but always ends with '_noise'.
     V3 data is identified by the presence of 'internet_scanner_intelligence' in the values.
     """
+
+    def _is_greynoise_match(match_data) -> bool:
+        return hasattr(match_data, "get") and match_data.get("internet_scanner_intelligence")
+
     enrichment = event.deep_get("p_enrichment", default={})
     for lut_name in enrichment.keys():
         if not lut_name.endswith("_noise"):
             continue
         for match_data in enrichment.get(lut_name, {}).values():
-            if hasattr(match_data, "get") and match_data.get("internet_scanner_intelligence"):
+            if isinstance(match_data, Sequence) and not isinstance(match_data, str):
+                if any(_is_greynoise_match(entry) for entry in match_data):
+                    return lut_name
+                continue
+            if _is_greynoise_match(match_data):
                 return lut_name
     return None
 

--- a/global_helpers/panther_gti_helpers.py
+++ b/global_helpers/panther_gti_helpers.py
@@ -65,14 +65,22 @@ def _find_gti_lut_name(event) -> str:
     presence of VT-distinctive fields ('gti_url' or 'last_analysis_stats') in the
     matched values rather than a fixed name/suffix.
     """
+
+    def _is_gti_match(match_data) -> bool:
+        return hasattr(match_data, "get") and (
+            match_data.get("gti_url") or match_data.get("last_analysis_stats")
+        )
+
     enrichment = event.deep_get("p_enrichment", default={})
     for lut_name, lut_values in enrichment.items():
         if not hasattr(lut_values, "values"):
             continue
         for match_data in lut_values.values():
-            if not hasattr(match_data, "get"):
+            if isinstance(match_data, Sequence) and not isinstance(match_data, str):
+                if any(_is_gti_match(entry) for entry in match_data):
+                    return lut_name
                 continue
-            if match_data.get("gti_url") or match_data.get("last_analysis_stats"):
+            if _is_gti_match(match_data):
                 return lut_name
     return None
 
@@ -146,6 +154,26 @@ class GTIIntelligence(LookupTableMatches):
 
     def undetected_count(self, match_field: str) -> Union[list[int], int]:
         return self._analysis_stat(match_field, "undetected")
+
+    def is_malicious(self, match_field: str) -> bool:
+        """Whether GTI/VirusTotal considers this indicator malicious.
+
+        True if any vendor flagged it malicious or GTI assigned a threat severity level.
+        A known indicator with no malicious detections and no severity (e.g. a benign,
+        well-catalogued IP/domain) is not considered malicious.
+        """
+        malicious_count = self.malicious_count(match_field)
+        counts = malicious_count if isinstance(malicious_count, list) else [malicious_count]
+        if any((count or 0) > 0 for count in counts):
+            return True
+
+        threat_severity_level = self.threat_severity_level(match_field)
+        levels = (
+            threat_severity_level
+            if isinstance(threat_severity_level, list)
+            else [threat_severity_level]
+        )
+        return any((level or "").upper() in _LEVEL_TO_SEVERITY for level in levels)
 
     # Threat classification fields
     def threat_severity_level(self, match_field: str) -> Union[list[str], str]:

--- a/global_helpers/panther_gti_helpers.py
+++ b/global_helpers/panther_gti_helpers.py
@@ -1,0 +1,330 @@
+# pylint: disable=too-many-public-methods
+import datetime
+from collections.abc import Sequence
+from typing import Union
+
+from dateutil import parser
+from panther_base_helpers import severity_greater_than  # re-exported for rule imports
+from panther_lookuptable_helpers import LookupTableMatches
+
+# `severity_greater_than` is re-exported above so rules importing it from this
+# module continue to work; the canonical definition lives in panther_base_helpers.
+_ = severity_greater_than
+
+# Values of `type` on a GTI/VirusTotal IOC that map to a VT GUI path segment
+# different from the raw type string.
+_GTI_TYPE_TO_URL_SEGMENT = {
+    "ip_address": "ip-address",
+}
+
+
+_LEVEL_TO_SEVERITY = {
+    "SEVERITY_HIGH": "CRITICAL",
+    "SEVERITY_MEDIUM": "HIGH",
+    "SEVERITY_LOW": "MEDIUM",
+}
+
+_MALICIOUS_COUNT_THRESHOLDS = (
+    (10, "HIGH"),
+    (3, "MEDIUM"),
+    (1, "LOW"),
+)
+
+
+def _severity_from_malicious_count(count: int, default: str) -> str:
+    count = count or 0
+    for threshold, sev in _MALICIOUS_COUNT_THRESHOLDS:
+        if count >= threshold:
+            return sev
+    return default
+
+
+def gti_severity_from_verdict(
+    threat_severity_level: str, malicious_count: int, default: str = "MEDIUM"
+) -> str:
+    """Derive a Panther severity from GTI/VirusTotal verdict data.
+
+    - GTI's own `threat_severity_level` is used when present (SEVERITY_HIGH -> CRITICAL,
+      SEVERITY_MEDIUM -> HIGH, SEVERITY_LOW -> MEDIUM).
+    - Otherwise, fall back to the number of vendors flagging the indicator malicious.
+    - Otherwise -> default (MEDIUM).
+    """
+    level = (threat_severity_level or "").upper()
+    if level in _LEVEL_TO_SEVERITY:
+        return _LEVEL_TO_SEVERITY[level]
+    return _severity_from_malicious_count(malicious_count, default)
+
+
+# GTI/VirusTotal Enrichment Helpers
+
+
+def _find_gti_lut_name(event) -> str:
+    """Auto-detect the GTI/VirusTotal lookup table name from the event enrichment.
+
+    The LUT name is user-customizable in Panther, so detection is based on the
+    presence of VT-distinctive fields ('gti_url' or 'last_analysis_stats') in the
+    matched values rather than a fixed name/suffix.
+    """
+    enrichment = event.deep_get("p_enrichment", default={})
+    for lut_name, lut_values in enrichment.items():
+        if not hasattr(lut_values, "values"):
+            continue
+        for match_data in lut_values.values():
+            if not hasattr(match_data, "get"):
+                continue
+            if match_data.get("gti_url") or match_data.get("last_analysis_stats"):
+                return lut_name
+    return None
+
+
+class GTIIntelligence(LookupTableMatches):
+    """Helper to access GTI/VirusTotal enrichment data for matched indicators."""
+
+    def __init__(self, event, lut_name=None):
+        super().__init__()
+        if lut_name is None:
+            lut_name = _find_gti_lut_name(event)
+        if lut_name:
+            super()._register(event, lut_name)
+
+    # Identity fields
+    def indicator_id(self, match_field: str) -> Union[list[str], str]:
+        return self._lookup(match_field, "id")
+
+    def indicator_type(self, match_field: str) -> Union[list[str], str]:
+        return self._lookup(match_field, "type")
+
+    def type_description(self, match_field: str) -> Union[list[str], str]:
+        return self._lookup(match_field, "type_description")
+
+    def meaningful_name(self, match_field: str) -> Union[list[str], str]:
+        return self._lookup(match_field, "meaningful_name")
+
+    def names(self, match_field: str) -> list:
+        names = self._lookup(match_field, "names")
+        if not names:
+            return []
+        if isinstance(names, str):
+            return [names]
+        return names
+
+    def md5(self, match_field: str) -> Union[list[str], str]:
+        return self._lookup(match_field, "md5")
+
+    def sha1(self, match_field: str) -> Union[list[str], str]:
+        return self._lookup(match_field, "sha1")
+
+    def sha256(self, match_field: str) -> Union[list[str], str]:
+        return self._lookup(match_field, "sha256")
+
+    # Verdict fields
+    def reputation(self, match_field: str) -> Union[list[int], int]:
+        return self._lookup(match_field, "reputation")
+
+    def gti_confidence_score(self, match_field: str) -> Union[list[int], int]:
+        return self._lookup(match_field, "gti_confidence_score")
+
+    def last_analysis_stats(self, match_field: str) -> Union[list[dict], dict]:
+        return self._lookup(match_field, "last_analysis_stats")
+
+    def _analysis_stat(self, match_field: str, stat: str) -> Union[list[int], int]:
+        stats = self.last_analysis_stats(match_field)
+        if stats is None:
+            return None
+        if isinstance(stats, Sequence) and not isinstance(stats, str):
+            return [s.get(stat, 0) if hasattr(s, "get") else 0 for s in stats]
+        return stats.get(stat, 0) if hasattr(stats, "get") else 0
+
+    def malicious_count(self, match_field: str) -> Union[list[int], int]:
+        return self._analysis_stat(match_field, "malicious")
+
+    def suspicious_count(self, match_field: str) -> Union[list[int], int]:
+        return self._analysis_stat(match_field, "suspicious")
+
+    def harmless_count(self, match_field: str) -> Union[list[int], int]:
+        return self._analysis_stat(match_field, "harmless")
+
+    def undetected_count(self, match_field: str) -> Union[list[int], int]:
+        return self._analysis_stat(match_field, "undetected")
+
+    # Threat classification fields
+    def threat_severity_level(self, match_field: str) -> Union[list[str], str]:
+        return self._lookup(match_field, "threat_severity", "threat_severity_level")
+
+    def threat_severity_description(self, match_field: str) -> Union[list[str], str]:
+        return self._lookup(match_field, "threat_severity", "level_description")
+
+    def suggested_threat_label(self, match_field: str) -> Union[list[str], str]:
+        return self._lookup(match_field, "popular_threat_classification", "suggested_threat_label")
+
+    def _threat_classification_values(self, match_field: str, key: str) -> list:
+        classification = self._lookup(match_field, "popular_threat_classification", key)
+        if not classification:
+            return []
+        if isinstance(classification, Sequence) and not isinstance(classification, str):
+            values = []
+            for entry in classification:
+                if hasattr(entry, "get"):
+                    values.append(entry.get("value"))
+            return values
+        return []
+
+    def threat_categories(self, match_field: str) -> list:
+        return self._threat_classification_values(match_field, "popular_threat_category")
+
+    def threat_names(self, match_field: str) -> list:
+        return self._threat_classification_values(match_field, "popular_threat_name")
+
+    def tags(self, match_field: str) -> list:
+        tags = self._lookup(match_field, "tags")
+        if not tags:
+            return []
+        if isinstance(tags, str):
+            return [tags]
+        return tags
+
+    def tags_string(self, match_field: str, limit: int = 10) -> str:
+        return ", ".join(self.tags(match_field)[:limit])
+
+    def capabilities_tags(self, match_field: str) -> list:
+        tags = self._lookup(match_field, "capabilities_tags")
+        if not tags:
+            return []
+        if isinstance(tags, str):
+            return [tags]
+        return tags
+
+    def categories(self, match_field: str) -> Union[list, dict]:
+        return self._lookup(match_field, "categories")
+
+    # Network/infrastructure fields (domain, IP, and URL IOCs)
+    def country(self, match_field: str) -> Union[list[str], str]:
+        return self._lookup(match_field, "country")
+
+    def as_owner(self, match_field: str) -> Union[list[str], str]:
+        return self._lookup(match_field, "as_owner")
+
+    def asn(self, match_field: str) -> Union[list[int], int]:
+        return self._lookup(match_field, "asn")
+
+    def network(self, match_field: str) -> Union[list[str], str]:
+        return self._lookup(match_field, "network")
+
+    def registrar(self, match_field: str) -> Union[list[str], str]:
+        return self._lookup(match_field, "registrar")
+
+    def title(self, match_field: str) -> Union[list[str], str]:
+        return self._lookup(match_field, "title")
+
+    def url(self, match_field: str) -> Union[list[str], str]:
+        return self._lookup(match_field, "url")
+
+    def last_final_url(self, match_field: str) -> Union[list[str], str]:
+        return self._lookup(match_field, "last_final_url")
+
+    # Timestamp fields
+    def _parse_time(self, match_field: str, key: str, use_max: bool = False):
+        time = self._lookup(match_field, key)
+        if not time:
+            return None
+        try:
+            if isinstance(time, Sequence) and not isinstance(time, str):
+                if len(time) == 0:
+                    return None
+                return (max if use_max else min)(parser.parse(t) for t in time)
+            return parser.parse(time)
+        except (ValueError, TypeError):
+            return None
+
+    def creation_date(self, match_field: str) -> datetime.date:
+        return self._parse_time(match_field, "creation_date")
+
+    def first_submission_date(self, match_field: str) -> datetime.date:
+        return self._parse_time(match_field, "first_submission_date")
+
+    def last_analysis_date(self, match_field: str) -> datetime.date:
+        return self._parse_time(match_field, "last_analysis_date", use_max=True)
+
+    def last_modification_date(self, match_field: str) -> datetime.date:
+        return self._parse_time(match_field, "last_modification_date", use_max=True)
+
+    # Links
+    def gti_link(self, match_field: str) -> Union[list[str], str, None]:
+        link = self._lookup(match_field, "gti_url")
+        if link:
+            return link
+
+        indicator_id = self.indicator_id(match_field)
+        indicator_type = self.indicator_type(match_field)
+        if not indicator_id or not indicator_type:
+            return None
+
+        def _build(ioc_id: str, ioc_type: str) -> str:
+            segment = _GTI_TYPE_TO_URL_SEGMENT.get(ioc_type, ioc_type)
+            return f"https://www.virustotal.com/gui/{segment}/{ioc_id}"
+
+        if isinstance(indicator_id, Sequence) and not isinstance(indicator_id, str):
+            return [
+                _build(ioc_id, ioc_type) for ioc_id, ioc_type in zip(indicator_id, indicator_type)
+            ]
+        return _build(indicator_id, indicator_type)
+
+    def context(self, match_field: str) -> dict:
+        return {
+            "Indicator": self.indicator_id(match_field),
+            "IndicatorType": self.indicator_type(match_field),
+            "Names": self.names(match_field),
+            "Reputation": self.reputation(match_field),
+            "MaliciousCount": self.malicious_count(match_field),
+            "SuspiciousCount": self.suspicious_count(match_field),
+            "ThreatSeverity": self.threat_severity_level(match_field),
+            "SuggestedThreatLabel": self.suggested_threat_label(match_field),
+            "Tags": self.tags(match_field),
+            "GTI_URL": self.gti_link(match_field),
+        }
+
+
+def get_gti_object(event):
+    """Returns a GTIIntelligence object or None if not available."""
+    lut_name = _find_gti_lut_name(event)
+    if lut_name:
+        return GTIIntelligence(event, lut_name=lut_name)
+    return None
+
+
+def gti_severity(event, field, default="MEDIUM"):
+    """Set severity based on GTI/VirusTotal verdict data (threat severity, detections)."""
+    lut_name = _find_gti_lut_name(event)
+    if not lut_name:
+        return default
+    gti = GTIIntelligence(event, lut_name=lut_name)
+
+    threat_severity_level = gti.threat_severity_level(field)
+    malicious_count = gti.malicious_count(field)
+
+    if isinstance(threat_severity_level, Sequence) and not isinstance(threat_severity_level, str):
+        # Multiple matches — return highest severity across all
+        highest = "INFO"
+        for level, count in zip(threat_severity_level, malicious_count):
+            sev = gti_severity_from_verdict(level, count, default)
+            if severity_greater_than(sev, highest):
+                highest = sev
+        return highest
+
+    return gti_severity_from_verdict(threat_severity_level, malicious_count, default)
+
+
+def gti_alert_context(event, field):
+    """Build a rich alert context dict from GTI/VirusTotal enrichment data."""
+    lut_name = _find_gti_lut_name(event)
+    if not lut_name:
+        return {}
+    gti = GTIIntelligence(event, lut_name=lut_name)
+    ctx = gti.context(field)
+    ctx["ThreatCategories"] = gti.threat_categories(field)
+    ctx["ThreatNames"] = gti.threat_names(field)
+    first_submission = gti.first_submission_date(field)
+    ctx["FirstSubmissionDate"] = str(first_submission) if first_submission is not None else None
+    last_analysis = gti.last_analysis_date(field)
+    ctx["LastAnalysisDate"] = str(last_analysis) if last_analysis is not None else None
+    return ctx

--- a/global_helpers/panther_gti_helpers.yml
+++ b/global_helpers/panther_gti_helpers.yml
@@ -1,0 +1,4 @@
+AnalysisType: global
+Filename: panther_gti_helpers.py
+GlobalID: "panther_gti_helpers"
+Description: Used to simplify the use of Google Threat Intelligence / VirusTotal Data in Rules

--- a/global_helpers/panther_otx_helpers.py
+++ b/global_helpers/panther_otx_helpers.py
@@ -38,12 +38,20 @@ def _find_otx_lut_name(event) -> str:
     The LUT name is user-customizable in Panther but always ends with '_otx'.
     OTX data is identified by the presence of 'indicator_type' in the values.
     """
+
+    def _is_otx_match(match_data) -> bool:
+        return hasattr(match_data, "get") and match_data.get("indicator_type")
+
     enrichment = event.deep_get("p_enrichment", default={})
     for lut_name in enrichment.keys():
         if not lut_name.endswith("_otx"):
             continue
         for match_data in enrichment.get(lut_name, {}).values():
-            if hasattr(match_data, "get") and match_data.get("indicator_type"):
+            if isinstance(match_data, Sequence) and not isinstance(match_data, str):
+                if any(_is_otx_match(entry) for entry in match_data):
+                    return lut_name
+                continue
+            if _is_otx_match(match_data):
                 return lut_name
     return None
 

--- a/indexes/alpha-index.md
+++ b/indexes/alpha-index.md
@@ -64,6 +64,8 @@
 
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)
   - Detects when an IP address in any log event matches a known threat indicator from AlienVault OTX pulse intelligence. Severity is elevated when the pulse includes a named adversary or known malware families.
 
@@ -323,6 +325,8 @@
   - A Root console login failed.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [IAM Administrator Role Policy Attached](../rules/aws_cloudtrail_rules/aws_iam_attach_admin_role_policy.yml)
   - An IAM role policy was attached with Administrator Access, which could indicate a potential security risk.
 - [IAM Assume Role Blocklist Ignored](../rules/aws_cloudtrail_rules/aws_iam_assume_role_blocklist_ignored.yml)
@@ -519,6 +523,8 @@
   - This detection identifies if an activity is recorded in the Kubernetes audit log where the user:username attribute begins with "system:" or "eks:" and the requests originating IP Address is a Public IP Address
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [IOC Activity in K8 Control Plane](../queries/kubernetes_queries/kubernetes_ioc_activity_query.yml)
   - This detection monitors for any kubernetes API Request originating from an Indicator of Compromise.
 - [Kubernetes Admission Controller Webhook Created](../rules/kubernetes_rules/k8s_admission_controller_created.yml)
@@ -827,6 +833,8 @@
   - Checks for the log status `SKIPDATA`, which indicates that data was lost either to an internal server error or due to capacity constraints.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)
   - Detects when an IP address in any log event matches a known threat indicator from AlienVault OTX pulse intelligence. Severity is elevated when the pulse includes a named adversary or known malware families.
 - [VPC Flow Logs Inbound Port Allowlist](../rules/aws_vpc_flow_rules/aws_vpc_inbound_traffic_port_allowlist.yml)
@@ -948,6 +956,8 @@
   - An actor user was denied login access more times than the configured threshold.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [Impossible Travel for Login Action](../rules/standard_rules/impossible_travel_login.yml)
   - A user has subsequent logins from two geographic locations that are very far apart
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)
@@ -968,6 +978,8 @@
   - An actor user was denied login access more times than the configured threshold.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [MFA Disabled](../rules/standard_rules/mfa_disabled.yml)
   - Detects when Multi-Factor Authentication (MFA) is disabled
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)
@@ -1201,6 +1213,8 @@
   - Detects OAuth authorization flows where Visual Studio Code successfully authenticates to Microsoft Graph. While legitimate for developers, this pattern is commonly abused in phishing campaigns where attackers use the trusted VS Code client ID to trick users into granting OAuth tokens.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [Kubernetes Admission Controller Webhook Created](../rules/kubernetes_rules/k8s_admission_controller_created.yml)
   - This detection monitors for creation of MutatingWebhookConfiguration or ValidatingWebhookConfiguration resources. Admission controller webhooks can intercept all API requests to the Kubernetes API server, allowing attackers to inspect, modify, or block any resource creation or modification. This provides powerful capabilities for persistence (modifying deployments to inject backdoors), credential theft (intercepting secrets), and reconnaissance (enumerating all cluster activity).
 - [Kubernetes All Secrets Dumped Across Namespaces](../rules/kubernetes_rules/k8s_secrets_dump_all_namespaces.yml)
@@ -1304,6 +1318,8 @@
   - An actor user was denied login access more times than the configured threshold.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [Malicious Content Detected](../rules/box_rules/box_malicious_content.yml)
   - Box has detect malicious content, such as a virus.
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)
@@ -1360,6 +1376,8 @@
   - Detects React2Shell (CVE-2025-55182) RCE attempts blocked by Cloudflare WAF
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)
   - Detects when an IP address in any log event matches a known threat indicator from AlienVault OTX pulse intelligence. Severity is elevated when the pulse includes a named adversary or known malware families.
 
@@ -1444,6 +1462,8 @@
   - Detects the execution of common command line tools (e.g., PowerShell, cmd.exe) with Base64 encoded arguments, which could indicate an attempt to obfuscate malicious commands.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [MacOS Browser Credential Access (crowdstrike_fdrevent table)](../queries/crowdstrike_queries/MacOS_Browser_Credential_Access_FDREvent.yml)
   - Detects processes that contain known browser credential files in arguments. (crowdstrike_fdrevent table)
 - [Malicious SSO DNS Lookup](../rules/standard_rules/malicious_sso_dns_lookup.yml)
@@ -1757,6 +1777,8 @@
   - Adversaries may access data objects from improperly secured cloud storage.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [Kubernetes Admission Controller Webhook Created](../rules/kubernetes_rules/k8s_admission_controller_created.yml)
   - This detection monitors for creation of MutatingWebhookConfiguration or ValidatingWebhookConfiguration resources. Admission controller webhooks can intercept all API requests to the Kubernetes API server, allowing attackers to inspect, modify, or block any resource creation or modification. This provides powerful capabilities for persistence (modifying deployments to inject backdoors), credential theft (intercepting secrets), and reconnaissance (enumerating all cluster activity).
 - [Kubernetes All Secrets Dumped Across Namespaces](../rules/kubernetes_rules/k8s_secrets_dump_all_namespaces.yml)
@@ -2031,6 +2053,8 @@
   - A Workspace Admin Has Disabled The Enforcement Of Strong Passwords
 - [GSuite Workspace Trusted Domain Allowlist Modified](../rules/gsuite_activityevent_rules/gsuite_workspace_trusted_domains_allowlist.yml)
   - A Workspace Admin Has Modified The Trusted Domains List
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [Malware Detected in Email](../rules/gsuite_activityevent_rules/gsuite_malware_in_email.yml)
   - Detects when malware is found in an email received by a user. Identifies different malware families including known malicious programs, viruses, worms, harmful content, and unwanted content. Severity is dynamically assigned based on the malware type, with known malicious programs and viruses triggering high-severity alerts.
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)
@@ -2136,6 +2160,8 @@
 
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [Impossible Travel for Login Action](../rules/standard_rules/impossible_travel_login.yml)
   - A user has subsequent logins from two geographic locations that are very far apart
 - [Notion Audit Log Exported](../rules/notion_rules/notion_workspace_audit_log_exported.yml)
@@ -2211,6 +2237,8 @@
   - An actor user was denied login access more times than the configured threshold.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [Impossible Travel for Login Action](../rules/standard_rules/impossible_travel_login.yml)
   - A user has subsequent logins from two geographic locations that are very far apart
 - [MFA Disabled](../rules/standard_rules/mfa_disabled.yml)
@@ -2313,6 +2341,8 @@
   - An actor user was denied login access more times than the configured threshold.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [New User Account Created](../rules/indicator_creation_rules/new_user_account_logging.yml)
   - A new account was created
 - [OneLogin Active Login Activity](../rules/onelogin_rules/onelogin_active_login_activity.yml)
@@ -2361,6 +2391,8 @@
   - Alerts when a user defined list of sensitive items in 1Password is accessed
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)
   - Detects when an IP address in any log event matches a known threat indicator from AlienVault OTX pulse intelligence. Severity is elevated when the pulse includes a named adversary or known malware families.
 - [Sign In from Rogue State](../rules/standard_rules/sign_in_from_rogue_state.yml)
@@ -2852,6 +2884,8 @@
   - User enabled or disabled zendesk support user assumption.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [MFA Disabled](../rules/standard_rules/mfa_disabled.yml)
   - Detects when Multi-Factor Authentication (MFA) is disabled
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)
@@ -2876,6 +2910,8 @@
 
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [New User Account Created](../rules/indicator_creation_rules/new_user_account_logging.yml)
   - A new account was created
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)

--- a/indexes/aws.md
+++ b/indexes/aws.md
@@ -12,6 +12,8 @@
 
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)
   - Detects when an IP address in any log event matches a known threat indicator from AlienVault OTX pulse intelligence. Severity is elevated when the pulse includes a named adversary or known malware families.
 
@@ -271,6 +273,8 @@
   - A Root console login failed.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [IAM Administrator Role Policy Attached](../rules/aws_cloudtrail_rules/aws_iam_attach_admin_role_policy.yml)
   - An IAM role policy was attached with Administrator Access, which could indicate a potential security risk.
 - [IAM Assume Role Blocklist Ignored](../rules/aws_cloudtrail_rules/aws_iam_assume_role_blocklist_ignored.yml)
@@ -467,6 +471,8 @@
   - This detection identifies if an activity is recorded in the Kubernetes audit log where the user:username attribute begins with "system:" or "eks:" and the requests originating IP Address is a Public IP Address
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [IOC Activity in K8 Control Plane](../queries/kubernetes_queries/kubernetes_ioc_activity_query.yml)
   - This detection monitors for any kubernetes API Request originating from an Indicator of Compromise.
 - [Kubernetes Admission Controller Webhook Created](../rules/kubernetes_rules/k8s_admission_controller_created.yml)
@@ -775,6 +781,8 @@
   - Checks for the log status `SKIPDATA`, which indicates that data was lost either to an internal server error or due to capacity constraints.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)
   - Detects when an IP address in any log event matches a known threat indicator from AlienVault OTX pulse intelligence. Severity is elevated when the pulse includes a named adversary or known malware families.
 - [VPC Flow Logs Inbound Port Allowlist](../rules/aws_vpc_flow_rules/aws_vpc_inbound_traffic_port_allowlist.yml)

--- a/indexes/detection-coverage.json
+++ b/indexes/detection-coverage.json
@@ -6360,6 +6360,34 @@
     },
     {
         "AnalysisType": "Rule",
+        "Description": "Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.",
+        "DisplayName": "GTI/VirusTotal Threat Intelligence Indicator Match",
+        "LogTypes": [
+            "AWS.ALB",
+            "AWS.CloudTrail",
+            "AWS.VPCFlow",
+            "Amazon.EKS.Audit",
+            "Asana.Audit",
+            "Atlassian.Audit",
+            "Azure.Audit",
+            "Azure.MonitorActivity",
+            "Box.Event",
+            "Cloudflare.Firewall",
+            "Cloudflare.HttpRequest",
+            "Crowdstrike.FDREvent",
+            "GCP.AuditLog",
+            "GSuite.ActivityEvent",
+            "Notion.AuditLogs",
+            "Okta.SystemLog",
+            "OneLogin.Events",
+            "OnePassword.SignInAttempt",
+            "Zendesk.Audit",
+            "Zoom.Activity"
+        ],
+        "YAMLPath": "rules/standard_rules/gti_malicious_indicator.yml"
+    },
+    {
+        "AnalysisType": "Rule",
         "Description": "An IAM role policy was attached with Administrator Access, which could indicate a potential security risk.",
         "DisplayName": "IAM Administrator Role Policy Attached",
         "LogTypes": [

--- a/indexes/gcp.md
+++ b/indexes/gcp.md
@@ -139,6 +139,8 @@
   - Adversaries may access data objects from improperly secured cloud storage.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [Kubernetes Admission Controller Webhook Created](../rules/kubernetes_rules/k8s_admission_controller_created.yml)
   - This detection monitors for creation of MutatingWebhookConfiguration or ValidatingWebhookConfiguration resources. Admission controller webhooks can intercept all API requests to the Kubernetes API server, allowing attackers to inspect, modify, or block any resource creation or modification. This provides powerful capabilities for persistence (modifying deployments to inject backdoors), credential theft (intercepting secrets), and reconnaissance (enumerating all cluster activity).
 - [Kubernetes All Secrets Dumped Across Namespaces](../rules/kubernetes_rules/k8s_secrets_dump_all_namespaces.yml)

--- a/indexes/gworkspace.md
+++ b/indexes/gworkspace.md
@@ -106,6 +106,8 @@
   - A Workspace Admin Has Disabled The Enforcement Of Strong Passwords
 - [GSuite Workspace Trusted Domain Allowlist Modified](../rules/gsuite_activityevent_rules/gsuite_workspace_trusted_domains_allowlist.yml)
   - A Workspace Admin Has Modified The Trusted Domains List
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [Malware Detected in Email](../rules/gsuite_activityevent_rules/gsuite_malware_in_email.yml)
   - Detects when malware is found in an email received by a user. Identifies different malware families including known malicious programs, viruses, worms, harmful content, and unwanted content. Severity is dynamically assigned based on the malware type, with known malicious programs and viruses triggering high-severity alerts.
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)

--- a/indexes/okta.md
+++ b/indexes/okta.md
@@ -8,6 +8,8 @@
   - An actor user was denied login access more times than the configured threshold.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [Impossible Travel for Login Action](../rules/standard_rules/impossible_travel_login.yml)
   - A user has subsequent logins from two geographic locations that are very far apart
 - [MFA Disabled](../rules/standard_rules/mfa_disabled.yml)

--- a/indexes/onelogin.md
+++ b/indexes/onelogin.md
@@ -8,6 +8,8 @@
   - An actor user was denied login access more times than the configured threshold.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [New User Account Created](../rules/indicator_creation_rules/new_user_account_logging.yml)
   - A new account was created
 - [OneLogin Active Login Activity](../rules/onelogin_rules/onelogin_active_login_activity.yml)

--- a/indexes/onepass.md
+++ b/indexes/onepass.md
@@ -16,6 +16,8 @@
   - Alerts when a user defined list of sensitive items in 1Password is accessed
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)
   - Detects when an IP address in any log event matches a known threat indicator from AlienVault OTX pulse intelligence. Severity is elevated when the pulse includes a named adversary or known malware families.
 - [Sign In from Rogue State](../rules/standard_rules/sign_in_from_rogue_state.yml)

--- a/indexes/saas.md
+++ b/indexes/saas.md
@@ -24,6 +24,8 @@
   - An actor user was denied login access more times than the configured threshold.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [Malicious Content Detected](../rules/box_rules/box_malicious_content.yml)
   - Box has detect malicious content, such as a virus.
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)
@@ -158,6 +160,8 @@
   - A Workspace Admin Has Disabled The Enforcement Of Strong Passwords
 - [GSuite Workspace Trusted Domain Allowlist Modified](../rules/gsuite_activityevent_rules/gsuite_workspace_trusted_domains_allowlist.yml)
   - A Workspace Admin Has Modified The Trusted Domains List
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [Malware Detected in Email](../rules/gsuite_activityevent_rules/gsuite_malware_in_email.yml)
   - Detects when malware is found in an email received by a user. Identifies different malware families including known malicious programs, viruses, worms, harmful content, and unwanted content. Severity is dynamically assigned based on the malware type, with known malicious programs and viruses triggering high-severity alerts.
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)
@@ -180,6 +184,8 @@
   - An actor user was denied login access more times than the configured threshold.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [Impossible Travel for Login Action](../rules/standard_rules/impossible_travel_login.yml)
   - A user has subsequent logins from two geographic locations that are very far apart
 - [MFA Disabled](../rules/standard_rules/mfa_disabled.yml)
@@ -282,6 +288,8 @@
   - An actor user was denied login access more times than the configured threshold.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [New User Account Created](../rules/indicator_creation_rules/new_user_account_logging.yml)
   - A new account was created
 - [OneLogin Active Login Activity](../rules/onelogin_rules/onelogin_active_login_activity.yml)
@@ -412,6 +420,8 @@
   - User enabled or disabled zendesk support user assumption.
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [MFA Disabled](../rules/standard_rules/mfa_disabled.yml)
   - Detects when Multi-Factor Authentication (MFA) is disabled
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)
@@ -436,6 +446,8 @@
 
 - [GreyNoise V3 Malicious IP Activity](../rules/standard_rules/greynoise_malicious_ip.yml)
   - Detects when an IP address in any log event is classified as malicious or unknown by GreyNoise V3 internet scanner intelligence. Known business services and benign IPs are excluded.
+- [GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)
+  - Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
 - [New User Account Created](../rules/indicator_creation_rules/new_user_account_logging.yml)
   - A new account was created
 - [OTX Threat Intelligence Indicator Match](../rules/standard_rules/otx_malicious_indicator.yml)

--- a/indexes/standard.md
+++ b/indexes/standard.md
@@ -66,6 +66,28 @@ Detects when an IP address in any log event is classified as malicious or unknow
   - Zoom
 
 
+[GTI/VirusTotal Threat Intelligence Indicator Match](../rules/standard_rules/gti_malicious_indicator.yml)  
+Detects when an IP address, domain, or file hash in any log event matches a known malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment. Severity is elevated based on GTI's threat severity verdict and the number of vendors flagging the indicator as malicious.
+  - AWS ALB
+  - AWS CloudTrail
+  - AWS EKS
+  - AWS VPCFlow
+  - Asana
+  - Atlassian
+  - Azure
+  - Box
+  - Cloudflare
+  - Crowdstrike
+  - GCP
+  - Google Workspace
+  - Notion
+  - Okta
+  - OneLogin
+  - OnePassword
+  - Zendesk
+  - Zoom
+
+
 [Impossible Travel for Login Action](../rules/standard_rules/impossible_travel_login.yml)  
 A user has subsequent logins from two geographic locations that are very far apart
   - AWS CloudTrail

--- a/rules/standard_rules/greynoise_malicious_ip.py
+++ b/rules/standard_rules/greynoise_malicious_ip.py
@@ -11,6 +11,16 @@ CLASSIFICATIONS_TO_ALERT = {"malicious", "unknown"}
 MATCHED_IPS = {}  # {ip: classification}
 
 
+def _alerting_classification(classification):
+    """Collapse a possibly list-shaped classification (multiple LUT hits) to the
+    single alertable classification, preferring 'malicious' over 'unknown'."""
+    values = classification if isinstance(classification, list) else [classification]
+    matches = [value for value in values if value in CLASSIFICATIONS_TO_ALERT]
+    if not matches:
+        return None
+    return "malicious" if "malicious" in matches else matches[0]
+
+
 def rule(event):
     global MATCHED_IPS  # pylint: disable=global-statement
     MATCHED_IPS = {}
@@ -25,11 +35,8 @@ def rule(event):
         if bsi and bsi.found(ip_addr):
             continue
 
-        classification = scanner.classification(ip_addr)
-        if not classification or classification == "benign":
-            continue
-
-        if classification in CLASSIFICATIONS_TO_ALERT:
+        classification = _alerting_classification(scanner.classification(ip_addr))
+        if classification:
             MATCHED_IPS[ip_addr] = classification
 
     return bool(MATCHED_IPS)

--- a/rules/standard_rules/greynoise_malicious_ip.yml
+++ b/rules/standard_rules/greynoise_malicious_ip.yml
@@ -145,3 +145,24 @@ Tests:
               name: "Google DNS"
               category: "public_dns"
               trust_level: 1
+  - Name: "Multi-Match List-Shaped Classification - Alerts"
+    ExpectedResult: true
+    Log:
+      p_any_ip_addresses:
+        - "198.51.100.9"
+      p_log_type: "AWS.CloudTrail"
+      p_enrichment:
+        greynoise_noise:
+          "198.51.100.9":
+            - ip: "198.51.100.9"
+              internet_scanner_intelligence:
+                classification: "benign"
+                found: true
+              business_service_intelligence:
+                found: false
+            - ip: "198.51.100.9"
+              internet_scanner_intelligence:
+                classification: "malicious"
+                found: true
+              business_service_intelligence:
+                found: false

--- a/rules/standard_rules/gti_malicious_indicator.py
+++ b/rules/standard_rules/gti_malicious_indicator.py
@@ -1,0 +1,64 @@
+from panther_gti_helpers import (
+    get_gti_object,
+    gti_alert_context,
+    gti_severity,
+    severity_greater_than,
+)
+
+INDICATOR_FIELDS = (
+    "p_any_ip_addresses",
+    "p_any_domain_names",
+    "p_any_md5_hashes",
+    "p_any_sha1_hashes",
+    "p_any_sha256_hashes",
+)
+
+MATCHED_INDICATORS = {}  # {indicator: indicator_type}
+
+
+def rule(event):
+    global MATCHED_INDICATORS  # pylint: disable=global-statement
+    MATCHED_INDICATORS = {}
+
+    gti = get_gti_object(event)
+    if not gti:
+        return False
+
+    for field in INDICATOR_FIELDS:
+        for value in event.get(field, []) or []:
+            if value in MATCHED_INDICATORS:
+                continue
+            indicator_type = gti.indicator_type(value)
+            if not indicator_type:
+                continue
+            MATCHED_INDICATORS[value] = indicator_type
+
+    return bool(MATCHED_INDICATORS)
+
+
+def title(event):
+    log_type = event.get("p_log_type", "Unknown")
+    if len(MATCHED_INDICATORS) == 1:
+        indicator, ioc_type = next(iter(MATCHED_INDICATORS.items()))
+        return f"GTI: Known malicious {ioc_type} [{indicator}] detected in {log_type}"
+    return f"GTI: {len(MATCHED_INDICATORS)} threat indicators detected in {log_type}"
+
+
+def severity(event):
+    highest = None
+    for indicator in MATCHED_INDICATORS:
+        sev = gti_severity(event, indicator)
+        if highest is None or severity_greater_than(sev, highest):
+            highest = sev
+    return highest or "DEFAULT"
+
+
+def alert_context(event):
+    if not MATCHED_INDICATORS:
+        return {}
+    ctx = {}
+    for indicator, indicator_type in MATCHED_INDICATORS.items():
+        indicator_ctx = gti_alert_context(event, indicator)
+        indicator_ctx["MatchedIndicatorType"] = indicator_type
+        ctx[indicator] = indicator_ctx
+    return ctx

--- a/rules/standard_rules/gti_malicious_indicator.py
+++ b/rules/standard_rules/gti_malicious_indicator.py
@@ -16,6 +16,13 @@ INDICATOR_FIELDS = (
 MATCHED_INDICATORS = {}  # {indicator: indicator_type}
 
 
+def _first(value):
+    """Collapse a possibly list-shaped lookup value (multiple LUT hits) to a single value."""
+    if isinstance(value, list):
+        return next((entry for entry in value if entry), None)
+    return value
+
+
 def rule(event):
     global MATCHED_INDICATORS  # pylint: disable=global-statement
     MATCHED_INDICATORS = {}
@@ -28,8 +35,10 @@ def rule(event):
         for value in event.get(field, []) or []:
             if value in MATCHED_INDICATORS:
                 continue
-            indicator_type = gti.indicator_type(value)
+            indicator_type = _first(gti.indicator_type(value))
             if not indicator_type:
+                continue
+            if not gti.is_malicious(value):
                 continue
             MATCHED_INDICATORS[value] = indicator_type
 

--- a/rules/standard_rules/gti_malicious_indicator.yml
+++ b/rules/standard_rules/gti_malicious_indicator.yml
@@ -1,0 +1,169 @@
+AnalysisType: rule
+Filename: gti_malicious_indicator.py
+RuleID: "Standard.GTI.MaliciousIndicator"
+DisplayName: "GTI/VirusTotal Threat Intelligence Indicator Match"
+Enabled: false
+Status: Experimental
+Severity: High
+Description: >-
+  Detects when an IP address, domain, or file hash in any log event matches a known
+  malicious indicator from Google Threat Intelligence (GTI) / VirusTotal enrichment.
+  Severity is elevated based on GTI's threat severity verdict and the number of
+  vendors flagging the indicator as malicious.
+Runbook: |
+  1. Review the alert context and open the GTI/VirusTotal URL to assess the indicator's
+     verdict, detection ratio, and suggested threat label.
+  2. Query the data lake for all events involving this indicator to determine what assets
+     or services were contacted and whether any connections were successful.
+  3. If the indicator is confirmed malicious and interaction was observed, block the
+     indicator, isolate affected hosts, and reset any credentials that may have been exposed.
+Reference: https://www.virustotal.com
+DedupPeriodMinutes: 60
+Reports:
+  MITRE ATT&CK:
+    - TA0043:T1595.001
+Tags:
+  - Reconnaissance:Active Scanning
+  - GTI
+  - VirusTotal
+  - Threat Intelligence
+SummaryAttributes:
+  - p_any_ip_addresses
+  - p_source_label
+LogTypes:
+  - Amazon.EKS.Audit
+  - Asana.Audit
+  - Atlassian.Audit
+  - AWS.ALB
+  - AWS.CloudTrail
+  - AWS.VPCFlow
+  - Azure.Audit
+  - Azure.MonitorActivity
+  - Box.Event
+  - Cloudflare.Firewall
+  - Cloudflare.HttpRequest
+  - Crowdstrike.FDREvent
+  - GCP.AuditLog
+  - GSuite.ActivityEvent
+  - Notion.AuditLogs
+  - Okta.SystemLog
+  - OneLogin.Events
+  - OnePassword.SignInAttempt
+  - Zendesk.Audit
+  - Zoom.Activity
+Tests:
+  - Name: "Known Malicious File Hash Detected - High Severity"
+    ExpectedResult: true
+    Log:
+      p_any_sha256_hashes:
+        - "0000000000000000000000000000000000000000000000000000000000000000"
+      p_log_type: "Crowdstrike.FDREvent"
+      p_enrichment:
+        vt_iocstream:
+          "0000000000000000000000000000000000000000000000000000000000000000":
+            id: "0000000000000000000000000000000000000000000000000000000000000000"
+            type: "file"
+            type_description: "Win32 EXE"
+            meaningful_name: "example-malware.exe"
+            names:
+              - "example-malware.exe"
+              - "svchost32.exe"
+            md5: "00000000000000000000000000000000"
+            sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+            reputation: -12
+            gti_url: "https://www.virustotal.com/gui/file/0000000000000000000000000000000000000000000000000000000000000000"
+            last_analysis_stats:
+              malicious: 57
+              suspicious: 0
+              harmless: 0
+              undetected: 13
+            threat_severity:
+              threat_severity_level: "SEVERITY_HIGH"
+              level_description: "Severity HIGH because it was considered trojan."
+            popular_threat_classification:
+              suggested_threat_label: "trojan.remcos/rescoms"
+              popular_threat_category:
+                - count: 32
+                  value: "trojan"
+              popular_threat_name:
+                - count: 18
+                  value: "remcos"
+            tags:
+              - "peexe"
+              - "payload"
+              - "malware"
+  - Name: "Known Malicious IP Detected - Medium Detections"
+    ExpectedResult: true
+    Log:
+      p_any_ip_addresses:
+        - "203.0.113.5"
+      p_log_type: "AWS.CloudTrail"
+      p_enrichment:
+        vt_iocstream:
+          "203.0.113.5":
+            id: "203.0.113.5"
+            type: "ip_address"
+            reputation: -5
+            country: "NL"
+            as_owner: "Example Hosting"
+            asn: 64500
+            last_analysis_stats:
+              malicious: 5
+              suspicious: 1
+              harmless: 60
+              undetected: 4
+            tags:
+              - "scanner"
+  - Name: "Multiple Malicious Domains Detected"
+    ExpectedResult: true
+    Log:
+      p_any_domain_names:
+        - "evil-c2.example.com"
+        - "phishing-page.example.com"
+      p_log_type: "Cloudflare.HttpRequest"
+      p_enrichment:
+        vt_iocstream:
+          "evil-c2.example.com":
+            id: "evil-c2.example.com"
+            type: "domain"
+            reputation: -20
+            categories:
+              - "malware"
+            last_analysis_stats:
+              malicious: 30
+              suspicious: 0
+              harmless: 40
+              undetected: 5
+          "phishing-page.example.com":
+            id: "phishing-page.example.com"
+            type: "domain"
+            reputation: -8
+            categories:
+              - "phishing"
+            last_analysis_stats:
+              malicious: 8
+              suspicious: 2
+              harmless: 55
+              undetected: 5
+  - Name: "Benign IP - No Enrichment"
+    ExpectedResult: false
+    Log:
+      p_any_ip_addresses:
+        - "10.0.0.1"
+      p_log_type: "AWS.VPCFlow"
+  - Name: "IP Not in GTI/VirusTotal Feed"
+    ExpectedResult: false
+    Log:
+      p_any_ip_addresses:
+        - "192.168.1.1"
+      p_log_type: "Cloudflare.HttpRequest"
+      p_enrichment:
+        vt_iocstream:
+          "192.168.1.1":
+            id: ""
+            type: ""
+            last_analysis_stats:
+              malicious: 0
+              suspicious: 0
+              harmless: 0
+              undetected: 0

--- a/rules/standard_rules/gti_malicious_indicator.yml
+++ b/rules/standard_rules/gti_malicious_indicator.yml
@@ -167,3 +167,42 @@ Tests:
               suspicious: 0
               harmless: 0
               undetected: 0
+  - Name: "Known Benign Indicator - No Malicious Detections"
+    ExpectedResult: false
+    Log:
+      p_any_ip_addresses:
+        - "198.51.100.42"
+      p_log_type: "AWS.VPCFlow"
+      p_enrichment:
+        vt_iocstream:
+          "198.51.100.42":
+            id: "198.51.100.42"
+            type: "ip_address"
+            reputation: 40
+            country: "US"
+            as_owner: "Example Cloud Provider"
+            last_analysis_stats:
+              malicious: 0
+              suspicious: 0
+              harmless: 80
+              undetected: 4
+  - Name: "Multiple LUT Matches For Same Value - List-Shaped Enrichment"
+    ExpectedResult: true
+    Log:
+      p_any_sha256_hashes:
+        - "1111111111111111111111111111111111111111111111111111111111111111"
+      p_log_type: "Crowdstrike.FDREvent"
+      p_enrichment:
+        vt_iocstream:
+          "1111111111111111111111111111111111111111111111111111111111111111":
+            - id: "1111111111111111111111111111111111111111111111111111111111111111"
+              type: "file"
+              gti_url: "https://www.virustotal.com/gui/file/1111111111111111111111111111111111111111111111111111111111111111"
+              last_analysis_stats:
+                malicious: 42
+                suspicious: 1
+                harmless: 0
+                undetected: 15
+              threat_severity:
+                threat_severity_level: "SEVERITY_HIGH"
+                level_description: "Severity HIGH because it was considered trojan."


### PR DESCRIPTION
## Summary
- Adds `panther_gti_helpers`, a reusable enrichment helper for Google Threat Intelligence / VirusTotal lookup-table data (`vt_iocs_iocstream`), mirroring the existing `panther_otx_helpers` pattern (built on the shared `LookupTableMatches` base).
- LUT auto-detection is signature-based (looks for `gti_url`/`last_analysis_stats` on matched values) since the VT LUT name is user-customizable.
- Adds a companion `Standard.GTI.MaliciousIndicator` detection (created disabled/experimental) that flags events whose IP/domain/file-hash indicators match a malicious GTI/VT verdict.
- 37 new unit tests for the helper (`global_helpers/global_helpers_test.py::TestGTIIntelligence`) plus 5 redacted rule tests (3 positive, 2 negative).

## Test plan
- [x] `make fmt && make lint && make test` — all pass (1074 pat tests + global helper unit tests, 0 failures)
- [x] `pipenv run python -m unittest global_helpers.global_helpers_test.TestGTIIntelligence` — 37/37 pass
- [x] `pipenv run panther_analysis_tool test --filter RuleID=Standard.GTI.MaliciousIndicator` — 5/5 pass

THREAT-691