### PR TITLE
Fix empty app_name alert for OnePassword.Unusual.Client

### DIFF
--- a/rules/onepassword_rules/onepassword_unusual_client.py
+++ b/rules/onepassword_rules/onepassword_unusual_client.py
@@ -24,7 +24,11 @@ def rule(event):
         "1Password SDK",
     ]
 
-    return event.deep_get("client", "app_name") not in client_allowlist
+    app_name = event.deep_get("client", "app_name")
+    if not app_name:
+        return False
+
+    return app_name not in client_allowlist
 
 
 def title(event):


### PR DESCRIPTION
### Background

The rule triggers when the `app_name` is not in the list. but on failures, the `app_name` could be empty. So the rule needs a fix

### Changes

Just return `False` on `rule` when the `app_name` is empty because our list-comparison would be wrong

### Sample log
```json
{
	"category": "credentials_failed",
	"client": {
		"ip_address": "22.11.181.54",
		"app_name": "",
		"app_version": "",
		"platform_name": "",
		"platform_version": "",
		"os_name": "",
		"os_version": ""
	},
	"country": "United States",
	"location": {
		"country": "United States",
		"region": "Georgia",
		"city": "Marietta",
		"latitude": 33.000,
		"longitude": -88.000
	},
	"session_uuid": "WGQ4WMVCNN0007KQIBBJ7SD3A",
	"target_user": {
		"uuid": "D3AI7SG5V500000VEB4WI5RLU",
		"name": "George Michael",
		"email": "george.michael@music.com"
	},
	"timestamp": "2026-07-03 18:24:19.763136186",
	"type": "password_secret_bad",
	"uuid": "N5WZK4DOL000002PXW7UR674"
}
```