### PR TITLE
Tune Crowdstrike.RealTimeResponse.Session

### DIFF
--- a/rules/crowdstrike_rules/crowdstrike_real_time_response_session.py
+++ b/rules/crowdstrike_rules/crowdstrike_real_time_response_session.py
@@ -22,6 +22,10 @@ def severity(event):
     return "DEFAULT"
 
 
+def dedup(event):
+    return get_crowdstrike_field(event, "UserName", default="<unknown-UserName>")
+
+
 def alert_context(event):
     return {
         "Start Time": get_crowdstrike_field(


### PR DESCRIPTION
### Background

Crowdstrike.RealTimeResponse.Session had no dedup(), so it fell back to title(), which embeds HostnameField — meaning automated RTR bursts generated a separate alert per target host, producing 1000+ alerts/hour. 
Added a dedup() that keys on UserName alone, collapsing repeated RTR sessions from the same actor within the dedup window into a single alert.

### Changes

- <Describe changes here>

### Testing

- <Testing steps>
