### PR TITLE
Tune AWS GetSignInToken

### DIFF
--- a/rules/aws_cloudtrail_rules/aws_console_getsignintoken.py
+++ b/rules/aws_cloudtrail_rules/aws_console_getsignintoken.py
@@ -1,7 +1,7 @@
 from panther_aws_helpers import aws_rule_context
 
 # User agents associated with legitimate AWS SSO portal sign-in token requests
-SSO_USER_AGENTS = ["Jersey/${project.version}"]
+SSO_USER_AGENTS = ["Jersey/${project.version}", "Go-http-client/2.0"]
 
 
 def rule(event):

--- a/rules/aws_cloudtrail_rules/aws_console_getsignintoken.yml
+++ b/rules/aws_cloudtrail_rules/aws_console_getsignintoken.yml
@@ -70,6 +70,23 @@ Tests:
           "arn": "arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_Admin/user@example.com"
         }
       }
+  - Name: Legitimate SSO Portal GetSigninToken (Go client)
+    ExpectedResult: false
+    Log:
+      {
+        "awsRegion": "us-east-1",
+        "eventName": "GetSigninToken",
+        "eventSource": "signin.amazonaws.com",
+        "eventTime": "2024-01-15T10:30:00Z",
+        "eventType": "AwsApiCall",
+        "recipientAccountId": "123456789012",
+        "sourceIPAddress": "10.0.0.1",
+        "userAgent": "Go-http-client/2.0",
+        "userIdentity": {
+          "type": "AssumedRole",
+          "arn": "arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_Admin/user@example.com"
+        }
+      }
   - Name: Unrelated Signin Event
     ExpectedResult: false
     Log:


### PR DESCRIPTION
### Background

The Go-http-client/2.0 user agent is the AWS SSO portal's backend service, not an attacker tool; this pattern generates consistent false positives for all SSO users 

### Changes

- Allowlist Go-http-client/2.0 user agent

### Testing

- new unit test
