### PR TITLE
Fix Kubernetes IOC query Snowflake clause order

### DIFF
--- a/queries/kubernetes_queries/kubernetes_ioc_activity_query.yml
+++ b/queries/kubernetes_queries/kubernetes_ioc_activity_query.yml
@@ -15,10 +15,10 @@ SnowflakeQuery: |
          ELSE 'Unknown'
          END AS IP_TYPE
   FROM panther_logs.public.amazon_eks_audit, lateral flatten(source_ips)
-  WHERE p_occurs_since('30 minutes')
    -- as an example, could be replaced with any IOC data store in a lookup table
   INNER JOIN panther_lookups.public.tor_exit_nodes
   ON value = ip
+  WHERE p_occurs_since('30 minutes')
   LIMIT 10
 
 DatabricksQuery: |


### PR DESCRIPTION
### Background

The Snowflake variant of the Kubernetes IOC activity query placed its `INNER JOIN` after the `WHERE` clause. That clause order is invalid, so the query could not be parsed or executed.

Closes #2101.

### Changes

- Move the Snowflake `WHERE` filter after the `INNER JOIN ... ON` clause.
- Leave the already-correct Databricks query unchanged.

### Testing

- `panther_analysis_tool test --path queries/kubernetes_queries --show-failures-only`: 15 passed, 0 failed, 0 invalid.
- SQLFluff 4.2.2 with the Snowflake dialect: 0 parse violations after the change; the original query reports an unparsable section at `INNER JOIN`.
- Repository formatting scope with the locked isort and Black versions: 1,115 files unchanged.
- Repository lint scope: Bandit found 0 issues, Pylint scored 10.00/10, and isort/Black checks passed.
- Global-helper unit tests: 218 passed.
- Data-model unit tests: 21 passed.
- Full Panther Analysis Tool run on Windows: 1,041 passed, 31 skipped, and 2 unrelated `Standard.*` analyses failed because existing code uses the Unix-only `strftime("%s")`; both failures reproduce on the unmodified `develop` commit.

Live Snowflake `EXPLAIN` was not run because it requires access to a Panther instance and data lake.
