### PR TITLE
Update SentinelOne Alert Passthrough for activityType schema change

### DIFF
--- a/rules/sentinelone_rules/sentinelone_alert_passthrough.py
+++ b/rules/sentinelone_rules/sentinelone_alert_passthrough.py
@@ -8,7 +8,7 @@ SENTINELONE_SEVERITY = {
 
 def rule(event):
     # 3608 corresponds to new alerts
-    return event.get("activitytype") == 3608
+    return event.get("activitytype") == "3608"
 
 
 def title(event):

--- a/rules/sentinelone_rules/sentinelone_alert_passthrough.yml
+++ b/rules/sentinelone_rules/sentinelone_alert_passthrough.yml
@@ -10,7 +10,7 @@ Tests:
     Log:
       accountid: "12345"
       accountname: Account1
-      activitytype: 3608
+      activitytype: "3608"
       activityuuid: f123-345-1234
       agentid: "1234567"
       createdat: "2022-12-07 17:36:05.076"
@@ -55,7 +55,7 @@ Tests:
     Log:
       accountid: "12345"
       accountname: Account1
-      activitytype: 3608
+      activitytype: "3608"
       activityuuid: f123-345-1234
       agentid: "1234567"
       createdat: "2022-12-07 17:36:05.076"
@@ -100,7 +100,7 @@ Tests:
     Log:
       accountid: "12345"
       accountname: Account1
-      activitytype: 90
+      activitytype: "90"
       activityuuid: 123-456-789
       agentid: "111111"
       createdat: "2022-12-07 16:06:35.483"


### PR DESCRIPTION
## Summary
- Panther v1.119 changes the `SentinelOne.Activity` log schema's `activityType` field from `int` to `string` (see [Panther help article](https://help.panther.com/articles/7838552432-sentinelone-activity-log-schema-change-in-panther-v1-119)).
- Updates `SentinelOne.Alert.Passthrough`'s rule logic to compare `activitytype` against the string `"3608"` instead of the int `3608`.
- Updates the corresponding unit test fixtures to use string `activitytype` values, matching the pattern already used in `SentinelOne.Threats`.

## Test plan
- [x] `panther_analysis_tool test --path rules/sentinelone_rules/` passes (positive CRITICAL/MEDIUM alert tests and negative Non-Alert test)
- [x] `black`/`isort` checked clean on the modified file