### PR TITLE
AWS RDS Instance Encryption Tuning

### DIFF
--- a/policies/aws_rds_policies/aws_rds_instance_encryption.py
+++ b/policies/aws_rds_policies/aws_rds_instance_encryption.py
@@ -1,2 +1,9 @@
 def policy(resource):
-    return resource["KmsKeyId"] is not None
+    # Aurora manages storage encryption at the cluster level. Since Feb 2024, AWS encrypts
+    # all new Aurora clusters by default with an AWS owned KMS key, which never populates
+    # KmsKeyId (or StorageEncrypted) on the instance resource, causing false positives here.
+    # Ref: https://aws.amazon.com/blogs/database/use-default-encryption-at-rest-for-new-amazon-aurora-clusters/  # pylint: disable=line-too-long
+    if resource.get("StorageType") == "aurora":
+        return True
+
+    return resource.get("KmsKeyId") is not None

--- a/policies/aws_rds_policies/aws_rds_instance_encryption.py
+++ b/policies/aws_rds_policies/aws_rds_instance_encryption.py
@@ -1,9 +1,14 @@
+# AWS began encrypting all new Amazon Aurora clusters by default with an AWS owned key
+# around this date. That default encryption never populates KmsKeyId (or StorageEncrypted)
+# on the instance resource, so only Aurora instances created on/after this date are exempted
+# below - older Aurora instances still require an explicit KmsKeyId to be considered compliant.
+# Ref: https://aws.amazon.com/blogs/database/use-default-encryption-at-rest-for-new-amazon-aurora-clusters/  # pylint: disable=line-too-long
+AURORA_DEFAULT_ENCRYPTION_DATE = "2026-02-17"
+
+
 def policy(resource):
-    # Aurora manages storage encryption at the cluster level. Since Feb 2024, AWS encrypts
-    # all new Aurora clusters by default with an AWS owned KMS key, which never populates
-    # KmsKeyId (or StorageEncrypted) on the instance resource, causing false positives here.
-    # Ref: https://aws.amazon.com/blogs/database/use-default-encryption-at-rest-for-new-amazon-aurora-clusters/  # pylint: disable=line-too-long
-    if resource.get("StorageType") == "aurora":
+    if resource.get("KmsKeyId") is not None:
         return True
 
-    return resource.get("KmsKeyId") is not None
+    created_at = resource.get("TimeCreated") or resource.get("InstanceCreateTime") or ""
+    return resource.get("StorageType") == "aurora" and created_at >= AURORA_DEFAULT_ENCRYPTION_DATE

--- a/policies/aws_rds_policies/aws_rds_instance_encryption.yml
+++ b/policies/aws_rds_policies/aws_rds_instance_encryption.yml
@@ -21,6 +21,59 @@ Runbook: >
   https://docs.runpanther.io/alert-runbooks/built-in-policies/aws-rds-instance-has-storage-encrypted
 Reference: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html
 Tests:
+  - Name: Aurora Instance With AWS Owned Key (No KmsKeyId)
+    ExpectedResult: true
+    Resource:
+      {
+        "AccountId": "123456789012",
+        "AllocatedStorage": 1,
+        "AutoMinorVersionUpgrade": true,
+        "AvailabilityZone": "us-east-1d",
+        "BackupRetentionPeriod": 1,
+        "CACertificateIdentifier": "",
+        "CopyTagsToSnapshot": false,
+        "DBClusterIdentifier": "example-aurora-cluster",
+        "DBInstanceClass": "db.serverless",
+        "DBInstanceStatus": "available",
+        "DBParameterGroups":
+          [
+            {
+              "DBParameterGroupName": "default.aurora-postgresql17",
+              "ParameterApplyStatus": "in-sync",
+            },
+          ],
+        "DbInstancePort": 0,
+        "DbiResourceId": "db-EXAMPLEID",
+        "DeletionProtection": false,
+        "Endpoint":
+          {
+            "Address": "example-aurora-instance.abcdefghijkl.us-east-1.rds.amazonaws.com",
+            "HostedZoneId": "ABCDEF1234",
+            "Port": 5432,
+          },
+        "Engine": "aurora-postgresql",
+        "EngineVersion": "17.7",
+        "IAMDatabaseAuthenticationEnabled": true,
+        "Id": "example-aurora-instance-1",
+        "LicenseModel": "postgresql-license",
+        "MasterUsername": "admin",
+        "MonitoringInterval": 0,
+        "MultiAZ": false,
+        "OptionGroupMemberships":
+          [{ "OptionGroupName": "default:aurora-postgresql-17", "Status": "in-sync" }],
+        "PerformanceInsightsEnabled": false,
+        "PreferredBackupWindow": "07:58-08:28",
+        "PreferredMaintenanceWindow": "mon:05:45-mon:06:15",
+        "PromotionTier": 1,
+        "PubliclyAccessible": false,
+        "Region": "us-east-1",
+        "ResourceId": "arn:aws:rds:us-east-1:123456789012:db:example-aurora-instance-1",
+        "ResourceType": "AWS.RDS.Instance",
+        "StorageEncrypted": false,
+        "StorageType": "aurora",
+        "Tags": {},
+        "TimeCreated": "2026-07-25T01:12:21.742Z",
+      }
   - Name: KMS Key Does Not Exist
     ExpectedResult: false
     Resource:

--- a/policies/aws_rds_policies/aws_rds_instance_encryption.yml
+++ b/policies/aws_rds_policies/aws_rds_instance_encryption.yml
@@ -74,6 +74,59 @@ Tests:
         "Tags": {},
         "TimeCreated": "2026-07-25T01:12:21.742Z",
       }
+  - Name: Legacy Aurora Instance Without Encryption
+    ExpectedResult: false
+    Resource:
+      {
+        "AccountId": "123456789012",
+        "AllocatedStorage": 1,
+        "AutoMinorVersionUpgrade": true,
+        "AvailabilityZone": "us-east-1d",
+        "BackupRetentionPeriod": 1,
+        "CACertificateIdentifier": "",
+        "CopyTagsToSnapshot": false,
+        "DBClusterIdentifier": "example-aurora-cluster-legacy",
+        "DBInstanceClass": "db.r5.large",
+        "DBInstanceStatus": "available",
+        "DBParameterGroups":
+          [
+            {
+              "DBParameterGroupName": "default.aurora-postgresql11",
+              "ParameterApplyStatus": "in-sync",
+            },
+          ],
+        "DbInstancePort": 0,
+        "DbiResourceId": "db-LEGACYEXAMPLEID",
+        "DeletionProtection": false,
+        "Endpoint":
+          {
+            "Address": "example-aurora-legacy-instance.abcdefghijkl.us-east-1.rds.amazonaws.com",
+            "HostedZoneId": "ABCDEF1234",
+            "Port": 5432,
+          },
+        "Engine": "aurora-postgresql",
+        "EngineVersion": "11.9",
+        "IAMDatabaseAuthenticationEnabled": false,
+        "Id": "example-aurora-legacy-instance-1",
+        "LicenseModel": "postgresql-license",
+        "MasterUsername": "admin",
+        "MonitoringInterval": 0,
+        "MultiAZ": false,
+        "OptionGroupMemberships":
+          [{ "OptionGroupName": "default:aurora-postgresql-11", "Status": "in-sync" }],
+        "PerformanceInsightsEnabled": false,
+        "PreferredBackupWindow": "07:58-08:28",
+        "PreferredMaintenanceWindow": "mon:05:45-mon:06:15",
+        "PromotionTier": 1,
+        "PubliclyAccessible": false,
+        "Region": "us-east-1",
+        "ResourceId": "arn:aws:rds:us-east-1:123456789012:db:example-aurora-legacy-instance-1",
+        "ResourceType": "AWS.RDS.Instance",
+        "StorageEncrypted": false,
+        "StorageType": "aurora",
+        "Tags": {},
+        "TimeCreated": "2023-01-01T00:00:00.000Z",
+      }
   - Name: KMS Key Does Not Exist
     ExpectedResult: false
     Resource:


### PR DESCRIPTION
### Background

<High level overview here>

### Changes

- Replaced the blanket StorageType == "aurora" exemption with a date-gated check: only Aurora instances created on/after 2026-02-17 (when AWS began encrypting new Aurora clusters by default with an AWS-owned key, per their blog) are exempted. Legacy Aurora instances created before that date still require an explicit KmsKeyId to pass.
- Uses TimeCreated (the field in the real-world false-positive log), falling back to InstanceCreateTime (the field name used in this policy's pre-existing tests) for compatibility.
- Added a regression test, "Legacy Aurora Instance Without Encryption" (created 2023-01-01, no KmsKeyId), which now correctly returns false/alerts — closing the false-negative gap.
### Testing

- <Testing steps>

tuning #2159 